### PR TITLE
use eeg fork of validator until merge with main

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
       pip install --no-deps -e .
       cd ../
     - python setup.py install
-    - npm install -g https://github.com/INCF/bids-validator.git#0.26.0
+    - npm install -g https://github.com/robertoostenveld/bids-validator.git#eeg-validator  # noqa use the EEG fork until merge
 script:
     - make
     - flake8 --count mne_bids


### PR DESCRIPTION
@jasmainak this was originally part of the big PR on including EEG. However we should merge this before, so that my changes get validated against the EEG-validator.

it's 14 commits ahead of bids-validator master, and none behind. and all of these commits only touch EEG stuff (adding json schemas, regex, etc.) see [here](https://github.com/robertoostenveld/bids-validator/tree/eeg-validator)