### PR TITLE
Fixes to copy raw files to the correct location

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
       pip install --no-deps -e .
       cd ../
     - python setup.py develop
-    - npm install -g https://github.com/INCF/bids-validator.git#0.26.0
+    - npm install -g https://github.com/INCF/bids-validator.git#0.26.18
 script:
     - make
     - flake8 --count mne_bids

--- a/mne_bids/meg_bids.py
+++ b/mne_bids/meg_bids.py
@@ -398,7 +398,7 @@ def raw_to_bids(subject_id, task, raw_file, output_path, session_id=None,
     data_meta_fname = make_bids_filename(
         subject=subject_id, session=session_id,
         suffix='%s.json' % kind, prefix=data_path)
-    if ext in ['.fif', '.gz']:
+    if ext in ['.fif', '.gz', '.ds']:
         raw_file_bids = make_bids_filename(
             subject=subject_id, session=session_id, task=task, run=run,
             suffix='%s%s' % (kind, ext))


### PR DESCRIPTION
This should fix #63 
The tests do fail however because the bids validator still doesn't like having raw files in a sub-directory. Because of this the BTI and KIT tests fail.
Also, I think the raw data for the BTI test doesn't copy over correctly (it just has a .pdf file?) (I am not too familiar with the BTI file format though...