### PR TITLE
fixes ordering of columns in the scans tsv

### DIFF
--- a/mne_bids/mne_bids.py
+++ b/mne_bids/mne_bids.py
@@ -184,8 +184,9 @@ def _scans_tsv(raw, raw_fname, fname, verbose):
         acq_time = datetime.fromtimestamp(
             meas_date).strftime('%Y-%m-%dT%H:%M:%S')
 
-    df = pd.DataFrame({'filename': ['%s' % raw_fname],
-                       'acq_time': [acq_time]})
+    df =pd.DataFrame(data={'filename': ['%s' % raw_fname],
+                           'acq_time': [acq_time]},
+                     columns=['filename', 'acq_time'])
 
     df.to_csv(fname, sep='\t', index=False, na_rep='n/a')
 

--- a/mne_bids/mne_bids.py
+++ b/mne_bids/mne_bids.py
@@ -184,9 +184,9 @@ def _scans_tsv(raw, raw_fname, fname, verbose):
         acq_time = datetime.fromtimestamp(
             meas_date).strftime('%Y-%m-%dT%H:%M:%S')
 
-    df =pd.DataFrame(data={'filename': ['%s' % raw_fname],
-                           'acq_time': [acq_time]},
-                     columns=['filename', 'acq_time'])
+    df = pd.DataFrame(data={'filename': ['%s' % raw_fname],
+                            'acq_time': [acq_time]},
+                      columns=['filename', 'acq_time'])
 
     df.to_csv(fname, sep='\t', index=False, na_rep='n/a')
 


### PR DESCRIPTION
I was going to add this code in a separate PR, but it is annoying that I have to essentially add this code to anything just so the bids-validator will not throw an error.
Do other people's validators not fail the test_mne_bids.py file because of the issue
`1: _scans.tsv files must have a 'filename' column. (code: 68 - FILENAME_COLUMN)`
I wasn't sure whether this should be fixed in the validator or here, but this is a very simple fix to make the column always be first so the validator doesn't fail (for me at least...)