### PR TITLE
[MRG + 1] Removes STI014 from channel list

### DIFF
--- a/mne_bids/mne_bids.py
+++ b/mne_bids/mne_bids.py
@@ -71,11 +71,10 @@ def _channels_tsv(raw, fname, verbose):
                     ref_meg='Reference channel')
 
     # get the manufacturer from the file in the Raw object
+    manufacturer = None
     if hasattr(raw, 'filenames'):
         _, ext = _parse_ext(raw.filenames[0], verbose=verbose)
         manufacturer = MANUFACTURERS[ext]
-    else:
-        manufacturer = None
 
     ignored_indexes = [raw.ch_names.index(ch_name) for ch_name in raw.ch_names
                        if ch_name in

--- a/mne_bids/mne_bids.py
+++ b/mne_bids/mne_bids.py
@@ -39,6 +39,7 @@ manufacturers = {'.sqd': 'KIT/Yokogawa', '.con': 'KIT/Yokogawa',
 
 IGNORED_CHANNELS = ['STI 014']
 
+
 def _channels_tsv(raw, fname, verbose):
     """Create a channels.tsv file and save it.
 

--- a/mne_bids/mne_bids.py
+++ b/mne_bids/mne_bids.py
@@ -38,6 +38,8 @@ MANUFACTURERS = {'.sqd': 'KIT/Yokogawa', '.con': 'KIT/Yokogawa',
                  '.fif': 'Elekta', '.pdf': '4D Magnes', '.ds': 'CTF',
                  '.meg4': 'CTF'}
 
+# List of synthetic channels by manufacturer that are to be excluded from the
+# channel list. Currently this is only for stimulus channels.
 IGNORED_CHANNELS = {'KIT/Yokogawa': ['STI 014']}
 
 
@@ -356,9 +358,9 @@ def _sidecar_json(raw, task, manufacturer, fname, kind,
         powerlinefrequency = 50
 
     # determine whether any channels have to be ignored:
-    num_ignored = len([ch_name for ch_name in
-                       IGNORED_CHANNELS.get(manufacturer, list()) if
-                       ch_name in raw.ch_names])
+    n_ignored = len([ch_name for ch_name in
+                     IGNORED_CHANNELS.get(manufacturer, list()) if
+                     ch_name in raw.ch_names])
     # all ignored channels are trigger channels at the moment...
 
     n_megchan = len([ch for ch in raw.info['chs']
@@ -380,7 +382,7 @@ def _sidecar_json(raw, task, manufacturer, fname, kind,
     n_miscchan = len([ch for ch in raw.info['chs']
                      if ch['kind'] == FIFF.FIFFV_MISC_CH])
     n_stimchan = len([ch for ch in raw.info['chs']
-                     if ch['kind'] == FIFF.FIFFV_STIM_CH]) - num_ignored
+                     if ch['kind'] == FIFF.FIFFV_STIM_CH]) - n_ignored
 
     # Define modality-specific JSON dictionaries
     ch_info_json_common = [

--- a/mne_bids/mne_bids.py
+++ b/mne_bids/mne_bids.py
@@ -32,7 +32,7 @@ ALLOWED_KINDS = ['meg', 'ieeg']
 ORIENTATION = {'.sqd': 'ALS', '.con': 'ALS', '.fif': 'RAS', '.pdf': 'ALS',
                '.ds': 'ALS'}
 
-UNTIS = {'.sqd': 'm', '.con': 'm', '.fif': 'm', '.pdf': 'm', '.ds': 'cm'}
+UNITS = {'.sqd': 'm', '.con': 'm', '.fif': 'm', '.pdf': 'm', '.ds': 'cm'}
 
 MANUFACTURERS = {'.sqd': 'KIT/Yokogawa', '.con': 'KIT/Yokogawa',
                  '.fif': 'Elekta', '.pdf': '4D Magnes', '.ds': 'CTF',

--- a/mne_bids/mne_bids.py
+++ b/mne_bids/mne_bids.py
@@ -75,10 +75,9 @@ def _channels_tsv(raw, fname, verbose):
     else:
         manufacturer = None
 
-    ignored_indexes = list()
-    for ch_name in IGNORED_CHANNELS.get(manufacturer, list()):
-        if ch_name in raw.ch_names:
-            ignored_indexes.append(raw.ch_names.index(ch_name))
+    ignored_indexes = [raw.ch_names.index(ch_name) for ch_name in raw.ch_names
+                       if ch_name in
+                       IGNORED_CHANNELS.get(manufacturer, list())]
 
     status, ch_type, description = list(), list(), list()
     for idx, ch in enumerate(raw.info['ch_names']):
@@ -357,10 +356,9 @@ def _sidecar_json(raw, task, manufacturer, fname, kind,
         powerlinefrequency = 50
 
     # determine whether any channels have to be ignored:
-    num_ignored = 0
-    for ch_name in IGNORED_CHANNELS.get(manufacturer, list()):
-        if ch_name in raw.ch_names:
-            num_ignored += 1
+    num_ignored = len([ch_name for ch_name in
+                       IGNORED_CHANNELS.get(manufacturer, list()) if
+                       ch_name in raw.ch_names])
     # all ignored channels are trigger channels at the moment...
 
     n_megchan = len([ch for ch in raw.info['chs']

--- a/mne_bids/mne_bids.py
+++ b/mne_bids/mne_bids.py
@@ -35,7 +35,8 @@ ORIENTATION = {'.sqd': 'ALS', '.con': 'ALS', '.fif': 'RAS', '.pdf': 'ALS',
 UNTIS = {'.sqd': 'm', '.con': 'm', '.fif': 'm', '.pdf': 'm', '.ds': 'cm'}
 
 MANUFACTURERS = {'.sqd': 'KIT/Yokogawa', '.con': 'KIT/Yokogawa',
-                 '.fif': 'Elekta', '.pdf': '4D Magnes', '.ds': 'CTF'}
+                 '.fif': 'Elekta', '.pdf': '4D Magnes', '.ds': 'CTF',
+                 '.meg4': 'CTF'}
 
 IGNORED_CHANNELS = {'KIT/Yokogawa': ['STI 014']}
 
@@ -357,7 +358,7 @@ def _sidecar_json(raw, task, manufacturer, fname, kind,
 
     # determine whether any channels have to be ignored:
     num_ignored = 0
-    for ch_name in IGNORED_CHANNELS[manufacturer]:
+    for ch_name in IGNORED_CHANNELS.get(manufacturer, list()):
         if ch_name in raw.ch_names:
             num_ignored += 1
     # all ignored channels are trigger channels at the moment...

--- a/mne_bids/tests/test_mne_bids.py
+++ b/mne_bids/tests/test_mne_bids.py
@@ -11,12 +11,13 @@ For each supported file format, implement a test.
 
 import os
 import os.path as op
+import pandas as pd
 
 import mne
 from mne.datasets import testing
 from mne.utils import _TempDir, run_subprocess
 
-from mne_bids import raw_to_bids
+from mne_bids import raw_to_bids, make_bids_filename
 
 base_path = op.join(op.dirname(mne.__file__), 'io')
 subject_id = '01'
@@ -89,6 +90,15 @@ def test_kit():
     cmd = ['bids-validator', output_path]
     run_subprocess(cmd, shell=shell)
     assert op.exists(op.join(output_path, 'participants.tsv'))
+
+    # ensure the channels file has no STI 014 channel:
+    channels_tsv = make_bids_filename(
+        subject=subject_id, session=session_id, task=task, run=run,
+        suffix='channels.tsv',
+        prefix=op.join(output_path, 'sub-01/ses-01/meg'))
+    if op.exists(channels_tsv):
+        df = pd.read_csv(channels_tsv, sep='\t')
+        assert not ('STI 014' in df['name'].values)
 
 
 def test_ctf():


### PR DESCRIPTION
Fix for #51 
Adds a list of channels we want ignored. If any channels have this name we drop them.
At the moment the only channel that we drop is STI014 which is a trigger channel, however if other channels would want to be dropped that aren't we would probably need to modify the logic a little to allow the number of channels of a different kind to be reduced accordingly