### PR TITLE
[MRG] Channel types are now correctly determined from the raw data

### DIFF
--- a/mne_bids/pick.py
+++ b/mne_bids/pick.py
@@ -1,0 +1,70 @@
+# Authors: Matt Sanderson <matt.sanderson@mq.edu.au>
+#
+# License: BSD (3-clause)
+
+from mne.io.constants import FIFF
+
+
+def get_coil_types():
+    """Return all known coul types.
+
+    Returns
+    -------
+    coil_types : dict
+        The keys contain the channel types, and the values contain the
+        corresponding values in the info['chs'][idx]['kind']
+    """
+
+    return dict(meggradaxial=(FIFF.FIFFV_COIL_KIT_GRAD,
+                              FIFF.FIFFV_COIL_CTF_GRAD,
+                              FIFF.FIFFV_COIL_AXIAL_GRAD_5CM,
+                              FIFF.FIFFV_COIL_BABY_GRAD),
+                megrefgradaxial=(FIFF.FIFFV_COIL_CTF_REF_GRAD,
+                                 FIFF.FIFFV_COIL_CTF_OFFDIAG_REF_GRAD,
+                                 FIFF.FIFFV_COIL_MAGNES_REF_GRAD,
+                                 FIFF.FIFFV_COIL_MAGNES_OFFDIAG_REF_GRAD),
+                meggradplanar=(FIFF.FIFFV_COIL_VV_PLANAR_T1,
+                               FIFF.FIFFV_COIL_VV_PLANAR_T2,
+                               FIFF.FIFFV_COIL_VV_PLANAR_T3),
+                megmag=(FIFF.FIFFV_COIL_POINT_MAGNETOMETER,
+                        FIFF.FIFFV_COIL_POINT_MAGNETOMETER_X,
+                        FIFF.FIFFV_COIL_POINT_MAGNETOMETER_Y,
+                        FIFF.FIFFV_COIL_VV_MAG_W,
+                        FIFF.FIFFV_COIL_VV_MAG_T1,
+                        FIFF.FIFFV_COIL_VV_MAG_T2,
+                        FIFF.FIFFV_COIL_VV_MAG_T3,
+                        FIFF.FIFFV_COIL_MAGNES_MAG,
+                        FIFF.FIFFV_COIL_BABY_MAG),
+                megrefmag=(FIFF.FIFFV_COIL_KIT_REF_MAG,
+                           FIFF.FIFFV_COIL_CTF_REF_MAG,
+                           FIFF.FIFFV_COIL_MAGNES_REF_MAG,
+                           FIFF.FIFFV_COIL_BABY_REF_MAG,
+                           FIFF.FIFFV_COIL_BABY_REF_MAG2,
+                           FIFF.FIFFV_COIL_ARTEMIS123_REF_MAG,
+                           FIFF.FIFFV_COIL_MAGNES_REF_MAG),
+                eeg=(FIFF.FIFFV_COIL_EEG,),
+                misc=(FIFF.FIFFV_COIL_NONE,))
+
+
+def coil_type(info, idx):
+    """Get coil type.
+
+    Parameters
+    ----------
+    info : dict
+        Measurement info
+    idx : int
+        Index of channel
+
+    Returns
+    -------
+    type : 'meggradaxial' | 'megrefgradaxial' | 'meggradplanar'
+           'megmag' | 'megrefmag' | 'eeg' | 'misc'
+        Type of coil
+    """
+    ch = info['chs'][idx]
+    for key, values in get_coil_types().items():
+        if ch['coil_type'] in values:
+            return key
+    raise ValueError('Unknown coil of type {0} '
+                     'for channel {1}'.format(ch['coil_type'], ch["ch_name"]))

--- a/mne_bids/pick.py
+++ b/mne_bids/pick.py
@@ -6,7 +6,7 @@ from mne.io.constants import FIFF
 
 
 def get_coil_types():
-    """Return all known coul types.
+    """Return all known coil types.
 
     Returns
     -------

--- a/mne_bids/tests/test_pick.py
+++ b/mne_bids/tests/test_pick.py
@@ -1,0 +1,23 @@
+"""Test for the coil type picking function"""
+
+import os.path as op
+import pytest
+
+from mne.datasets import testing
+from mne.io import read_raw_fif
+from mne_bids.pick import coil_type
+
+
+def test_coil_type():
+    """Test the correct coil type is retrieved."""
+    data_path = testing.data_path()
+    raw_fname = op.join(data_path, 'MEG', 'sample',
+                        'sample_audvis_trunc_raw.fif')
+    raw = read_raw_fif(raw_fname)
+    assert coil_type(raw.info, 0) == 'meggradplanar'
+    assert coil_type(raw.info, 2) == 'megmag'
+    assert coil_type(raw.info, 306) == 'misc'
+    assert coil_type(raw.info, 315) == 'eeg'
+    raw.info['chs'][0]['coil_type'] = 1234
+    with pytest.raises(ValueError):
+        coil_type(raw.info, 0)


### PR DESCRIPTION
Fixes #45 
Added a new pick.py file similar to how it is done in mne-python (maybe this file should be more suited to be located there??)
Also, no new test yet for the file sorry.
Finally, there are probably some other channel types that would need to be added. At the moment this is just for the 4 test data types we have (I believe the ctf data looks correct after having spoken with someone familiar with the data format). You may want to look at the .fif and 4D yourself to make sure that the channel types are exactly what they are meant to be as I don't know for sure (it is hard to know if a reference gradiometer is axial or planar as the constants file doesn't always say)