### PR TITLE
reads and sets the DigitizedLandmarks and DigitizedHeadPoints fields

### DIFF
--- a/mne_bids/mne_bids.py
+++ b/mne_bids/mne_bids.py
@@ -23,6 +23,7 @@ from mne import Epochs
 from mne.io.constants import FIFF
 from mne.io.pick import channel_type
 from mne.io import BaseRaw
+from mne.externals.six import string_types
 from mne.channels.channels import _unit2human
 from mne.utils import check_version
 
@@ -658,15 +659,8 @@ def write_raw_bids(raw, bids_basename, output_path, events_data=None,
     acquisition, task, run = params['acq'], params['task'], params['run']
     kind = _handle_kind(raw)
 
-    # dictionary containing any other data potentially required information
-    extra_data = dict()
-
     electrode = raw._init_kwargs.get('electrode', None)
     hsp = raw._init_kwargs.get('hsp', None)
-
-    # Indicate the appropriate data has been provided
-    extra_data["DigitizedLandmarks"] = electrode is not None
-    extra_data["DigitizedHeadPoints"] = hsp is not None
 
     bids_fname = bids_basename + '_%s%s' % (kind, ext)
     data_path = make_bids_folders(subject=subject_id, session=session_id,
@@ -758,7 +752,7 @@ def write_raw_bids(raw, bids_basename, output_path, events_data=None,
     for key, f in d.items():
         if isinstance(f, string_types):
             acq = (key if exts_same else None)
-            headshape_fname = make_bids_filename(
+            headshape_fname = make_bids_basename(
                 subject=subject_id, session=session_id, acquisition=acq,
                 suffix='headshape%s' % _parse_ext(f)[1], prefix=data_path)
             sh.copyfile(f, headshape_fname)
@@ -766,7 +760,7 @@ def write_raw_bids(raw, bids_basename, output_path, events_data=None,
     for key, f in d.items():
         if isinstance(f, string_types):
             acq = (key if exts_same else None)
-            headshape_fname = make_bids_filename(
+            headshape_fname = make_bids_basename(
                 subject=subject_id, session=session_id, acquisition=acq,
                 suffix='headshape%s' % ".pos", prefix=data_path)
             sh.copyfile(f, headshape_fname)

--- a/mne_bids/mne_bids.py
+++ b/mne_bids/mne_bids.py
@@ -426,6 +426,12 @@ def _coordsystem_json(raw, unit, orient, manufacturer, fname, extra_data,
 
     if len(coords) != 0:
         extra_data['DigitizedLandmarks'] = True
+    hsp_count = 0
+    for d in dig:
+        if d['kind'] == FIFF.FIFFV_POINT_EXTRA:
+            hsp_count += 1
+    if hsp_count != 0:
+        extra_data['DigitizedHeadPoints'] = True
 
     fid_json = {'MEGCoordinateSystem': manufacturer,
                 'MEGCoordinateUnits': unit,  # XXX validate this
@@ -440,7 +446,8 @@ def _coordsystem_json(raw, unit, orient, manufacturer, fname, extra_data,
 
 
 def _sidecar_json(raw, task, manufacturer, fname, kind, overwrite=False,
-                  extra_data=dict(), verbose=True):
+                  digitized_landmarks=False, digitized_head_points=False,
+                  verbose=True):
     """Create a sidecar json file depending on the kind and save it.
 
     The sidecar json file provides meta data about the data of a certain kind.
@@ -461,8 +468,10 @@ def _sidecar_json(raw, task, manufacturer, fname, kind, overwrite=False,
     overwrite : bool
         Whether to overwrite the existing file.
         Defaults to False.
-    extra_data : dict
-        A dictionary containing any extra data required in the various files.
+    digitized_landmarks : bool
+        Whether the recording contains digitized landmark data
+    digitized_head_points : bool
+        Whether the recording contains digitized head point data
     verbose : bool
         Set verbose output to true or false. Defaults to true.
 
@@ -518,8 +527,8 @@ def _sidecar_json(raw, task, manufacturer, fname, kind, overwrite=False,
         ('RecordingType', rec_type)]
     ch_info_json_meg = [
         ('DewarPosition', 'n/a'),
-        ("DigitizedLandmarks", extra_data.get("DigitizedLandmarks", False)),
-        ("DigitizedHeadPoints", extra_data.get("DigitizedHeadPoints", False)),
+        ("DigitizedLandmarks", digitized_landmarks),
+        ("DigitizedHeadPoints", digitized_head_points),
         ('MEGChannelCount', n_megchan),
         ('MEGREFChannelCount', n_megrefchan)]
     ch_info_json_eeg = [
@@ -720,7 +729,8 @@ def write_raw_bids(raw, bids_basename, output_path, events_data=None,
 
     make_dataset_description(output_path, name=" ", verbose=verbose)
     _sidecar_json(raw, task, manufacturer, sidecar_fname, kind, overwrite,
-                  extra_data, verbose)
+                  extra_data["DigitizedLandmarks"],
+                  extra_data["DigitizedHeadPoints"], verbose)
     _channels_tsv(raw, channels_fname, overwrite, verbose)
 
     # set the raw file name to now be the absolute path to ensure the files

--- a/mne_bids/tests/test_mne_bids.py
+++ b/mne_bids/tests/test_mne_bids.py
@@ -16,7 +16,7 @@ import os.path as op
 import pytest
 
 import pandas as pd
-
+import json
 import mne
 from mne.datasets import testing
 from mne.utils import _TempDir, run_subprocess
@@ -104,8 +104,15 @@ def test_fif():
 
     cmd = ['bids-validator', output_path]
     run_subprocess(cmd, shell=shell)
-
     assert op.exists(op.join(output_path, 'participants.tsv'))
+
+    data_meta_fname = make_bids_filename(
+        subject=subject_id, session=session_id, task=task, run=run,
+        suffix='%s.json' % 'meg',
+        prefix=op.join(output_path, 'sub-01/ses-01/meg'))
+    sidecar = json.load(open(data_meta_fname, 'r'))
+    assert sidecar['DigitizedLandmarks'] is True
+    assert sidecar['DigitizedHeadPoints'] is True
 
 
 def test_kit():
@@ -127,6 +134,15 @@ def test_kit():
     cmd = ['bids-validator', output_path]
     run_subprocess(cmd, shell=shell)
     assert op.exists(op.join(output_path, 'participants.tsv'))
+
+    # we provided the hsp and elp data, so sidecar.json should reflect this
+    data_meta_fname = make_bids_filename(
+        subject=subject_id, session=session_id, task=task, run=run,
+        suffix='%s.json' % 'meg',
+        prefix=op.join(output_path, 'sub-01/ses-01/meg'))
+    sidecar = json.load(open(data_meta_fname, 'r'))
+    assert sidecar['DigitizedLandmarks'] is True
+    assert sidecar['DigitizedHeadPoints'] is True
 
     # ensure the channels file has no STI 014 channel:
     channels_tsv = make_bids_basename(
@@ -174,6 +190,14 @@ def test_ctf():
 
     assert op.exists(op.join(output_path, 'participants.tsv'))
 
+    data_meta_fname = make_bids_filename(
+        subject=subject_id, session=session_id, task=task, run=run,
+        suffix='%s.json' % 'meg',
+        prefix=op.join(output_path, 'sub-01/ses-01/meg'))
+    sidecar = json.load(open(data_meta_fname, 'r'))
+    assert sidecar['DigitizedLandmarks'] is True
+    assert sidecar['DigitizedHeadPoints'] is False
+
 
 def test_bti():
     """Test functionality of the write_raw_bids conversion for BTi data."""
@@ -191,6 +215,14 @@ def test_bti():
 
     cmd = ['bids-validator', output_path]
     run_subprocess(cmd, shell=shell)
+
+    data_meta_fname = make_bids_filename(
+        subject=subject_id, session=session_id, task=task, run=run,
+        suffix='%s.json' % 'meg',
+        prefix=op.join(output_path, 'sub-01/ses-01/meg'))
+    sidecar = json.load(open(data_meta_fname, 'r'))
+    assert sidecar['DigitizedLandmarks'] is True
+    assert sidecar['DigitizedHeadPoints'] is True
 
 
 def test_vhdr():

--- a/mne_bids/tests/test_mne_bids.py
+++ b/mne_bids/tests/test_mne_bids.py
@@ -106,9 +106,9 @@ def test_fif():
     run_subprocess(cmd, shell=shell)
     assert op.exists(op.join(output_path, 'participants.tsv'))
 
-    data_meta_fname = make_bids_filename(
+    data_meta_fname = make_bids_basename(
         subject=subject_id, session=session_id, task=task, run=run,
-        suffix='%s.json' % 'meg',
+        acquisition=acq, suffix='%s.json' % 'meg',
         prefix=op.join(output_path, 'sub-01/ses-01/meg'))
     sidecar = json.load(open(data_meta_fname, 'r'))
     assert sidecar['DigitizedLandmarks'] is True
@@ -136,9 +136,9 @@ def test_kit():
     assert op.exists(op.join(output_path, 'participants.tsv'))
 
     # we provided the hsp and elp data, so sidecar.json should reflect this
-    data_meta_fname = make_bids_filename(
+    data_meta_fname = make_bids_basename(
         subject=subject_id, session=session_id, task=task, run=run,
-        suffix='%s.json' % 'meg',
+        acquisition=acq, suffix='%s.json' % 'meg',
         prefix=op.join(output_path, 'sub-01/ses-01/meg'))
     sidecar = json.load(open(data_meta_fname, 'r'))
     assert sidecar['DigitizedLandmarks'] is True
@@ -147,7 +147,7 @@ def test_kit():
     # ensure the channels file has no STI 014 channel:
     channels_tsv = make_bids_basename(
         subject=subject_id, session=session_id, task=task, run=run,
-        suffix='channels.tsv', acquisition=acq,
+        acquisition=acq, suffix='channels.tsv',
         prefix=op.join(output_path, 'sub-01/ses-01/meg'))
     df = pd.read_csv(channels_tsv, sep='\t')
     assert not ('STI 014' in df['name'].values)
@@ -190,9 +190,9 @@ def test_ctf():
 
     assert op.exists(op.join(output_path, 'participants.tsv'))
 
-    data_meta_fname = make_bids_filename(
+    data_meta_fname = make_bids_basename(
         subject=subject_id, session=session_id, task=task, run=run,
-        suffix='%s.json' % 'meg',
+        acquisition=acq, suffix='%s.json' % 'meg',
         prefix=op.join(output_path, 'sub-01/ses-01/meg'))
     sidecar = json.load(open(data_meta_fname, 'r'))
     assert sidecar['DigitizedLandmarks'] is True
@@ -216,9 +216,9 @@ def test_bti():
     cmd = ['bids-validator', output_path]
     run_subprocess(cmd, shell=shell)
 
-    data_meta_fname = make_bids_filename(
+    data_meta_fname = make_bids_basename(
         subject=subject_id, session=session_id, task=task, run=run,
-        suffix='%s.json' % 'meg',
+        acquisition=acq, suffix='%s.json' % 'meg',
         prefix=op.join(output_path, 'sub-01/ses-01/meg'))
     sidecar = json.load(open(data_meta_fname, 'r'))
     assert sidecar['DigitizedLandmarks'] is True


### PR DESCRIPTION
ref: #48 
So after having a bit of a work on this a few comments:
 - if the `electrode` and `hsp` arguments are passed this works pretty much perfectly.
 - For files that don't provide this the best I can get is for the `DigitizedLandmarks` value to be True. Are the head points stored anywhere in MNE? I can't find them anywhere...
 - The `_parse_ext` function in `io.py` I think needs to be modified to not put `.pdf` as the extension by default as this sets the extension for the BTI headshape file to be `.pdf` which I assume is incorrect.
 - The bids validator fails on the tests for the two data sets that this copies the files for (cf. sec. 8.4.5 in the bids specification). I do however notice that there is a discrepancy in the specification (which I have commented on). So not sure if the files should actually be in the same folder as the sidecar json or the folder up. Both locations cause the validator to fail, so I guess this is an issue with it.