### PR TITLE
[MRG+1] Add bep006 eeg

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -15,6 +15,7 @@ Current
 Changelog
 ~~~~~~~~~
 
+- Add support for EEG and a corresponding example: `make_eeg_bids.py` by `Stefan Appelhoff`_ (`#78 <https://github.com/mne-tools/mne-bids/pull/78>`_)
 - Update :func:`mne_bids.raw_to_bids` to work for KIT and BTi systems, by `Teon Brooks`_ (`#16 <https://github.com/mne-tools/mne-bids/pull/16/files>`_)
 - Add support for iEEG and add :func:`mne_bids.make_bids_folders` and :func:`mne_bids.make_bids_folders`, by `Chris Holdgraf`_ (`#28 <https://github.com/mne-tools/mne-bids/pull/28>`_ and `#37 <https://github.com/mne-tools/mne-bids/pull/37>`_)
 - Add command line interface by `Teon Brooks`_ (`#31 <https://github.com/mne-tools/mne-bids/pull/31>`_)

--- a/examples/make_eeg_bids.py
+++ b/examples/make_eeg_bids.py
@@ -184,10 +184,9 @@ print_dir_tree(output_path)
 # meta data files, it started an `events.tsv` and `channels.tsv` and made an
 # initial `dataset_description` on top!
 #
-# That's nice and it has saved us a lot of work. However, a few things are not
-# yet covered by MNE-BIDS for EEG data and will require some manual tweaking.
-# Make sure to pay a lot of attention to the automatic output and make
-# adjustments where necessary.
+# Now it's time to manually check the BIDS directory and the meta files to add
+# all the information that MNE-BIDS could not infer. these places are marked
+# with "n/a".
 #
 # Remember that there is a convenient javascript tool to validate all your BIDS
 # directories called the "BIDS-validator", available as a web version and a

--- a/examples/make_eeg_bids.py
+++ b/examples/make_eeg_bids.py
@@ -1,0 +1,173 @@
+"""
+=========================
+Use MNE-Bids for EEG Data
+=========================
+
+In this example, we use MNE-Bids to create a BIDS-compatible directory of EEG
+data. Specifically, we will follow these steps:
+
+1. Download some EEG data from the Open Science Framework (https://osf.io)
+2. Load the data, extract information, and save in a new BIDS directory
+3. Check the result and compare it with the standard
+
+"""
+
+# Authors: Stefan Appelhoff <stefan.appelhoff@mailbox.org>
+# License: BSD (3-clause)
+
+###############################################################################
+# We are importing everything we need for this example:
+import os
+
+from mne import find_events
+from mne.io import read_raw_brainvision
+
+from mne_bids import raw_to_bids
+from mne_bids.datasets import download_matchingpennies_subj
+from mne_bids.utils import print_dir_tree
+
+###############################################################################
+# Step 1: Download the data
+# -------------------------
+#
+# First, we need some data to work with. We will use the example data that is
+# provided with the report on the BIDS extension for EEF data: The "Matching
+# Pennies" dataset. See here for more information: https://osf.io/cj2dr/
+#
+# For convenience, MNE-Bids has a function to download this data.
+
+# make a directory to save the data to
+home = os.path.expanduser('~')
+data_dir = os.path.join(home, 'mne_data', 'eeg_matchingpennies')
+if not os.path.exists(data_dir):
+    os.makedirs(data_dir)
+
+###############################################################################
+# Now, we download data for participant sub-05 (about 350MB). We could also
+# download the whole dataset by specifying `url_dict` as an input to
+# `download_matchingpennies_subj`, see the function's docstring for more
+# information.
+download_matchingpennies_subj(directory=data_dir)
+
+###############################################################################
+# Let's see whether the data has been downloaded using a quick visualization
+# of the directory tree.
+print_dir_tree(data_dir)
+
+###############################################################################
+# The data are part of the example suite for the EEG specification of BIDS, so
+# they are already in BIDS format as we can see from the file names (also, see
+# the `channels.tsv` and `events.tsv` files). However, we want to start from
+# scratch and will only use the "pure" EEG data in its BrainVision format with
+# the following files:
+#
+# * '.eeg' for binary data
+# * '.vhdr' for header information
+# * '.vmrk' for specifying the event markers within the data.
+
+###############################################################################
+# Step 2: Formatting as BIDS
+# --------------------------
+#
+# We are reading the data using MNE-Python's io module and the
+# `read_raw_brainvision` function, which takes a `.vhdr` file as an input.
+vhdr_path = os.path.join(data_dir, 'sub-05_task-matchingpennies_eeg.vhdr')
+raw = read_raw_brainvision(vhdr_path)
+print(raw)
+
+###############################################################################
+# By reading the raw data, MNE-Python has also read the `.vmrk` file in which
+# the events of the EEG recording are stored. It has automatically created a
+# new "stimulus channel" containing the event pulses and appended this to our
+# data:
+print(raw.ch_names)  # There should be a channel called 'STI 014'
+
+###############################################################################
+# For BIDS, we specify all events in a dedicated `events.tsv` file. Let's read
+# the events from our stimulus channel using `find_events`
+events = find_events(raw)
+
+###############################################################################
+# Now we have everything to start a new BIDS directory using our data.
+# To do that, we can use the high level function `raw_to_bids`, which is the
+# core of MNE-BIDS. Generally, `raw_to_bids` tries to extract as much meta data
+# as possible from the raw data and then format it in a BIDS compatible way.
+# `raw_to_bids` takes a bunch of inputs, most of which are however optional.
+# The required inputs are:
+#
+# * subject_id
+# * task
+# * raw_file
+# * output_path
+#
+# as you can see in the docstring:
+help(raw_to_bids)
+
+###############################################################################
+# Let's assume the previous file name `sub-05_task-matchingpennies_eeg`
+# contained an error and that this was actually `sub-01` and we also want to
+# have another task name `MatchingPennies`.
+subject_id = '01'
+task = 'MatchingPennies'
+raw_file = raw  # We can specify the raw file, or the path to the .vhdr file.
+output_path = os.path.join(home, 'mne_data', 'eeg_matchingpennies_bids_tmp')
+
+###############################################################################
+# Now we just need to specify a few more EEG details to get something sensible:
+
+# First, tell `MNE-BIDS` that it is working with EEG data:
+kind = 'eeg'
+
+# The EEG reference used for the recording
+eeg_reference = 'Fz'
+
+# brief description of the event markers present in the data. This will become
+# the `trial_type` column in our BIDS `events.tsv`.
+event_id = {'left': 1, 'right': 2}
+
+# Now convert our data to be in a new BIDS dataset.
+raw_to_bids(subject_id=subject_id, task=task, raw_file=raw_file,
+            output_path=output_path, kind=kind,
+            eeg_reference=eeg_reference, event_id=event_id)
+
+###############################################################################
+# Step 3: Check and compare with standard
+# ---------------------------------------
+# Now we have written our BIDS directory. Having read the BIDS specification,
+# we know that the structure should approximately look like this:
+#
+# .. code-block:: python
+#
+#    ---------- CHANGES
+#    ---------- dataset_description.json
+#    ---------- participants.tsv
+#    ---------- README
+#    ---------- sub-xx
+#        ---------- modality
+#            ---------- sub-xx_task-yy_modality.ext
+#            ---------- sub-xx_task-yy_modality.json
+#            ---------- sub-xx_task-yy_events.tsv
+#
+#
+# Now, what does it actually look like?
+print_dir_tree(output_path)
+
+###############################################################################
+# The three actual data files `.eeg`, `.vhdr`, and `.vmrk` have their new names
+# and the internal pointers within each data file have been updated
+# accordingly. In addition to that, MNE-BIDS has created a suitable directory
+# structure for us, started an `events.tsv` and `channels.tsv` and made an
+# initial `dataset_description` on top!
+#
+# That's nice and it has saved us a lot of work. However, a few things are not
+# yet covered by MNE-BIDS for EEG data and will have to be added by hand. Most
+# importantly, the `README` file at the root of the directory, but also
+# `CHANGES`, `participants.tsv`, and some more specific entries.
+#
+# Remember that there is a convenient javascript tool to validate all your BIDS
+# directories called the "BIDS-validator", available as a web version and a
+# command line tool:
+#
+# Web version: https://incf.github.io/bids-validator/
+#
+# Command line tool: https://www.npmjs.com/package/bids-validator

--- a/examples/make_eeg_bids.py
+++ b/examples/make_eeg_bids.py
@@ -1,9 +1,9 @@
 """
 =========================
-Use MNE-Bids for EEG Data
+Use MNE-BIDS for EEG Data
 =========================
 
-In this example, we use MNE-Bids to create a BIDS-compatible directory of EEG
+In this example, we use MNE-BIDS to create a BIDS-compatible directory of EEG
 data. Specifically, we will follow these steps:
 
 #. Download some EEG data from the
@@ -94,7 +94,7 @@ print(raw)
 # With this simple step we have everything to start a new BIDS directory using
 # our data. To do that, we can use the high level function `raw_to_bids`, which
 # is the core of MNE-BIDS. Generally, `raw_to_bids` tries to extract as much
-# meta data as possible from the raw data and then format it in a BIDS
+# meta data as possible from the raw data and then formats it in a BIDS
 # compatible way. `raw_to_bids` takes a bunch of inputs, most of which are
 # however optional. The required inputs are:
 #

--- a/examples/make_eeg_bids.py
+++ b/examples/make_eeg_bids.py
@@ -6,8 +6,7 @@ Use MNE-BIDS for EEG Data
 In this example, we use MNE-BIDS to create a BIDS-compatible directory of EEG
 data. Specifically, we will follow these steps:
 
-#. Download some EEG data from the
-`PhysioBank database <https://physionet.org/physiobank/database>`_.
+#. Download some EEG data from the `PhysioBank database <https://physionet.org/physiobank/database>`_.
 
 #. Load the data, extract information, and save in a new BIDS directory
 

--- a/examples/make_eeg_bids.py
+++ b/examples/make_eeg_bids.py
@@ -185,7 +185,7 @@ print_dir_tree(output_path)
 # initial `dataset_description` on top!
 #
 # Now it's time to manually check the BIDS directory and the meta files to add
-# all the information that MNE-BIDS could not infer. these places are marked
+# all the information that MNE-BIDS could not infer. These places are marked
 # with "n/a".
 #
 # Remember that there is a convenient javascript tool to validate all your BIDS

--- a/mne_bids/io.py
+++ b/mne_bids/io.py
@@ -33,7 +33,7 @@ def _parse_ext(raw_fname, verbose=False):
 
 
 def _read_raw(raw_fname, electrode=None, hsp=None, hpi=None, config=None,
-              verbose=None):
+              montage=None, verbose=None):
     """Read a raw file into MNE, making inferences based on extension."""
     fname, ext = _parse_ext(raw_fname)
 
@@ -75,7 +75,7 @@ def _read_raw(raw_fname, electrode=None, hsp=None, hpi=None, config=None,
 
     # Neuroscan .cnt format
     elif ext == '.cnt':
-        raw = io.read_raw_cnt(raw_fname)
+        raw = io.read_raw_cnt(raw_fname, montage=montage)
 
     # No supported data found ...
     # ---------------------------

--- a/mne_bids/io.py
+++ b/mne_bids/io.py
@@ -9,7 +9,15 @@
 from mne import io
 import os
 
-ALLOWED_EXTENSIONS = ['.con', '.sqd', '.fif', '.pdf', '.ds']
+allowed_extensions_meg = ['.con', '.sqd', '.fif', '.pdf', '.ds']
+allowed_extensions_eeg = ['.eeg', '.vhdr', '.vmrk',  # BrainVision
+                          '.edf',  # European Data Format
+                          '.bdf',  # Biosemi
+                          '.set', '.fdt',  # EEGLAB
+                          '.cnt',  # Neuroscan
+                          ]
+
+ALLOWED_EXTENSIONS = allowed_extensions_meg + allowed_extensions_eeg
 
 
 def _parse_ext(raw_fname, verbose=False):
@@ -50,6 +58,25 @@ def _read_raw(raw_fname, electrode=None, hsp=None, hpi=None, config=None,
     # CTF systems
     elif ext == '.ds':
         raw = io.read_raw_ctf(raw_fname)
+
+    # EEG File Types
+    # --------------
+    # BrainVision format by Brain Products, expects also a .eeg and .vmrk file
+    elif ext == '.vhdr':
+        raw = io.read_raw_brainvision(raw_fname)
+
+    # EDF (european data format) or BDF (biosemi) format
+    elif ext == '.edf' or ext == '.bdf':
+        raw = io.read_raw_edf(raw_fname)
+
+    # EEGLAB .set format, if there is a separate .fdt file, it should be in the
+    # same folder as the .set file
+    elif ext == '.set':
+        raw = io.read_raw_eeglab(raw_fname)
+
+    # Neuroscan .cnt format
+    elif ext == '.cnt':
+        raw = io.read_raw_cnt(raw_fname)
 
     # No supported data found ...
     # ---------------------------

--- a/mne_bids/io.py
+++ b/mne_bids/io.py
@@ -67,7 +67,7 @@ def _read_raw(raw_fname, electrode=None, hsp=None, hpi=None, config=None,
 
     # EDF (european data format) or BDF (biosemi) format
     elif ext == '.edf' or ext == '.bdf':
-        raw = io.read_raw_edf(raw_fname)
+        raw = io.read_raw_edf(raw_fname, preload=True)
 
     # EEGLAB .set format, a .fdt file is potentially linked from the .set
     elif ext == '.set':

--- a/mne_bids/io.py
+++ b/mne_bids/io.py
@@ -10,10 +10,10 @@ from mne import io
 import os
 
 allowed_extensions_meg = ['.con', '.sqd', '.fif', '.pdf', '.ds']
-allowed_extensions_eeg = ['.eeg', '.vhdr', '.vmrk',  # BrainVision
+allowed_extensions_eeg = ['.vhdr',  # BrainVision, accompanied by .vmrk, .eeg
                           '.edf',  # European Data Format
                           '.bdf',  # Biosemi
-                          '.set', '.fdt',  # EEGLAB
+                          '.set',  # EEGLAB, potentially accompanied by .fdt
                           '.cnt',  # Neuroscan
                           ]
 
@@ -61,7 +61,7 @@ def _read_raw(raw_fname, electrode=None, hsp=None, hpi=None, config=None,
 
     # EEG File Types
     # --------------
-    # BrainVision format by Brain Products, expects also a .eeg and .vmrk file
+    # BrainVision format by Brain Products, links to  a .eeg and a .vmrk file
     elif ext == '.vhdr':
         raw = io.read_raw_brainvision(raw_fname)
 
@@ -69,8 +69,7 @@ def _read_raw(raw_fname, electrode=None, hsp=None, hpi=None, config=None,
     elif ext == '.edf' or ext == '.bdf':
         raw = io.read_raw_edf(raw_fname)
 
-    # EEGLAB .set format, if there is a separate .fdt file, it should be in the
-    # same folder as the .set file
+    # EEGLAB .set format, a .fdt file is potentially linked from the .set
     elif ext == '.set':
         raw = io.read_raw_eeglab(raw_fname)
 

--- a/mne_bids/mne_bids.py
+++ b/mne_bids/mne_bids.py
@@ -586,7 +586,7 @@ def raw_to_bids(subject_id, task, raw_file, output_path, session_id=None,
     data_meta_fname = make_bids_filename(
         subject=subject_id, session=session_id, task=task, run=run,
         suffix='%s.json' % kind, prefix=data_path)
-    if ext in ['.fif', '.ds', '.vhdr', '.edf', '.bdf']:
+    if ext in ['.fif', '.ds', '.vhdr', '.edf', '.bdf', '.set', '.cnt']:
         raw_file_bids = make_bids_filename(
             subject=subject_id, session=session_id, task=task, run=run,
             suffix='%s%s' % (kind, ext))

--- a/mne_bids/mne_bids.py
+++ b/mne_bids/mne_bids.py
@@ -93,7 +93,7 @@ def _channels_tsv(raw, fname, verbose):
                     ecog='Electrocorticography',
                     seeg='StereoEEG',
                     ecg='ElectroCardioGram',
-                    eog='ElectrOculoGram',
+                    eog='ElectroOculoGram',
                     misc='Miscellaneous')
     get_specific = ('mag', 'ref_meg', 'grad')
 

--- a/mne_bids/mne_bids.py
+++ b/mne_bids/mne_bids.py
@@ -567,7 +567,7 @@ def raw_to_bids(subject_id, task, raw_file, output_path, session_id=None,
                                   overwrite=overwrite,
                                   verbose=verbose)
     if session_id is None:
-        ses_path = data_path
+        ses_path = os.sep.join(data_path.split(os.sep)[:-1])
     else:
         ses_path = make_bids_folders(subject=subject_id, session=session_id,
                                      root=output_path,

--- a/mne_bids/mne_bids.py
+++ b/mne_bids/mne_bids.py
@@ -617,16 +617,16 @@ def raw_to_bids(subject_id, task, raw_file, output_path, session_id=None,
         _coordsystem_json(raw, unit, orient, manufacturer, coordsystem_fname,
                           verbose)
 
+    events = _read_events(events_data, raw)
+    if len(events) > 0:
+        _events_tsv(events, raw, events_tsv_fname, event_id, verbose)
+
     make_dataset_description(output_path, name=" ", verbose=verbose)
     _sidecar_json(raw, task, manufacturer, data_meta_fname, kind, eeg_ref,
                   eeg_gnd, verbose)
     _participants_tsv(raw, subject_id, "n/a", participants_fname, verbose)
     _channels_tsv(raw, channels_fname, verbose)
     _scans_tsv(raw, os.path.join(kind, raw_file_bids), scans_fname, verbose)
-
-    events = _read_events(events_data, raw)
-    if len(events) > 0:
-        _events_tsv(events, raw, events_tsv_fname, event_id, verbose)
 
     # set the raw file name to now be the absolute path to ensure the files
     # are placed in the right location

--- a/mne_bids/mne_bids.py
+++ b/mne_bids/mne_bids.py
@@ -586,7 +586,7 @@ def raw_to_bids(subject_id, task, raw_file, output_path, session_id=None,
     data_meta_fname = make_bids_filename(
         subject=subject_id, session=session_id, task=task, run=run,
         suffix='%s.json' % kind, prefix=data_path)
-    if ext in ['.fif', '.ds', '.vhdr']:
+    if ext in ['.fif', '.ds', '.vhdr', '.edf', '.bdf']:
         raw_file_bids = make_bids_filename(
             subject=subject_id, session=session_id, task=task, run=run,
             suffix='%s%s' % (kind, ext))

--- a/mne_bids/mne_bids.py
+++ b/mne_bids/mne_bids.py
@@ -439,7 +439,7 @@ def _sidecar_json(raw, task, manufacturer, fname, kind, eeg_ref=None,
         ('RecordingDuration', raw.times[-1]),
         ('RecordingType', rec_type)]
     ch_info_json_meg = [
-        ('DewarPosition', 'XXX'),
+        ('DewarPosition', 'n/a'),
         ('DigitizedLandmarks', False),
         ('DigitizedHeadPoints', False),
         ('MEGChannelCount', n_megchan),

--- a/mne_bids/mne_bids.py
+++ b/mne_bids/mne_bids.py
@@ -645,6 +645,7 @@ def raw_to_bids(subject_id, task, raw_file, output_path, session_id=None,
 
     # Copy the imaging data files
     # Re-save FIF files to fix the file pointer for files with multiple parts
+    # This is WIP, see: https://github.com/mne-tools/mne-python/pull/5470
     if ext in ['.fif']:
         raw.save(raw_file_bids, overwrite=overwrite)
     # CTF data is saved in a directory

--- a/mne_bids/mne_bids.py
+++ b/mne_bids/mne_bids.py
@@ -586,7 +586,7 @@ def raw_to_bids(subject_id, task, raw_file, output_path, session_id=None,
     data_meta_fname = make_bids_filename(
         subject=subject_id, session=session_id, task=task, run=run,
         suffix='%s.json' % kind, prefix=data_path)
-    if ext in ['.fif', '.ds']:
+    if ext in ['.fif', '.ds', '.vhdr']:
         raw_file_bids = make_bids_filename(
             subject=subject_id, session=session_id, task=task, run=run,
             suffix='%s%s' % (kind, ext))

--- a/mne_bids/mne_bids.py
+++ b/mne_bids/mne_bids.py
@@ -45,8 +45,9 @@ meg_manufacturers = {'.sqd': 'KIT/Yokogawa', '.con': 'KIT/Yokogawa',
                      '.fif': 'Elekta', '.pdf': '4D Magnes', '.ds': 'CTF',
                      '.meg4': 'CTF'}
 
-eeg_manufacturers = {'.vhdr': 'BrainProducts', '.edf': 'Mixed',
-                     '.bdf': 'Biosemi', '.set': 'Mixed', '.cnt': 'Neuroscan'}
+eeg_manufacturers = {'.vhdr': 'BrainProducts', '.eeg': 'BrainProducts',
+                     '.edf': 'Mixed', '.bdf': 'Biosemi', '.set': 'Mixed',
+                     '.cnt': 'Neuroscan'}
 
 # Merge the manufacturer dictionaries in a python2 / python3 compatible way
 MANUFACTURERS = dict()
@@ -604,9 +605,9 @@ def raw_to_bids(subject_id, task, raw_file, output_path, session_id=None,
         suffix='channels.tsv', prefix=data_path)
 
     # Read in Raw object and extract metadata from Raw object if needed
-    orient = ORIENTATION[ext]
-    unit = UNITS[ext]
-    manufacturer = MANUFACTURERS[ext]
+    orient = ORIENTATION.get(ext, 'n/a')
+    unit = UNITS.get(ext, 'n/a')
+    manufacturer = MANUFACTURERS.get(ext, 'n/a')
     if manufacturer == 'Mixed':
         manufacturer = 'n/a'
 

--- a/mne_bids/tests/test_io.py
+++ b/mne_bids/tests/test_io.py
@@ -7,7 +7,7 @@ import pytest
 from mne_bids.io import _parse_ext, _read_raw
 
 
-def test__parse_ext():
+def test_parse_ext():
     """Test the file extension extraction."""
     f = 'sub-05_task-matchingpennies.vhdr'
     fname, ext = _parse_ext(f)
@@ -21,7 +21,7 @@ def test__parse_ext():
     assert ext == '.pdf'
 
 
-def test__read_raw():
+def test_read_raw():
     """Test the raw reading."""
     # Use a file ending that does not exist
     f = 'file.bogus'

--- a/mne_bids/tests/test_mne_bids.py
+++ b/mne_bids/tests/test_mne_bids.py
@@ -138,3 +138,47 @@ def test_bti():
     with pytest.raises(subprocess.CalledProcessError):
         cmd = ['bids-validator', output_path]
         run_subprocess(cmd, shell=shell)
+
+
+# EEG Tests
+# ---------
+def test_vhdr():
+    """Test raw_to_bids conversion for BrainVision data."""
+    output_path = _TempDir()
+    data_path = op.join(base_path, 'brainvision', 'tests', 'data')
+    raw_fname = op.join(data_path, 'test.vhdr')
+
+    raw_to_bids(subject_id=subject_id, session_id=session_id, run=run,
+                task=task, raw_file=raw_fname, output_path=output_path,
+                overwrite=True, kind='eeg')
+
+    cmd = ['bids-validator', '--bep006', output_path]
+    run_subprocess(cmd, shell=shell)
+
+
+def test_edf():
+    """Test raw_to_bids conversion for European Data Format data."""
+    output_path = _TempDir()
+    cmd = ['bids-validator', '--bep006', output_path]
+    run_subprocess(cmd, shell=shell)
+
+
+def test_bdf():
+    """Test raw_to_bids conversion for Biosemi data."""
+    output_path = _TempDir()
+    cmd = ['bids-validator', '--bep006', output_path]
+    run_subprocess(cmd, shell=shell)
+
+
+def test_set():
+    """Test raw_to_bids conversion for EEGLAB data."""
+    output_path = _TempDir()
+    cmd = ['bids-validator', '--bep006', output_path]
+    run_subprocess(cmd, shell=shell)
+
+
+def test_cnt():
+    """Test raw_to_bids conversion for Neuroscan data."""
+    output_path = _TempDir()
+    cmd = ['bids-validator', '--bep006', output_path]
+    run_subprocess(cmd, shell=shell)

--- a/mne_bids/tests/test_mne_bids.py
+++ b/mne_bids/tests/test_mne_bids.py
@@ -158,7 +158,14 @@ def test_vhdr():
 
 def test_edf():
     """Test raw_to_bids conversion for European Data Format data."""
-    output_path = '/home/stefanappelhoff/Desktop/bogus'  # _TempDir()
+    output_path = _TempDir()
+    data_path = op.join(testing.data_path(), 'EDF')
+    raw_fname = op.join(data_path, 'test_reduced.edf')
+
+    raw_to_bids(subject_id=subject_id, session_id=session_id, run=run,
+                task=task, raw_file=raw_fname, output_path=output_path,
+                overwrite=True, kind='eeg')
+
     cmd = ['bids-validator', '--bep006', output_path]
     run_subprocess(cmd, shell=shell)
 
@@ -166,13 +173,27 @@ def test_edf():
 def test_bdf():
     """Test raw_to_bids conversion for Biosemi data."""
     output_path = _TempDir()
+    data_path = op.join(testing.data_path(), 'BDF')
+    raw_fname = op.join(data_path, 'test_bdf_stim_channel.bdf')
+
+    raw_to_bids(subject_id=subject_id, session_id=session_id, run=run,
+                task=task, raw_file=raw_fname, output_path=output_path,
+                overwrite=True, kind='eeg')
+
     cmd = ['bids-validator', '--bep006', output_path]
     run_subprocess(cmd, shell=shell)
 
 
 def test_set():
     """Test raw_to_bids conversion for EEGLAB data."""
-    output_path = _TempDir()
+    output_path = '/home/stefanappelhoff/Desktop/bogus'  # _TempDir()
+    data_path = op.join(testing.data_path(), 'EEGLAB')
+    raw_fname = op.join(data_path, 'test_raw_onefile.set')
+
+    raw_to_bids(subject_id=subject_id, session_id=session_id, run=run,
+                task=task, raw_file=raw_fname, output_path=output_path,
+                overwrite=True, kind='eeg')
+
     cmd = ['bids-validator', '--bep006', output_path]
     run_subprocess(cmd, shell=shell)
 

--- a/mne_bids/tests/test_mne_bids.py
+++ b/mne_bids/tests/test_mne_bids.py
@@ -158,7 +158,7 @@ def test_vhdr():
 
 def test_edf():
     """Test raw_to_bids conversion for European Data Format data."""
-    output_path = _TempDir()
+    output_path = '/home/stefanappelhoff/Desktop/bogus'  # _TempDir()
     cmd = ['bids-validator', '--bep006', output_path]
     run_subprocess(cmd, shell=shell)
 

--- a/mne_bids/tests/test_mne_bids.py
+++ b/mne_bids/tests/test_mne_bids.py
@@ -186,7 +186,7 @@ def test_bdf():
 
 def test_set():
     """Test raw_to_bids conversion for EEGLAB data."""
-    output_path = '/home/stefanappelhoff/Desktop/bogus'  # _TempDir()
+    output_path = _TempDir()
     data_path = op.join(testing.data_path(), 'EEGLAB')
     raw_fname = op.join(data_path, 'test_raw_onefile.set')
 

--- a/mne_bids/tests/test_mne_bids.py
+++ b/mne_bids/tests/test_mne_bids.py
@@ -201,5 +201,12 @@ def test_set():
 def test_cnt():
     """Test raw_to_bids conversion for Neuroscan data."""
     output_path = _TempDir()
+    data_path = op.join(testing.data_path(), 'CNT')
+    raw_fname = op.join(data_path, 'scan41_short.cnt')
+
+    raw_to_bids(subject_id=subject_id, session_id=session_id, run=run,
+                task=task, raw_file=raw_fname, output_path=output_path,
+                overwrite=True, kind='eeg')
+
     cmd = ['bids-validator', '--bep006', output_path]
     run_subprocess(cmd, shell=shell)

--- a/mne_bids/tests/test_utils.py
+++ b/mne_bids/tests/test_utils.py
@@ -57,7 +57,7 @@ def test_make_folders():
     assert op.isdir(op.join(output_path, 'sub-hi', 'ba'))
 
 
-def test__check_types():
+def test_check_types():
     """Test the check whether vars are str or None."""
     assert _check_types(['foo', 'bar', None]) is None
     with pytest.raises(ValueError):
@@ -117,7 +117,7 @@ def test_copyfile_brainvision():
 
     # IO error testing
     with pytest.raises(ValueError):
-        copyfile_brainvision(raw_fname, new_name+'.eeg')
+        copyfile_brainvision(raw_fname, new_name + '.eeg')
 
     # Try to copy the file
     copyfile_brainvision(raw_fname, new_name)
@@ -142,7 +142,7 @@ def test_copyfile_eeglab():
 
     # IO error testing
     with pytest.raises(ValueError):
-        copyfile_eeglab(raw_fname, new_name+'.wrong')
+        copyfile_eeglab(raw_fname, new_name + '.wrong')
 
     # .fdt not implemented error
     with pytest.raises(ValueError):

--- a/mne_bids/tests/test_utils.py
+++ b/mne_bids/tests/test_utils.py
@@ -151,13 +151,23 @@ def test_copyfile_eeglab():
 
 def test_infer_eeg_placement_scheme():
     """Test inferring a correct EEG placement scheme."""
-    data_path = op.join(base_path, 'brainvision', 'tests', 'data')
+    # no eeg channels case (e.g., MEG data)
+    data_path = op.join(base_path, 'bti', 'tests', 'data')
+    raw_fname = op.join(data_path, 'test_pdf_linux')
+    config_fname = op.join(data_path, 'test_config_linux')
+    headshape_fname = op.join(data_path, 'test_hs_linux')
+    raw = mne.io.read_raw_bti(raw_fname, config_fname, headshape_fname)
+    placement_scheme = _infer_eeg_placement_scheme(raw)
+    assert placement_scheme == 'n/a'
 
+    # 1020 case
+    data_path = op.join(base_path, 'brainvision', 'tests', 'data')
     raw_fname = op.join(data_path, 'test.vhdr')
     raw = mne.io.read_raw_brainvision(raw_fname)
     placement_scheme = _infer_eeg_placement_scheme(raw)
     assert placement_scheme == 'based on the extended 10/20 system'
 
+    # Unknown case
     raw_fname = op.join(testing.data_path(), 'Brainvision', 'test_NO.vhdr')
     raw = mne.io.read_raw_brainvision(raw_fname)
     placement_scheme = _infer_eeg_placement_scheme(raw)

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -486,7 +486,7 @@ def copyfile_eeglab(src, dest):
     # Extract matlab struct "EEG" from EEGLAB file
     # if the data field is a string, it points to a .fdt file in src dir
     eeg = _check_load_mat(src, None)
-    if isinstance(eeg['data'], str):
+    if isinstance(eeg['data'], string_types):
         raise ValueError('Found associated .fdt file containing the binary '
                          'EEG data: {}.\nMNE-BIDS does currently not support '
                          ' .fdt files. Please re-load your .set file using '

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -430,7 +430,7 @@ def copyfile_brainvision(vhdr_src, vhdr_dest):
     fname_dest, ext_dest = _parse_ext(vhdr_dest)
     if ext_src != ext_dest:
         raise ValueError('Need to move data with same extension'
-                         ' but got {}, {}'.format(ext_src, ext_dest))
+                         ' but got "{}", "{}"'.format(ext_src, ext_dest))
 
     eeg_file_path, vmrk_file_path = _get_brainvision_paths(vhdr_src)
 
@@ -472,8 +472,8 @@ def copyfile_eeglab(src, dest):
 
     Notes
     -----
-    NOT IMPLEMENTED YET. This function will abort upon the encounter of a .fdt
-    file. There are s
+    Work in progress. This function will abort upon the encounter of a .fdt
+    file.
 
     """
     # Get extenstion of the EEGLAB file

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -536,14 +536,11 @@ def _infer_eeg_placement_scheme(raw):
 
     """
     # How many of the channels in raw are based on the extended 10/20 system
-    # If more than 80 percent, assume it is 10/20
+    raw.pick_types(meg=False, eeg=True)
+    channel_names = raw.ch_names
     montage1005 = read_montage(kind='standard_1005')
-    counter1005 = 0
-    for ch in raw.ch_names:
-        if ch in montage1005.ch_names:
-            counter1005 += 1
 
-    if counter1005 >= int(0.8*len(raw.ch_names)):
+    if set(channel_names).issubset(set(montage1005.ch_names)):
         placement_scheme = 'based on the extended 10/20 system'
     else:
         placement_scheme = 'n/a'

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -352,7 +352,7 @@ def _read_events(events_data, raw):
                              'found %s' % events_data.shape[1])
         events = events_data
     else:
-        events = find_events(raw, min_duration=0.001)
+        events = find_events(raw, min_duration=0.001, initial_event=True)
     return events
 
 

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -32,9 +32,9 @@ def print_dir_tree(dir):
 
     for root, dirs, files in os.walk(dir):
         path = root.split(os.sep)
-        print('|%s %s' % ((len(path) - 1) * '-----', op.basename(root)))
+        print('|%s %s' % ((len(path) - 1) * '---', op.basename(root)))
         for file in files:
-            print('|%s %s' % (len(path) * '-----', file))
+            print('|%s %s' % (len(path) * '---', file))
 
 
 def _mkdir_p(path, overwrite=False, verbose=False):


### PR DESCRIPTION
This will introduce BEP_006 "EEG" to MNE-BIDS and close #34 

Current state of the BEP_006: [Google doc](https://docs.google.com/document/d/1ArMZ9Y_quTKXC-jNXZksnedK2VHHoKP3HCeO5HPcgLE)

BEP_006 Examples: https://github.com/incf/bids-examples/tree/bep006_eeg

The bids-validator can already deal with EEG data by including the bep006 flag such as: `bids-validator --bep006 /path/to/dataset`

# To Do:
- [x] Make MNE-BIDS aware that there are more types of data next to MEG (contingent on #73)
    - for now, keep using `kind`
- [x] Introduce all EEG supported file types and test that they are converted and written correctly
    - BrainVision is a multi-file format: .vhdr, .eeg, .vmrk
    - EEGLAB .set files might be accompanied by a .fdt file
- [x] Make an example for EEG to be posted in the [gallery](https://mne-tools.github.io/mne-bids/auto_examples/index.html)
- [x] skip `coordsystem.json` and `electrodes.tsv` for EEG until the handling of coordinates is resolved in MNE-Python (i.e., no rescaling of the coordinates read from a file: https://github.com/mne-tools/mne-python/pull/5472)
- [x] `scans.tsv` is equal across modalities, write it for all (so far it was only written for meg)
- [x] `events.tsv` has been adjusted already in #55, no changes
- [x] reformat `sidecar.json` to better cover all shared keys. Issue for EEG REQUIRED: `EEGReference` ... make it `n/a` until we find a good way to infer it from mne.raw
- [x] find solution for EDF data
    - for `mne.find_events`, it wants a parameter `initialEvent=True`
    - when being read, it wants `preload=True`

------------
# General list of things to implement
### Must-haves in the future:
- `coordsystem.json` for EEG
- `electrodes.tsv` for EEG

### Nice to haves ... but not too important and hard to implement
... for these, I currently do not have an idea how to extract the information automatically. Adding them as optional (None-defaulting) parameters would clutter the API - so I don't work on them for now.
- Several `sidecar.json` fields in decreasing order of importance
    - HardwareFilters
    - ManufacturersModelName
    - CapManufacturer
    - CapManufacturersModelName

--> as a potential solution, see #47 
