### PR TITLE
Added acquisition parameter to raw_to_bids

### DIFF
--- a/mne_bids/mne_bids.py
+++ b/mne_bids/mne_bids.py
@@ -486,9 +486,10 @@ def _sidecar_json(raw, task, manufacturer, fname, kind, eeg_ref=None,
 
 
 def raw_to_bids(subject_id, task, raw_file, output_path, session_id=None,
-                run=None, kind='meg', events_data=None, event_id=None,
-                hpi=None, electrode=None, hsp=None, eeg_ref=None,
-                eeg_gnd=None, config=None, overwrite=True, verbose=True):
+                acquisition=None, run=None, kind='meg', events_data=None,
+                event_id=None, hpi=None, electrode=None, hsp=None,
+                eeg_ref=None, eeg_gnd=None, config=None, overwrite=True,
+                verbose=True):
     """Walk over a folder of files and create BIDS compatible folder.
 
     Parameters
@@ -504,6 +505,8 @@ def raw_to_bids(subject_id, task, raw_file, output_path, session_id=None,
         The path of the BIDS compatible folder
     session_id : str | None
         The session name in BIDS compatible format.
+    acquisition : str | None
+        Acquisition parameter for the dataset.
     run : int | None
         The run number for this dataset.
     kind : str, one of ('meg', 'eeg', 'ieeg')
@@ -586,28 +589,30 @@ def raw_to_bids(subject_id, task, raw_file, output_path, session_id=None,
     participants_fname = make_bids_filename(prefix=output_path,
                                             suffix='participants.tsv')
     coordsystem_fname = make_bids_filename(
-        subject=subject_id, session=session_id,
+        subject=subject_id, session=session_id, acquisition=acquisition,
         suffix='coordsystem.json', prefix=data_path)
     data_meta_fname = make_bids_filename(
         subject=subject_id, session=session_id, task=task, run=run,
-        suffix='%s.json' % kind, prefix=data_path)
+        acquisition=acquisition, suffix='%s.json' % kind, prefix=data_path)
     if ext in ['.fif', '.ds', '.vhdr', '.edf', '.bdf', '.set', '.cnt']:
         raw_file_bids = make_bids_filename(
             subject=subject_id, session=session_id, task=task, run=run,
-            suffix='%s%s' % (kind, ext))
+            acquisition=acquisition, suffix='%s%s' % (kind, ext))
     else:
         raw_folder = make_bids_filename(
             subject=subject_id, session=session_id, task=task, run=run,
-            suffix='%s' % kind)
+            acquisition=acquisition, suffix='%s' % kind)
         raw_file_bids = make_bids_filename(
             subject=subject_id, session=session_id, task=task, run=run,
-            suffix='%s%s' % (kind, ext), prefix=raw_folder)
+            acquisition=acquisition, suffix='%s%s' % (kind, ext),
+            prefix=raw_folder)
     events_tsv_fname = make_bids_filename(
         subject=subject_id, session=session_id, task=task,
-        run=run, suffix='events.tsv', prefix=data_path)
+        acquisition=acquisition, run=run, suffix='events.tsv',
+        prefix=data_path)
     channels_fname = make_bids_filename(
         subject=subject_id, session=session_id, task=task, run=run,
-        suffix='channels.tsv', prefix=data_path)
+        acquisition=acquisition, suffix='channels.tsv', prefix=data_path)
 
     # Read in Raw object and extract metadata from Raw object if needed
     orient = ORIENTATION.get(ext, 'n/a')

--- a/mne_bids/tests/test_mne_bids.py
+++ b/mne_bids/tests/test_mne_bids.py
@@ -27,6 +27,7 @@ subject_id = '01'
 subject_id2 = '02'
 session_id = '01'
 run = '01'
+acq = '01'
 task = 'testing'
 
 # for windows, shell = True is needed
@@ -53,8 +54,9 @@ def test_fif():
                            'sample_audvis_trunc_raw-eve.fif')
 
     raw_to_bids(subject_id=subject_id, session_id=session_id, run=run,
-                task=task, raw_file=raw_fname, events_data=events_fname,
-                output_path=output_path, event_id=event_id, overwrite=True)
+                acquisition=acq, task=task, raw_file=raw_fname,
+                events_data=events_fname, output_path=output_path,
+                event_id=event_id, overwrite=True)
 
     # give the raw object some fake participant data
     raw = mne.io.read_raw_fif(raw_fname)
@@ -64,7 +66,7 @@ def test_fif():
     data_path2 = _TempDir()
     raw_fname2 = op.join(data_path2, 'sample_audvis_raw.fif')
     raw.save(raw_fname2)
-    raw_to_bids(subject_id=subject_id2, run=run, task=task,
+    raw_to_bids(subject_id=subject_id2, run=run, task=task, acquisition=acq,
                 session_id=session_id, raw_file=raw_fname2,
                 events_data=events_fname, output_path=output_path,
                 event_id=event_id, overwrite=True)
@@ -86,8 +88,8 @@ def test_kit():
     event_id = dict(cond=1)
 
     raw_to_bids(subject_id=subject_id, session_id=session_id, run=run,
-                task=task, raw_file=raw_fname, events_data=events_fname,
-                event_id=event_id, hpi=hpi_fname,
+                task=task, acquisition=acq, raw_file=raw_fname,
+                events_data=events_fname, event_id=event_id, hpi=hpi_fname,
                 electrode=electrode_fname, hsp=headshape_fname,
                 output_path=output_path, overwrite=True)
     cmd = ['bids-validator', output_path]
@@ -111,8 +113,8 @@ def test_ctf():
     raw_fname = op.join(data_path, 'testdata_ctf.ds')
 
     raw_to_bids(subject_id=subject_id, session_id=session_id, run=run,
-                task=task, raw_file=raw_fname, output_path=output_path,
-                overwrite=True)
+                task=task, acquisition=acq, raw_file=raw_fname,
+                output_path=output_path, overwrite=True)
     cmd = ['bids-validator', output_path]
     run_subprocess(cmd, shell=shell)
     assert op.exists(op.join(output_path, 'participants.tsv'))
@@ -127,9 +129,9 @@ def test_bti():
     headshape_fname = op.join(data_path, 'test_hs_linux')
 
     raw_to_bids(subject_id=subject_id, session_id=session_id, run=run,
-                task=task, raw_file=raw_fname, config=config_fname,
-                hsp=headshape_fname, output_path=output_path,
-                verbose=True, overwrite=True)
+                task=task, acquisition=acq, raw_file=raw_fname,
+                config=config_fname, hsp=headshape_fname,
+                output_path=output_path, verbose=True, overwrite=True)
 
     assert op.exists(op.join(output_path, 'participants.tsv'))
 
@@ -150,8 +152,8 @@ def test_vhdr():
     raw_fname = op.join(data_path, 'test.vhdr')
 
     raw_to_bids(subject_id=subject_id, session_id=session_id, run=run,
-                task=task, raw_file=raw_fname, output_path=output_path,
-                overwrite=True, kind='eeg')
+                task=task, acquisition=acq, raw_file=raw_fname,
+                output_path=output_path, overwrite=True, kind='eeg')
 
     cmd = ['bids-validator', '--bep006', output_path]
     run_subprocess(cmd, shell=shell)
@@ -168,8 +170,9 @@ def test_edf():
     raw.info['chs'][0]['coil_type'] = FIFF.FIFFV_COIL_EEG_BIPOLAR
 
     raw_to_bids(subject_id=subject_id, session_id=session_id, run=run,
-                task=task, raw_file=raw, output_path=output_path,
-                overwrite=True, kind='eeg')
+                task=task, acquisition=acq, raw_file=raw,
+                output_path=output_path, overwrite=True, kind='eeg')
+
     cmd = ['bids-validator', '--bep006', output_path]
     run_subprocess(cmd, shell=shell)
 
@@ -181,8 +184,8 @@ def test_bdf():
     raw_fname = op.join(data_path, 'test.bdf')
 
     raw_to_bids(subject_id=subject_id, session_id=session_id, run=run,
-                task=task, raw_file=raw_fname, output_path=output_path,
-                overwrite=True, kind='eeg')
+                task=task, acquisition=acq, raw_file=raw_fname,
+                output_path=output_path, overwrite=True, kind='eeg')
 
     cmd = ['bids-validator', '--bep006', output_path]
     run_subprocess(cmd, shell=shell)
@@ -196,8 +199,8 @@ def test_set():
     raw_fname = op.join(data_path, 'test_raw_onefile.set')
 
     raw_to_bids(subject_id=subject_id, session_id=session_id, run=run,
-                task=task, raw_file=raw_fname, output_path=output_path,
-                overwrite=True, kind='eeg')
+                task=task, acquisition=acq, raw_file=raw_fname,
+                output_path=output_path, overwrite=True, kind='eeg')
 
     cmd = ['bids-validator', '--bep006', output_path]
     run_subprocess(cmd, shell=shell)
@@ -222,8 +225,8 @@ def test_cnt():
     raw_fname = op.join(data_path, 'scan41_short.cnt')
 
     raw_to_bids(subject_id=subject_id, session_id=session_id, run=run,
-                task=task, raw_file=raw_fname, output_path=output_path,
-                overwrite=True, kind='eeg')
+                task=task, acquisition=acq, raw_file=raw_fname,
+                output_path=output_path, overwrite=True, kind='eeg')
 
     cmd = ['bids-validator', '--bep006', output_path]
     run_subprocess(cmd, shell=shell)

--- a/mne_bids/tests/test_mne_bids.py
+++ b/mne_bids/tests/test_mne_bids.py
@@ -99,7 +99,7 @@ def test_kit():
     # ensure the channels file has no STI 014 channel:
     channels_tsv = make_bids_filename(
         subject=subject_id, session=session_id, task=task, run=run,
-        suffix='channels.tsv',
+        suffix='channels.tsv', acquisition=acq,
         prefix=op.join(output_path, 'sub-01/ses-01/meg'))
     if op.exists(channels_tsv):
         df = pd.read_csv(channels_tsv, sep='\t')


### PR DESCRIPTION
This was a fix I added in the previous PR that I trashed because it tried to do too much.
Simply adds the acquisition parameter to the `raw_to_bids` function.
While this parameter is supposedly synonymous with the `run` parameter it would still be good to be able to handle it (also it will be used by the headspace/electrode placement files, but that doesn't really affect this).