### PR TITLE
use print of __doc__ instead of help in example

### DIFF
--- a/examples/make_eeg_bids.py
+++ b/examples/make_eeg_bids.py
@@ -103,7 +103,7 @@ print(raw)
 # * output_path
 #
 # ... as you can see in the docstring:
-help(raw_to_bids)
+print(raw_to_bids.__doc__)
 
 ###############################################################################
 # We loaded 'S001R02.edf', which corresponds to subject 1 in the second task.


### PR DESCRIPTION
to perhaps fix circleci ... the previous `help()` call might be blocking python (...if ipython is used).

This achieves the same but has less potential to crash something.