### PR TITLE
[MRG] fix channel units for EEG and iEEG

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ pypi. Update your installation as follows.
 
 Then, install the following python packages:
 
-    $ pip install flake8 pytest pytest-cov
+    $ pip install flake8 pytest pytest-cov coverage
 
 Finally, it is necessary to install the
 [BIDS validator](https://github.com/bids-standard/bids-validator). The outputs

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -9,8 +9,8 @@ What's new?
 
 .. _current:
 
-Version 0.1
------------
+Current
+-------
 
 Changelog
 ~~~~~~~~~
@@ -18,7 +18,8 @@ Changelog
 Bug
 ~~~
 
-- Fix logic with inferring unknown channel types for CTF data, by `Mainak Jas`_ (`#129 <https://github.com/mne-tools/mne-bids/pull/16/files>`_)
+- The original units present in the raw data will now correctly be written to channels.tsv files for BrainVision, EEGLAB, and EDF, by `Stefan Appelhoff`_ (`#125 <https://github.com/mne-tools/mne-bids/pull/125>`_)
+- Fix logic with inferring unknown channel types for CTF data, by `Mainak Jas`_ (`#129 <https://github.com/mne-tools/mne-bids/pull/16>`_)
 
 API
 ~~~
@@ -34,7 +35,7 @@ Changelog
 - Add example for how to rename BrainVision file triplets: `rename_brainvision_files.py` by `Stefan Appelhoff`_ (`#104 <https://github.com/mne-tools/mne-bids/pull/104>`_)
 - Add function to fetch BrainVision testing data :func:`mne_bids.datasets.fetch_brainvision_testing_data` `Stefan Appelhoff`_ (`#104 <https://github.com/mne-tools/mne-bids/pull/104>`_)
 - Add support for EEG and a corresponding example: `make_eeg_bids.py` by `Stefan Appelhoff`_ (`#78 <https://github.com/mne-tools/mne-bids/pull/78>`_)
-- Update :func:`mne_bids.raw_to_bids` to work for KIT and BTi systems, by `Teon Brooks`_ (`#16 <https://github.com/mne-tools/mne-bids/pull/16/files>`_)
+- Update :func:`mne_bids.raw_to_bids` to work for KIT and BTi systems, by `Teon Brooks`_ (`#16 <https://github.com/mne-tools/mne-bids/pull/16>`_)
 - Add support for iEEG and add :func:`mne_bids.make_bids_folders` and :func:`mne_bids.make_bids_folders`, by `Chris Holdgraf`_ (`#28 <https://github.com/mne-tools/mne-bids/pull/28>`_ and `#37 <https://github.com/mne-tools/mne-bids/pull/37>`_)
 - Add command line interface by `Teon Brooks`_ (`#31 <https://github.com/mne-tools/mne-bids/pull/31>`_)
 - Add :func:`mne_bids.utils.print_dir_tree` for visualizing directory structures and restructuring package to be more

--- a/mne_bids/mne_bids.py
+++ b/mne_bids/mne_bids.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Make BIDS compatible directory structures and infer meta data from MNE."""
 # Authors: Mainak Jas <mainak.jas@telecom-paristech.fr>
 #          Alexandre Gramfort <alexandre.gramfort@telecom-paristech.fr>

--- a/mne_bids/mne_bids.py
+++ b/mne_bids/mne_bids.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Make BIDS compatible directory structures and infer meta data from MNE."""
 # Authors: Mainak Jas <mainak.jas@telecom-paristech.fr>
 #          Alexandre Gramfort <alexandre.gramfort@telecom-paristech.fr>

--- a/mne_bids/mne_bids.py
+++ b/mne_bids/mne_bids.py
@@ -131,8 +131,12 @@ def _channels_tsv(raw, fname, overwrite=False, verbose=True):
         ch_type.append(map_chs[_channel_type])
         description.append(map_desc[_channel_type])
     low_cutoff, high_cutoff = (raw.info['highpass'], raw.info['lowpass'])
-    units = [_unit2human.get(ch_i['unit'], 'n/a') for ch_i in raw.info['chs']]
-    units = [u if u not in ['NA'] else 'n/a' for u in units]
+    if raw._orig_units:
+        units = [raw._orig_units.get(ch, 'n/a') for ch in raw.ch_names]
+    else:
+        units = [_unit2human.get(ch_i['unit'], 'n/a')
+                 for ch_i in raw.info['chs']]
+        units = [u if u not in ['NA'] else 'n/a' for u in units]
     n_channels = raw.info['nchan']
     sfreq = raw.info['sfreq']
 

--- a/mne_bids/tests/test_mne_bids.py
+++ b/mne_bids/tests/test_mne_bids.py
@@ -200,7 +200,7 @@ def test_vhdr():
                                 'ses-' + session_id, 'eeg',
                                 bids_basename + '_channels.tsv')
     df = pd.read_csv(channels_tsv_name, sep='\t', keep_default_na=False)
-    assert df.loc[df['name'] == 'FP1', 'units'].all() == u'µV'
+    assert df.loc[df['name'] == 'FP1', 'units'].all() == 'µV'
     assert df.loc[df['name'] == 'CP5', 'units'].all() == 'n/a'
 
     # create another bids folder with the overwrite command and check

--- a/mne_bids/tests/test_mne_bids.py
+++ b/mne_bids/tests/test_mne_bids.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Test the MNE BIDS converter.
 
 For each supported file format, implement a test.
@@ -22,7 +23,6 @@ from mne.utils import _TempDir, run_subprocess
 from mne.io.constants import FIFF
 
 from mne_bids import make_bids_basename, make_bids_folders, write_raw_bids
-from mne_bids.mne_bids import _channels_tsv
 
 base_path = op.join(op.dirname(mne.__file__), 'io')
 subject_id = '01'
@@ -194,6 +194,14 @@ def test_vhdr():
 
     cmd = ['bids-validator', '--bep006', output_path]
     run_subprocess(cmd, shell=shell)
+
+    # Test that correct channel units are written
+    channels_tsv_name = op.join(output_path, 'sub-' + subject_id,
+                                'ses-' + session_id, 'eeg',
+                                bids_basename + '_channels.tsv')
+    df = pd.read_csv(channels_tsv_name, sep='\t', keep_default_na=False)
+    assert df.loc[df['name'] == 'FP1', 'units'].all() == u'µV'
+    assert df.loc[df['name'] == 'CP5', 'units'].all() == 'n/a'
 
     # create another bids folder with the overwrite command and check
     # no files are in the folder

--- a/mne_bids/tests/test_mne_bids.py
+++ b/mne_bids/tests/test_mne_bids.py
@@ -22,6 +22,7 @@ from mne.utils import _TempDir, run_subprocess
 from mne.io.constants import FIFF
 
 from mne_bids import make_bids_basename, make_bids_folders, write_raw_bids
+from mne_bids.mne_bids import _channels_tsv
 
 base_path = op.join(op.dirname(mne.__file__), 'io')
 subject_id = '01'

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -362,11 +362,11 @@ def _write_json(dictionary, fname, overwrite=False, verbose=False):
 
 
 def _write_tsv(fname, df, overwrite=False, verbose=False):
-    """Write dataframe to a .tsv file"""
+    """Write dataframe to a .tsv file."""
     if op.exists(fname) and not overwrite:
         raise OSError(errno.EEXIST, '"%s" already exists. Please set '
                       'overwrite to True.' % fname)
-    df.to_csv(fname, sep='\t', index=False, na_rep='n/a')
+    df.to_csv(fname, sep='\t', index=False, na_rep='n/a', encoding='utf-8')
 
     if verbose:
         print(os.linesep + "Writing '%s'..." % fname + os.linesep)


### PR DESCRIPTION
closes #81

Using MNE-Python Master (or soon 0.17), I will be able to fix this for BrainVision and EDF (the primary formats both for EEG and iEEG) ... and probably also for BDF and EEGLAB.

I will not be able to fix it for

- Neuroscan CNT
- Any MEG system (no knowledge whatsoever and unfortunately not a lot of time to invest)