### PR TITLE
[MRG] fix split naming for single FIF files

### DIFF
--- a/mne_bids/mne_bids.py
+++ b/mne_bids/mne_bids.py
@@ -726,7 +726,8 @@ def write_raw_bids(raw, bids_basename, output_path, events_data=None,
             split_naming = 'bids'
             raw.save(bids_fname, split_naming=split_naming, overwrite=True)
         else:
-            raw.save(bids_fname, overwrite=True, split_naming='bids')
+            # This ensures that single FIF files do not have the part param
+            raw.save(bids_fname, overwrite=True, split_naming='neuromag')
 
     # CTF data is saved in a directory
     elif ext == '.ds':

--- a/mne_bids/tests/test_mne_bids.py
+++ b/mne_bids/tests/test_mne_bids.py
@@ -134,6 +134,7 @@ def test_fif():
     for FILE in files:
         assert 'part' in FILE
 
+
 def test_kit():
     """Test functionality of the write_raw_bids conversion for KIT data."""
     output_path = _TempDir()

--- a/mne_bids/tests/test_mne_bids.py
+++ b/mne_bids/tests/test_mne_bids.py
@@ -14,6 +14,7 @@ For each supported file format, implement a test.
 import os
 import os.path as op
 import pytest
+from glob import glob
 
 import pandas as pd
 
@@ -72,8 +73,11 @@ def test_fif():
     raw.save(raw_fname2)
 
     bids_basename2 = bids_basename.replace(subject_id, subject_id2)
-    write_raw_bids(raw, bids_basename2, output_path, events_data=events_fname,
-                   event_id=event_id, overwrite=False)
+    raw = mne.io.read_raw_fif(raw_fname2)
+    bids_output_path = write_raw_bids(raw, bids_basename2, output_path,
+                                      events_data=events_fname,
+                                      event_id=event_id, overwrite=False)
+
     # check that the overwrite parameters work correctly for the participant
     # data
     # change the gender but don't force overwrite.
@@ -107,6 +111,28 @@ def test_fif():
 
     assert op.exists(op.join(output_path, 'participants.tsv'))
 
+    # asserting that single fif files do not include the part key
+    files = glob(op.join(bids_output_path, 'sub-' + subject_id2,
+                         'ses-' + subject_id2, 'meg', '*.fif'))
+    for ii, FILE in enumerate(files):
+        assert 'part' not in FILE
+    assert ii < 1
+
+    # check that split files have part key
+    data_path3 = _TempDir()
+    raw_fname3 = op.join(data_path3, 'sample_audvis_raw.fif')
+    raw.save(raw_fname3, buffer_size_sec=1.0, split_size='10MB',
+               split_naming='neuromag', overwrite=True)
+    raw = mne.io.read_raw_fif(raw_fname3)
+    subject_id3 = '03'
+    bids_basename3 = bids_basename.replace(subject_id, subject_id3)
+    bids_output_path = write_raw_bids(raw_fname3, bids_basename3, output_path,
+                                      events_data=events_fname,
+                                      event_id=event_id, overwrite=False)
+    files = glob(op.join(bids_output_path, 'sub-' + subject_id3,
+                         'ses-' + subject_id3, 'meg', '*.fif'))
+    for FILE in files:
+        assert 'part' in FILE
 
 def test_kit():
     """Test functionality of the write_raw_bids conversion for KIT data."""

--- a/mne_bids/tests/test_mne_bids.py
+++ b/mne_bids/tests/test_mne_bids.py
@@ -119,16 +119,16 @@ def test_fif():
     assert ii < 1
 
     # check that split files have part key
+    raw = mne.io.read_raw_fif(raw_fname)
     data_path3 = _TempDir()
     raw_fname3 = op.join(data_path3, 'sample_audvis_raw.fif')
     raw.save(raw_fname3, buffer_size_sec=1.0, split_size='10MB',
-               split_naming='neuromag', overwrite=True)
+             split_naming='neuromag', overwrite=True)
     raw = mne.io.read_raw_fif(raw_fname3)
     subject_id3 = '03'
     bids_basename3 = bids_basename.replace(subject_id, subject_id3)
-    bids_output_path = write_raw_bids(raw_fname3, bids_basename3, output_path,
-                                      events_data=events_fname,
-                                      event_id=event_id, overwrite=False)
+    bids_output_path = write_raw_bids(raw, bids_basename3, output_path,
+                                      overwrite=False)
     files = glob(op.join(bids_output_path, 'sub-' + subject_id3,
                          'ses-' + subject_id3, 'meg', '*.fif'))
     for FILE in files:


### PR DESCRIPTION
closes  #136. This fixes the split naming problem @jasmainak pointed out. @jasmainak, was there a particular test you saw that failed? all the core `split_naming` testing is done in mne-python to make sure the mechanics worked. i actually didn't see any particular tests in mne-bids