### PR TITLE
[MRG] remove py2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ node_js:
 language: python
 
 env:
-  - PYTHON_VERSION=2.7
   - PYTHON_VERSION=3.6
 
 before_install:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ Installation
 ------------
 
 We recommend the [Anaconda](https://www.anaconda.com/download/) Python
-distribution. Besides `numpy`, `scipy`, `matplotlib`, and `pandas` (which are
+distribution. We require that you use a minimum Python version of 3.4.
+Besides `numpy`, `scipy`, `matplotlib`, and `pandas` (which are
 included in the standard Anaconda installation), you will need to install the
 most recent version of MNE using the `pip` tool:
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Installation
 ------------
 
 We recommend the [Anaconda](https://www.anaconda.com/download/) Python
-distribution. We require that you use a minimum Python version of 3.4.
+distribution. We require that you use Python 3.
 Besides `numpy`, `scipy`, `matplotlib`, and `pandas` (which are
 included in the standard Anaconda installation), you will need to install the
 most recent version of MNE using the `pip` tool:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,9 +3,6 @@ environment:
       nodejs_version: "10.0.0"
       PYTHON: "C:\\conda"
   matrix:
-      - PYTHON_VERSION: "2.7"
-        PYTHON_ARCH: "64"
-
       - PYTHON_VERSION: "3.6"
         PYTHON_ARCH: "64"
 

--- a/mne_bids/datasets.py
+++ b/mne_bids/datasets.py
@@ -10,7 +10,7 @@ import os
 import os.path as op
 import shutil
 import tarfile
-from six.moves import urllib
+import urllib
 
 from mne.utils import _fetch_file
 

--- a/mne_bids/mne_bids.py
+++ b/mne_bids/mne_bids.py
@@ -710,7 +710,7 @@ def write_raw_bids(raw, bids_basename, output_path, events_data=None,
     bids_fname = os.path.join(data_path, bids_fname)
     if os.path.exists(bids_fname) and not overwrite:
         raise FileExistsError(errno.EEXIST, '"%s" already exists. Please set '
-                      'overwrite to True.' % bids_fname)
+                              'overwrite to True.' % bids_fname)
     _mkdir_p(os.path.dirname(bids_fname))
 
     if verbose:

--- a/mne_bids/mne_bids.py
+++ b/mne_bids/mne_bids.py
@@ -276,7 +276,7 @@ def _participants_tsv(raw, subject_id, fname, overwrite=False,
         # if the subject data provided is different to the currently existing
         # data and overwrite is not True raise an error
         if (sid_included and not exact_included) and not overwrite:
-            raise OSError(errno.EEXIST, '"%s" already exists in the '
+            raise FileExistsError(errno.EEXIST, '"%s" already exists in the '
                           'participant list. Please set overwrite to '
                           'True.' % subject_id)
         # otherwise add the new data
@@ -359,7 +359,7 @@ def _scans_tsv(raw, raw_fname, fname, overwrite=False, verbose=True):
         orig_df = pd.read_csv(fname, sep='\t')
         # if the file name is already in the file raise an error
         if raw_fname in orig_df['filename'].values and not overwrite:
-            raise OSError(errno.EEXIST, '"%s" already exists in the '
+            raise FileExistsError(errno.EEXIST, '"%s" already exists in the '
                           'scans list. Please set overwrite to '
                           'True.' % raw_fname)
         # otherwise add the new data
@@ -709,7 +709,7 @@ def write_raw_bids(raw, bids_basename, output_path, events_data=None,
     # are placed in the right location
     bids_fname = os.path.join(data_path, bids_fname)
     if os.path.exists(bids_fname) and not overwrite:
-        raise OSError(errno.EEXIST, '"%s" already exists. Please set '
+        raise FileExistsError(errno.EEXIST, '"%s" already exists. Please set '
                       'overwrite to True.' % bids_fname)
     _mkdir_p(os.path.dirname(bids_fname))
 

--- a/mne_bids/mne_bids.py
+++ b/mne_bids/mne_bids.py
@@ -277,8 +277,8 @@ def _participants_tsv(raw, subject_id, fname, overwrite=False,
         # data and overwrite is not True raise an error
         if (sid_included and not exact_included) and not overwrite:
             raise FileExistsError(errno.EEXIST, '"%s" already exists in the '
-                          'participant list. Please set overwrite to '
-                          'True.' % subject_id)
+                                  'participant list. Please set overwrite to '
+                                  'True.' % subject_id)
         # otherwise add the new data
         df = orig_df.append(df)
         # and drop any duplicates as we want overwrite = True to force the old
@@ -360,8 +360,8 @@ def _scans_tsv(raw, raw_fname, fname, overwrite=False, verbose=True):
         # if the file name is already in the file raise an error
         if raw_fname in orig_df['filename'].values and not overwrite:
             raise FileExistsError(errno.EEXIST, '"%s" already exists in the '
-                          'scans list. Please set overwrite to '
-                          'True.' % raw_fname)
+                                  'scans list. Please set overwrite to '
+                                  'True.' % raw_fname)
         # otherwise add the new data
         df = orig_df.append(df)
         # and drop any duplicates as we want overwrite = True to force the old

--- a/mne_bids/tests/test_mne_bids.py
+++ b/mne_bids/tests/test_mne_bids.py
@@ -79,7 +79,7 @@ def test_fif():
     # change the gender but don't force overwrite.
     raw.info['subject_info'] = {'his_id': subject_id2,
                                 'birthday': (1994, 1, 26), 'sex': 2}
-    with pytest.raises(OSError, match="already exists"):
+    with pytest.raises(FileExistsError, match="already exists"):
         write_raw_bids(raw, bids_basename2, output_path,
                        events_data=events_fname, event_id=event_id,
                        overwrite=False)
@@ -169,7 +169,7 @@ def test_ctf():
     run_subprocess(cmd, shell=shell)
 
     # test to check that running again with overwrite == False raises an error
-    with pytest.raises(OSError, match="already exists"):
+    with pytest.raises(FileExistsError, match="already exists"):
         write_raw_bids(raw, bids_basename, output_path=output_path)
 
     assert op.exists(op.join(output_path, 'participants.tsv'))
@@ -311,7 +311,7 @@ def test_set():
     raw = mne.io.read_raw_eeglab(raw_fname)
     write_raw_bids(raw, bids_basename, output_path, overwrite=False)
 
-    with pytest.raises(OSError, match="already exists"):
+    with pytest.raises(FileExistsError, match="already exists"):
         write_raw_bids(raw, bids_basename, output_path=output_path,
                        overwrite=False)
 

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -18,7 +18,6 @@ import shutil as sh
 import numpy as np
 from scipy.io import loadmat, savemat
 from mne import read_events, find_events
-from mne.externals.six import string_types
 from mne.channels import read_montage
 from mne.io.pick import pick_types
 
@@ -160,13 +159,13 @@ def make_bids_basename(subject=None, session=None, task=None,
                          ('proc', processing),
                          ('space', space),
                          ('recording', recording)])
-    if order['run'] is not None and not isinstance(order['run'], string_types):
+    if order['run'] is not None and not isinstance(order['run'], str):
         # Ensure that run is a string
         order['run'] = '{:02}'.format(order['run'])
 
     _check_types(order.values())
 
-    if not any(isinstance(ii, string_types) for ii in order.keys()):
+    if not any(isinstance(ii, str) for ii in order.keys()):
         raise ValueError("At least one parameter must be given.")
 
     filename = []
@@ -175,11 +174,11 @@ def make_bids_basename(subject=None, session=None, task=None,
             _check_key_val(key, val)
             filename.append('%s-%s' % (key, val))
 
-    if isinstance(suffix, string_types):
+    if isinstance(suffix, str):
         filename.append(suffix)
 
     filename = '_'.join(filename)
-    if isinstance(prefix, string_types):
+    if isinstance(prefix, str):
         filename = op.join(prefix, filename)
     return filename
 
@@ -233,12 +232,12 @@ def make_bids_folders(subject, session=None, kind=None, output_path=None,
         _check_key_val('ses', session)
 
     path = ['sub-%s' % subject]
-    if isinstance(session, string_types):
+    if isinstance(session, str):
         path.append('ses-%s' % session)
-    if isinstance(kind, string_types):
+    if isinstance(kind, str):
         path.append(kind)
     path = op.join(*path)
-    if isinstance(output_path, string_types):
+    if isinstance(output_path, str):
         path = op.join(output_path, path)
 
     if make_dir is True:
@@ -292,11 +291,11 @@ def make_dataset_description(path, name=None, data_license=None,
 
     """
     # Put potential string input into list of strings
-    if isinstance(authors, string_types):
+    if isinstance(authors, str):
         authors = authors.split(', ')
-    if isinstance(funding, string_types):
+    if isinstance(funding, str):
         funding = funding.split(', ')
-    if isinstance(references_and_links, string_types):
+    if isinstance(references_and_links, str):
         references_and_links = references_and_links.split(', ')
 
     fname = op.join(path, 'dataset_description.json')
@@ -340,7 +339,7 @@ def _age_on_date(bday, exp_date):
 def _check_types(variables):
     """Make sure all vars are str or None."""
     for var in variables:
-        if not isinstance(var, (string_types, type(None))):
+        if not isinstance(var, (str, type(None))):
             raise ValueError("All values must be either None or strings. "
                              "Found type %s." % type(var))
 
@@ -402,7 +401,7 @@ def _read_events(events_data, raw):
         before the event or immediately after.
 
     """
-    if isinstance(events_data, string_types):
+    if isinstance(events_data, str):
         events = read_events(events_data).astype(int)
     elif isinstance(events_data, np.ndarray):
         if events_data.ndim != 2:

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -54,7 +54,7 @@ def _mkdir_p(path, overwrite=False, verbose=False):
         os.makedirs(path)
         if verbose is True:
             print('Creating folder: %s' % path)
-    except OSError as exc:  # Python >2.5
+    except FileExistsError as exc:
         if exc.errno == errno.EEXIST and op.isdir(path):
             pass
         else:
@@ -347,7 +347,7 @@ def _check_types(variables):
 def _write_json(dictionary, fname, overwrite=False, verbose=False):
     """Write JSON to a file."""
     if op.exists(fname) and not overwrite:
-        raise OSError(errno.EEXIST, '"%s" already exists. Please set '
+        raise FileExistsError(errno.EEXIST, '"%s" already exists. Please set '
                       'overwrite to True.' % fname)
 
     json_output = json.dumps(dictionary, indent=4)
@@ -363,7 +363,7 @@ def _write_json(dictionary, fname, overwrite=False, verbose=False):
 def _write_tsv(fname, df, overwrite=False, verbose=False):
     """Write dataframe to a .tsv file."""
     if op.exists(fname) and not overwrite:
-        raise OSError(errno.EEXIST, '"%s" already exists. Please set '
+        raise FileExistsError(errno.EEXIST, '"%s" already exists. Please set '
                       'overwrite to True.' % fname)
     df.to_csv(fname, sep='\t', index=False, na_rep='n/a', encoding='utf-8')
 

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -348,7 +348,7 @@ def _write_json(dictionary, fname, overwrite=False, verbose=False):
     """Write JSON to a file."""
     if op.exists(fname) and not overwrite:
         raise FileExistsError(errno.EEXIST, '"%s" already exists. Please set '
-                      'overwrite to True.' % fname)
+                              'overwrite to True.' % fname)
 
     json_output = json.dumps(dictionary, indent=4)
     with open(fname, 'w') as fid:
@@ -364,7 +364,7 @@ def _write_tsv(fname, df, overwrite=False, verbose=False):
     """Write dataframe to a .tsv file."""
     if op.exists(fname) and not overwrite:
         raise FileExistsError(errno.EEXIST, '"%s" already exists. Please set '
-                      'overwrite to True.' % fname)
+                              'overwrite to True.' % fname)
     df.to_csv(fname, sep='\t', index=False, na_rep='n/a', encoding='utf-8')
 
     if verbose:


### PR DESCRIPTION
PR to remove py2 support from `mne-bids`. `mne-python` has removed compatibility for py2 and we depend on it. we no longer have `mne.externals.six` to maintain compatibility.