### PR TITLE
[MRG] Py3 syntax fixes

### DIFF
--- a/mne_bids/datasets.py
+++ b/mne_bids/datasets.py
@@ -10,7 +10,7 @@ import os
 import os.path as op
 import shutil
 import tarfile
-import urllib
+import urllib.request
 
 from mne.utils import _fetch_file
 

--- a/mne_bids/mne_bids.py
+++ b/mne_bids/mne_bids.py
@@ -9,7 +9,6 @@
 # License: BSD (3-clause)
 
 import os
-import errno
 import os.path as op
 
 import shutil as sh
@@ -275,8 +274,8 @@ def _participants_tsv(raw, subject_id, fname, overwrite=False,
         # if the subject data provided is different to the currently existing
         # data and overwrite is not True raise an error
         if (sid_included and not exact_included) and not overwrite:
-            raise FileExistsError(errno.EEXIST, '"%s" already exists in the '
-                                  'participant list. Please set overwrite to '
+            raise FileExistsError('"%s" already exists in the participant '
+                                  'list. Please set overwrite to '
                                   'True.' % subject_id)
         # otherwise add the new data
         df = orig_df.append(df)
@@ -358,9 +357,8 @@ def _scans_tsv(raw, raw_fname, fname, overwrite=False, verbose=True):
         orig_df = pd.read_csv(fname, sep='\t')
         # if the file name is already in the file raise an error
         if raw_fname in orig_df['filename'].values and not overwrite:
-            raise FileExistsError(errno.EEXIST, '"%s" already exists in the '
-                                  'scans list. Please set overwrite to '
-                                  'True.' % raw_fname)
+            raise FileExistsError('"%s" already exists in the scans list. '
+                                  'Please set overwrite to True.' % raw_fname)
         # otherwise add the new data
         df = orig_df.append(df)
         # and drop any duplicates as we want overwrite = True to force the old
@@ -708,7 +706,7 @@ def write_raw_bids(raw, bids_basename, output_path, events_data=None,
     # are placed in the right location
     bids_fname = os.path.join(data_path, bids_fname)
     if os.path.exists(bids_fname) and not overwrite:
-        raise FileExistsError(errno.EEXIST, '"%s" already exists. Please set '
+        raise FileExistsError('"%s" already exists. Please set '
                               'overwrite to True.' % bids_fname)
     _mkdir_p(os.path.dirname(bids_fname))
 

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -10,7 +10,6 @@
 import os
 import os.path as op
 import re
-import errno
 from collections import OrderedDict
 import json
 import shutil as sh
@@ -50,15 +49,9 @@ def _mkdir_p(path, overwrite=False, verbose=False):
         if verbose is True:
             print('Clearing path: %s' % path)
 
-    try:
-        os.makedirs(path)
-        if verbose is True:
-            print('Creating folder: %s' % path)
-    except FileExistsError as exc:
-        if exc.errno == errno.EEXIST and op.isdir(path):
-            pass
-        else:
-            raise
+    os.makedirs(path, exist_ok=True)
+    if verbose is True:
+        print('Creating folder: %s' % path)
 
 
 def _parse_bids_filename(fname, verbose):
@@ -347,7 +340,7 @@ def _check_types(variables):
 def _write_json(dictionary, fname, overwrite=False, verbose=False):
     """Write JSON to a file."""
     if op.exists(fname) and not overwrite:
-        raise FileExistsError(errno.EEXIST, '"%s" already exists. Please set '
+        raise FileExistsError('"%s" already exists. Please set '
                               'overwrite to True.' % fname)
 
     json_output = json.dumps(dictionary, indent=4)
@@ -363,7 +356,7 @@ def _write_json(dictionary, fname, overwrite=False, verbose=False):
 def _write_tsv(fname, df, overwrite=False, verbose=False):
     """Write dataframe to a .tsv file."""
     if op.exists(fname) and not overwrite:
-        raise FileExistsError(errno.EEXIST, '"%s" already exists. Please set '
+        raise FileExistsError('"%s" already exists. Please set '
                               'overwrite to True.' % fname)
     df.to_csv(fname, sep='\t', index=False, na_rep='n/a', encoding='utf-8')
 


### PR DESCRIPTION
Removed the requirement for the `errno` library (was required for py2), as well as changing how `_mkdir_p` works to use a more recently added parameter to simplify the code