### PR TITLE
decoding/encoding errors with brainvision .vhdr/.vmrk

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -18,7 +18,7 @@ Changelog
 Bug
 ~~~
 
-- Encoding of BrainVision .vhdr/.vmrk files is checked to prevent encoding/decoding errors when modifying, by `Dominik Welke`_ (`#155 <https://github.com/mne-tools/mne-bids/pull/155>`_)
+- Encoding of BrainVision .vhdr/.vmrk files is checked to prevent encoding/decoding errors when modifying, by Dominik Welke (`#155 <https://github.com/mne-tools/mne-bids/pull/155>`_)
 - The original units present in the raw data will now correctly be written to channels.tsv files for BrainVision, EEGLAB, and EDF, by `Stefan Appelhoff`_ (`#125 <https://github.com/mne-tools/mne-bids/pull/125>`_)
 - Fix logic with inferring unknown channel types for CTF data, by `Mainak Jas`_ (`#129 <https://github.com/mne-tools/mne-bids/pull/16>`_)
 - Fix the file naming for FIF files to only expose the part key-value pair when files are split, by `Teon Brooks`_ (`#137 <https://github.com/mne-tools/mne-bids/pull/137>`_)

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -18,7 +18,7 @@ Changelog
 Bug
 ~~~
 
-- Encoding of BrainVision .vhdr/.vmrk files is checked to prevent encoding/decoding errors when modifying, by Dominik Welke (`#155 <https://github.com/mne-tools/mne-bids/pull/155>`_)
+- Encoding of BrainVision .vhdr/.vmrk files is checked to prevent encoding/decoding errors when modifying, by `Dominik Welke`_ (`#155 <https://github.com/mne-tools/mne-bids/pull/155>`_)
 - The original units present in the raw data will now correctly be written to channels.tsv files for BrainVision, EEGLAB, and EDF, by `Stefan Appelhoff`_ (`#125 <https://github.com/mne-tools/mne-bids/pull/125>`_)
 - Fix logic with inferring unknown channel types for CTF data, by `Mainak Jas`_ (`#129 <https://github.com/mne-tools/mne-bids/pull/16>`_)
 - Fix the file naming for FIF files to only expose the part key-value pair when files are split, by `Teon Brooks`_ (`#137 <https://github.com/mne-tools/mne-bids/pull/137>`_)
@@ -79,3 +79,4 @@ People who contributed to this release  (in alphabetical order):
 .. _Chris Holdgraf: https://bids.berkeley.edu/people/chris-holdgraf
 .. _Matt Sanderson: https://github.com/monkeyman192
 .. _Stefan Appelhoff: http://stefanappelhoff.com/
+.. _Dominik Welke: https://github.com/dominikwelke

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -18,6 +18,7 @@ Changelog
 Bug
 ~~~
 
+- Encoding of BrainVision .vhdr/.vmrk files is checked to prevent encoding/decoding errors when modifying, by `Dominik Welke`_ (`#155 <https://github.com/mne-tools/mne-bids/pull/155>`_)
 - The original units present in the raw data will now correctly be written to channels.tsv files for BrainVision, EEGLAB, and EDF, by `Stefan Appelhoff`_ (`#125 <https://github.com/mne-tools/mne-bids/pull/125>`_)
 - Fix logic with inferring unknown channel types for CTF data, by `Mainak Jas`_ (`#129 <https://github.com/mne-tools/mne-bids/pull/16>`_)
 - Fix the file naming for FIF files to only expose the part key-value pair when files are split, by `Teon Brooks`_ (`#137 <https://github.com/mne-tools/mne-bids/pull/137>`_)

--- a/mne_bids/mne_bids.py
+++ b/mne_bids/mne_bids.py
@@ -482,9 +482,9 @@ def _sidecar_json(raw, task, manufacturer, fname, kind, overwrite=False,
     n_eegchan = len([ch for ch in raw.info['chs']
                      if ch['kind'] == FIFF.FIFFV_EEG_CH])
     n_ecogchan = len([ch for ch in raw.info['chs']
-                     if ch['kind'] == FIFF.FIFFV_ECOG_CH])
+                      if ch['kind'] == FIFF.FIFFV_ECOG_CH])
     n_seegchan = len([ch for ch in raw.info['chs']
-                     if ch['kind'] == FIFF.FIFFV_SEEG_CH])
+                      if ch['kind'] == FIFF.FIFFV_SEEG_CH])
     n_eogchan = len([ch for ch in raw.info['chs']
                      if ch['kind'] == FIFF.FIFFV_EOG_CH])
     n_ecgchan = len([ch for ch in raw.info['chs']
@@ -492,9 +492,9 @@ def _sidecar_json(raw, task, manufacturer, fname, kind, overwrite=False,
     n_emgchan = len([ch for ch in raw.info['chs']
                      if ch['kind'] == FIFF.FIFFV_EMG_CH])
     n_miscchan = len([ch for ch in raw.info['chs']
-                     if ch['kind'] == FIFF.FIFFV_MISC_CH])
+                      if ch['kind'] == FIFF.FIFFV_MISC_CH])
     n_stimchan = len([ch for ch in raw.info['chs']
-                     if ch['kind'] == FIFF.FIFFV_STIM_CH]) - n_ignored
+                      if ch['kind'] == FIFF.FIFFV_STIM_CH]) - n_ignored
 
     # Define modality-specific JSON dictionaries
     ch_info_json_common = [

--- a/mne_bids/tests/test_utils.py
+++ b/mne_bids/tests/test_utils.py
@@ -16,9 +16,9 @@ from mne.utils import _TempDir
 
 from mne_bids.utils import (make_bids_folders, make_bids_basename,
                             _check_types, print_dir_tree, _age_on_date,
-                            _get_brainvision_paths, copyfile_brainvision,
-                            copyfile_eeglab, _infer_eeg_placement_scheme,
-                            _handle_kind)
+                            _get_brainvision_encoding, _get_brainvision_paths,
+                            copyfile_brainvision, copyfile_eeglab,
+                            _infer_eeg_placement_scheme, _handle_kind)
 
 base_path = op.join(op.dirname(mne.__file__), 'io')
 
@@ -111,6 +111,16 @@ def test_age_on_date():
     assert _age_on_date(bday, exp3) == 24
     with pytest.raises(ValueError):
         _age_on_date(bday, exp4)
+
+
+def test_get_brainvision_encoding():
+    """Test getting the file-encoding from a BrainVision header."""
+    data_path = op.join(base_path, 'brainvision', 'tests', 'data')
+    raw_fname = op.join(data_path, 'test.vhdr')
+
+    enc = _get_brainvision_encoding(raw_fname, logging=True)
+    assert isinstance(enc, str)
+    assert enc == 'UTF-8'
 
 
 def test_get_brainvision_paths():

--- a/mne_bids/tests/test_utils.py
+++ b/mne_bids/tests/test_utils.py
@@ -66,11 +66,11 @@ def test_make_filenames():
     prefix_data = dict(subject='one', session='two', task='three',
                        acquisition='four', run='five', processing='six',
                        recording='seven', suffix='suffix.csv')
-    assert make_bids_basename(**prefix_data) == 'sub-one_ses-two_task-three_acq-four_run-five_proc-six_recording-seven_suffix.csv' # noqa
+    assert make_bids_basename(**prefix_data) == 'sub-one_ses-two_task-three_acq-four_run-five_proc-six_recording-seven_suffix.csv'  # noqa
 
     # subsets of keys works
-    assert make_bids_basename(subject='one', task='three') == 'sub-one_task-three' # noqa
-    assert make_bids_basename(subject='one', task='three', suffix='hi.csv') == 'sub-one_task-three_hi.csv' # noqa
+    assert make_bids_basename(subject='one', task='three') == 'sub-one_task-three'  # noqa
+    assert make_bids_basename(subject='one', task='three', suffix='hi.csv') == 'sub-one_task-three_hi.csv'  # noqa
 
     with pytest.raises(ValueError):
         make_bids_basename(subject='one-two', suffix='there.csv')
@@ -96,7 +96,7 @@ def test_check_types():
     """Test the check whether vars are str or None."""
     assert _check_types(['foo', 'bar', None]) is None
     with pytest.raises(ValueError):
-            _check_types([None, 1, 3.14, 'meg', [1, 2]])
+        _check_types([None, 1, 3.14, 'meg', [1, 2]])
 
 
 def test_age_on_date():

--- a/mne_bids/tests/test_utils.py
+++ b/mne_bids/tests/test_utils.py
@@ -118,9 +118,13 @@ def test_get_brainvision_encoding():
     data_path = op.join(base_path, 'brainvision', 'tests', 'data')
     raw_fname = op.join(data_path, 'test.vhdr')
 
+    with pytest.raises(UnicodeDecodeError):
+        with open(raw_fname, 'r', encoding='ascii') as f:
+            f.readlines()
+
     enc = _get_brainvision_encoding(raw_fname, verbose=True)
-    assert isinstance(enc, str)
-    assert enc == 'UTF-8'
+    with open(raw_fname, 'r', encoding=enc) as f:
+        f.readlines()
 
 
 def test_get_brainvision_paths():

--- a/mne_bids/tests/test_utils.py
+++ b/mne_bids/tests/test_utils.py
@@ -118,7 +118,7 @@ def test_get_brainvision_encoding():
     data_path = op.join(base_path, 'brainvision', 'tests', 'data')
     raw_fname = op.join(data_path, 'test.vhdr')
 
-    enc = _get_brainvision_encoding(raw_fname, logging=True)
+    enc = _get_brainvision_encoding(raw_fname, verbose=True)
     assert isinstance(enc, str)
     assert enc == 'UTF-8'
 

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -414,9 +414,9 @@ def _get_brainvision_encoding(vhdr_file, verbose=False):
 
     Parameters
     ----------
-    vhdr_path : str
+    vhdr_file : str
         path to the header file
-    verbose   : Bool
+    verbose : Bool
         determine whether results should be logged.
         (default False)
 
@@ -424,9 +424,8 @@ def _get_brainvision_encoding(vhdr_file, verbose=False):
     -------
     enc : str
         encoding of the .vhdr file to pass it on to open() function
-        either 'utf-8' (default) or whatever encoding scheme is specified
+        either 'UTF-8' (default) or whatever encoding scheme is specified
         in the header
-
     """
     with open(vhdr_file, 'rb') as ef:
         enc = ef.read()

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -409,14 +409,14 @@ def _read_events(events_data, raw):
     return events
 
 
-def _get_brainvision_encoding(vhdr_file, logging=False):
+def _get_brainvision_encoding(vhdr_file, verbose=False):
     """get the encoding of .vhdr and .vmrk files.
 
     Parameters
     ----------
     vhdr_path : str
         path to the header file
-    logging   : Bool
+    verbose   : Bool
         determine whether results should be logged.
         (default False)
 
@@ -438,7 +438,7 @@ def _get_brainvision_encoding(vhdr_file, logging=False):
         else:
             enc = 'UTF-8'
             src = '(default)'
-        if logging:
+        if verbose is True:
             print('file encoding: %s %s' % (enc, src))
     return enc
 
@@ -526,7 +526,7 @@ def copyfile_brainvision(vhdr_src, vhdr_dest):
     eeg_file_path, vmrk_file_path = _get_brainvision_paths(vhdr_src)
 
     # extract encoding from brainvision header file, or default to utf-8
-    enc = _get_brainvision_encoding(vhdr_src, logging=True)
+    enc = _get_brainvision_encoding(vhdr_src, verbose=True)
 
     # Copy data .eeg ... no links to repair
     sh.copyfile(eeg_file_path, fname_dest + '.eeg')


### PR DESCRIPTION
solves #154 

note that my implementation adds a dependency to the chardet module
any thoughts on this?

I see 2 alternatives: 
- hardcoding `encoding='utf-8'`, if this would be brainvision-default (i'm not sure).
- extracting the encoding from the `Codepage='...'` line in the header, which would fall if there are files without this information.