### PR TITLE
[MRG] adding a check_version

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -18,6 +18,7 @@ Changelog
 Bug
 ~~~
 
+- Assert a minimum required MNE-version, by `Dominik Welke`_ (`#166 <https://github.com/mne-tools/mne-bids/pull/166>`_)
 - Add function in mne_bids.utils to copy and rename CTF files :func:`mne_bids.utils.copyfile_ctf`, by `Romain Quentin`_ (`#162 <https://github.com/mne-tools/mne-bids/pull/162>`_)
 - Encoding of BrainVision .vhdr/.vmrk files is checked to prevent encoding/decoding errors when modifying, by `Dominik Welke`_ (`#155 <https://github.com/mne-tools/mne-bids/pull/155>`_)
 - The original units present in the raw data will now correctly be written to channels.tsv files for BrainVision, EEGLAB, and EDF, by `Stefan Appelhoff`_ (`#125 <https://github.com/mne-tools/mne-bids/pull/125>`_)

--- a/mne_bids/io.py
+++ b/mne_bids/io.py
@@ -58,9 +58,9 @@ def _read_raw(raw_fname, electrode=None, hsp=None, hpi=None, config=None,
 
     # BTi systems
     elif ext == '.pdf' and os.path.isfile(raw_fname):
-            raw = io.read_raw_bti(raw_fname, config_fname=config,
-                                  head_shape_fname=hsp,
-                                  preload=False, verbose=verbose)
+        raw = io.read_raw_bti(raw_fname, config_fname=config,
+                              head_shape_fname=hsp,
+                              preload=False, verbose=verbose)
 
     elif ext in ['.fif', '.ds', '.vhdr', '.set']:
         raw = reader[ext](raw_fname)

--- a/mne_bids/mne_bids.py
+++ b/mne_bids/mne_bids.py
@@ -595,7 +595,8 @@ def write_raw_bids(raw, bids_basename, output_path, events_data=None,
 
     """
     if not check_version('mne', '0.17'):
-        raise ValueError('Your version of MNE is too old. please update to 0.17 or newer')
+        raise ValueError('Your version of MNE is too old. '
+                         'Please update to 0.17 or newer.')
 
     if not isinstance(raw, BaseRaw):
         raise ValueError('raw_file must be an instance of BaseRaw, '

--- a/mne_bids/mne_bids.py
+++ b/mne_bids/mne_bids.py
@@ -32,7 +32,7 @@ from .utils import (make_bids_basename, make_bids_folders,
                     _read_events, _mkdir_p, _age_on_date,
                     copyfile_brainvision, copyfile_eeglab, copyfile_ctf,
                     _infer_eeg_placement_scheme, _parse_bids_filename,
-                    _handle_kind)
+                    _handle_kind, assert_mne_version)
 from .io import _parse_ext, ALLOWED_EXTENSIONS, reader
 from mne_bids.tsv_handler import _from_tsv, _combine, _drop, _contains_row
 
@@ -614,7 +614,9 @@ def write_raw_bids(raw, bids_basename, output_path, events_data=None,
     raw_fname = raw_fname.replace('.fdt', '.set')
     _, ext = _parse_ext(raw_fname, verbose=verbose)
 
+    assert_mne_version('0.17')
     raw_orig = reader[ext](**raw._init_kwargs)
+
     assert_array_equal(raw.times, raw_orig.times,
                        "raw.times should not have changed since reading"
                        " in from the file. It may have been cropped.")
@@ -737,7 +739,9 @@ def write_raw_bids(raw, bids_basename, output_path, events_data=None,
         copyfile_eeglab(raw_fname, bids_fname)
     else:
         sh.copyfile(raw_fname, bids_fname)
+
     # KIT data requires the marker file to be copied over too
+    assert_mne_version('0.17')
     if 'mrk' in raw._init_kwargs:
         hpi = raw._init_kwargs['mrk']
         _, marker_ext = _parse_ext(hpi)

--- a/mne_bids/mne_bids.py
+++ b/mne_bids/mne_bids.py
@@ -22,6 +22,7 @@ from mne.io.constants import FIFF
 from mne.io.pick import channel_type
 from mne.io import BaseRaw
 from mne.channels.channels import _unit2human
+from mne.utils import check_version
 
 from datetime import datetime
 from warnings import warn
@@ -32,7 +33,7 @@ from .utils import (make_bids_basename, make_bids_folders,
                     _read_events, _mkdir_p, _age_on_date,
                     copyfile_brainvision, copyfile_eeglab, copyfile_ctf,
                     _infer_eeg_placement_scheme, _parse_bids_filename,
-                    _handle_kind, assert_mne_version)
+                    _handle_kind)
 from .io import _parse_ext, ALLOWED_EXTENSIONS, reader
 from mne_bids.tsv_handler import _from_tsv, _combine, _drop, _contains_row
 
@@ -593,6 +594,9 @@ def write_raw_bids(raw, bids_basename, output_path, events_data=None,
     of the participant correctly.
 
     """
+    if not check_version('mne', '0.17'):
+        raise ValueError('Your version of MNE is too old. please update to 0.17 or newer')
+
     if not isinstance(raw, BaseRaw):
         raise ValueError('raw_file must be an instance of BaseRaw, '
                          'got %s' % type(raw))
@@ -614,9 +618,7 @@ def write_raw_bids(raw, bids_basename, output_path, events_data=None,
     raw_fname = raw_fname.replace('.fdt', '.set')
     _, ext = _parse_ext(raw_fname, verbose=verbose)
 
-    assert_mne_version('0.17')
     raw_orig = reader[ext](**raw._init_kwargs)
-
     assert_array_equal(raw.times, raw_orig.times,
                        "raw.times should not have changed since reading"
                        " in from the file. It may have been cropped.")
@@ -739,9 +741,7 @@ def write_raw_bids(raw, bids_basename, output_path, events_data=None,
         copyfile_eeglab(raw_fname, bids_fname)
     else:
         sh.copyfile(raw_fname, bids_fname)
-
     # KIT data requires the marker file to be copied over too
-    assert_mne_version('0.17')
     if 'mrk' in raw._init_kwargs:
         hpi = raw._init_kwargs['mrk']
         _, marker_ext = _parse_ext(hpi)

--- a/mne_bids/tests/test_mne_bids.py
+++ b/mne_bids/tests/test_mne_bids.py
@@ -350,6 +350,15 @@ def test_set():
     raw_fname = op.join(data_path, 'test_raw.set')
 
     raw = mne.io.read_raw_eeglab(raw_fname)
+
+    # embedded - test mne-version assertion
+    tmp_version = mne.__version__
+    mne.__version__ = '0.16'
+    with pytest.raises(ValueError, match='Your version of MNE is too old.'):
+        write_raw_bids(raw, bids_basename, output_path)
+    mne.__version__ = tmp_version
+
+    # proceed with the actual test for EEGLAB data
     write_raw_bids(raw, bids_basename, output_path, overwrite=False)
 
     with pytest.raises(FileExistsError, match="already exists"):
@@ -368,13 +377,3 @@ def test_set():
 
     cmd = ['bids-validator', '--bep010', output_path]
     run_subprocess(cmd, shell=shell)
-
-
-def test_assert_mne_version():
-    """Test functionality of mne-version assertion"""
-    tmp_version = mne.__version__
-    mne.__version__ = '0.16'
-    raw, bids_basename, output_path = [], [], []
-    with pytest.raises(ValueError, match='Your version of MNE is too old.'):
-        write_raw_bids(raw, bids_basename, output_path)
-    mne.__version__ = tmp_version

--- a/mne_bids/tests/test_mne_bids.py
+++ b/mne_bids/tests/test_mne_bids.py
@@ -368,3 +368,13 @@ def test_set():
 
     cmd = ['bids-validator', '--bep010', output_path]
     run_subprocess(cmd, shell=shell)
+
+
+def test_assert_mne_version():
+    """Test functionality of mne-version assertion"""
+    tmp_version = mne.__version__
+    mne.__version__ = '0.16'
+    raw, bids_basename, output_path = [], [], []
+    with pytest.raises(ValueError, match='Your version of MNE is too old.'):
+        write_raw_bids(raw, bids_basename, output_path)
+    mne.__version__ = tmp_version

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -19,25 +19,10 @@ from scipy.io import loadmat, savemat
 from mne import read_events, find_events
 from mne.channels import read_montage
 from mne.io.pick import pick_types
-from mne.utils import check_version
 
 from .config import BIDS_VERSION
 from .io import _parse_ext
 from .tsv_handler import _to_tsv, _tsv_to_str
-
-
-def assert_mne_version(min_version):
-    """Asserts required minimum mne-version.
-    Parameters
-    ----------
-    min_version : str
-        The minimum version string. Anything that matches
-        ``'(\d+ | [a-z]+ | \.)'``.
-    """
-    ok = check_version('mne', min_version)
-    if not ok:
-        raise ValueError(
-            'Your version of MNE is too old. please update to %s or newer' % min_version)
 
 
 def print_dir_tree(folder):

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -19,10 +19,25 @@ from scipy.io import loadmat, savemat
 from mne import read_events, find_events
 from mne.channels import read_montage
 from mne.io.pick import pick_types
+from mne.utils import check_version
 
 from .config import BIDS_VERSION
 from .io import _parse_ext
 from .tsv_handler import _to_tsv, _tsv_to_str
+
+
+def assert_mne_version(min_version):
+    """Asserts required minimum mne-version.
+    Parameters
+    ----------
+    min_version : str
+        The minimum version string. Anything that matches
+        ``'(\d+ | [a-z]+ | \.)'``.
+    """
+    ok = check_version('mne', min_version)
+    if not ok:
+        raise ValueError(
+            'Your version of MNE is too old. please update to %s or newer' % min_version)
 
 
 def print_dir_tree(folder):


### PR DESCRIPTION
hi all,

as discussed before (eg. #151 ) a check for mne-version might help making mne-bids more stable across different user environments.

I drafted two potential options:
1. a simple and generic return of the version as string 
2. a check function that returns True if a specified minimal required version is met

which way to go depends on how it would be implemented in the rest of mne-bids code. 
feedback is appreciated :)

EDIT: 
closes #151 

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [x] All comments resolved
- [x] This is not your own PR
- [x] All CIs are happy
- [x] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [x] PR description includes phrase "closes <#issue-number>"
- [x] Commit history does not contain any merge commits
