### PR TITLE
[MRG] Don't write events.tsv if stim channel is not present

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ error messages:
 
     $ python -c 'import mne_bids'
 
+If you want to use the latest development version, use the following command:
+
+    $ pip install https://api.github.com/repos/mne-tools/mne-bids/zipball/master
+
 Command Line Interface
 ----------------------
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -31,6 +31,10 @@ To check if everything worked fine, you can do::
 
 and it should not give any error messages.
 
+If you want to use the latest development version, use the following command::
+
+    $ pip install https://api.github.com/repos/mne-tools/mne-bids/zipball/master
+
 Quickstart
 ==========
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -23,6 +23,7 @@ Bug
 - The original units present in the raw data will now correctly be written to channels.tsv files for BrainVision, EEGLAB, and EDF, by `Stefan Appelhoff`_ (`#125 <https://github.com/mne-tools/mne-bids/pull/125>`_)
 - Fix logic with inferring unknown channel types for CTF data, by `Mainak Jas`_ (`#129 <https://github.com/mne-tools/mne-bids/pull/16>`_)
 - Fix the file naming for FIF files to only expose the part key-value pair when files are split, by `Teon Brooks`_ (`#137 <https://github.com/mne-tools/mne-bids/pull/137>`_)
+- Allow files with no stim channel, which could be the case for example in resting state data, by `Mainak Jas`_ (`#167 <https://github.com/mne-tools/mne-bids/pull/167/files>`_)
 
 API
 ~~~
@@ -30,6 +31,7 @@ API
 - Remove support for Neuroscan ``.cnt`` data because its support is no longer planned in BIDS, by `Stefan Appelhoff`_ (`#142 <https://github.com/mne-tools/mne-bids/pull/142>`_)
 - Remove support for Python 2 because it is no longer supported in MNE-Python, by `Teon Brooks`_ (`#141 <https://github.com/mne-tools/mne-bids/pull/141>`_)
 - Remove Pandas requirement to reduce number of dependencies, by `Matt Sanderson`_ (`#122 <https://github.com/mne-tools/mne-bids/pull/122>`_)
+- Use more modern API of event_from_annotations in MNE for extracting events in .vhdr and .set files, by `Mainak Jas`_ (`#167 <https://github.com/mne-tools/mne-bids/pull/167/files>`_)
 
 .. _changes_0_1:
 

--- a/mne_bids/mne_bids.py
+++ b/mne_bids/mne_bids.py
@@ -692,7 +692,7 @@ def write_raw_bids(raw, bids_basename, output_path, events_data=None,
         _coordsystem_json(raw, unit, orient, manufacturer, coordsystem_fname,
                           overwrite, verbose)
 
-    events = _read_events(events_data, raw)
+    events, event_id = _read_events(events_data, event_id, raw, ext)
     if events is not None and len(events) > 0 and not emptyroom:
         _events_tsv(events, raw, events_fname, event_id, overwrite, verbose)
 

--- a/mne_bids/mne_bids.py
+++ b/mne_bids/mne_bids.py
@@ -693,7 +693,7 @@ def write_raw_bids(raw, bids_basename, output_path, events_data=None,
                           overwrite, verbose)
 
     events = _read_events(events_data, raw)
-    if len(events) > 0 and not emptyroom:
+    if events is not None and len(events) > 0 and not emptyroom:
         _events_tsv(events, raw, events_fname, event_id, overwrite, verbose)
 
     make_dataset_description(output_path, name=" ", verbose=verbose)

--- a/mne_bids/tests/test_mne_bids.py
+++ b/mne_bids/tests/test_mne_bids.py
@@ -20,7 +20,7 @@ from datetime import datetime
 
 import mne
 from mne.datasets import testing
-from mne.utils import _TempDir, run_subprocess
+from mne.utils import _TempDir, run_subprocess, check_version
 from mne.io.constants import FIFF
 
 from mne_bids import make_bids_basename, make_bids_folders, write_raw_bids
@@ -374,10 +374,13 @@ def test_set():
     run_subprocess(cmd, shell=shell)
 
     # check events.tsv is written
+    # XXX: only from 0.18 onwards because events_from_annotations
+    # is broken for earlier versions
     events_tsv_fname = op.join(output_path, 'sub-' + subject_id,
                                'ses-' + session_id, 'eeg',
                                bids_basename + '_events.tsv')
-    assert op.exists(events_tsv_fname)
+    if check_version('mne', '0.18dev0'):
+        assert op.exists(events_tsv_fname)
 
     # Also cover iEEG
     # We use the same data and pretend that eeg channels are ecog

--- a/mne_bids/tests/test_mne_bids.py
+++ b/mne_bids/tests/test_mne_bids.py
@@ -264,6 +264,10 @@ def test_vhdr():
     assert data['units'][data['name'].index('FP1')] == 'µV'
     assert data['units'][data['name'].index('CP5')] == 'n/a'
 
+    # check events.tsv is written
+    events_tsv_fname = channels_tsv_name.replace('channels', 'events')
+    assert op.exists(events_tsv_fname)
+
     # create another bids folder with the overwrite command and check
     # no files are in the folder
     data_path = make_bids_folders(subject=subject_id, session=session_id,
@@ -368,6 +372,12 @@ def test_set():
 
     cmd = ['bids-validator', '--bep006', output_path]
     run_subprocess(cmd, shell=shell)
+
+    # check events.tsv is written
+    events_tsv_fname = op.join(output_path, 'sub-' + subject_id,
+                               'ses-' + session_id, 'eeg',
+                               bids_basename + '_events.tsv')
+    assert op.exists(events_tsv_fname)
 
     # Also cover iEEG
     # We use the same data and pretend that eeg channels are ecog

--- a/mne_bids/tests/test_mne_bids.py
+++ b/mne_bids/tests/test_mne_bids.py
@@ -64,6 +64,15 @@ def test_fif():
     write_raw_bids(raw, bids_basename, output_path, events_data=events_fname,
                    event_id=event_id, overwrite=False)
 
+    # check if BIDS works without stim channel
+    raw.set_channel_types({raw.ch_names[i]: 'misc'
+                           for i in mne.pick_types(raw.info, stim=True, meg=False)})
+    output_path = _TempDir()
+    write_raw_bids(raw, bids_basename, output_path, overwrite=False)
+
+    cmd = ['bids-validator', output_path]
+    run_subprocess(cmd, shell=shell)
+
     # write the same data but pretend it is empty room data:
     er_date = datetime.fromtimestamp(
         raw.info['meas_date'][0]).strftime('%Y%m%d')
@@ -226,6 +235,7 @@ def test_bti():
 
     raw = mne.io.read_raw_bti(raw_fname, config_fname=config_fname,
                               head_shape_fname=headshape_fname)
+
     write_raw_bids(raw, bids_basename, output_path, verbose=True)
 
     assert op.exists(op.join(output_path, 'participants.tsv'))

--- a/mne_bids/tests/test_mne_bids.py
+++ b/mne_bids/tests/test_mne_bids.py
@@ -64,7 +64,7 @@ def test_fif():
     write_raw_bids(raw, bids_basename, output_path, events_data=events_fname,
                    event_id=event_id, overwrite=False)
 
-    # check if BIDS works without stim channel
+    # check if write_raw_bids works when there is no stim channel
     raw.set_channel_types({raw.ch_names[i]: 'misc'
                            for i in
                            mne.pick_types(raw.info, stim=True, meg=False)})

--- a/mne_bids/tests/test_mne_bids.py
+++ b/mne_bids/tests/test_mne_bids.py
@@ -66,7 +66,8 @@ def test_fif():
 
     # check if BIDS works without stim channel
     raw.set_channel_types({raw.ch_names[i]: 'misc'
-                           for i in mne.pick_types(raw.info, stim=True, meg=False)})
+                           for i in
+                           mne.pick_types(raw.info, stim=True, meg=False)})
     output_path = _TempDir()
     write_raw_bids(raw, bids_basename, output_path, overwrite=False)
 

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -417,8 +417,9 @@ def _read_events(events_data, event_id,
     elif ext in ['.vhdr', '.set'] and check_version('mne', '0.18.dev0'):
         events, event_id = events_from_annotations(raw)
     else:
-        warnings.warn('No events found or provided. Please make sure to set channel'
-                      'type using raw.set_channel_types or provide events_data.')
+        warnings.warn('No events found or provided. Please make sure to'
+                      ' set channel type using raw.set_channel_types'
+                      ' or provide events_data.')
         events = None
     return events, event_id
 

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -10,6 +10,7 @@
 import os
 import os.path as op
 import re
+import warnings
 from collections import OrderedDict
 import json
 import shutil as sh
@@ -405,8 +406,12 @@ def _read_events(events_data, raw):
             raise ValueError('Events must have second dimension of length 3, '
                              'found %s' % events_data.shape[1])
         events = events_data
-    else:
+    elif 'stim' in raw:
         events = find_events(raw, min_duration=0.001, initial_event=True)
+    else:
+        warnings.warn('No events found or provided. Please make sure to set channel'
+                      'type using raw.set_channel_types or provide events_data.')
+        events = None
     return events
 
 

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -376,8 +376,7 @@ def _check_key_val(key, val):
     return key, val
 
 
-def _read_events(events_data, event_id,
- raw, ext):
+def _read_events(events_data, event_id, raw, ext):
     """Read in events data.
 
     Parameters

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -386,7 +386,8 @@ def _read_events(events_data, event_id, raw, ext):
         the MNE events array (shape n_events, 3). If None, events will be
         inferred from the stim channel using `find_events`.
     event_id : dict
-        The event_id provided in write_raw_bids.
+        The event_id dict as provided in write_raw_bids, mapping a
+        description key to an integer valued event code.
     raw : instance of Raw
         The data as MNE-Python Raw object.
     ext : str


### PR DESCRIPTION
Thanks for contributing. If this is your first time,
make sure to read [contributing.md](https://github.com/mne-tools/mne-bids/blob/master/CONTRIBUTING.md)

PR Description
--------------

This PR closes #165 #164 

Now mne-bids can also handle resting state data where there isn't necessarily a stim channel marked. In that case, the events.tsv will not be written.

Also it uses the more modern `events_from_annotations` for vhdr and set files.

cc  @paulineduret

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [x] All CIs are happy
- [x] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [x] PR description includes phrase "closes <#issue-number>"
- [x] Commit history does not contain any merge commits
