### PR TITLE
[MRG] Fix minor tsv handler issue

### DIFF
--- a/mne_bids/mne_bids.py
+++ b/mne_bids/mne_bids.py
@@ -561,8 +561,7 @@ def write_raw_bids(raw, bids_basename, output_path, events_data=None,
             sub-01_ses-01_task-testing_acq-01_run-01_channels.tsv
             sub-01_ses-01_task-testing_acq-01_run-01_coordsystem.json
 
-        and the following one if events_data is not None
-        ::
+        and the following one if events_data is not None::
 
             sub-01_ses-01_task-testing_acq-01_run-01_events.tsv
 

--- a/mne_bids/mne_bids.py
+++ b/mne_bids/mne_bids.py
@@ -263,7 +263,9 @@ def _participants_tsv(raw, subject_id, fname, overwrite=False,
         orig_data = _from_tsv(fname)
         # whether the new data exists identically in the previous data
         exact_included = _contains_row(orig_data,
-                                       [subject_id, subject_age, sex])
+                                       {'participant_id': subject_id,
+                                        'age': subject_age,
+                                        'sex': sex})
         # whether the subject id is in the previous data
         sid_included = subject_id in orig_data['participant_id']
         # if the subject data provided is different to the currently existing

--- a/mne_bids/mne_bids.py
+++ b/mne_bids/mne_bids.py
@@ -552,18 +552,25 @@ def write_raw_bids(raw, bids_basename, output_path, events_data=None,
     bids_basename : str
         The base filename of the BIDS compatible files. Typically, this can be
         generated using make_bids_basename.
-        Example: sub-01_ses-01_task-testing_acq-01_run-01
-        This will write the following files in the correct subfolder
-        of output_path:
+        Example: `sub-01_ses-01_task-testing_acq-01_run-01`.
+        This will write the following files in the correct subfolder of the
+        output_path::
+
             sub-01_ses-01_task-testing_acq-01_run-01_meg.fif
             sub-01_ses-01_task-testing_acq-01_run-01_meg.json
             sub-01_ses-01_task-testing_acq-01_run-01_channels.tsv
             sub-01_ses-01_task-testing_acq-01_run-01_coordsystem.json
+
         and the following one if events_data is not None
+        ::
+
             sub-01_ses-01_task-testing_acq-01_run-01_events.tsv
-        and add a line to the following files:
+
+        and add a line to the following files::
+
             participants.tsv
             scans.tsv
+
         Note that the modality 'meg' is automatically inferred from the raw
         object and extension '.fif' is copied from raw.filenames.
     output_path : str

--- a/mne_bids/tests/test_tsv_handler.py
+++ b/mne_bids/tests/test_tsv_handler.py
@@ -15,7 +15,7 @@ from mne.utils import _TempDir
 def test_tsv_handler():
     # create some dummy data
     d = odict(a=[1, 2, 3, 4], b=['five', 'six', 'seven', 'eight'])
-    assert _contains_row(d, [1, 'five'])
+    assert _contains_row(d, {'a': 1, 'b': 'five'})
     d2 = odict(a=[5], b=['nine'])
     d = _combine(d, d2)
     assert 5 in d['a']
@@ -56,3 +56,4 @@ def test_tsv_handler():
     d2 = odict(a=[5])
     d = _combine(d, d2)
     assert d['b'] == ['three', 'four', 'n/a']
+    assert _contains_row(d, {'a': 5})

--- a/mne_bids/tsv_handler.py
+++ b/mne_bids/tsv_handler.py
@@ -49,18 +49,24 @@ def _contains_row(data, row_data):
     ----------
     data : collections.OrderedDict
         OrderedDict to check.
-    row_data : list
-        List of values to be searched for. This must match the contents of a
-        row exactly for a positive match to be returned.
+    row_data : dict
+        Dictionary with column names as keys, and values being the column value
+        to match within a row.
 
     Returns
     -------
     bool
         True if `row_data` exists in `data`.
+
+    Note
+    ----
+    This function will return True if the supplied `row_data` contains less
+    columns than the number of columns in the existing data but there is still
+    a match for the partial row data.
     """
     mask = None
-    for idx, column_data in enumerate(data.values()):
-        column_mask = np.in1d(np.array(column_data), row_data[idx])
+    for key, value in row_data.items():
+        column_mask = np.in1d(np.array(data[key]), value)
         mask = column_mask if mask is None else (mask & column_mask)
     return np.any(mask)
 


### PR DESCRIPTION
PR Description
--------------

When using mne-BIDS to write tsv files such as the participant files, it would break because of our overwrite check when trying to write to a file that contains more columns than are generated using mne-BIDS. In my case I add a `groups` column in a post-processing of data generated by mne-BIDS, but when mne-BIDS tries to add more data to the participants.tsv file it breaks.
I fix this by passing a `dict` to `_contains_row`.

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [x] All comments resolved
- [x] This is not your own PR
- [x] All CIs are happy
- [x] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
- [x] Commit history does not contain any merge commits
