### PR TITLE
[MRG] FIX: handle unicode strings better

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
                   conda update --yes --quiet conda
                   conda create -n testenv --yes python=3.6
                   source activate testenv
-                  conda install --yes --quiet numpy=1.13.1 scipy=0.19.1 matplotlib
+                  conda install --yes --quiet numpy=1.14 scipy=0.19.1 matplotlib
                   pip install sphinx numpydoc sphinx-gallery sphinx_bootstrap_theme pillow
                   pip install -U mne
                   python setup.py develop

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
 install:
     - conda create -n testenv --yes python=${PYTHON_VERSION}
     - source activate testenv
-    - conda install --yes --quiet numpy=1.13.1 scipy=0.19.1
+    - conda install --yes --quiet numpy=1.14 scipy=0.19.1
     - pip install flake8 pytest pytest-sugar pytest-faulthandler check-manifest
     - |
       git clone --depth 1 https://github.com/mne-tools/mne-python.git -b maint/0.17

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ install:
   - "powershell ci-helpers/appveyor/install-miniconda.ps1"
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
   - "activate test"
-  - "conda install numpy=1.13.1 scipy=0.19.1"
+  - "conda install numpy=1.14 scipy=0.19.1"
   - "pip install flake8 pytest pytest-cov pytest-sugar pytest-faulthandler codecov"
   - "pip uninstall -yq mne"
   - |-

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -25,6 +25,7 @@ Bug
 - Fix logic with inferring unknown channel types for CTF data, by `Mainak Jas`_ (`#129 <https://github.com/mne-tools/mne-bids/pull/16>`_)
 - Fix the file naming for FIF files to only expose the part key-value pair when files are split, by `Teon Brooks`_ (`#137 <https://github.com/mne-tools/mne-bids/pull/137>`_)
 - Allow files with no stim channel, which could be the case for example in resting state data, by `Mainak Jas`_ (`#167 <https://github.com/mne-tools/mne-bids/pull/167/files>`_)
+- Better handling of unicode strings in TSV files, by `Mainak Jas`_ (`#172 <https://github.com/mne-tools/mne-bids/pull/172/files>`_)
 - Fix separator in scans.tsv to always be `/`, by `Matt Sanderson`_ (`#176 <https://github.com/mne-tools/mne-bids/pull/176>`_)
 
 API

--- a/mne_bids/tsv_handler.py
+++ b/mne_bids/tsv_handler.py
@@ -113,7 +113,7 @@ def _from_tsv(fname, dtypes=None):
     data_dict : collections.OrderedDict
         Keys are the column names, and values are the column data.
     """
-    data = np.loadtxt(fname, dtype=str, delimiter='\t')
+    data = np.loadtxt(fname, dtype=str, delimiter='\t', encoding='utf-8')
     column_names = data[0, :]
     info = data[1:, :]
     data_dict = OrderedDict()
@@ -142,8 +142,8 @@ def _to_tsv(data, fname):
     n_rows = len(data[list(data.keys())[0]])
     output = _tsv_to_str(data, n_rows)
 
-    with open(fname, 'w') as f:
-        f.write(output)
+    with open(fname, 'wb') as f:
+        f.write(output.encode('utf-8'))
 
 
 def _tsv_to_str(data, rows=5):


### PR DESCRIPTION
PR Description
--------------

@paulineduret does this solve the unicode issue that your colleague is facing? Basically for EEG data, we have the micro character that needs to be written for the units. cc @sappelhoff 

The error is something like this:

```py
UnicodeEncodeError: 'ascii' codec can't encode character '\xb5' in position 85: ordinal not in range(128)
```

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [x] All comments resolved
- [x] This is not your own PR
- [x] All CIs are happy
- [x] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
<s>- [ ] PR description includes phrase "closes <#issue-number>"</s>
- [x] Commit history does not contain any merge commits
