### PR TITLE
Allow for multiple marker files and correctly name in BIDS output

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -18,6 +18,8 @@ Changelog
 Bug
 ~~~
 
+- Allow raw data from KIT systems to have two marker files specified, by `Matt Sanderson`_ (`#167 <https://github.com/mne-tools/mne-bids/pull/173>`_)
+
 API
 ~~~
 
@@ -50,7 +52,6 @@ Bug
   such as config and headshape are copied correctly, by `Mainak Jas`_ (`#135 <https://github.com/mne-tools/mne-bids/pull/135>`_)
 - Fix name of "sample" and "value" columns on events.tsv files, by `Ezequiel Mikulan`_ (`#185 <https://github.com/mne-tools/mne-bids/pull/185>`_)
 - Update function to copy KIT files to the `meg` directory, by `Matt Sanderson`_ (`#187 <https://github.com/mne-tools/mne-bids/pull/187>`_)
-- Allow raw data from KIT systems to have two marker files specified, by `Matt Sanderson`_ (`#167 <https://github.com/mne-tools/mne-bids/pull/173>`_)
 
 API
 ~~~

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -50,6 +50,7 @@ Bug
   such as config and headshape are copied correctly, by `Mainak Jas`_ (`#135 <https://github.com/mne-tools/mne-bids/pull/135>`_)
 - Fix name of "sample" and "value" columns on events.tsv files, by `Ezequiel Mikulan`_ (`#185 <https://github.com/mne-tools/mne-bids/pull/185>`_)
 - Update function to copy KIT files to the `meg` directory, by `Matt Sanderson`_ (`#187 <https://github.com/mne-tools/mne-bids/pull/187>`_)
+- Allow raw data from KIT systems to have two marker files specified, by `Matt Sanderson`_ (`#167 <https://github.com/mne-tools/mne-bids/pull/173>`_)
 
 API
 ~~~

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -194,8 +194,7 @@ def test_kit():
     headshape_fname = op.join(data_path, 'test_hsp.txt')
     event_id = dict(cond=1)
 
-    kit_bids_basename = make_bids_basename(
-        subject=subject_id, session=session_id, run=run, task=task)
+    kit_bids_basename = bids_basename.replace('_acq-01', '')
 
     raw = mne.io.read_raw_kit(
         raw_fname, mrk=hpi_fname, elp=electrode_fname,

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -252,7 +252,7 @@ def test_kit():
     marker_fname = make_bids_basename(
         subject=subject_id2, session=session_id, task=task, run=run,
         suffix='markers.sqd', acquisition='pre',
-        prefix=os.path.join(output_path, 'sub-02/ses-01/meg'))
+        prefix=os.path.join(output_path, 'sub-02', 'ses-01', meg'))
     info = get_kit_info(marker_fname, False)[0]
     assert info['meas_date'] == get_kit_info(hpi_pre_fname,
                                              False)[0]['meas_date']

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -206,8 +206,7 @@ def test_kit():
     run_subprocess(cmd, shell=shell)
     assert op.exists(op.join(output_path, 'participants.tsv'))
 
-    # Test reading of raw data
-    raw2, events, _ = read_raw_bids(bids_basename + '_meg.sqd',
+    raw2, events, _ = read_raw_bids(kit_bids_basename + '_meg.sqd',
                                     output_path)
 
     # ensure the channels file has no STI 014 channel:
@@ -221,7 +220,7 @@ def test_kit():
     # ensure the marker file is produced in the right place
     marker_fname = make_bids_basename(
         subject=subject_id, session=session_id, task=task, run=run,
-        acquisition=acq, suffix='markers.sqd',
+        suffix='markers.sqd',
         prefix=op.join(output_path, 'sub-01', 'ses-01', 'meg'))
     assert op.exists(marker_fname)
 

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -252,7 +252,7 @@ def test_kit():
     marker_fname = make_bids_basename(
         subject=subject_id2, session=session_id, task=task, run=run,
         suffix='markers.sqd', acquisition='pre',
-        prefix=os.path.join(output_path, 'sub-02', 'ses-01', meg'))
+        prefix=os.path.join(output_path, 'sub-02', 'ses-01', 'meg'))
     info = get_kit_info(marker_fname, False)[0]
     assert info['meas_date'] == get_kit_info(hpi_pre_fname,
                                              False)[0]['meas_date']

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -241,7 +241,7 @@ def test_kit():
                        overwrite=True)
     # test correct naming of marker files
     raw = mne.io.read_raw_kit(
-        raw_fname, mrk=[hpi_post_fname, hpi_pre_fname], elp=electrode_fname,
+        raw_fname, mrk=[hpi_pre_fname, hpi_post_fname], elp=electrode_fname,
         hsp=headshape_fname)
     write_raw_bids(raw,
                    kit_bids_basename.replace('sub-01', 'sub-%s' % subject_id2),
@@ -261,6 +261,17 @@ def test_kit():
     info = get_kit_info(marker_fname, False)[0]
     assert info['meas_date'] == get_kit_info(hpi_post_fname,
                                              False)[0]['meas_date']
+
+    # check that providing markers in the wrong order raises an error
+    raw = mne.io.read_raw_kit(
+        raw_fname, mrk=[hpi_post_fname, hpi_pre_fname], elp=electrode_fname,
+        hsp=headshape_fname)
+    with pytest.raises(ValueError, match='Markers'):
+        write_raw_bids(
+            raw,
+            kit_bids_basename.replace('sub-01', 'sub-%s' % subject_id2),
+            output_path, events_data=events_fname, event_id=event_id,
+            overwrite=True)
 
 
 def test_ctf():

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -12,12 +12,14 @@ import os.path as op
 import warnings
 import json
 import shutil as sh
+from datetime import datetime
 
 import numpy as np
 from mne import read_events, find_events, events_from_annotations
 from mne.utils import check_version
 from mne.channels import read_montage
 from mne.io.pick import pick_types
+from mne.io.kit.kit import get_kit_info
 
 from .tsv_handler import _to_tsv, _tsv_to_str
 
@@ -209,6 +211,19 @@ def _read_events(events_data, event_id, raw, ext):
                       ' or provide events_data.')
         events = None
     return events, event_id
+
+
+def _get_mrk_meas_date(mrk):
+    """Find the measurement date from a KIT marker file."""
+    info = get_kit_info(mrk, False)[0]
+    meas_date = info.get('meas_date', None)
+    if isinstance(meas_date, (tuple, list, np.ndarray)):
+        meas_date = meas_date[0]
+    if meas_date is not None:
+        meas_datetime = datetime.fromtimestamp(meas_date)
+    else:
+        meas_datetime = datetime.min
+    return meas_datetime
 
 
 def _infer_eeg_placement_scheme(raw):

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -948,7 +948,7 @@ def write_raw_bids(raw, bids_basename, output_path, events_data=None,
             marker_fname = make_bids_basename(
                 subject=subject_id, session=session_id, task=task, run=run,
                 acquisition=key, suffix='markers%s' % marker_ext,
-                prefix=os.path.join(data_path, bids_raw_folder))
+                prefix=data_path)
             sh.copyfile(value, marker_fname)
 
     return output_path

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -937,8 +937,8 @@ def write_raw_bids(raw, bids_basename, output_path, events_data=None,
         hpi = raw._init_kwargs['mrk']
         acq_map = dict()
         if isinstance(hpi, list):
-            # order hpi list by acquisition time
-            hpi.sort(key=_get_mrk_meas_date)
+            if _get_mrk_meas_date(hpi[0]) > _get_mrk_meas_date(hpi[1]):
+                raise ValueError('Markers provided in incorrect order.')
             _, marker_ext = _parse_ext(hpi[0])
             acq_map = dict(zip(['pre', 'post'], hpi))
         else:


### PR DESCRIPTION
PR Description
--------------

Implement marker naming as specified [here](https://github.com/bids-standard/bids-specification/pull/62).
I am getting this PR ready so when https://github.com/bids-standard/bids-specification/pull/62 is (hopefully) merged, this PR is good to go.
I thought there was an issue relating to this but I cannot find it sorry.

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [x] All comments resolved
- [x] This is not your own PR
- [x] All CIs are happy
- [ ] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
- [x] Commit history does not contain any merge commits
