### PR TITLE
[MRG] FIX: copytree on NFS file systems

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -27,7 +27,8 @@ Bug
 - Allow files with no stim channel, which could be the case for example in resting state data, by `Mainak Jas`_ (`#167 <https://github.com/mne-tools/mne-bids/pull/167/files>`_)
 - Better handling of unicode strings in TSV files, by `Mainak Jas`_ (`#172 <https://github.com/mne-tools/mne-bids/pull/172/files>`_)
 - Fix separator in scans.tsv to always be `/`, by `Matt Sanderson`_ (`#176 <https://github.com/mne-tools/mne-bids/pull/176>`_)
-- Add seeg to :func:`mne_bids.utils._handle_kind` when determining the kind of ieeg data, by `Ezequiel Mikulan`_
+- Add seeg to :func:`mne_bids.utils._handle_kind` when determining the kind of ieeg data, by `Ezequiel Mikulan`_ (`#180 <https://github.com/mne-tools/mne-bids/pull/180/files>`_)
+- Fix problem in copying CTF files on Network File System due to a bug upstream in Python by `Mainak Jas`_ (`#174 <https://github.com/mne-tools/mne-bids/pull/174/files>`_)
 
 API
 ~~~

--- a/mne_bids/fixes.py
+++ b/mne_bids/fixes.py
@@ -1,0 +1,17 @@
+"""Temporary fixes/workarounds for bugs in upstream code."""
+
+# Authors: Mainak Jas <mainakjas@gmail.com>
+
+import shutil
+import os.path as op
+
+
+def _copytree(src, dst, **kwargs):
+    """See: https://github.com/jupyterlab/jupyterlab/pull/5150."""
+    try:
+        shutil.copytree(src, dst, **kwargs)
+    except shutil.Error as error:
+        # `copytree` throws an error if copying to + from NFS even though
+        # the copy is successful (see https://bugs.python.org/issue24564)
+        if '[Errno 22]' not in str(error) or not op.exists(dst):
+            raise

--- a/mne_bids/mne_bids.py
+++ b/mne_bids/mne_bids.py
@@ -34,6 +34,7 @@ from .utils import (make_bids_basename, make_bids_folders,
                     copyfile_brainvision, copyfile_eeglab, copyfile_ctf,
                     _infer_eeg_placement_scheme, _parse_bids_filename,
                     _handle_kind)
+
 from .io import _parse_ext, ALLOWED_EXTENSIONS, reader
 from mne_bids.tsv_handler import _from_tsv, _combine, _drop, _contains_row
 

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -23,6 +23,7 @@ from mne.channels import read_montage
 from mne.io.pick import pick_types
 
 from .config import BIDS_VERSION
+from .fixes import _copytree
 from .io import _parse_ext
 from .tsv_handler import _to_tsv, _tsv_to_str
 
@@ -528,7 +529,7 @@ def copyfile_ctf(src, dest):
     dest : str
         path to the destination of the new bids folder.
     """
-    sh.copytree(src, dest)
+    _copytree(src, dest)
     # list of file types to rename
     file_types = ('.acq', '.eeg', '.hc', '.hist', '.infods', '.bak',
                   '.meg4', '.newds', '.res4')


### PR DESCRIPTION
PR Description
--------------

This PR partially fixes #169 as `sh.copytree` does not work on NFS systems. It's related to a bug [upstream in Python](https://bugs.python.org/issue24564). Not sure if we need to test this (or how to). @agramfort what's your opinion?

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
- [ ] Commit history does not contain any merge commits
