### PR TITLE
[MRG] Fix separator in scans.tsv

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -25,6 +25,7 @@ Bug
 - Fix logic with inferring unknown channel types for CTF data, by `Mainak Jas`_ (`#129 <https://github.com/mne-tools/mne-bids/pull/16>`_)
 - Fix the file naming for FIF files to only expose the part key-value pair when files are split, by `Teon Brooks`_ (`#137 <https://github.com/mne-tools/mne-bids/pull/137>`_)
 - Allow files with no stim channel, which could be the case for example in resting state data, by `Mainak Jas`_ (`#167 <https://github.com/mne-tools/mne-bids/pull/167/files>`_)
+- Fix separator in scans.tsv to always be `/`, by `Matt Sanderson`_ (`#176 <https://github.com/mne-tools/mne-bids/pull/176>`_)
 
 API
 ~~~

--- a/mne_bids/mne_bids.py
+++ b/mne_bids/mne_bids.py
@@ -341,6 +341,9 @@ def _scans_tsv(raw, raw_fname, fname, overwrite=False, verbose=True):
     else:
         acq_time = 'n/a'
 
+    # fix the separator to always be `/`
+    raw_fname = raw_fname.replace(os.sep, '/')
+
     data = OrderedDict([('filename', ['%s' % raw_fname]),
                         ('acq_time', [acq_time])])
 
@@ -697,8 +700,7 @@ def write_raw_bids(raw, bids_basename, output_path, events_data=None,
     _participants_tsv(raw, subject_id, participants_tsv_fname, overwrite,
                       verbose)
     _participants_json(participants_json_fname, True, verbose)
-    _scans_tsv(raw, '/'.join([kind, bids_fname.replace(os.sep, '/')]),
-               scans_fname, overwrite, verbose)
+    _scans_tsv(raw, op.join(kind, bids_fname), scans_fname, overwrite, verbose)
 
     # TODO: Implement coordystem.json and electrodes.tsv for EEG and  iEEG
     if kind == 'meg' and not emptyroom:

--- a/mne_bids/mne_bids.py
+++ b/mne_bids/mne_bids.py
@@ -716,6 +716,7 @@ def write_raw_bids(raw, bids_basename, output_path, events_data=None,
 
     # set the raw file name to now be the absolute path to ensure the files
     # are placed in the right location
+    bids_fname = bids_fname.replace('/', op.sep)
     bids_fname = os.path.join(data_path, bids_fname)
     if os.path.exists(bids_fname) and not overwrite:
         raise FileExistsError('"%s" already exists. Please set '

--- a/mne_bids/mne_bids.py
+++ b/mne_bids/mne_bids.py
@@ -686,7 +686,7 @@ def write_raw_bids(raw, bids_basename, output_path, events_data=None,
         acquisition=acquisition, suffix='channels.tsv', prefix=data_path)
     if ext not in ['.fif', '.ds', '.vhdr', '.edf', '.bdf', '.set']:
         bids_raw_folder = bids_fname.split('.')[0]
-        bids_fname = op.join(bids_raw_folder, bids_fname)
+        bids_fname = '/'.join([bids_raw_folder, bids_fname])
 
     # Read in Raw object and extract metadata from Raw object if needed
     orient = ORIENTATION.get(ext, 'n/a')
@@ -697,7 +697,7 @@ def write_raw_bids(raw, bids_basename, output_path, events_data=None,
     _participants_tsv(raw, subject_id, participants_tsv_fname, overwrite,
                       verbose)
     _participants_json(participants_json_fname, True, verbose)
-    _scans_tsv(raw, os.path.join(kind, bids_fname), scans_fname,
+    _scans_tsv(raw, '/'.join([kind, bids_fname]), scans_fname,
                overwrite, verbose)
 
     # TODO: Implement coordystem.json and electrodes.tsv for EEG and  iEEG

--- a/mne_bids/mne_bids.py
+++ b/mne_bids/mne_bids.py
@@ -341,11 +341,8 @@ def _scans_tsv(raw, raw_fname, fname, overwrite=False, verbose=True):
     else:
         acq_time = 'n/a'
 
-    # fix the separator to always be `/`
-    raw_fname = raw_fname.replace(os.sep, '/')
-
-    data = OrderedDict([('filename', ['%s' % raw_fname]),
-                        ('acq_time', [acq_time])])
+    data = OrderedDict([('filename', ['%s' % raw_fname.replace(os.sep, '/')]),
+                       ('acq_time', [acq_time])])
 
     if os.path.exists(fname):
         orig_data = _from_tsv(fname)

--- a/mne_bids/mne_bids.py
+++ b/mne_bids/mne_bids.py
@@ -686,7 +686,7 @@ def write_raw_bids(raw, bids_basename, output_path, events_data=None,
         acquisition=acquisition, suffix='channels.tsv', prefix=data_path)
     if ext not in ['.fif', '.ds', '.vhdr', '.edf', '.bdf', '.set']:
         bids_raw_folder = bids_fname.split('.')[0]
-        bids_fname = '/'.join([bids_raw_folder, bids_fname])
+        bids_fname = op.join(bids_raw_folder, bids_fname)
 
     # Read in Raw object and extract metadata from Raw object if needed
     orient = ORIENTATION.get(ext, 'n/a')
@@ -697,8 +697,8 @@ def write_raw_bids(raw, bids_basename, output_path, events_data=None,
     _participants_tsv(raw, subject_id, participants_tsv_fname, overwrite,
                       verbose)
     _participants_json(participants_json_fname, True, verbose)
-    _scans_tsv(raw, '/'.join([kind, bids_fname]), scans_fname,
-               overwrite, verbose)
+    _scans_tsv(raw, '/'.join([kind, bids_fname.replace(os.sep, '/')]),
+               scans_fname, overwrite, verbose)
 
     # TODO: Implement coordystem.json and electrodes.tsv for EEG and  iEEG
     if kind == 'meg' and not emptyroom:
@@ -716,7 +716,6 @@ def write_raw_bids(raw, bids_basename, output_path, events_data=None,
 
     # set the raw file name to now be the absolute path to ensure the files
     # are placed in the right location
-    bids_fname = bids_fname.replace('/', op.sep)
     bids_fname = os.path.join(data_path, bids_fname)
     if os.path.exists(bids_fname) and not overwrite:
         raise FileExistsError('"%s" already exists. Please set '

--- a/mne_bids/tests/test_mne_bids.py
+++ b/mne_bids/tests/test_mne_bids.py
@@ -183,7 +183,7 @@ def test_kit():
     channels_tsv = make_bids_basename(
         subject=subject_id, session=session_id, task=task, run=run,
         suffix='channels.tsv', acquisition=acq,
-        prefix=op.join(output_path, 'sub-01/ses-01/meg'))
+        prefix=op.join(output_path, 'sub-01', 'ses-01', 'meg'))
     data = _from_tsv(channels_tsv)
     assert 'STI 014' not in data['name']
 
@@ -194,7 +194,7 @@ def test_kit():
     marker_fname = make_bids_basename(
         subject=subject_id, session=session_id, task=task, run=run,
         acquisition=acq, suffix='markers.sqd',
-        prefix=os.path.join(output_path, 'sub-01/ses-01/meg', raw_folder))
+        prefix=op.join(output_path, 'sub-01', 'ses-01', 'meg', raw_folder))
     assert op.exists(marker_fname)
 
 
@@ -314,14 +314,14 @@ def test_edf():
     channels_tsv = make_bids_basename(
         subject=subject_id, session=session_id, task=task, run=run,
         suffix='channels.tsv', acquisition=acq,
-        prefix=op.join(output_path, 'sub-01/ses-01/eeg'))
+        prefix=op.join(output_path, 'sub-01', 'ses-01', 'eeg'))
     data = _from_tsv(channels_tsv)
     assert 'ElectroMyoGram' in data['description']
 
     # check that the scans list contains two scans
     scans_tsv = make_bids_basename(
         subject=subject_id, session=session_id, suffix='scans.tsv',
-        prefix=op.join(output_path, 'sub-01/ses-01'))
+        prefix=op.join(output_path, 'sub-01', 'ses-01'))
     data = _from_tsv(scans_tsv)
     assert len(list(data.values())[0]) == 2
 


### PR DESCRIPTION
PR Description
--------------
closes #175 
separator for raw file name in scans.tsv is fixed to `/`
Also made the paths as OS-independent as possible in the tests.

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [x] All comments resolved
- [x] This is not your own PR
- [x] All CIs are happy
- [x] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [x] PR description includes phrase "closes <#issue-number>"
- [x] Commit history does not contain any merge commits
