### PR TITLE
[MRG] fix participants.json wording

### DIFF
--- a/mne_bids/mne_bids.py
+++ b/mne_bids/mne_bids.py
@@ -302,7 +302,7 @@ def _participants_json(fname, overwrite=False, verbose=True):
     """
     cols = OrderedDict()
     cols['participant_id'] = {'Description': 'Unique participant identifier'}
-    cols['age'] = {'Description': 'Unique participant identifier',
+    cols['age'] = {'Description': 'Age of the participant at time of testing',
                    'Units': 'years'}
     cols['sex'] = {'Description': 'Biological sex of the participant',
                    'Levels': {'F': 'female', 'M': 'male'}}


### PR DESCRIPTION
PR Description
--------------

Description for Age was wrong in participants.json

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
- [ ] Commit history does not contain any merge commits
