### PR TITLE
add support for "processed" files in raw_to_bids

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -31,6 +31,7 @@ Bug
 API
 ~~~
 
+- Add processing tag to raw_to_bids files to allow Maxwell filtered data, by `Maximilien Chaumon`_ (`https://github.com/mne-tools/mne-bids/pull/178`_)
 - Add support for non maxfiltered .fif files, by `Maximilien Chaumon`_ (`#171 <https://github.com/mne-tools/mne-bids/pull/171>`_)
 - Remove support for Neuroscan ``.cnt`` data because its support is no longer planned in BIDS, by `Stefan Appelhoff`_ (`#142 <https://github.com/mne-tools/mne-bids/pull/142>`_)
 - Remove support for Python 2 because it is no longer supported in MNE-Python, by `Teon Brooks`_ (`#141 <https://github.com/mne-tools/mne-bids/pull/141>`_)

--- a/mne_bids/commands/mne_bids_raw_to_bids.py
+++ b/mne_bids/commands/mne_bids_raw_to_bids.py
@@ -35,7 +35,7 @@ def run():
                       help='The run number for this dataset.',
                       metavar='run')
     parser.add_option('--proc', dest='proc',
-                      help='Processing tag (e.g. tsss).',
+                      help='Processing tag.',
                       metavar='proc')
     parser.add_option('--acq', dest='acq',
                       help='The acquisition parameter.',

--- a/mne_bids/commands/mne_bids_raw_to_bids.py
+++ b/mne_bids/commands/mne_bids_raw_to_bids.py
@@ -34,6 +34,9 @@ def run():
     parser.add_option('--run', dest='run',
                       help='The run number for this dataset.',
                       metavar='run')
+    parser.add_option('--proc', dest='proc',
+                      help='Processing tag (e.g. tsss).',
+                      metavar='proc')
     parser.add_option('--acq', dest='acq',
                       help='The acquisition parameter.',
                       metavar='acq')
@@ -62,7 +65,7 @@ def run():
 
     bids_basename = make_bids_basename(
         subject=opt.subject_id, session=opt.session_id, run=opt.run,
-        acquisition=opt.acq, task=opt.task)
+        processing=opt.proc, acquisition=opt.acq, task=opt.task)
     raw = _read_raw(opt.raw_fname, hpi=opt.hpi, electrode=opt.electrode,
                     hsp=opt.hsp, config=opt.config,
                     allow_maxshield=opt.allow_maxshield)


### PR DESCRIPTION
PR Description
--------------

Adding a _proc_ tag to some files is supported by write_raw_bids. raw_to_bids needed an additional option so support it.

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
- [ ] Commit history does not contain any merge commits
