### PR TITLE
[MRG] Add seeg when checking ieeg kind

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -27,6 +27,7 @@ Bug
 - Allow files with no stim channel, which could be the case for example in resting state data, by `Mainak Jas`_ (`#167 <https://github.com/mne-tools/mne-bids/pull/167/files>`_)
 - Better handling of unicode strings in TSV files, by `Mainak Jas`_ (`#172 <https://github.com/mne-tools/mne-bids/pull/172/files>`_)
 - Fix separator in scans.tsv to always be `/`, by `Matt Sanderson`_ (`#176 <https://github.com/mne-tools/mne-bids/pull/176>`_)
+- Add seeg to :func:`mne_bids.utils._handle_kind` when determining the kind of ieeg data, by `Ezequiel Mikulan`_
 
 API
 ~~~
@@ -90,3 +91,4 @@ People who contributed to this release  (in alphabetical order):
 .. _Romain Quentin: https://github.com/romquentin
 .. _Dominik Welke: https://github.com/dominikwelke
 .. _Maximilien Chaumon: https://github.com/dnacombo
+.. _Ezequiel Mikulan: https://github.com/ezemikulan

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -81,13 +81,13 @@ def _parse_bids_filename(fname, verbose):
 
 def _handle_kind(raw):
     """Get kind."""
-    if 'eeg' in raw and 'ecog' in raw:
+    if 'eeg' in raw and ('ecog' in raw or 'seeg' in raw):
         raise ValueError('Both EEG and iEEG channels found in data.'
                          'There is currently no specification on how'
                          'to handle this data. Please proceed manually.')
     elif 'meg' in raw:
         kind = 'meg'
-    elif 'ecog' in raw:
+    elif 'ecog' in raw  or 'seeg' in raw:
         kind = 'ieeg'
     elif 'eeg' in raw:
         kind = 'eeg'

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -87,7 +87,7 @@ def _handle_kind(raw):
                          'to handle this data. Please proceed manually.')
     elif 'meg' in raw:
         kind = 'meg'
-    elif 'ecog' in raw  or 'seeg' in raw:
+    elif 'ecog' in raw or 'seeg' in raw:
         kind = 'ieeg'
     elif 'eeg' in raw:
         kind = 'eeg'


### PR DESCRIPTION
PR Description
--------------
The __handle_kind_ function of utils.py was not considering _seeg_ when determining the _ieeg_ kind (considered only _ecog_). The PR adds _seeg_ to the check for _ieeg_ kind. 
closes #179 

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [x] All comments resolved
- [x] This is not your own PR
- [x] All CIs are happy
- [x] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [x] PR description includes phrase "closes <#issue-number>"
- [x] Commit history does not contain any merge commits
