### PR TITLE
[MRG] fix names of value and sample columns in events file

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -33,6 +33,7 @@ Bug
 - Fix problem in copying CTF files on Network File System due to a bug upstream in Python by `Mainak Jas`_ (`#174 <https://github.com/mne-tools/mne-bids/pull/174/files>`_)
 - Fix problem in copying BTi files. Now, a utility function ensures that all the related files
   such as config and headshape are copied correctly, by `Mainak Jas`_ (`#135 <https://github.com/mne-tools/mne-bids/pull/135>`_>)
+- Fix name of "sample" and "value" columns on events.tsv files, by `Ezequiel Mikulan`
 
 API
 ~~~

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -32,8 +32,8 @@ Bug
 - Add seeg to :func:`mne_bids.utils._handle_kind` when determining the kind of ieeg data, by `Ezequiel Mikulan`_ (`#180 <https://github.com/mne-tools/mne-bids/pull/180/files>`_)
 - Fix problem in copying CTF files on Network File System due to a bug upstream in Python by `Mainak Jas`_ (`#174 <https://github.com/mne-tools/mne-bids/pull/174/files>`_)
 - Fix problem in copying BTi files. Now, a utility function ensures that all the related files
-  such as config and headshape are copied correctly, by `Mainak Jas`_ (`#135 <https://github.com/mne-tools/mne-bids/pull/135>`_>)
-- Fix name of "sample" and "value" columns on events.tsv files, by `Ezequiel Mikulan`
+  such as config and headshape are copied correctly, by `Mainak Jas`_ (`#135 <https://github.com/mne-tools/mne-bids/pull/135>`_)
+- Fix name of "sample" and "value" columns on events.tsv files, by `Ezequiel Mikulan`_ (`#185 <https://github.com/mne-tools/mne-bids/pull/185>`_)
 
 API
 ~~~

--- a/mne_bids/mne_bids.py
+++ b/mne_bids/mne_bids.py
@@ -157,7 +157,7 @@ def _events_tsv(events, raw, fname, trial_type, overwrite=False,
     """Create an events.tsv file and save it.
 
     This function will write the mandatory 'onset', and 'duration' columns as
-    well as the optional 'event_value' and 'event_sample'. The 'event_value'
+    well as the optional 'value' and 'sample'. The 'value'
     corresponds to the marker value as found in the TRIG channel of the
     recording. In addition, the 'trial_type' field can be written.
 
@@ -195,8 +195,8 @@ def _events_tsv(events, raw, fname, trial_type, overwrite=False,
     data = OrderedDict([('onset', events[:, 0] / sfreq),
                         ('duration', np.zeros(events.shape[0])),
                         ('trial_type', None),
-                        ('event_value', events[:, 2]),
-                        ('event_sample', events[:, 0])])
+                        ('value', events[:, 2]),
+                        ('sample', events[:, 0])])
 
     # Now check if trial_type is specified or should be removed
     if trial_type:


### PR DESCRIPTION
PR Description
--------------
closes #184 

This PR fixes the names of the "sample" and "value" columns of the *events.tsv files in order to match the [specification](https://bids-specification.readthedocs.io/en/stable/04-modality-specific-files/05-task-events.html) as they were previously called "event_sample" and "event_value".

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [x] All comments resolved
- [x] This is not your own PR
- [x] All CIs are happy
- [x] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [x] PR description includes phrase "closes <#issue-number>"
- [x] Commit history does not contain any merge commits
