### PR TITLE
fix dirtree branch len

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -20,6 +20,7 @@ Changelog
 Bug
 ~~~
 
+- Normalize the length of the branches in :func:`print_dir_tree` by the length of the root path, leading to more adequate visual display, by `Stefan Appelhoff`_ (`#192 <https://github.com/mne-tools/mne-bids/pull/192>`_)
 - Assert a minimum required MNE-version, by `Dominik Welke`_ (`#166 <https://github.com/mne-tools/mne-bids/pull/166>`_)
 - Add function in mne_bids.utils to copy and rename CTF files :func:`mne_bids.utils.copyfile_ctf`, by `Romain Quentin`_ (`#162 <https://github.com/mne-tools/mne-bids/pull/162>`_)
 - Encoding of BrainVision .vhdr/.vmrk files is checked to prevent encoding/decoding errors when modifying, by `Dominik Welke`_ (`#155 <https://github.com/mne-tools/mne-bids/pull/155>`_)

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -33,11 +33,15 @@ def print_dir_tree(folder):
     if not op.exists(folder):
         raise ValueError('Directory does not exist: {}'.format(folder))
 
+    baselen = len(folder.split(os.sep)) - 1  # makes tree always start at 0 len
     for root, dirs, files in os.walk(folder):
-        path = root.split(os.sep)
-        print('|%s %s' % ((len(path) - 1) * '---', op.basename(root)))
+        branchlen = len(root.split(os.sep)) - baselen
+        if branchlen <= 1:
+            print('|%s' % (op.basename(root)))
+        else:
+            print('|%s %s' % ((branchlen - 1) * '---', op.basename(root)))  # noqa: E501
         for file in files:
-            print('|%s %s' % (len(path) * '---', file))
+            print('|%s %s' % (branchlen * '---', file))
 
 
 def _mkdir_p(path, overwrite=False, verbose=False):


### PR DESCRIPTION
Our dirtree utility function was printing branches that were too long.

Directories with a very long path would end up having proportionally long branches even for the root.

See the image (the branch is unusually long before even the root of the folder starts):

![image](https://user-images.githubusercontent.com/9084751/56598795-84263480-65f5-11e9-944f-f2ce04952ddb.png)


In this PR I "normalize" the branch length with the length of the root path: This leads to more easily readable (and more sensible) directory trees printed out.