### PR TITLE
enable binder links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ pypi. Update your installation as follows.
 
 Then, install the following python packages:
 
-    $ pip install flake8 pytest pytest-cov coverage
+    $ pip install flake8 pytest pytest-cov
 
 Finally, it is necessary to install the
 [BIDS validator](https://github.com/bids-standard/bids-validator). The outputs

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -197,7 +197,7 @@ sphinx_gallery_conf = {
         # Required keys
         'org': 'mne-tools',
         'repo': 'mne-bids',
-        'ref': 'gh-pages',  # noqa: E501 Can be any branch, tag, or commit hash. Use a branch that hosts your docs.
+        'branch': 'gh-pages',  # noqa: E501 Can be any branch, tag, or commit hash. Use a branch that hosts your docs.
         'binderhub_url': 'https://mybinder.org',  # noqa: E501 Any URL of a binderhub deployment. Must be full URL (e.g. https://mybinder.org).
         'dependencies': [
             '../environment.yml'

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -192,5 +192,15 @@ sphinx_gallery_conf = {
         'mne': 'http://mne-tools.github.io/stable/',
         'numpy': 'http://docs.scipy.org/doc/numpy-1.9.1',
         'scipy': 'http://docs.scipy.org/doc/scipy-0.17.0/reference'
+    },
+    'binder': {
+        # Required keys
+        'org': 'mne-tools',
+        'repo': 'mne-bids',
+        'ref': 'gh-pages',  # noqa: E501 Can be any branch, tag, or commit hash. Use a branch that hosts your docs.
+        'binderhub_url': 'https://mybinder.org',  # noqa: E501 Any URL of a binderhub deployment. Must be full URL (e.g. https://mybinder.org).
+        'dependencies': [
+            '../environment.yml'
+        ],
     }
 }

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -18,7 +18,7 @@ Changelog
 Bug
 ~~~
 
-- Allow raw data from KIT systems to have two marker files specified, by `Matt Sanderson`_ (`#167 <https://github.com/mne-tools/mne-bids/pull/173>`_)
+- Allow raw data from KIT systems to have two marker files specified, by `Matt Sanderson`_ (`#173 <https://github.com/mne-tools/mne-bids/pull/173>`_)
 
 API
 ~~~

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,24 @@
+name: mne_bids
+channels:
+- defaults
+- conda-forge
+dependencies:
+- python<3.7
+- pip==19
+- mkl
+- numpy
+- scipy
+- matplotlib
+- pip:
+  - mne
+  - mne-bids
+  - flake8
+  - pytest
+  - pytest-cov
+  - pytest-sugar
+  - pytest-faulthandler
+  - sphinx
+  - pillow
+  - numpydoc
+  - sphinx_bootstrap_theme
+  - sphinx_gallery

--- a/examples/convert_group_studies.py
+++ b/examples/convert_group_studies.py
@@ -32,6 +32,7 @@ from mne_bids.utils import print_dir_tree
 
 ###############################################################################
 # And fetch the data.
+# .. warning:: This will download 7.9 GB of data for one subject!
 
 subject_ids = [1]
 runs = range(1, 7)
@@ -43,8 +44,6 @@ fetch_faces_data(data_path, repo, subject_ids)
 output_path = op.join(data_path, 'ds000117-bids')
 
 ###############################################################################
-#
-# .. warning:: This will download 7.9 GB of data for one subject!
 # Define event_ids.
 
 event_id = {

--- a/examples/convert_group_studies.py
+++ b/examples/convert_group_studies.py
@@ -77,4 +77,5 @@ for subject_id in subject_ids:
 
 ###############################################################################
 # Now let's see the structure of the BIDS folder we created.
+
 print_dir_tree(output_path)


### PR DESCRIPTION
closes #183 and closes #152 

This seems to have worked, there are Binder links (Scroll to bottom): https://773-89170358-gh.circle-artifacts.com/0/html/auto_examples/rename_brainvision_files.html#sphx-glr-auto-examples-rename-brainvision-files-py

... however, launching the binder does not work yet, because it's pointing to our `gh-pages` branch, which does not yet have the `/notebooks` directory in the build.

A solution could be to release `0.2.1` and push to gh-pages ... or merge this PR and accept that `launch binder` links will only start to work after the next release

note: This is how the 7.9GB example would look like (not interactive yet, see above): https://nbviewer.jupyter.org/urls/773-89170358-gh.circle-artifacts.com/0/html/notebooks/auto_examples/convert_group_studies.ipynb

I'll make a commit fixing this as well: The warning about downloading 8GB should come **before** the downloading :-)