### PR TITLE
Reader: Auto handle raw.info['bads'] and use mne.Annotations instead of returning events

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,11 @@ node_js:
   - "10.15.2"
 language: python
 
+# Specify version of BIDS-validator to be used, 'master', or 'stable'
 env:
+  - VALIDATOR_VERSION='master'
   - PYTHON_VERSION=3.6
+
 
 before_install:
   - wget -q https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
@@ -12,6 +15,7 @@ before_install:
   - export PATH=/home/travis/miniconda/bin:$PATH
   - conda update --yes --quiet conda
   - npm i -g npm
+  - yarn self-update
 
 install:
     - conda create -n testenv --yes python=${PYTHON_VERSION}
@@ -24,11 +28,23 @@ install:
       pip install --no-deps -e .
       cd ../
     - python setup.py develop
-    - npm install -g bids-validator
+    - if [ $VALIDATOR_VERSION=='master'];then
+          git clone --depth 1 https://github.com/bids-standard/bids-validator
+          cd bids_validator
+          yarn
+          cd ..
+          PATH=$PATH:~/bids-validator/bids-validator/bin
+      elif [ $VALIDATOR_VERSION == 'stable'];then
+          npm install -g bids-validator
+      else
+          echo "VALIDATOR_VERSION should be set to master or stable"
+      fi
 
 # Cache the python dependencies
 # https://blog.travis-ci.com/2016-05-03-caches-are-coming-to-everyone
-cache: pip
+cache:
+    - pip
+    - yarn
 
 script:
     - pytest . --cov=./mne_bids --cov-report=xml --verbose --ignore mne-python

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,10 @@ language: python
 
 # Specify version of BIDS-validator to be used, 'master', or 'stable'
 env:
-  - VALIDATOR_VERSION='master'
-  - PYTHON_VERSION=3.6
+  global:
+    - VALIDATOR_VERSION='master'
+  matrix:
+    - PYTHON_VERSION=3.6
 
 
 before_install:
@@ -15,7 +17,7 @@ before_install:
   - export PATH=/home/travis/miniconda/bin:$PATH
   - conda update --yes --quiet conda
   - npm i -g npm
-  - yarn self-update
+  - yarn --version
 
 install:
     - conda create -n testenv --yes python=${PYTHON_VERSION}
@@ -28,17 +30,19 @@ install:
       pip install --no-deps -e .
       cd ../
     - python setup.py develop
-    - if [ $VALIDATOR_VERSION=='master'];then
+    - |
+      if [ $VALIDATOR_VERSION=='master' ];then
           git clone --depth 1 https://github.com/bids-standard/bids-validator
           cd bids_validator
           yarn
           cd ..
           PATH=$PATH:~/bids-validator/bids-validator/bin
-      elif [ $VALIDATOR_VERSION == 'stable'];then
+      elif [ $VALIDATOR_VERSION == 'stable' ];then
           npm install -g bids-validator
       else
           echo "VALIDATOR_VERSION should be set to master or stable"
       fi
+    - which bids-validator
 
 # Cache the python dependencies
 # https://blog.travis-ci.com/2016-05-03-caches-are-coming-to-everyone

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: python
 # Specify version of BIDS-validator to be used, 'master', or 'stable'
 env:
   global:
-    - VALIDATOR_VERSION='master'
+    - VALIDATOR_VERSION="master"
   matrix:
     - PYTHON_VERSION=3.6
 
@@ -25,7 +25,7 @@ before_install:
 install:
     - echo $PATH
     - |
-      if [ $VALIDATOR_VERSION=='master' ];then
+      if [ $VALIDATOR_VERSION == 'master' ];then
           pushd ~
           git clone --depth 1 https://github.com/bids-standard/bids-validator
           cd bids-validator
@@ -36,6 +36,7 @@ install:
           npm install -g bids-validator
       else
           echo "VALIDATOR_VERSION should be set to master or stable"
+          echo "but VALIDATOR_VERSION=$VALIDATOR_VERSION"
       fi
     - echo $PATH
     - bids-validator --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 node_js:
-  - "10.15.2"
+  - "10.0.0"
 language: python
 
 # Specify version of BIDS-validator to be used, 'master', or 'stable'
@@ -16,10 +16,30 @@ before_install:
   - ./miniconda.sh -b -p /home/travis/miniconda
   - export PATH=/home/travis/miniconda/bin:$PATH
   - conda update --yes --quiet conda
-  - npm i -g npm
+  - npm install -g npm stable
+  - npm install -g node@10.0.0
+  - npm --version
+  - node --version
   - yarn --version
 
 install:
+    - echo $PATH
+    - |
+      if [ $VALIDATOR_VERSION=='master' ];then
+          pushd ~
+          git clone --depth 1 https://github.com/bids-standard/bids-validator
+          cd bids-validator
+          yarn
+          export PATH=~/bids-validator/bids-validator/bin:$PATH
+          popd
+      elif [ $VALIDATOR_VERSION == 'stable' ];then
+          npm install -g bids-validator
+      else
+          echo "VALIDATOR_VERSION should be set to master or stable"
+      fi
+    - echo $PATH
+    - bids-validator --version
+    - which bids-validator
     - conda create -n testenv --yes python=${PYTHON_VERSION}
     - source activate testenv
     - conda install --yes --quiet numpy scipy matplotlib
@@ -30,19 +50,6 @@ install:
       pip install --no-deps -e .
       cd ../
     - python setup.py develop
-    - |
-      if [ $VALIDATOR_VERSION=='master' ];then
-          git clone --depth 1 https://github.com/bids-standard/bids-validator
-          cd bids_validator
-          yarn
-          cd ..
-          PATH=$PATH:~/bids-validator/bids-validator/bin
-      elif [ $VALIDATOR_VERSION == 'stable' ];then
-          npm install -g bids-validator
-      else
-          echo "VALIDATOR_VERSION should be set to master or stable"
-      fi
-    - which bids-validator
 
 # Cache the python dependencies
 # https://blog.travis-ci.com/2016-05-03-caches-are-coming-to-everyone

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,6 +24,7 @@ install:
       set PATH="%PATH%;C:\projects\mne-bids\bids-validator\bids-validator\bin\" )
   - cmd: if [%VALIDATOR_VERSION%]==[stable] (
       npm install -g bids-validator )
+  - dir C:\projects\mne-bids\bids-validator\bids-validator\bin\
   - path
   - bids-validator --version
   - which bids-validator

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,9 +18,9 @@ install:
       git clone --depth 1 https://github.com/bids-standard/bids-validator &&
       cd bids-validator &&
       yarn &&
-      cd ..
-      set PATH="%PATH%;C:\projects\mne-bids\bids-validator\bids-validator\bin\" )
-      set VALIDATOR_EXECUTABLE ="C:\projects\mne-bids\bids-validator\bids-validator\bin\bids-validator"
+      cd .. &&
+      set PATH="%PATH%;C:\projects\mne-bids\bids-validator\bids-validator\bin\" &&
+      set VALIDATOR_EXECUTABLE ="C:\projects\mne-bids\bids-validator\bids-validator\bin\bids-validator" )
   - cmd: if [%VALIDATOR_VERSION%]==[stable] (
       npm install -g bids-validator )
   - bids-validator --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,12 @@
 environment:
+# Specify version of BIDS-validator to be used, 'master', or 'stable'
   global:
-      nodejs_version: "10.0.0"
-      PYTHON: "C:\\conda"
+        VALIDATOR_VERSION: 'master'
+        nodejs_version: "10.0.0"
+        PYTHON: "C:\\conda"
   matrix:
-      - PYTHON_VERSION: "3.6"
+      - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+        PYTHON_VERSION: "3.6"
         PYTHON_ARCH: "64"
 
 install:
@@ -23,10 +26,18 @@ install:
     cd mne-bids
   - "python setup.py develop"
   - ps: Install-Product node $env:nodejs_version
-  - npm install -g bids-validator
+  - cmd: if [%VALIDATOR_VERSION%]==[master] (
+      git clone --depth 1 https://github.com/bids-standard/bids-validator &&
+      cd bids_validator &&
+      yarn &&
+      cd .. &&
+      PATH=$PATH:~/bids-validator/bids-validator/bin )
+  - cmd: if [%VALIDATOR_VERSION%]==[stable] (
+      npm install -g bids-validator )
   - node --version
   - npm --version
   - bids-validator --version
+  - path
   - which bids-validator
   - "python -c \"import mne; mne.datasets.testing.data_path()\""
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,9 @@
 environment:
 # Specify version of BIDS-validator to be used, 'master', or 'stable'
+# NOTE: only 'stable' possible, because BIDS-validator does not support Windows
+# as of 2019-06-25, see: https://github.com/bids-standard/bids-validator/issues/790
   global:
-        VALIDATOR_VERSION: "master"
+        VALIDATOR_VERSION: "stable"
         nodejs_version: "10.0.0"
         PYTHON: "C:\\conda"
   matrix:
@@ -14,18 +16,14 @@ install:
   - node --version
   - npm --version
   - yarn --version
-  - path
   - cmd: if [%VALIDATOR_VERSION%]==[master] (
       git clone --depth 1 https://github.com/bids-standard/bids-validator &&
       cd bids-validator &&
       yarn &&
-      cd .. )
-  - cmd: if [%VALIDATOR_VERSION%]==[master] (
+      cd ..
       set PATH="%PATH%;C:\projects\mne-bids\bids-validator\bids-validator\bin\" )
   - cmd: if [%VALIDATOR_VERSION%]==[stable] (
       npm install -g bids-validator )
-  - dir C:\projects\mne-bids\bids-validator\bids-validator\bin\
-  - path
   - bids-validator --version
   - which bids-validator
   - "git clone --depth 1 git://github.com/astropy/ci-helpers.git"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,23 @@ environment:
         PYTHON_ARCH: "64"
 
 install:
+  - ps: Install-Product node $env:nodejs_version
+  - node --version
+  - npm --version
+  - yarn --version
+  - path
+  - cmd: if [%VALIDATOR_VERSION%]==[master] (
+      git clone --depth 1 https://github.com/bids-standard/bids-validator &&
+      cd bids-validator &&
+      yarn &&
+      cd .. )
+  - cmd: if [%VALIDATOR_VERSION%]==[master] (
+      set PATH="%PATH%;C:\projects\mne-bids\bids-validator\bids-validator\bin\" )
+  - cmd: if [%VALIDATOR_VERSION%]==[stable] (
+      npm install -g bids-validator )
+  - path
+  - bids-validator --version
+  - which bids-validator
   - "git clone --depth 1 git://github.com/astropy/ci-helpers.git"
   - "powershell ci-helpers/appveyor/install-miniconda.ps1"
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
@@ -25,20 +42,6 @@ install:
     cd ..
     cd mne-bids
   - "python setup.py develop"
-  - ps: Install-Product node $env:nodejs_version
-  - cmd: if [%VALIDATOR_VERSION%]==[master] (
-      git clone --depth 1 https://github.com/bids-standard/bids-validator &&
-      cd bids_validator &&
-      yarn &&
-      cd .. &&
-      PATH=$PATH:~/bids-validator/bids-validator/bin )
-  - cmd: if [%VALIDATOR_VERSION%]==[stable] (
-      npm install -g bids-validator )
-  - node --version
-  - npm --version
-  - bids-validator --version
-  - path
-  - which bids-validator
   - "python -c \"import mne; mne.datasets.testing.data_path()\""
 
 # cache pip unless appveyor.yml is changed

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
 # Specify version of BIDS-validator to be used, 'master', or 'stable'
   global:
-        VALIDATOR_VERSION: 'master'
+        VALIDATOR_VERSION: "master"
         nodejs_version: "10.0.0"
         PYTHON: "C:\\conda"
   matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,11 +20,13 @@ install:
       yarn &&
       cd .. &&
       set PATH="%PATH%;C:\projects\mne-bids\bids-validator\bids-validator\bin\" &&
-      set VALIDATOR_EXECUTABLE ="C:\projects\mne-bids\bids-validator\bids-validator\bin\bids-validator" )
+      set VALIDATOR_EXECUTABLE ="C:\projects\mne-bids\bids-validator\bids-validator\bin\bids-validator"
+      echo "Using development version of bids-validator!")
   - cmd: if [%VALIDATOR_VERSION%]==[stable] (
-      npm install -g bids-validator )
-  - bids-validator --version
-  - which bids-validator
+      npm install -g bids-validator
+      bids-validator --version
+      which bids-validator
+      )
   - "git clone --depth 1 git://github.com/astropy/ci-helpers.git"
   - "powershell ci-helpers/appveyor/install-miniconda.ps1"
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,7 @@
 environment:
 # Specify version of BIDS-validator to be used, 'master', or 'stable'
-# NOTE: only 'stable' possible, because BIDS-validator does not support Windows
-# as of 2019-06-25, see: https://github.com/bids-standard/bids-validator/issues/790
   global:
-        VALIDATOR_VERSION: "stable"
+        VALIDATOR_VERSION: "master"
         nodejs_version: "10.0.0"
         PYTHON: "C:\\conda"
   matrix:
@@ -22,6 +20,7 @@ install:
       yarn &&
       cd ..
       set PATH="%PATH%;C:\projects\mne-bids\bids-validator\bids-validator\bin\" )
+      set VALIDATOR_EXECUTABLE ="C:\projects\mne-bids\bids-validator\bids-validator\bin\bids-validator"
   - cmd: if [%VALIDATOR_VERSION%]==[stable] (
       npm install -g bids-validator )
   - bids-validator --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,11 @@
 environment:
-# Specify version of BIDS-validator to be used, 'master', or 'stable'
+# Specify version of BIDS-validator to be used, "master", or "stable"
+# NOTE: For "master" you MUST adjust VALIDATOR_EXECUTABLE to the following value:
+# "C:\\projects\\mne-bids\\bids-validator\\bids-validator\\bin\\bids-validator"
+# ... whereas for "stable", VALIDATOR_EXECUTABLE MUST be set to "n/a"
   global:
         VALIDATOR_VERSION: "master"
+        VALIDATOR_EXECUTABLE: "C:\\projects\\mne-bids\\bids-validator\\bids-validator\\bin\\bids-validator"
         nodejs_version: "10.0.0"
         PYTHON: "C:\\conda"
   matrix:
@@ -19,9 +23,7 @@ install:
       cd bids-validator &&
       yarn &&
       cd .. &&
-      set PATH="%PATH%;C:\projects\mne-bids\bids-validator\bids-validator\bin\" &&
-      set VALIDATOR_EXECUTABLE ="C:\projects\mne-bids\bids-validator\bids-validator\bin\bids-validator"
-      echo "Using development version of bids-validator!")
+      set PATH="%PATH%;C:\projects\mne-bids\bids-validator\bids-validator\bin\" )
   - cmd: if [%VALIDATOR_VERSION%]==[stable] (
       npm install -g bids-validator
       bids-validator --version

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -15,6 +15,9 @@ Current
 Changelog
 ~~~~~~~~~
 
+- :func:`read_raw_bids` will return the the raw object with :code:`raw.info['bads']` already populated, whenever a :code:`channels.tsv` file is present, by `Stefan Appelhoff`_ (`#209 <https://github.com/mne-tools/mne-bids/pull/209>`_)
+- :func:`read_raw_bids` no longer optionally returns :code:`events` and :code:`event_id` but returns the raw object with :code:`mne.Annotations`, whenever an :code:`events.tsv` file is present, by `Stefan Appelhoff`_ (`#209 <https://github.com/mne-tools/mne-bids/pull/209>`_)
+
 Bug
 ~~~
 

--- a/examples/convert_mne_sample.py
+++ b/examples/convert_mne_sample.py
@@ -10,7 +10,8 @@ BIDS-compatible folder.
 # Authors: Mainak Jas <mainak.jas@telecom-paristech.fr>
 #          Alexandre Gramfort <alexandre.gramfort@telecom-paristech.fr>
 #          Teon Brooks <teon.brooks@gmail.com>
-
+#          Stefan Appelhoff <stefan.appelhoff@mailbox.org>
+#
 # License: BSD (3-clause)
 
 ###############################################################################
@@ -65,9 +66,10 @@ print_dir_tree(output_path)
 
 ###############################################################################
 # Finally, we can read the BIDS data we created as well.
-raw, events, event_id = read_raw_bids(bids_basename + '_meg.fif', output_path)
+raw = read_raw_bids(bids_basename + '_meg.fif', output_path)
 
 ###############################################################################
 # The data is already in a convenient form to create epochs and evokeds.
+events, event_id = mne.events_from_annotations(raw)
 epochs = mne.Epochs(raw, events, event_id)
 epochs['Auditory'].average().plot()

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -175,8 +175,13 @@ def read_raw_bids(bids_fname, bids_root, return_events=True,
         if 'status' not in channels_dict:
             raise ValueError('status column is missing. Cannot populate bads')
 
+        # find bads from channels.tsv
         bad_bool = [True if chn == 'bad' else False
                     for chn in channels_dict['status']]
-        raw.info['bads'] += list(np.asarray(channels_dict['name'])[bad_bool])
+        bads = np.asarray(channels_dict['name'])[bad_bool]
+
+        # merge with bads already present in raw data file (if there are any)
+        unique_bads = set(raw.info['bads']).union(set(bads))
+        raw.info['bads'] = list(unique_bads)
 
     return raw, events, event_id

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -55,7 +55,8 @@ bids_validator_exe = ['bids-validator']
 if platform.system() == 'Windows':
     shell = True
     if 'VALIDATOR_EXECUTABLE' in os.environ:
-        bids_validator_exe = ['node', os.environ['VALIDATOR_EXECUTABLE']]
+        if 'VALIDATOR_EXECUTABLE' != 'n/a':
+            bids_validator_exe = ['node', os.environ['VALIDATOR_EXECUTABLE']]
 
 
 def test_fif():

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -237,14 +237,15 @@ def test_kit():
     event_data = np.loadtxt(events_fname)
     # make the data the wrong number of dimensions
     event_data_3d = np.atleast_3d(event_data)
+    other_output_path = _TempDir()
     with pytest.raises(ValueError, match='two dimensions'):
-        write_raw_bids(raw, bids_basename, output_path,
+        write_raw_bids(raw, bids_basename, other_output_path,
                        events_data=event_data_3d, event_id=event_id,
                        overwrite=True)
     # remove 3rd column
     event_data = event_data[:, :2]
     with pytest.raises(ValueError, match='second dimension'):
-        write_raw_bids(raw, bids_basename, output_path,
+        write_raw_bids(raw, bids_basename, other_output_path,
                        events_data=event_data, event_id=event_id,
                        overwrite=True)
     # test correct naming of marker files

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -52,10 +52,17 @@ bids_basename = make_bids_basename(
 # see: https://stackoverflow.com/q/28891053/5201771
 shell = False
 bids_validator_exe = ['bids-validator']
+print('\n\n\n\n\n\n\n\n\n\n\n\n\n')
+print(platform.system(), platform.system() == 'Windows')
+print(os.environ)
+print('VALIDATOR_EXECUTABLE' in os.environ)
 if platform.system() == 'Windows':
     shell = True
     if 'VALIDATOR_EXECUTABLE' in os.environ:
         bids_validator_exe = ['node', os.environ['VALIDATOR_EXECUTABLE']]
+
+print(bids_validator_exe)
+print('\n\n\n\n\n\n\n\n\n\n\n\n\n')
 
 
 def test_fif():

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -341,7 +341,7 @@ def test_vhdr():
 
     # read and also get the bad channels
     raw, __, __ = read_raw_bids(bids_basename + '_eeg.vhdr', output_path,
-                                return_events=False, populate_bads=True)
+                                return_events=False)
 
     # Check that injected bad channel shows up in raw after reading
     np.testing.assert_array_equal(np.asarray(raw.info['bads']),

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -52,21 +52,21 @@ bids_basename = make_bids_basename(
 # see: https://stackoverflow.com/q/28891053/5201771
 shell = False
 bids_validator_exe = ['bids-validator']
-print('\n\n\n\n\n\n\n\n\n\n\n\n\n')
-print(platform.system(), platform.system() == 'Windows')
-print(os.environ)
-print('VALIDATOR_EXECUTABLE' in os.environ)
 if platform.system() == 'Windows':
     shell = True
     if 'VALIDATOR_EXECUTABLE' in os.environ:
         bids_validator_exe = ['node', os.environ['VALIDATOR_EXECUTABLE']]
 
-print(bids_validator_exe)
-print('\n\n\n\n\n\n\n\n\n\n\n\n\n')
-
 
 def test_fif():
     """Test functionality of the write_raw_bids conversion for fif."""
+    print('\n\n\n\n\n\n\n\n\n\n\n\n\n')
+    print(platform.system(), platform.system() == 'Windows')
+    print(os.environ)
+    print('VALIDATOR_EXECUTABLE' in os.environ)
+    print(bids_validator_exe)
+    print('\n\n\n\n\n\n\n\n\n\n\n\n\n')
+
     output_path = _TempDir()
     data_path = testing.data_path()
     raw_fname = op.join(data_path, 'MEG', 'sample',

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -132,7 +132,8 @@ def test_fif():
     # now force the overwrite
     write_raw_bids(raw, bids_basename2, output_path, events_data=events_fname,
                    event_id=event_id, overwrite=True)
-    raw, events, _ = read_raw_bids(bids_basename2 + '_meg.fif', output_path)
+    raw = read_raw_bids(bids_basename2 + '_meg.fif', output_path)
+    events, _ = mne.events_from_annotations(raw)
     events2 = mne.read_events(events_fname)
     events2 = events2[events2[:, 2] != 0]
     assert_array_equal(events2[:, 0], events[:, 0])
@@ -206,8 +207,7 @@ def test_kit():
     run_subprocess(cmd, shell=shell)
     assert op.exists(op.join(output_path, 'participants.tsv'))
 
-    raw2, events, _ = read_raw_bids(kit_bids_basename + '_meg.sqd',
-                                    output_path)
+    read_raw_bids(kit_bids_basename + '_meg.sqd', output_path)
 
     # ensure the channels file has no STI 014 channel:
     channels_tsv = make_bids_basename(
@@ -285,11 +285,7 @@ def test_ctf():
     cmd = ['bids-validator', output_path]
     run_subprocess(cmd, shell=shell)
 
-    with pytest.raises(ValueError, match="not found"):
-        read_raw_bids(bids_basename + '_meg.ds', output_path)
-
-    raw, __, __ = read_raw_bids(bids_basename + '_meg.ds', output_path,
-                                return_events=False)
+    raw = read_raw_bids(bids_basename + '_meg.ds', output_path)
 
     # test to check that running again with overwrite == False raises an error
     with pytest.raises(FileExistsError, match="already exists"):  # noqa: F821
@@ -316,8 +312,7 @@ def test_bti():
     cmd = ['bids-validator', output_path]
     run_subprocess(cmd, shell=shell)
 
-    raw, __, __ = read_raw_bids(bids_basename + '_meg',
-                                output_path, return_events=False)
+    raw = read_raw_bids(bids_basename + '_meg', output_path)
 
 
 def test_vhdr():
@@ -340,8 +335,7 @@ def test_vhdr():
     run_subprocess(cmd, shell=shell)
 
     # read and also get the bad channels
-    raw, __, __ = read_raw_bids(bids_basename + '_eeg.vhdr', output_path,
-                                return_events=False)
+    raw = read_raw_bids(bids_basename + '_eeg.vhdr', output_path)
 
     # Check that injected bad channel shows up in raw after reading
     np.testing.assert_array_equal(np.asarray(raw.info['bads']),
@@ -397,8 +391,7 @@ def test_edf():
     raw.set_channel_types({'EMG': 'emg'})
 
     write_raw_bids(raw, bids_basename, output_path)
-    read_raw_bids(bids_basename + '_eeg.edf',
-                  output_path, return_events=False)
+    read_raw_bids(bids_basename + '_eeg.edf', output_path)
 
     bids_fname = bids_basename.replace('run-01', 'run-%s' % run2)
     write_raw_bids(raw, bids_fname, output_path, overwrite=True)
@@ -444,8 +437,7 @@ def test_bdf():
     cmd = ['bids-validator', output_path]
     run_subprocess(cmd, shell=shell)
 
-    read_raw_bids(bids_basename + '_eeg.bdf',
-                  output_path, return_events=False)
+    read_raw_bids(bids_basename + '_eeg.bdf', output_path)
 
     raw.crop(0, raw.times[-2])
     with pytest.raises(AssertionError, match='cropped'):
@@ -474,8 +466,7 @@ def test_set():
 
     # proceed with the actual test for EEGLAB data
     write_raw_bids(raw, bids_basename, output_path, overwrite=False)
-    read_raw_bids(bids_basename + '_eeg.set',
-                  output_path, return_events=False)
+    read_raw_bids(bids_basename + '_eeg.set', output_path)
 
     with pytest.raises(FileExistsError, match="already exists"):  # noqa: F821
         write_raw_bids(raw, bids_basename, output_path=output_path,

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -54,20 +54,13 @@ shell = False
 bids_validator_exe = ['bids-validator']
 if platform.system() == 'Windows':
     shell = True
-    if 'VALIDATOR_EXECUTABLE' in os.environ:
-        if 'VALIDATOR_EXECUTABLE' != 'n/a':
-            bids_validator_exe = ['node', os.environ['VALIDATOR_EXECUTABLE']]
+    exe = os.getenv('VALIDATOR_EXECUTABLE', 'n/a')
+    if 'VALIDATOR_EXECUTABLE' != 'n/a':
+        bids_validator_exe = ['node', exe]
 
 
 def test_fif():
     """Test functionality of the write_raw_bids conversion for fif."""
-    print('\n\n\n\n\n\n\n\n\n\n\n\n\n')
-    print(platform.system(), platform.system() == 'Windows')
-    print(os.environ)
-    print('VALIDATOR_EXECUTABLE' in os.environ)
-    print(bids_validator_exe)
-    print('\n\n\n\n\n\n\n\n\n\n\n\n\n')
-
     output_path = _TempDir()
     data_path = testing.data_path()
     raw_fname = op.join(data_path, 'MEG', 'sample',


### PR DESCRIPTION
closes #182 
fixes #202 

In this PR I am also changing `read_raw_bids` to always output 3 parameters instead of dynamically outputting 1 OR 3 parameters depending on the input arguments.

I think this is cleaner and easier to work with.


Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [x] All comments resolved
- [x] This is not your own PR
- [x] All CIs are happy
- [ ] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [x] PR description includes phrase "closes <#issue-number>"
- [x] Commit history does not contain any merge commits
