### PR TITLE
FIX: read_raw_bids must not assume that session is a mandatory param

### DIFF
--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -98,9 +98,17 @@ def read_raw_bids(bids_fname, bids_root, verbose=True):
     kind = bids_fname.split('_')[-1].split('.')[0]
     _, ext = _parse_ext(bids_fname)
 
+    # Get the BIDS parameters (=entities)
     params = _parse_bids_filename(bids_basename, verbose)
-    kind_dir = op.join(bids_root, 'sub-%s' % params['sub'],
-                       'ses-%s' % params['ses'], kind)
+
+    # Construct the path to the "kind" where the data is stored
+    # Subject is mandatory ...
+    kind_dir = op.join(bids_root, 'sub-{}'.format(params['sub']))
+    # Session is optional ...
+    if params['ses']:
+        kind_dir = op.join(kind_dir, 'ses-{}'.format(params['ses']))
+    # Kind is mandatory
+    kind_dir = op.join(kind_dir, kind)
 
     config = None
     if ext in ('.fif', '.ds', '.vhdr', '.edf', '.bdf', '.set', '.sqd', '.con'):

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -105,7 +105,7 @@ def read_raw_bids(bids_fname, bids_root, verbose=True):
     # Subject is mandatory ...
     kind_dir = op.join(bids_root, 'sub-{}'.format(params['sub']))
     # Session is optional ...
-    if params['ses']:
+    if params['ses'] is not None:
         kind_dir = op.join(kind_dir, 'ses-{}'.format(params['ses']))
     # Kind is mandatory
     kind_dir = op.join(kind_dir, kind)


### PR DESCRIPTION
fixes a bug I discovered while working on https://github.com/mne-tools/mne-study-template/pull/35

The BIDS `session` parameter is not mandatory ... if we happen to have a dataset with no session, `read_raw_bids` would create a bids basename including `ses-None` ... which will point to a nonexisting directory.

