### PR TITLE
MRG: read_raw_bids can set channels according to channels.tsv

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,7 @@ Installation
 We recommend the `Anaconda <https://www.anaconda.com/download/>`_ Python
 distribution. We require that you use Python 3.
 Besides ``numpy`` and ``scipy`` (which are included in the standard Anaconda
-installation), you will need to install the most recent version of ``MNE ``
+installation), you will need to install the most recent version of ``MNE``
 using the ``pip`` tool:
 
 .. code-block:: bash
@@ -119,8 +119,8 @@ Cite
 If you use ``mne-bids`` in your work, please cite one of the following papers,
 depending on which modality you used:
 
-MEG
-###
+`MEG <http://doi.org/10.1038/sdata.2018.110>`_
+##############################################
 
 .. code-block:: Text
 
@@ -131,8 +131,8 @@ MEG
    http://doi.org/10.1038/sdata.2018.110
 
 
-EEG
-###
+`EEG <https://doi.org/10.1038/s41597-019-0104-8>`_
+##################################################
 
 .. code-block:: Text
 
@@ -142,8 +142,8 @@ EEG
    Data, 6, 103. https://doi.org/10.1038/s41597-019-0104-8
 
 
-iEEG
-####
+`iEEG <https://doi.org/10.1038/s41597-019-0105-7>`_
+###################################################
 
 .. code-block:: Text
 

--- a/bin/mne_bids
+++ b/bin/mne_bids
@@ -1,8 +1,8 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
 """CLI for MNE-BIDS."""
-
-
+# Authors: Teon Brooks <teon.brooks@gmail.com>
+#          Stefan Appelhoff <stefan.appelhoff@mailbox.org>
+#
+# License: BSD (3-clause)
 import sys
 import glob
 import subprocess
@@ -10,7 +10,7 @@ import os.path as op
 
 import mne_bids
 
-mne_bin_dir = op.dirname(mne_bids.__file__)
+mne_bin_dir = op.abspath(op.join(op.dirname(mne_bids.__file__), '..'))
 valid_commands = sorted(glob.glob(op.join(mne_bin_dir,
                                           'cli', 'mne_bids_*.py')))
 valid_commands = [c.split(op.sep)[-1][9:-3] for c in valid_commands]

--- a/cli/mne_bids_raw_to_bids.py
+++ b/cli/mne_bids_raw_to_bids.py
@@ -1,12 +1,12 @@
-#!/usr/bin/env python
-# Authors: Teon Brooks  <teon.brooks@gmail.com>
-
 """Command line interface for mne_bids.
 
 example usage:  $ mne_bids raw_to_bids --subject_id sub01 --task rest
 --raw data.edf --output_path new_path
 
 """
+# Authors: Teon Brooks <teon.brooks@gmail.com>
+#
+# License: BSD (3-clause)
 from mne_bids import write_raw_bids, make_bids_basename
 from mne_bids.read import _read_raw
 

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -6,7 +6,8 @@
 API Documentation
 =================
 
-MNE BIDS (:py:mod:`mne_bids`):
+MNE BIDS (:py:mod:`mne_bids`)
+=============================
 
 .. currentmodule:: mne_bids
 
@@ -21,7 +22,8 @@ MNE BIDS (:py:mod:`mne_bids`):
    write_anat
    get_head_mri_trans
 
-Utils (:py:mod:`mne_bids.utils`):
+Utils (:py:mod:`mne_bids.utils`)
+================================
 
 .. currentmodule:: mne_bids.utils
 
@@ -30,7 +32,8 @@ Utils (:py:mod:`mne_bids.utils`):
 
    print_dir_tree
 
-Copyfiles (:py:mod:`mne_bids.copyfiles`):
+Copyfiles (:py:mod:`mne_bids.copyfiles`)
+========================================
 
 .. currentmodule:: mne_bids.copyfiles
 
@@ -42,7 +45,8 @@ Copyfiles (:py:mod:`mne_bids.copyfiles`):
    copyfile_ctf
    copyfile_bti
 
-Datasets (:py:mod:`mne_bids.datasets`):
+Datasets (:py:mod:`mne_bids.datasets`)
+======================================
 
 .. currentmodule:: mne_bids.datasets
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -14,11 +14,12 @@ Current
 
 Changelog
 ~~~~~~~~~
+
+- :func:`read_raw_bids` now also reads channels.tsv files accompanying a raw BIDS file and sets the channel types accordingly, by `Stefan Appelhoff`_ (`#219 <https://github.com/mne-tools/mne-bids/pull/219>`_)
 - Add example :code:`convert_mri_and_trans` for using :func:`get_head_mri_trans` and :func:`write_anat`, by `Stefan Appelhoff`_ (`#211 <https://github.com/mne-tools/mne-bids/pull/211>`_)
 - :func:`get_head_mri_trans` allows retrieving a :code:`trans` object from a BIDS dataset that contains MEG and T1 weighted MRI data, by `Stefan Appelhoff`_ (`#211 <https://github.com/mne-tools/mne-bids/pull/211>`_)
 - :func:`write_anat` allows writing T1 weighted MRI scans for subjects and optionally creating a T1w.json sidecar from a supplied :code:`trans` object, by `Stefan Appelhoff`_ (`#211 <https://github.com/mne-tools/mne-bids/pull/211>`_)
 - :func:`read_raw_bids` will return the the raw object with :code:`raw.info['bads']` already populated, whenever a :code:`channels.tsv` file is present, by `Stefan Appelhoff`_ (`#209 <https://github.com/mne-tools/mne-bids/pull/209>`_)
-- :func:`read_raw_bids` no longer optionally returns :code:`events` and :code:`event_id` but returns the raw object with :code:`mne.Annotations`, whenever an :code:`events.tsv` file is present, by `Stefan Appelhoff`_ (`#209 <https://github.com/mne-tools/mne-bids/pull/209>`_)
 
 Bug
 ~~~
@@ -27,6 +28,8 @@ Bug
 
 API
 ~~~
+
+- :func:`read_raw_bids` no longer optionally returns :code:`events` and :code:`event_id` but returns the raw object with :code:`mne.Annotations`, whenever an :code:`events.tsv` file is present, by `Stefan Appelhoff`_ (`#209 <https://github.com/mne-tools/mne-bids/pull/209>`_)
 
 .. _changes_0_2:
 

--- a/examples/convert_mne_sample.py
+++ b/examples/convert_mne_sample.py
@@ -68,7 +68,8 @@ print_dir_tree(output_path)
 
 ###############################################################################
 # Finally, we can read the BIDS data we created as well.
-raw = read_raw_bids(bids_basename + '_meg.fif', output_path)
+bids_fname = bids_basename + '_meg.fif'
+raw = read_raw_bids(bids_fname, output_path)
 
 ###############################################################################
 # The data is already in a convenient form to create epochs and evokeds.

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -125,8 +125,10 @@ def read_raw_bids(bids_fname, bids_root, verbose=True):
 
     # Try to find an associated events.tsv to get information about the
     # events in the recorded data
-    events_fname = op.join(kind_dir, bids_basename + '_events.tsv')
-    if op.exists(events_fname):
+    events_fname = _find_matching_sidecar(bids_fname, bids_root, 'events.tsv',
+                                          allow_fail=True)
+
+    if events_fname is not None:
         events_dict = _from_tsv(events_fname)
     else:
         events_dict = dict()

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -137,14 +137,17 @@ def _handle_channels_reading(channels_fname, raw):
         # Create a mapping to channel types
         channel_type_dict = dict()
 
-        # Try mapping from BIDS nomenclature of channel types to MNE
-        bids_to_mne_ch_types = _get_ch_type_mapping()
+        # Get the best mapping we currently have from BIDS to MNE nomenclature
+        bids_to_mne_ch_types = _get_ch_type_mapping(from_mne_to_bids=False)
         for ch in ch_names_json:
             # Get channel type
             ch_type = channels_dict['type'][channels_dict['name'].index(ch)]
 
-            # Map from BIDS nomenclature to MNE
-            channel_type_dict[ch] = bids_to_mne_ch_types[ch_type.lower()]
+            # Try to map from BIDS nomenclature to MNE, leave channel type
+            # untouched if we are uncertain
+            updated_ch_type = bids_to_mne_ch_types.get(ch_type, None)
+            if updated_ch_type is not None:
+                channel_type_dict[ch] = updated_ch_type
 
         # Set the channel types in the raw data according to channels.tsv
         raw.set_channel_types(channel_type_dict)

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -25,7 +25,7 @@ from .utils import (_parse_bids_filename, _extract_landmarks,
 reader = {'.con': io.read_raw_kit, '.sqd': io.read_raw_kit,
           '.fif': io.read_raw_fif, '.pdf': io.read_raw_bti,
           '.ds': io.read_raw_ctf, '.vhdr': io.read_raw_brainvision,
-          '.edf': io.read_raw_edf, '.bdf': io.read_raw_edf,
+          '.edf': io.read_raw_edf, '.bdf': io.read_raw_bdf,
           '.set': io.read_raw_eeglab}
 
 

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -119,7 +119,7 @@ def _handle_channels_reading(channels_fname, raw):
     # column from which to infer good and bad channels
     if 'status' in channels_dict:
         # find bads from channels.tsv
-        bad_bool = [True if chn == 'bad' else False
+        bad_bool = [True if chn.lower() == 'bad' else False
                     for chn in channels_dict['status']]
         bads = np.asarray(channels_dict['name'])[bad_bool]
 

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -144,7 +144,7 @@ def _handle_channels_reading(channels_fname, bids_fname, raw):
     channel_type_dict = dict()
 
     # Get the best mapping we currently have from BIDS to MNE nomenclature
-    bids_to_mne_ch_types = _get_ch_type_mapping(from_mne_to_bids=False)
+    bids_to_mne_ch_types = _get_ch_type_mapping(fro='bids', to='mne')
     ch_types_json = channels_dict['type']
     for ch_name, ch_type in zip(ch_names_tsv, ch_types_json):
 

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -81,16 +81,16 @@ def _handle_events_reading(events_fname, raw):
 
     # Get the descriptions of the events
     if 'trial_type' in events_dict:
-        descriptions = np.asarray(events_dict['trial_type'], dtype=str)
         # Drop events unrelated to a trial type
         events_dict = _drop(events_dict, 'n/a', 'trial_type')
+        descriptions = np.asarray(events_dict['trial_type'], dtype=str)
 
     # If we don't have a proper description of the events, perhaps we have
     # at least an event value?
     elif 'value' in events_dict:
-        descriptions = np.asarray(events_dict['value'], dtype=str)
         # Drop events unrelated to value
         events_dict = _drop(events_dict, 'n/a', 'value')
+        descriptions = np.asarray(events_dict['value'], dtype=str)
 
     # Worst case, we go with 'n/a' for all events
     else:

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -130,8 +130,10 @@ def _handle_channels_reading(channels_fname, bids_fname, raw):
                        len(ch_names_raw), bids_fname, ch_names_raw)
                )
 
-        # this could be due to MNE inserting a 'STI 014' channel as the last
-        # channel: In that case, we can work
+        # XXX: this could be due to MNE inserting a 'STI 014' channel as the
+        # last channel: In that case, we can work. --> Can be removed soon,
+        # because MNE will stop the synthesis of stim channels in the near
+        # future
         if not (ch_names_raw[-1] == 'STI 014' and
                 ch_names_raw[:-1] == ch_names_tsv):
             raise RuntimeError(msg)

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -9,7 +9,6 @@
 import os.path as op
 import glob
 import json
-import warnings
 
 import numpy as np
 import mne

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -62,8 +62,10 @@ def test_get_head_mri_trans():
 
     # Write it to BIDS
     raw = mne.io.read_raw_fif(raw_fname)
-    write_raw_bids(raw, bids_basename, output_path, events_data=events_fname,
-                   event_id=event_id, overwrite=False)
+    with pytest.warns(UserWarning, match='No line frequency'):
+        write_raw_bids(raw, bids_basename, output_path,
+                       events_data=events_fname, event_id=event_id,
+                       overwrite=False)
 
     # We cannot recover trans, if no MRI has yet been written
     with pytest.raises(RuntimeError):

--- a/mne_bids/tests/test_utils.py
+++ b/mne_bids/tests/test_utils.py
@@ -182,8 +182,10 @@ def test_find_matching_sidecar():
                            'sample_audvis_trunc_raw-eve.fif')
 
     raw = mne.io.read_raw_fif(raw_fname)
-    write_raw_bids(raw, bids_basename, output_path, events_data=events_fname,
-                   event_id=event_id, overwrite=False)
+    with pytest.warns(UserWarning, match='No line frequency'):
+        write_raw_bids(raw, bids_basename, output_path,
+                       events_data=events_fname, event_id=event_id,
+                       overwrite=False)
 
     # Now find a sidecar
     sidecar_fname = _find_matching_sidecar(bids_basename, output_path,

--- a/mne_bids/tests/test_utils.py
+++ b/mne_bids/tests/test_utils.py
@@ -194,8 +194,11 @@ def test_find_matching_sidecar():
     assert sidecar_fname.endswith(expected_file)
 
     # Find multiple sidecars, triggering an error
-    with pytest.raises(RuntimeError):
+    with pytest.raises(RuntimeError, match='Expected to find a single'):
         open(sidecar_fname.replace('coordsystem.json',
                                    '2coordsystem.json'), 'w').close()
-        sidecar_fname = _find_matching_sidecar(bids_basename, output_path,
-                                               'coordsystem.json')
+        _find_matching_sidecar(bids_basename, output_path, 'coordsystem.json')
+
+    # Find nothing but receive None, because we set `allow_fail` to True
+    with pytest.warns(UserWarning, match='Expected to find a single'):
+        _find_matching_sidecar(bids_basename, output_path, 'foo.bogus', True)

--- a/mne_bids/tests/test_utils.py
+++ b/mne_bids/tests/test_utils.py
@@ -16,7 +16,8 @@ from mne.datasets import testing
 from mne_bids import make_bids_folders, make_bids_basename, write_raw_bids
 from mne_bids.utils import (_check_types, print_dir_tree, _age_on_date,
                             _infer_eeg_placement_scheme, _handle_kind,
-                            _find_matching_sidecar, _parse_ext)
+                            _find_matching_sidecar, _parse_ext,
+                            _get_ch_type_mapping)
 
 
 base_path = op.join(op.dirname(mne.__file__), 'io')
@@ -29,6 +30,12 @@ task = 'testing'
 bids_basename = make_bids_basename(
     subject=subject_id, session=session_id, run=run, acquisition=acq,
     task=task)
+
+
+def test_get_ch_type_mapping():
+    """Test getting a correct channel mapping."""
+    with pytest.raises(ValueError, match='specified from "bogus" to "mne"'):
+        _get_ch_type_mapping(fro='bogus', to='mne')
 
 
 def test_handle_kind():

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -92,6 +92,7 @@ def test_fif():
     run_subprocess(cmd, shell=shell)
 
     # write the same data but pretend it is empty room data:
+    raw = mne.io.read_raw_fif(raw_fname)
     er_date = datetime.fromtimestamp(
         raw.info['meas_date'][0]).strftime('%Y%m%d')
     er_bids_basename = 'sub-emptyroom_ses-{0}_task-noise'.format(str(er_date))

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -444,7 +444,7 @@ def test_bdf():
     data_path = op.join(base_path, 'edf', 'tests', 'data')
     raw_fname = op.join(data_path, 'test.bdf')
 
-    raw = mne.io.read_raw_edf(raw_fname)
+    raw = mne.io.read_raw_bdf(raw_fname)
     write_raw_bids(raw, bids_basename, output_path, overwrite=False)
 
     cmd = bids_validator_exe + [output_path]

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -18,6 +18,7 @@ from datetime import datetime
 import platform
 import shutil as sh
 import json
+from distutils.version import LooseVersion
 
 import numpy as np
 from numpy.testing import assert_array_equal
@@ -333,6 +334,10 @@ def test_bti():
     raw = read_raw_bids(bids_basename + '_meg', output_path)
 
 
+# XXX: vhdr test currently passes only on MNE master. Skip until next release.
+# see: https://github.com/mne-tools/mne-python/pull/6558
+@pytest.mark.skipif(LooseVersion(mne.__version__) < LooseVersion('0.19'),
+                    reason="requires mne 0.19.dev0 or higher")
 def test_vhdr():
     """Test write_raw_bids conversion for BrainVision data."""
     output_path = _TempDir()

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -297,12 +297,13 @@ def test_ctf():
     raw_fname = op.join(data_path, 'testdata_ctf.ds')
 
     raw = mne.io.read_raw_ctf(raw_fname)
-    write_raw_bids(raw, bids_basename, output_path=output_path)
+    with pytest.warns(UserWarning, match='No line frequency'):
+        write_raw_bids(raw, bids_basename, output_path=output_path)
 
     cmd = bids_validator_exe + [output_path]
     run_subprocess(cmd, shell=shell)
-
-    raw = read_raw_bids(bids_basename + '_meg.ds', output_path)
+    with pytest.warns(UserWarning, match='Expected to find a single events'):
+        raw = read_raw_bids(bids_basename + '_meg.ds', output_path)
 
     # test to check that running again with overwrite == False raises an error
     with pytest.raises(FileExistsError, match="already exists"):  # noqa: F821

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -412,7 +412,13 @@ def test_edf():
     raw.set_channel_types({'EMG': 'emg'})
 
     write_raw_bids(raw, bids_basename, output_path)
-    read_raw_bids(bids_basename + '_eeg.edf', output_path)
+
+    # Reading the file back should raise an error, because we renamed channels
+    # in `raw` and used that information to write a channels.tsv. Yet, we
+    # saved the unchanged `raw` in the BIDS folder, so channels in the TSV and
+    # in raw clash
+    with pytest.raises(RuntimeError, match='Channels do not correspond'):
+        read_raw_bids(bids_basename + '_eeg.edf', output_path)
 
     bids_fname = bids_basename.replace('run-01', 'run-%s' % run2)
     write_raw_bids(raw, bids_fname, output_path, overwrite=True)

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -85,7 +85,8 @@ def test_fif():
                            for i in
                            mne.pick_types(raw.info, stim=True, meg=False)})
     output_path = _TempDir()
-    write_raw_bids(raw, bids_basename, output_path, overwrite=False)
+    with pytest.warns(UserWarning, match='No events found or provided.'):
+        write_raw_bids(raw, bids_basename, output_path, overwrite=False)
 
     cmd = bids_validator_exe + [output_path]
     run_subprocess(cmd, shell=shell)

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -26,6 +26,15 @@ from mne.io.constants import FIFF
 from .tsv_handler import _to_tsv, _tsv_to_str
 
 
+def _get_ch_type_mapping():
+    """Map from BIDS to MNE nomenclature for channel types."""
+    bids_to_mne_ch_types = {'trig': 'stim',
+                            'eeg': 'eeg',
+                            'misc': 'misc',
+                            }
+    return bids_to_mne_ch_types
+
+
 def print_dir_tree(folder):
     """Recursively print a directory tree starting from `folder`."""
     if not op.exists(folder):

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -35,8 +35,7 @@ def _get_ch_type_mapping(from_mne_to_bids=True):
     """
     # from_mne_to_bids:
     map_chs = dict(eeg='EEG', misc='MISC', stim='TRIG', emg='EMG',
-                   ecog='ECOG', seeg='SEEG', eog='EOG', ecg='ECG',
-                   resp='RESP')
+                   ecog='ECOG', seeg='SEEG', eog='EOG', ecg='ECG')
     default_value = 'OTHER'
 
     # or if not ...
@@ -45,7 +44,7 @@ def _get_ch_type_mapping(from_mne_to_bids=True):
         map_chs = {val: key for key, val in map_chs.items()}
 
         # And we need some additional key-value pairs
-        map_chs.update(VEOG='eog', HEOG='heog')
+        map_chs.update(VEOG='eog', HEOG='eog')
         default_value = 'misc'
 
     # Make it a defaultdict to prevent key errors

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -27,8 +27,22 @@ from mne.io.constants import FIFF
 from .tsv_handler import _to_tsv, _tsv_to_str
 
 
-def _get_ch_type_mapping(from_mne_to_bids=True):
+def _get_ch_type_mapping(fro='mne', to='bids'):
     """Map between BIDS and MNE nomenclatures for channel types.
+
+    Parameters
+    ----------
+    fro : str
+        Mapping from nomenclature of `fro`. Can be 'mne', 'bids'
+    to : str
+        Mapping to nomenclature of `to`. Can be 'mne', 'bids'
+
+    Returns
+    -------
+    ch_type_mapping : collections.defaultdict
+        Dictionary mapping from one nomenclature of channel types to another.
+        If a key is not present, a default value will be returned that depends
+        on the `fro` and `to` parameters.
 
     Notes
     -----
@@ -37,7 +51,7 @@ def _get_ch_type_mapping(from_mne_to_bids=True):
     one-to-many/many-to-one.
 
     """
-    if from_mne_to_bids:
+    if fro == 'mne' and to == 'bids':
         map_chs = dict(eeg='EEG', misc='MISC', stim='TRIG', emg='EMG',
                        ecog='ECOG', seeg='SEEG', eog='EOG', ecg='ECG',
                        # MEG channels
@@ -47,7 +61,7 @@ def _get_ch_type_mapping(from_mne_to_bids=True):
                        )
         default_value = 'OTHER'
 
-    else:  # from_bids_to_mne
+    elif fro == 'bids' and to == 'mne':
         map_chs = dict(EEG='eeg', MISC='misc', TRIG='stim', EMG='emg',
                        ECOG='ecog', SEEG='seeg', EOG='eog', ECG='ecg',
                        # No MEG channels for now
@@ -55,6 +69,11 @@ def _get_ch_type_mapping(from_mne_to_bids=True):
                        VEOG='eog', HEOG='eog',
                        )
         default_value = 'misc'
+
+    else:
+        raise ValueError('Only two types of mappings are currently supported: '
+                         'from mne to bids, or from bids to mne. However, '
+                         'you specified from "{}" to "{}"'.format(fro, to))
 
     # Make it a defaultdict to prevent key errors
     ch_type_mapping = defaultdict(lambda: default_value)

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -28,23 +28,32 @@ from .tsv_handler import _to_tsv, _tsv_to_str
 
 
 def _get_ch_type_mapping(from_mne_to_bids=True):
-    """Limited map between BIDS and MNE nomenclatures for channel types.
+    """Map between BIDS and MNE nomenclatures for channel types.
 
-    MEG channel types are ignored for now.
+    Notes
+    -----
+    For the mapping from BIDS to MNE, MEG channel types are ignored for now.
+    Furthermore, this is not a one-to-one mapping: Incomplete and partially
+    one-to-many/many-to-one.
 
     """
-    # from_mne_to_bids:
-    map_chs = dict(eeg='EEG', misc='MISC', stim='TRIG', emg='EMG',
-                   ecog='ECOG', seeg='SEEG', eog='EOG', ecg='ECG')
-    default_value = 'OTHER'
+    if from_mne_to_bids:
+        map_chs = dict(eeg='EEG', misc='MISC', stim='TRIG', emg='EMG',
+                       ecog='ECOG', seeg='SEEG', eog='EOG', ecg='ECG',
+                       # MEG channels
+                       meggradaxial='MEGGRADAXIAL', megmag='MEGMAG',
+                       megrefgradaxial='MEGREFGRADAXIAL',
+                       meggradplanar='MEGGRADPLANAR', megrefmag='MEGREFMAG',
+                       )
+        default_value = 'OTHER'
 
-    # or if not ...
-    if not from_mne_to_bids:
-        # ... invert the map so that it is from_bids_to_mne
-        map_chs = {val: key for key, val in map_chs.items()}
-
-        # And we need some additional key-value pairs
-        map_chs.update(VEOG='eog', HEOG='eog')
+    else:  # from_bids_to_mne
+        map_chs = dict(EEG='eeg', MISC='misc', TRIG='stim', EMG='emg',
+                       ECOG='ecog', SEEG='seeg', EOG='eog', ECG='ecg',
+                       # No MEG channels for now
+                       # Many to one mapping
+                       VEOG='eog', HEOG='eog',
+                       )
         default_value = 'misc'
 
     # Make it a defaultdict to prevent key errors

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -317,7 +317,6 @@ def _find_matching_sidecar(bids_fname, bids_root, suffix, allow_fail=False):
     """
     # We only use subject and session as identifier, because all other
     # parameters are potentially not binding for metadata sidecar files
-    warnings.warn(bids_fname)
     if 'ses' in bids_fname:
         search_str = '_'.join(bids_fname.split('_')[:2])
     else:

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -61,7 +61,7 @@ def _channels_tsv(raw, fname, overwrite=False, verbose=True):
 
     """
     # Get channel type mappings between BIDS and MNE nomenclatures
-    map_chs = _get_ch_type_mapping(from_mne_to_bids=True)
+    map_chs = _get_ch_type_mapping(fro='mne', to='bids')
 
     # Prepare the descriptions for each channel type
     map_desc = defaultdict(lambda: 'Other type of channel')

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -32,7 +32,8 @@ from .pick import coil_type
 from .utils import (_write_json, _write_tsv, _read_events, _mkdir_p,
                     _age_on_date, _infer_eeg_placement_scheme, _check_key_val,
                     _parse_bids_filename, _handle_kind, _check_types,
-                    _get_mrk_meas_date, _extract_landmarks, _parse_ext)
+                    _get_mrk_meas_date, _extract_landmarks, _parse_ext,
+                    _get_ch_type_mapping)
 from .copyfiles import (copyfile_brainvision, copyfile_eeglab, copyfile_ctf,
                         copyfile_bti)
 
@@ -59,26 +60,29 @@ def _channels_tsv(raw, fname, overwrite=False, verbose=True):
         Set verbose output to true or false.
 
     """
-    map_chs = defaultdict(lambda: 'OTHER')
+    # Get channel type mappings between nomenclatures
+    map_chs = _get_ch_type_mapping(from_mne_to_bids=True)
+    # Add MEG channels to mapping (ignored in _get_ch_type_mapping for now)
     map_chs.update(meggradaxial='MEGGRADAXIAL',
                    megrefgradaxial='MEGREFGRADAXIAL',
                    meggradplanar='MEGGRADPLANAR',
-                   megmag='MEGMAG', megrefmag='MEGREFMAG',
-                   eeg='EEG', misc='MISC', stim='TRIG', emg='EMG',
-                   ecog='ECOG', seeg='SEEG', eog='EOG', ecg='ECG')
+                   megmag='MEGMAG', megrefmag='MEGREFMAG')
+
     map_desc = defaultdict(lambda: 'Other type of channel')
     map_desc.update(meggradaxial='Axial Gradiometer',
                     megrefgradaxial='Axial Gradiometer Reference',
                     meggradplanar='Planar Gradiometer',
                     megmag='Magnetometer',
                     megrefmag='Magnetometer Reference',
-                    stim='Trigger', eeg='ElectroEncephaloGram',
+                    stim='Trigger',
+                    eeg='ElectroEncephaloGram',
                     ecog='Electrocorticography',
                     seeg='StereoEEG',
                     ecg='ElectroCardioGram',
                     eog='ElectroOculoGram',
                     emg='ElectroMyoGram',
-                    misc='Miscellaneous')
+                    misc='Miscellaneous',
+                    resp='Respiration')
     get_specific = ('mag', 'ref_meg', 'grad')
 
     # get the manufacturer from the file in the Raw object

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -60,14 +60,10 @@ def _channels_tsv(raw, fname, overwrite=False, verbose=True):
         Set verbose output to true or false.
 
     """
-    # Get channel type mappings between nomenclatures
+    # Get channel type mappings between BIDS and MNE nomenclatures
     map_chs = _get_ch_type_mapping(from_mne_to_bids=True)
-    # Add MEG channels to mapping (ignored in _get_ch_type_mapping for now)
-    map_chs.update(meggradaxial='MEGGRADAXIAL',
-                   megrefgradaxial='MEGREFGRADAXIAL',
-                   meggradplanar='MEGGRADPLANAR',
-                   megmag='MEGMAG', megrefmag='MEGREFMAG')
 
+    # Prepare the descriptions for each channel type
     map_desc = defaultdict(lambda: 'Other type of channel')
     map_desc.update(meggradaxial='Axial Gradiometer',
                     megrefgradaxial='Axial Gradiometer Reference',

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -81,8 +81,7 @@ def _channels_tsv(raw, fname, overwrite=False, verbose=True):
                     ecg='ElectroCardioGram',
                     eog='ElectroOculoGram',
                     emg='ElectroMyoGram',
-                    misc='Miscellaneous',
-                    resp='Respiration')
+                    misc='Miscellaneous')
     get_specific = ('mag', 'ref_meg', 'grad')
 
     # get the manufacturer from the file in the Raw object


### PR DESCRIPTION
closes #218 

also replaces some custom code with the relatively new `_find_matching_sidecar`. For that to work, I had to extend its arguments by an `allow_fail` argument. When set to `True`, it only WARNS instead of raising a RuntimeError.

And to top it off, I did some maintenance and housekeeping with the docs and the tests. E.g., MNE-Python now has separate functions for reading EDF and BDF, ...

# To do
- [x] https://github.com/mne-tools/mne-python/issues/6557 needs to be merged for this to pass
- [x] update Whatsnew
- [x] add tests

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [x] All CIs are happy
- [x] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [x] PR description includes phrase "closes <#issue-number>"
- [x] Commit history does not contain any merge commits
