### PR TITLE
[MRG] Expose copyfile utilities to command line interface

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,10 +26,12 @@ jobs:
 
             - run:
                 name: Setup Python environment
+                # ... but use latest version of MNE
                 command: |
                   conda update --yes --quiet conda
                   conda env create -f environment.yml --name=testenv
                   source activate testenv
+                  pip install -U https://api.github.com/repos/mne-tools/mne-python/zipball/master
                   python setup.py develop
 
             - run:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ language: python
 env:
   global:
     - VALIDATOR_VERSION="master"
+    - MNE_VERSION="master"  # can be "maint/0.18" ... or "master"
 
 
 before_install:
@@ -43,7 +44,7 @@ install:
     - source activate testenv
     - pip uninstall --yes --quiet mne  # uninstall the pip version of mne to install dev version below
     - |
-      git clone --depth 1 https://github.com/mne-tools/mne-python.git -b maint/0.18
+      git clone --depth 1 https://github.com/mne-tools/mne-python.git -b $MNE_VERSION
       cd mne-python
       pip install --no-deps -e .
       cd ../

--- a/README.rst
+++ b/README.rst
@@ -72,12 +72,13 @@ error messages:
 
    $ python -c 'import mne_bids'
 
-For full functionality of ``mne-bids``, you will also need to install the
-following packages:
+For full functionality of ``mne-bids``, you will also need to `` pip install``
+the following packages:
 
 - nibabel
 
-If you want to use the latest development version, use the following command:
+If you want to use the latest development version of ``mne-bids``, use the
+following command:
 
 .. code-block:: bash
 
@@ -99,13 +100,17 @@ iEEG is experimental at the moment.
 Command Line Interface
 ----------------------
 
-In addition to ``import mne_bids``\ , you can use the command line interface.
+In addition to ``import mne_bids``, you can use the command line interface.
+Simply type ``mne_bids`` in your command line and press enter, to see the
+accepted commands. Then type ``mne_bids <command> --help``, where ``<command>``
+is one of the accepted commands, to get more information about that
+``<command>``.
 
 Example:
 
 .. code-block:: bash
 
-   $ mne_bids raw_to_bids --subject_id sub01 --task rest --raw data.edf --output_path new_path
+   $ mne_bids raw_to_bids --help
 
 Bug reports
 -----------

--- a/README.rst
+++ b/README.rst
@@ -110,7 +110,7 @@ Example:
 
 .. code-block:: bash
 
-   $ mne_bids raw_to_bids --help
+  $ mne_bids raw_to_bids --subject_id sub01 --task rest --raw data.edf --output_path new_path
 
 Bug reports
 -----------

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,7 @@ environment:
 # ... whereas for "stable", VALIDATOR_EXECUTABLE MUST be set to "n/a"
   global:
         VALIDATOR_VERSION: "master"
+        MNE_VERSION: "master"  # can be "maint/0.18" ... or "master"
         VALIDATOR_EXECUTABLE: "C:\\projects\\mne-bids\\bids-validator\\bids-validator\\bin\\bids-validator"
         nodejs_version: "10.0.0"
         PYTHON: "C:\\conda"
@@ -38,7 +39,7 @@ install:
   - "pip uninstall -yq mne"
   - |-
     cd ..
-    git clone --depth 1 https://github.com/mne-tools/mne-python.git -b maint/0.18
+    git clone --depth 1 https://github.com/mne-tools/mne-python.git -b $MNE_VERSION
     cd mne-python
     python setup.py develop
     cd ..

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ environment:
         VALIDATOR_VERSION: "master"
         MNE_VERSION: "master"  # can be "maint/0.18" ... or "master"
         VALIDATOR_EXECUTABLE: "C:\\projects\\mne-bids\\bids-validator\\bids-validator\\bin\\bids-validator"
-        nodejs_version: "10.0.0"
+        NODEJS_VERSION: "10.0.0"
         PYTHON: "C:\\conda"
   matrix:
       - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
@@ -15,7 +15,7 @@ environment:
         PYTHON_ARCH: "64"
 
 install:
-  - ps: Install-Product node $env:nodejs_version
+  - ps: Install-Product node $env:NODEJS_VERSION
   - node --version
   - npm --version
   - yarn --version
@@ -37,13 +37,13 @@ install:
   - "conda install numpy scipy"
   - "pip install nibabel flake8 pytest pytest-sugar pytest-faulthandler"
   - "pip uninstall -yq mne"
-  - |-
-    cd ..
-    git clone --depth 1 https://github.com/mne-tools/mne-python.git -b $MNE_VERSION
-    cd mne-python
-    python setup.py develop
-    cd ..
-    cd mne-bids
+  - ps: |-
+        cd ..
+        git clone --depth 1 https://github.com/mne-tools/mne-python.git -b $env:MNE_VERSION
+        cd mne-python
+        python setup.py develop
+        cd ..
+        cd mne-bids
   - "python setup.py develop"
   - "python -c \"import mne; mne.datasets.testing.data_path()\""
 

--- a/cli/mne_bids_cp.py
+++ b/cli/mne_bids_cp.py
@@ -1,7 +1,56 @@
-"""Provide copyfile utilities to the command line.
+"""Rename files (making a copy) and update their internal pointers.
 
 example usage: $ mne_bids cp --input myfile.vhdr --output sub-01_task-test.vhdr
 """
 # Authors: Stefan Appelhoff <stefan.appelhoff@mailbox.org>
 #
 # License: BSD (3-clause)
+import mne_bids
+from mne_bids.copyfiles import (copyfile_brainvision, copyfile_eeglab,
+                                copyfile_ctf)
+
+
+def run():
+    """Run the cp command."""
+    from mne.commands.utils import get_optparser
+
+    accepted_formats_msg = ('Accepted formats are BrainVision (.vhdr), '
+                            'EEGLAB (.set), CTF (.ds).')
+
+    parser = get_optparser(__file__, usage="usage: %prog -i INPUT -o OUTPUT",
+                           prog='mne_bids', version=mne_bids.__version__)
+
+    parser.add_option('-i', '--input', dest='input',
+                      help=('Path to the input file. {}'
+                            .format(accepted_formats_msg)), metavar='INPUT')
+
+    parser.add_option('-o', '--output', dest='output',
+                      help=('Path to the output file. MUST be same format '
+                            'as input file.'), metavar='OUTPUT')
+
+    opt, args = parser.parse_args()
+    opt_dict = vars(opt)
+
+    # Check the usage and raise error if invalid
+    if len(args) > 0:
+        parser.error('Do not specify additional arguments. Found: "{}"'
+                     .format(args))
+
+    if not opt_dict.get('input') or not opt_dict.get('output'):
+        parser.error('Incorrect number of arguments. Supply one input and one '
+                     'output file. You supplied: "{}"'.format(opt))
+
+    # Attempt to do the copying. Errors will be raised by the copyfile
+    # functions if there are issues with the file formats
+    if opt.input.endswith('.vhdr'):
+        copyfile_brainvision(opt.input, opt.output)
+    elif opt.input.endswith('.set'):
+        copyfile_eeglab(opt.input, opt.output)
+    elif opt.input.endswith('.ds'):
+        copyfile_ctf(opt.input, opt.output)
+    else:
+        parser.error('{} You supplied: "{}"'.format(accepted_formats_msg, opt))
+
+
+if __name__ == '__main__':  # pragma: no cover
+    run()

--- a/cli/mne_bids_cp.py
+++ b/cli/mne_bids_cp.py
@@ -18,7 +18,8 @@ def run():
                             'EEGLAB (.set), CTF (.ds).')
 
     parser = get_optparser(__file__, usage="usage: %prog -i INPUT -o OUTPUT",
-                           prog='mne_bids', version=mne_bids.__version__)
+                           prog_prefix='mne_bids',
+                           version=mne_bids.__version__)
 
     parser.add_option('-i', '--input', dest='input',
                       help=('Path to the input file. {}'

--- a/cli/mne_bids_cp.py
+++ b/cli/mne_bids_cp.py
@@ -1,0 +1,7 @@
+"""Provide copyfile utilities to the command line.
+
+example usage: $ mne_bids cp --input myfile.vhdr --output sub-01_task-test.vhdr
+"""
+# Authors: Stefan Appelhoff <stefan.appelhoff@mailbox.org>
+#
+# License: BSD (3-clause)

--- a/cli/mne_bids_cp.py
+++ b/cli/mne_bids_cp.py
@@ -28,12 +28,16 @@ def run():
                       help=('Path to the output file. MUST be same format '
                             'as input file.'), metavar='OUTPUT')
 
+    parser.add_option('-v', '--verbose', dest="verbose",
+                      help='Set logging level to verbose', action="store_true")
+
     opt, args = parser.parse_args()
     opt_dict = vars(opt)
 
     # Check the usage and raise error if invalid
     if len(args) > 0:
-        parser.error('Do not specify additional arguments. Found: "{}"'
+        parser.error('Do not specify arguments without flags. Found: "{}".\n'
+                     'Did you forget to provide -i and -o?'
                      .format(args))
 
     if not opt_dict.get('input') or not opt_dict.get('output'):
@@ -43,7 +47,7 @@ def run():
     # Attempt to do the copying. Errors will be raised by the copyfile
     # functions if there are issues with the file formats
     if opt.input.endswith('.vhdr'):
-        copyfile_brainvision(opt.input, opt.output)
+        copyfile_brainvision(opt.input, opt.output, opt.verbose)
     elif opt.input.endswith('.set'):
         copyfile_eeglab(opt.input, opt.output)
     elif opt.input.endswith('.ds'):

--- a/cli/mne_bids_raw_to_bids.py
+++ b/cli/mne_bids_raw_to_bids.py
@@ -18,7 +18,8 @@ def run():
     from mne.commands.utils import get_optparser
 
     parser = get_optparser(__file__, usage="usage: %prog options args",
-                           prog='mne_bids', version=mne_bids.__version__)
+                           prog_prefix='mne_bids',
+                           version=mne_bids.__version__)
 
     parser.add_option('--subject_id', dest='subject_id',
                       help=('The subject name in BIDS compatible format'

--- a/cli/mne_bids_raw_to_bids.py
+++ b/cli/mne_bids_raw_to_bids.py
@@ -1,62 +1,57 @@
-"""Command line interface for mne_bids.
+"""Write raw files to BIDS format.
 
 example usage:  $ mne_bids raw_to_bids --subject_id sub01 --task rest
 --raw data.edf --output_path new_path
 
 """
 # Authors: Teon Brooks <teon.brooks@gmail.com>
+#          Stefan Appelhoff <stefan.appelhoff@mailbox.org>
 #
 # License: BSD (3-clause)
+import mne_bids
 from mne_bids import write_raw_bids, make_bids_basename
 from mne_bids.read import _read_raw
 
 
 def run():
-    """Run command."""
+    """Run the raw_to_bids command."""
     from mne.commands.utils import get_optparser
 
-    parser = get_optparser(__file__)
+    parser = get_optparser(__file__, usage="usage: %prog options args",
+                           prog='mne_bids', version=mne_bids.__version__)
 
     parser.add_option('--subject_id', dest='subject_id',
-                      help=('The subject name in BIDS compatible format',
-                            '(01,02, etc.)'), metavar='s')
+                      help=('The subject name in BIDS compatible format'
+                            '(01,02, etc.)'))
     parser.add_option('--task', dest='task',
-                      help='Name of the task the data is based on.',
-                      metavar='t')
+                      help='Name of the task the data is based on.')
     parser.add_option('--raw', dest='raw_fname',
-                      help='The path to the raw MEG file.', metavar='r')
+                      help='The path to the raw MEG file.')
     parser.add_option('--output_path', dest='output_path',
-                      help='The path of the BIDS compatible folder.',
-                      metavar='o')
+                      help='The path of the BIDS compatible folder.')
     parser.add_option('--session_id', dest='session_id',
-                      help='The session name in BIDS compatible format.',
-                      metavar='ses')
+                      help='The session name in BIDS compatible format.')
     parser.add_option('--run', dest='run',
-                      help='The run number for this dataset.',
-                      metavar='run')
+                      help='The run number for this dataset.')
     parser.add_option('--acq', dest='acq',
-                      help='The acquisition parameter.',
-                      metavar='acq')
+                      help='The acquisition parameter.')
     parser.add_option('--events_data', dest='events_data',
-                      help='The events file.', metavar='evt')
+                      help='The events file.')
     parser.add_option('--event_id', dest='event_id',
                       help='The event id dict.', metavar='eid')
     parser.add_option('--hpi', dest='hpi',
-                      help='The path to the MEG Marker points',
-                      metavar='filename')
+                      help='The path to the MEG Marker points')
     parser.add_option('--electrode', dest='electrode',
-                      help='The path to head-native Digitizer points',
-                      metavar='elec')
+                      help='The path to head-native Digitizer points')
     parser.add_option('--hsp', dest='hsp',
-                      help='The path to headshape points.', metavar='hsp')
+                      help='The path to headshape points.')
     parser.add_option('--config', dest='config',
-                      help='The path to the configuration file', metavar='cfg')
+                      help='The path to the configuration file')
     parser.add_option('--overwrite', dest='overwrite',
-                      help=("Boolean. Whether to overwrite existing data"),
-                      metavar='ow')
+                      help="Boolean. Whether to overwrite existing data")
     parser.add_option('--allow_maxshield', dest='allow_maxshield',
-                      help=("Boolean. Whether to allow non Maxfiltered data."),
-                      metavar='mxf', action='store_true')
+                      help="Boolean. Whether to allow non Maxfiltered data.",
+                      action='store_true')
 
     opt, args = parser.parse_args()
 
@@ -71,6 +66,5 @@ def run():
                    verbose=True)
 
 
-is_main = (__name__ == '__main__')
-if is_main:  # pragma: no cover
+if __name__ == '__main__':  # pragma: no cover
     run()

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -1,6 +1,6 @@
-# -*- coding: utf-8 -*-
 """Test command line."""
 # Authors: Teon L Brooks <teon.brooks@gmail.com>
+#          Stefan Appelhoff <stefan.appelhoff@mailbox.org>
 #
 # License: BSD (3-clause)
 from os import path as op
@@ -8,7 +8,9 @@ from os import path as op
 from mne.datasets import testing
 from mne.utils import _TempDir, run_tests_if_main, ArgvSetter
 
-from cli import mne_bids_raw_to_bids
+from mne_bids.datasets import fetch_brainvision_testing_data
+
+from cli import mne_bids_raw_to_bids, mne_bids_cp
 
 
 subject_id = '01'
@@ -36,6 +38,17 @@ def test_raw_to_bids():
     with ArgvSetter(('--subject_id', subject_id, '--task', task, '--raw',
                      raw_fname, '--output_path', output_path)):
         mne_bids_raw_to_bids.run()
+
+
+def test_cp():
+    """Test mne_bids cp."""
+    output_path = _TempDir()
+    data_path = fetch_brainvision_testing_data()
+    raw_fname = op.join(data_path, 'test.vhdr')
+    outname = op.join(output_path, 'test2.vhdr')
+    # check_usage(mne_bids_cp)
+    with ArgvSetter(('--input', raw_fname, '--output', outname)):
+        mne_bids_cp.run()
 
 
 run_tests_if_main()

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -1,13 +1,16 @@
 :orphan:
 
 .. _api_documentation:
-.. contents::
-   :local:
-   :depth: 2
 
 =================
 API Documentation
 =================
+
+Here we list the Application Programming Interface (API) for MNE-BIDS.
+
+.. contents:: Contents
+   :local:
+   :depth: 2
 
 MNE BIDS (:py:mod:`mne_bids`)
 =============================

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -16,6 +16,14 @@ sys.path.append(os.path.abspath(os.path.join(curdir, '..', 'mne_bids')))
 sys.path.append(os.path.abspath(os.path.join(curdir, 'sphinxext')))
 
 
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+curdir = os.path.dirname(__file__)
+sys.path.append(os.path.abspath(os.path.join(curdir, '..', 'mne_bids')))
+sys.path.append(os.path.abspath(os.path.join(curdir, 'sphinxext')))
+
+
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
@@ -29,11 +37,12 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.mathjax',
     'sphinx.ext.viewcode',
-    'numpydoc',
     'sphinx.ext.autosummary',
     'sphinx.ext.doctest',
     'sphinx.ext.intersphinx',
-    'sphinx_gallery.gen_gallery'
+    'sphinx_gallery.gen_gallery',
+    'numpydoc',
+    'gen_cli'  # custom extension, see ./sphinxext/gen_cli.py
 ]
 
 # generate autosummary even if no references

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -99,6 +99,7 @@ html_theme_options = {
     'navbar_links': [
         ("Examples", "auto_examples/index"),
         ("API", "api"),
+        ("CLI", "generated/cli"),
         ("What's new", "whats_new"),
         ("Github", "https://github.com/mne-tools/mne-bids", True),
     ]}

--- a/doc/sphinxext/gen_cli.py
+++ b/doc/sphinxext/gen_cli.py
@@ -29,11 +29,15 @@ def setup(app):
 # 4. -   : Command sections (Examples, Notes)
 
 header = """\
-.. _python_commands:
+:orphan:
 
-===============================
-Command line tools using Python
-===============================
+.. _python_cli:
+
+=====================================
+MNE-BIDS Command Line Interface (CLI)
+=====================================
+
+Here we list the MNE-BIDS tools that you can use from the command line.
 
 .. contents:: Contents
    :local:
@@ -63,18 +67,18 @@ def generate_cli_rst(app=None):
         os.mkdir(out_dir)
     out_fname = op.join(out_dir, 'cli.rst.new')
 
-    command_path = op.abspath(
-        op.join(os.path.dirname(__file__), '..', '..', 'mne', 'cli'))
+    cli_path = op.abspath(
+        op.join(os.path.dirname(__file__), '..', '..', 'cli'))
     fnames = sorted([
         op.basename(fname)
-        for fname in glob.glob(op.join(command_path, 'mne_*.py'))])
+        for fname in glob.glob(op.join(cli_path, 'mne_bids*.py'))])
     iterator = sphinx_compatibility.status_iterator(
-        fnames, 'generating MNE command help ... ', length=len(fnames))
+        fnames, 'generating MNE-BIDS cli help ... ', length=len(fnames))
     with open(out_fname, 'w') as f:
         f.write(header)
         for fname in iterator:
             cmd_name = fname[:-3]
-            run_name = op.join(command_path, fname)
+            run_name = op.join(cli_path, fname)
             output, _ = run_subprocess([sys.executable, run_name, '--help'],
                                        stdout=subprocess.PIPE,
                                        stderr=subprocess.PIPE, verbose=False)
@@ -89,7 +93,7 @@ def generate_cli_rst(app=None):
 
             # Add code styling for the "Usage: " line
             for li, line in enumerate(output):
-                if line.startswith('Usage: mne '):
+                if line.startswith('Usage: mne_bids '):
                     output[li] = 'Usage: ``%s``' % line[7:]
                     break
 
@@ -103,7 +107,7 @@ def generate_cli_rst(app=None):
                 output.insert(ii + 4, '')
             output = '\n'.join(output)
             f.write(command_rst % (cmd_name,
-                                   cmd_name.replace('mne_', 'mne '),
+                                   cmd_name.replace('mne_bids_', 'mne_bids '),
                                    '=' * len(cmd_name),
                                    output))
     _replace_md5(out_fname)

--- a/doc/sphinxext/gen_cli.py
+++ b/doc/sphinxext/gen_cli.py
@@ -61,10 +61,10 @@ def generate_cli_rst(app=None):
     out_dir = op.abspath(op.join(op.dirname(__file__), '..', 'generated'))
     if not op.isdir(out_dir):
         os.mkdir(out_dir)
-    out_fname = op.join(out_dir, 'commands.rst.new')
+    out_fname = op.join(out_dir, 'cli.rst.new')
 
     command_path = op.abspath(
-        op.join(os.path.dirname(__file__), '..', '..', 'mne', 'commands'))
+        op.join(os.path.dirname(__file__), '..', '..', 'mne', 'cli'))
     fnames = sorted([
         op.basename(fname)
         for fname in glob.glob(op.join(command_path, 'mne_*.py'))])

--- a/doc/sphinxext/gen_cli.py
+++ b/doc/sphinxext/gen_cli.py
@@ -1,0 +1,115 @@
+"""Custom sphinx extension to generate docs for the command line interace.
+
+Inspired by MNE-Python's `gen_commands.py`
+see: github.com/mne-tools/mne-python/blob/master/doc/sphinxext/gen_commands.py
+"""
+# Authors: Eric Larson <larson.eric.d@gmail.com>
+#          Alexandre Gramfort <alexandre.gramfort@telecom-paristech.fr>
+#          Stefan Appelhoff <stefan.appelhoff@mailbox.org>
+#
+# License: BSD (3-clause)
+import os
+import glob
+from os import path as op
+import subprocess
+import sys
+
+from mne.utils import run_subprocess, _replace_md5
+
+
+def setup(app):
+    """Set up the app."""
+    app.connect('builder-inited', generate_cli_rst)
+
+
+# Header markings go:
+# 1. =/= : Page title
+# 2. =   : Command name
+# 3. -/- : Command description
+# 4. -   : Command sections (Examples, Notes)
+
+header = """\
+.. _python_commands:
+
+===============================
+Command line tools using Python
+===============================
+
+.. contents:: Contents
+   :local:
+   :depth: 1
+
+"""
+
+command_rst = """
+
+.. _gen_%s:
+
+%s
+%s
+
+.. rst-class:: callout
+
+%s
+
+"""
+
+
+def generate_cli_rst(app=None):
+    """Generate the command line interface docs."""
+    from sphinx_gallery import sphinx_compatibility
+    out_dir = op.abspath(op.join(op.dirname(__file__), '..', 'generated'))
+    if not op.isdir(out_dir):
+        os.mkdir(out_dir)
+    out_fname = op.join(out_dir, 'commands.rst.new')
+
+    command_path = op.abspath(
+        op.join(os.path.dirname(__file__), '..', '..', 'mne', 'commands'))
+    fnames = sorted([
+        op.basename(fname)
+        for fname in glob.glob(op.join(command_path, 'mne_*.py'))])
+    iterator = sphinx_compatibility.status_iterator(
+        fnames, 'generating MNE command help ... ', length=len(fnames))
+    with open(out_fname, 'w') as f:
+        f.write(header)
+        for fname in iterator:
+            cmd_name = fname[:-3]
+            run_name = op.join(command_path, fname)
+            output, _ = run_subprocess([sys.executable, run_name, '--help'],
+                                       stdout=subprocess.PIPE,
+                                       stderr=subprocess.PIPE, verbose=False)
+            output = output.splitlines()
+
+            # Swap usage and title lines
+            output[0], output[2] = output[2], output[0]
+
+            # Add header marking
+            for idx in (1, 0):
+                output.insert(idx, '-' * len(output[0]))
+
+            # Add code styling for the "Usage: " line
+            for li, line in enumerate(output):
+                if line.startswith('Usage: mne '):
+                    output[li] = 'Usage: ``%s``' % line[7:]
+                    break
+
+            # Turn "Options:" into field list
+            if 'Options:' in output:
+                ii = output.index('Options:')
+                output[ii] = 'Options'
+                output.insert(ii + 1, '-------')
+                output.insert(ii + 2, '')
+                output.insert(ii + 3, '.. rst-class:: field-list cmd-list')
+                output.insert(ii + 4, '')
+            output = '\n'.join(output)
+            f.write(command_rst % (cmd_name,
+                                   cmd_name.replace('mne_', 'mne '),
+                                   '=' * len(cmd_name),
+                                   output))
+    _replace_md5(out_fname)
+    print('[Done]')
+
+
+# This is useful for testing/iterating to see what the result looks like
+if __name__ == '__main__':
+    generate_cli_rst()

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -22,6 +22,7 @@ Current
 Changelog
 ~~~~~~~~~
 
+- New command line function exposed :code:`cp` for renaming/copying files including automatic doc generation "CLI", by `Stefan Appelhoff`_ (`#225 <https://github.com/mne-tools/mne-bids/pull/225>`_)
 - :func:`read_raw_bids` now also reads channels.tsv files accompanying a raw BIDS file and sets the channel types accordingly, by `Stefan Appelhoff`_ (`#219 <https://github.com/mne-tools/mne-bids/pull/219>`_)
 - Add example :code:`convert_mri_and_trans` for using :func:`get_head_mri_trans` and :func:`write_anat`, by `Stefan Appelhoff`_ (`#211 <https://github.com/mne-tools/mne-bids/pull/211>`_)
 - :func:`get_head_mri_trans` allows retrieving a :code:`trans` object from a BIDS dataset that contains MEG and T1 weighted MRI data, by `Stefan Appelhoff`_ (`#211 <https://github.com/mne-tools/mne-bids/pull/211>`_)

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -1,12 +1,16 @@
 :orphan:
 
 .. _whats_new:
-.. contents::
-   :local:
-   :depth: 3
+
 
 What's new?
 ===========
+
+Here we list a changelog of MNE-BIDS.
+
+.. contents:: Contents
+   :local:
+   :depth: 3
 
 .. currentmodule:: mne_bids
 

--- a/examples/README.txt
+++ b/examples/README.txt
@@ -3,6 +3,8 @@
 Examples Gallery
 ================
 
+Here we show some exemplary use cases for MNE-BIDS.
+
 .. contents:: Contents
    :local:
    :depth: 3

--- a/examples/rename_brainvision_files.py
+++ b/examples/rename_brainvision_files.py
@@ -19,6 +19,10 @@ adjusting the internal links, we corrupt the file format.
 
 In this example, we use MNE-BIDS to rename BrainVision data files including a
 repair of the internal file pointers.
+
+For the command line version of this tool, see the :code:`cp` tool in the docs
+for the :ref:`Python Command Line Interface <python_cli>`.
+
 """
 
 # Authors: Stefan Appelhoff <stefan.appelhoff@mailbox.org>

--- a/mne_bids/copyfiles.py
+++ b/mne_bids/copyfiles.py
@@ -65,7 +65,7 @@ def _get_brainvision_encoding(vhdr_file, verbose=False):
             enc = 'UTF-8'
             src = '(default)'
         if verbose is True:
-            print('file encoding: %s %s' % (enc, src))
+            print('Detected file encoding: %s %s.' % (enc, src))
     return enc
 
 
@@ -154,7 +154,7 @@ def copyfile_ctf(src, dest):
                   op.join(dest, bids_folder_name + ext))
 
 
-def copyfile_brainvision(vhdr_src, vhdr_dest):
+def copyfile_brainvision(vhdr_src, vhdr_dest, verbose=False):
     """Copy a BrainVision file triplet to a new location and repair links.
 
     Parameters
@@ -176,7 +176,7 @@ def copyfile_brainvision(vhdr_src, vhdr_dest):
     eeg_file_path, vmrk_file_path = _get_brainvision_paths(vhdr_src)
 
     # extract encoding from brainvision header file, or default to utf-8
-    enc = _get_brainvision_encoding(vhdr_src, verbose=True)
+    enc = _get_brainvision_encoding(vhdr_src, verbose)
 
     # Copy data .eeg ... no links to repair
     sh.copyfile(eeg_file_path, fname_dest + '.eeg')
@@ -204,6 +204,12 @@ def copyfile_brainvision(vhdr_src, vhdr_dest):
                 if line.strip() in search_lines:
                     line = line.replace(basename_src, basename_dest)
                 fout.write(line)
+
+    if verbose:
+        for ext in ['.eeg', '.vhdr', '.vmrk']:
+            print('Created "{}" in "{}"'
+                  .format(fname_dest + ext,
+                          op.dirname(op.realpath(vhdr_dest))))
 
 
 def copyfile_eeglab(src, dest):

--- a/mne_bids/pick.py
+++ b/mne_bids/pick.py
@@ -2,7 +2,6 @@
 # Authors: Matt Sanderson <matt.sanderson@mq.edu.au>
 #
 # License: BSD (3-clause)
-
 from mne.io.constants import FIFF
 
 

--- a/mne_bids/tests/test_copyfiles.py
+++ b/mne_bids/tests/test_copyfiles.py
@@ -71,11 +71,11 @@ def test_copyfile_brainvision():
     new_name = op.join(output_path, 'tested_conversion.vhdr')
 
     # IO error testing
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='Need to move data with same'):
         copyfile_brainvision(raw_fname, new_name + '.eeg')
 
     # Try to copy the file
-    copyfile_brainvision(raw_fname, new_name)
+    copyfile_brainvision(raw_fname, new_name, verbose=True)
 
     # Have all been copied?
     head, tail = op.split(new_name)


### PR DESCRIPTION
closes #220 

rendered docs: https://882-89170358-gh.circle-artifacts.com/0/html/generated/cli.html

# To Do:

- [x] make MNE-Python's optparse wrapper more versatile to use in mne-bids
    - [x] see: https://github.com/mne-tools/mne-python/pull/6572 ... needs to be merged
- [x] make `mne_bids cp` work for
    - BrainVision
    - CTF
    - EEGLAB format (.set / .fdt)
    - ...
-  ~~make a documentation "entry point" for mne-bids and from there, linking to:~~
    - don't do that --- cli can be linked from pagenav for now.
    - [x] examples (currently called "Gallery")
    - [x] docs page for CLI
- [x] make a documentation page for CLI
- [x] get rid of "source" and "this page" links at top of docs: They take away space

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [x] All CIs are happy
- [x] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [x] PR description includes phrase "closes <#issue-number>"
- [x] Commit history does not contain any merge commits
