### PR TITLE
[MRG] Make `write_anat` and `get_head_mri_trans` more robust

### DIFF
--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -10,7 +10,6 @@ import os
 import os.path as op
 import glob
 import json
-import warnings
 
 import numpy as np
 import mne
@@ -254,7 +253,7 @@ def get_head_mri_trans(bids_fname, bids_root):
     Parameters
     ----------
     bids_fname : str
-        Full name of the MEG data file (not a path)
+        Full name of the MEG data file
     bids_root : str
         Path to root of the BIDS folder
 
@@ -270,8 +269,6 @@ def get_head_mri_trans(bids_fname, bids_root):
 
     # Get the sidecar file for MRI landmarks
     if os.sep in bids_fname:
-        warnings.warn('`bids_fname` seems to be a path. Attempting to take '
-                      'only the name WITHOUT the path ... ')
         bids_fname = op.basename(bids_fname)
     t1w_json_path = _find_matching_sidecar(bids_fname, bids_root, 'T1w.json')
 

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -6,9 +6,11 @@
 #          Stefan Appelhoff <stefan.appelhoff@mailbox.org>
 #
 # License: BSD (3-clause)
+import os
 import os.path as op
 import glob
 import json
+from warnings import warn
 
 import numpy as np
 import mne
@@ -267,6 +269,10 @@ def get_head_mri_trans(bids_fname, bids_root):
     import nibabel as nib
 
     # Get the sidecar file for MRI landmarks
+    if os.sep in bids_fname:
+        warn('`bids_fname` seems to be a path. Attempting to take only the '
+             'the name WITHOUT the path ... ')
+        bids_fname = op.basename(bids_fname)
     t1w_json_path = _find_matching_sidecar(bids_fname, bids_root, 'T1w.json')
 
     # Get MRI landmarks from the JSON sidecar

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -268,8 +268,7 @@ def get_head_mri_trans(bids_fname, bids_root):
     import nibabel as nib
 
     # Get the sidecar file for MRI landmarks
-    if os.sep in bids_fname:
-        bids_fname = op.basename(bids_fname)
+    bids_fname = op.basename(bids_fname)
     t1w_json_path = _find_matching_sidecar(bids_fname, bids_root, 'T1w.json')
 
     # Get MRI landmarks from the JSON sidecar

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -10,7 +10,7 @@ import os
 import os.path as op
 import glob
 import json
-from warnings import warn
+import warnings
 
 import numpy as np
 import mne
@@ -270,8 +270,8 @@ def get_head_mri_trans(bids_fname, bids_root):
 
     # Get the sidecar file for MRI landmarks
     if os.sep in bids_fname:
-        warn('`bids_fname` seems to be a path. Attempting to take only the '
-             'the name WITHOUT the path ... ')
+        warnings.warn('`bids_fname` seems to be a path. Attempting to take '
+                      'only the name WITHOUT the path ... ')
         bids_fname = op.basename(bids_fname)
     t1w_json_path = _find_matching_sidecar(bids_fname, bids_root, 'T1w.json')
 

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -6,7 +6,6 @@
 #          Stefan Appelhoff <stefan.appelhoff@mailbox.org>
 #
 # License: BSD (3-clause)
-import os
 import os.path as op
 import glob
 import json

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -93,12 +93,11 @@ def test_get_head_mri_trans():
     print(trans)
     print(estimated_trans)
 
-    # Provoke a warning by passing a path to bids_fname instead of a NAME
+    # Passing a path instead of a name works well
     bids_fpath = op.join(output_path, 'sub-{}'.format(subject_id),
                          'ses-{}'.format(session_id), 'meg',
                          bids_basename + '_meg.fif')
-    with pytest.warns(UserWarning, match='`bids_fname` seems to be a path.'):
-        estimated_trans = get_head_mri_trans(bids_fpath, output_path)
+    estimated_trans = get_head_mri_trans(bids_fpath, output_path)
 
     # provoke an error by pointing introducing NaNs into MEG coords
     with pytest.raises(RuntimeError, match='AnatomicalLandmarkCoordinates'):

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -93,6 +93,13 @@ def test_get_head_mri_trans():
     print(trans)
     print(estimated_trans)
 
+    # Provoke a warning by passing a path to bids_fname instead of a NAME
+    bids_fpath = op.join(output_path, 'sub-{}'.format(subject_id),
+                         'ses-{}'.format(session_id), 'meg',
+                         bids_basename + '_meg.fif')
+    with pytest.warns(UserWarning, match='`bids_fname` seems to be a path.'):
+        estimated_trans = get_head_mri_trans(bids_fpath, output_path)
+
     # provoke an error by pointing introducing NaNs into MEG coords
     with pytest.raises(RuntimeError, match='AnatomicalLandmarkCoordinates'):
         raw.info['dig'][0]['r'] = np.ones(3) * np.nan

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -620,15 +620,19 @@ def test_write_anat():
         _find_matching_sidecar('sub-01_ses-01_acq-01_T1w.nii.gz',
                                output_path, 'T1w.json')
 
-    # trans is not a Transform
-    with pytest.raises(ValueError, match='must be of type "Transform"'):
+    # trans has a wrong type
+    wrong_type = 1
+    match = 'transform type {} not known, must be'.format(type(wrong_type))
+    with pytest.raises(ValueError, match=match):
         write_anat(output_path, subject_id, t1w_mgh, session_id, raw=raw,
-                   trans=1, verbose=True, overwrite=True)
+                   trans=wrong_type, verbose=True, overwrite=True)
 
     # trans is a str, but file does not exist
-    with pytest.raises(ValueError, match='Expected `trans` to point to a '):
+    wrong_fname = 'not_a_trans'
+    match = 'trans file "{}" not found'.format(wrong_fname)
+    with pytest.raises(IOError, match=match):
         write_anat(output_path, subject_id, t1w_mgh, session_id, raw=raw,
-                   trans='not a trans', verbose=True, overwrite=True)
+                   trans=wrong_fname, verbose=True, overwrite=True)
 
     # However, reading trans if it is a string pointing to trans is fine
     write_anat(output_path, subject_id, t1w_mgh, session_id, raw=raw,

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -371,8 +371,7 @@ def _find_matching_sidecar(bids_fname, bids_root, suffix, allow_fail=False):
         and no sidecar_fname was found
 
     """
-    if op.sep in bids_fname:
-        bids_fname = op.basename(bids_fname)
+    bids_fname = op.basename(bids_fname)
 
     # We only use subject and session as identifier, because all other
     # parameters are potentially not binding for metadata sidecar files

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -355,7 +355,7 @@ def _find_matching_sidecar(bids_fname, bids_root, suffix, allow_fail=False):
     Parameters
     ----------
     bids_fname : str
-        Full name of the data file (not a path)
+        Full name of the data file
     bids_root : str
         Path to root of the BIDS folder
     suffix : str
@@ -371,6 +371,9 @@ def _find_matching_sidecar(bids_fname, bids_root, suffix, allow_fail=False):
         and no sidecar_fname was found
 
     """
+    if op.sep in bids_fname:
+        bids_fname = op.basename(bids_fname)
+
     # We only use subject and session as identifier, because all other
     # parameters are potentially not binding for metadata sidecar files
     if 'ses' in bids_fname:

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -976,9 +976,11 @@ def write_anat(bids_root, subject, t1w, session=None, acquisition=None,
     raw : instance of Raw | None
         The raw data of `subject` corresponding to `t1w`. If `raw` is None,
         `trans` has to be None as well
-    trans : instance of mne.transforms.Transform | None
-        The transformation matrix from head coordinates to MRI coordinates.
-        If None, no sidecar JSON file will be written for `t1w`
+    trans : instance of mne.transforms.Transform | str | None
+        The transformation matrix from head coordinates to MRI coordinates. Can
+        also be a string pointing to a *.trans file containing the
+        transformation matrix. If None, no sidecar JSON file will be written
+        for `t1w`
     overwrite : bool
         Whether to overwrite existing files or data in files.
         Defaults to False.
@@ -1038,9 +1040,12 @@ def write_anat(bids_root, subject, t1w, session=None, acquisition=None,
     if trans is None:
         return anat_dir
 
-    if not isinstance(trans, mne.transforms.Transform):
-        raise ValueError('`trans` must be a "Transform" but is of type "{}"'
-                         .format(type(trans)))
+    if not (isinstance(trans, mne.transforms.Transform) or not
+            isinstance(trans, str)):
+        raise ValueError('`trans` must be of type "Transform" or "str", '
+                         'but is of type "{}"'.format(type(trans)))
+    if isinstance(trans, str):
+        trans = mne.read_trans(trans)
 
     if not isinstance(raw, BaseRaw):
         raise ValueError('`raw` must be specified if `trans` is not None')

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1046,7 +1046,7 @@ def write_anat(bids_root, subject, t1w, session=None, acquisition=None,
                          'but is of type "{}"'.format(type(trans)))
     if isinstance(trans, str):
         if not op.exists(trans):
-            raise ValueError('Expected `trans` to point to a *.trans file, '
+            raise ValueError('Expected `trans` to point to a *-trans.fif file, '
                              'but it does not exist: "{}"'.format(trans))
         trans = mne.read_trans(trans)
 

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1040,11 +1040,14 @@ def write_anat(bids_root, subject, t1w, session=None, acquisition=None,
     if trans is None:
         return anat_dir
 
-    if not (isinstance(trans, mne.transforms.Transform) or not
-            isinstance(trans, str)):
+    if not(isinstance(trans, mne.transforms.Transform) or
+           isinstance(trans, str)):
         raise ValueError('`trans` must be of type "Transform" or "str", '
                          'but is of type "{}"'.format(type(trans)))
     if isinstance(trans, str):
+        if not op.exists(trans):
+            raise ValueError('Expected `trans` to point to a *.trans file, '
+                             'but it does not exist: "{}"'.format(trans))
         trans = mne.read_trans(trans)
 
     if not isinstance(raw, BaseRaw):

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1003,8 +1003,11 @@ def write_anat(bids_root, subject, t1w, session=None, acquisition=None,
     import nibabel as nib
 
     # Make directory for anatomical data
-    anat_dir = op.join(bids_root, 'sub-{}'.format(subject),
-                       'ses-{}'.format(session), 'anat')
+    anat_dir = op.join(bids_root, 'sub-{}'.format(subject))
+    # Session is optional
+    if session is not None:
+        anat_dir = op.join(anat_dir, 'ses-{}'.format(session))
+    anat_dir = op.join(anat_dir, 'anat')
     if not op.exists(anat_dir):
         os.makedirs(anat_dir)
 


### PR DESCRIPTION
some issues discovered with `write_anat` and `get_head_mri_trans` ... as surfaced by @agramfort 

- `write_anat` no longer writes a session directory if None is given
- `get_head_mri_trans`
  - accepts `str` pointer to trans as well as trans objects
  - recovers gracefully when a path is passed instead of a name (=op.basename(path))
