### PR TITLE
[MRG] Make _find_matching_sidecar more powerful

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -28,6 +28,7 @@ Changelog
 - :func:`get_head_mri_trans` allows retrieving a :code:`trans` object from a BIDS dataset that contains MEG and T1 weighted MRI data, by `Stefan Appelhoff`_ (`#211 <https://github.com/mne-tools/mne-bids/pull/211>`_)
 - :func:`write_anat` allows writing T1 weighted MRI scans for subjects and optionally creating a T1w.json sidecar from a supplied :code:`trans` object, by `Stefan Appelhoff`_ (`#211 <https://github.com/mne-tools/mne-bids/pull/211>`_)
 - :func:`read_raw_bids` will return the the raw object with :code:`raw.info['bads']` already populated, whenever a :code:`channels.tsv` file is present, by `Stefan Appelhoff`_ (`#209 <https://github.com/mne-tools/mne-bids/pull/209>`_)
+- :func:`read_raw_bids` is now more likely to find event and channel sidecar json files, by `Marijn van Vliet`_ (`#233 <https://github.com/mne-tools/mne-bids/pull/233>`_)
 
 Bug
 ~~~
@@ -150,3 +151,4 @@ People who contributed to this release (in alphabetical order):
 .. _Dominik Welke: https://github.com/dominikwelke
 .. _Maximilien Chaumon: https://github.com/dnacombo
 .. _Ezequiel Mikulan: https://github.com/ezemikulan
+.. _Marijn van Vliet: https://github.com/wmvanvliet

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -195,8 +195,10 @@ def read_raw_bids(bids_fname, bids_root, verbose=True):
         The data as MNE-Python Raw object.
 
     """
+
     # Full path to data file is needed so that mne-bids knows
     # what is the modality -- meg, eeg, ieeg to read
+    bids_fname = op.basename(bids_fname)
     bids_basename = '_'.join(bids_fname.split('_')[:-1])
     kind = bids_fname.split('_')[-1].split('.')[0]
     _, ext = _parse_ext(bids_fname)

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -13,7 +13,7 @@ import json
 import numpy as np
 import mne
 from mne import io
-from mne.utils import has_nibabel
+from mne.utils import has_nibabel, logger
 from mne.coreg import fit_matched_points
 from mne.transforms import apply_trans
 
@@ -76,6 +76,7 @@ def _handle_events_reading(events_fname, raw):
 
     Handle onset, duration, and description of each event.
     """
+    logger.info('Reading events from {}.'.format(events_fname))
     events_dict = _from_tsv(events_fname)
 
     # Get the descriptions of the events
@@ -112,6 +113,7 @@ def _handle_channels_reading(channels_fname, bids_fname, raw):
 
     Updates status (bad) and types of channels.
     """
+    logger.info('Reading channel info from {}.'.format(channels_fname))
     channels_dict = _from_tsv(channels_fname)
 
     # First, make sure that ordering of names in channels.tsv matches the

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -195,7 +195,6 @@ def read_raw_bids(bids_fname, bids_root, verbose=True):
         The data as MNE-Python Raw object.
 
     """
-
     # Full path to data file is needed so that mne-bids knows
     # what is the modality -- meg, eeg, ieeg to read
     bids_fname = op.basename(bids_fname)

--- a/mne_bids/tests/test_utils.py
+++ b/mne_bids/tests/test_utils.py
@@ -203,7 +203,7 @@ def test_infer_eeg_placement_scheme():
     # No candidates match
     (['sub-02_ses-02', 'sub-01_ses-01'], []),
 
-    # Second candidate is disqualified (session doesn't match)
+    # First candidate is disqualified (session doesn't match)
     (['sub-01_ses-01', 'sub-01_ses-02'], ['sub-01_ses-02']),
 
     # Multiple equally good candidates

--- a/mne_bids/tests/test_utils.py
+++ b/mne_bids/tests/test_utils.py
@@ -216,7 +216,6 @@ def test_find_matching_sidecar():
                                            'coordsystem.json')
     expected_file = op.join('sub-01', 'ses-01', 'meg',
                             'sub-01_ses-01_acq-01_coordsystem.json')
-
     assert sidecar_fname.endswith(expected_file)
 
     # Now find multiple sidecar candidates and pick the one that matches best
@@ -224,6 +223,11 @@ def test_find_matching_sidecar():
     sidecar_fname = _find_matching_sidecar(bids_basename, output_path,
                                            'coordsystem.json')
     assert sidecar_fname.endswith(expected_file)
+    sidecar_fname2 = _find_matching_sidecar(
+        bids_basename.replace('acq-01', 'acq-02'),
+        output_path, 'coordsystem.json')
+    expected_file2 = expected_file.replace('acq-01', 'acq-02')
+    assert sidecar_fname2.endswith(expected_file2)
 
     # Find multiple sidecars, tied in score, triggering an error
     with pytest.raises(RuntimeError, match='Expected to find a single'):

--- a/mne_bids/tests/test_utils.py
+++ b/mne_bids/tests/test_utils.py
@@ -203,7 +203,7 @@ def test_infer_eeg_placement_scheme():
     # No candidates match
     (['sub-02_ses-02', 'sub-01_ses-01'], []),
 
-    # Second candidates is disqualified (session doesn't match)
+    # Second candidate is disqualified (session doesn't match)
     (['sub-01_ses-01', 'sub-01_ses-02'], ['sub-01_ses-02']),
 
     # Multiple equally good candidates

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -303,7 +303,7 @@ def test_ctf():
 
     cmd = bids_validator_exe + [output_path]
     run_subprocess(cmd, shell=shell)
-    with pytest.warns(UserWarning, match='Expected to find a single events'):
+    with pytest.warns(UserWarning, match='Did not find any events'):
         raw = read_raw_bids(bids_basename + '_meg.ds', output_path)
 
     # test to check that running again with overwrite == False raises an error
@@ -616,7 +616,7 @@ def test_write_anat():
     sh.rmtree(anat_dir)
     write_anat(output_path, subject_id, t1w_mgh, session_id)
     # Assert that we truly cannot find a sidecar
-    with pytest.raises(RuntimeError, match='Expected to find a single'):
+    with pytest.raises(RuntimeError, match='Did not find any'):
         _find_matching_sidecar('sub-01_ses-01_acq-01_T1w.nii.gz',
                                output_path, 'T1w.json')
 

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -407,7 +407,7 @@ def _find_matching_sidecar(bids_fname, bids_root, suffix, allow_fail=False):
                 else:
                     # Incompatible entity found, candidate is disqualified
                     candidate_disqualified = True
-                    continue
+                    break
         if not candidate_disqualified and n_matches >= best_score:
             best_score = n_matches
             best_candidates.append(candidate)

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -394,15 +394,21 @@ def _find_matching_sidecar(bids_fname, bids_root, suffix, allow_fail=False):
     best_score = 0
     for candidate in candidate_list:
         n_matches = 0
+        candidate_disqualified = False
         candidate_params = _parse_bids_filename(candidate, verbose=False)
         for entity, value in params.items():
+            if value is None:
+                continue
             if entity in candidate_params:
-                if candidate_params[entity] == value:
+                if candidate_params[entity] is None:
+                    continue
+                elif candidate_params[entity] == value:
                     n_matches += 1
                 else:
                     # Incompatible entity found, candidate is disqualified
+                    candidate_disqualified = True
                     continue
-        if n_matches >= best_score:
+        if not candidate_disqualified and n_matches >= best_score:
             best_score = n_matches
             best_candidates.append(candidate)
 

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -140,7 +140,6 @@ param_regex = re.compile(r'([^-_\.\\\/]+)-([^-_\.\\\/]+)')
 
 def _parse_bids_filename(fname, verbose):
     """Get dict from BIDS fname."""
-    # Extract part of the filename containing the parameters
     keys = ['sub', 'ses', 'task', 'acq', 'run', 'proc', 'run', 'space',
             'recording', 'kind']
     params = {key: None for key in keys}

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -358,8 +358,8 @@ def _find_best_candidates(params, candidate_list):
 
     Assign each candidate a score, based on how many entities are shared with
     the ones supplied in the `params` parameter. The candidate with the highest
-    score wins. Candidates with entities that conflict with bids_fname are
-    disqualified.
+    score wins. Candidates with entities that conflict with the supplied
+    `params` are disqualified.
 
     Parameters
     ----------

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -388,7 +388,9 @@ def _find_matching_sidecar(bids_fname, bids_root, suffix, allow_fail=False):
     search_str = op.join(bids_root, '**', search_str + '*' + suffix)
     candidate_list = glob.glob(search_str, recursive=True)
 
-    # Sort the list of potential sidebar files by how many params are matched
+    # Assign each candidate a score, based on how many entities are shared with
+    # bids_fname. The candidate with the highest score wins. Candidates with
+    # entities that conflict with bids_fname are disqualified.
     best_candidates = []
     best_score = 0
     for candidate in candidate_list:

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -377,7 +377,7 @@ def _find_best_candidates(params, candidate_list):
     params = {key: value for key, value in params.items() if value is not None}
 
     best_candidates = []
-    best_score = 0
+    best_n_matches = 0
     for candidate in candidate_list:
         n_matches = 0
         candidate_disqualified = False
@@ -393,10 +393,10 @@ def _find_best_candidates(params, candidate_list):
                     candidate_disqualified = True
                     break
         if not candidate_disqualified:
-            if n_matches > best_score:
-                best_score = n_matches
+            if n_matches > best_n_matches:
+                best_n_matches = n_matches
                 best_candidates = [candidate]
-            elif n_matches == best_score:
+            elif n_matches == best_n_matches:
                 best_candidates.append(candidate)
 
     return best_candidates

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -380,7 +380,7 @@ def _find_matching_sidecar(bids_fname, bids_root, suffix, allow_fail=False):
     # We only use subject and session as identifier, because all other
     # parameters are potentially not binding for metadata sidecar files
     search_str = 'sub-' + params['sub']
-    if 'ses' in params:
+    if params['ses'] is not None:
         search_str += '_ses-' + params['ses']
 
     # Find all potential sidecar files, doing a recursive glob from bids_root

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -375,8 +375,6 @@ def _find_best_candidates(params, candidate_list):
         Hopefully, the list will have a length of one.
     """
     params = {key: value for key, value in params.items() if value is not None}
-    print('params:', params)
-    print('candidates:', candidate_list)
 
     best_candidates = []
     best_score = 0
@@ -389,10 +387,8 @@ def _find_best_candidates(params, candidate_list):
                 if candidate_params[entity] is None:
                     continue
                 elif candidate_params[entity] == value:
-                    print('match:', entity, candidate_params[entity], value)
                     n_matches += 1
                 else:
-                    print('no match:', entity, candidate_params[entity], value)
                     # Incompatible entity found, candidate is disqualified
                     candidate_disqualified = True
                     break


### PR DESCRIPTION
In the current implementation, `_find_matching_sidecar` finds the sidecar file by glob searching based on subject and session. This fails if multiple sidecar files exists for the same subject and session, for
example multiple runs:

```
├── sub-01
│   ├── ses-01
│   │   ├── meg
│   │   │   ├── sub-01_ses-01_coordsystem.json
│   │   │   ├── sub-01_ses-01_task-naming_run-01_channels.tsv
│   │   │   ├── sub-01_ses-01_task-naming_run-01_events.tsv
│   │   │   ├── sub-01_ses-01_task-naming_run-01_meg.fif
│   │   │   ├── sub-01_ses-01_task-naming_run-01_meg.json
│   │   │   ├── sub-01_ses-01_task-naming_run-02_channels.tsv
│   │   │   ├── sub-01_ses-01_task-naming_run-02_events.tsv
│   │   │   ├── sub-01_ses-01_task-naming_run-02_meg.fif
│   │   │   ├── sub-01_ses-01_task-naming_run-02_meg.json
│   │   │   ├── sub-01_ses-01_task-naming_run-03_channels.tsv
│   │   │   ├── sub-01_ses-01_task-naming_run-03_events.tsv
│   │   │   ├── sub-01_ses-01_task-naming_run-03_meg.fif
│   │   │   └── sub-01_ses-01_task-naming_run-03_meg.json
│   │   └── sub-01_ses-01_scans.tsv
```

In the above case, `_find_matching_sidecar` will fail when instructed to find an events or channel sidecar file, as the glob search will match all the runs.

In this PR, the search strategy is made more powerful. First, a list of all candidate sidecar files is compiled, using the existing glob search based on subject and session. Then, each candidate is assigned a score, based on how many entities (sub/ses/run/task/etc.) are shared with the raw file. The candidate with the highest score wins and gets returned. Candidates with entities that conflict with the raw file are disqualified. If multiple candidates are tied for top score, the existing functionality is triggered regarding multiple matches (a warning in case of `allow_fail=True` and an exception otherwise).

To make this process a bit more transparant, some logging output has been added (Reading events from ..., Reading channel data from ...)

To make the implementation of the "candidate race" easier, the `_parse_bids_filename` has been modified to operate on full filenames. So this PR also closes #230 and closes #231.

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [x] All CIs are happy
- [x] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [X] PR description includes phrase "closes <#issue-number>"
- [x] Commit history does not contain any merge commits