### PR TITLE
handle `n/a` in events reading from BIDS

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -32,6 +32,7 @@ Changelog
 Bug
 ~~~
 
+- Fixed bug where :func:`read_raw_bids` would throw a ValueError upon encountering strings in the "onset" or "duration" column of events.tsv files, by `Stefan Appelhoff`_ (`#234 <https://github.com/mne-tools/mne-bids/pull/234>`_)
 - Allow raw data from KIT systems to have two marker files specified, by `Matt Sanderson`_ (`#173 <https://github.com/mne-tools/mne-bids/pull/173>`_)
 
 API

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -95,9 +95,16 @@ def _handle_events_reading(events_fname, raw):
     else:
         descriptions = 'n/a'
 
+    # Check for 'n/a' strings before converting to float
+    ons = list(map(lambda on: np.nan if on == 'n/a' else on,
+               events_dict['onset']))
+
+    durs = list(map(lambda dur: np.nan if dur == 'n/a' else dur,
+                events_dict['duration']))
+
     # Add Events to raw as annotations
-    onsets = np.asarray(events_dict['onset'], dtype=float)
-    durations = np.asarray(events_dict['duration'], dtype=float)
+    onsets = np.asarray(ons, dtype=float)
+    durations = np.asarray(durs, dtype=float)
     annot_from_events = mne.Annotations(onset=onsets,
                                         duration=durations,
                                         description=descriptions,

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -95,16 +95,13 @@ def _handle_events_reading(events_fname, raw):
     else:
         descriptions = 'n/a'
 
-    # Check for 'n/a' strings before converting to float
-    ons = list(map(lambda on: np.nan if on == 'n/a' else on,
-               events_dict['onset']))
-
-    durs = list(map(lambda dur: np.nan if dur == 'n/a' else dur,
-                events_dict['duration']))
+    # Deal with "n/a" strings before converting to float
+    ons = [np.nan if on == 'n/a' else on for on in events_dict['onset']]
+    dus = [np.nan if du == 'n/a' else du for du in events_dict['duration']]
 
     # Add Events to raw as annotations
     onsets = np.asarray(ons, dtype=float)
-    durations = np.asarray(durs, dtype=float)
+    durations = np.asarray(dus, dtype=float)
     annot_from_events = mne.Annotations(onset=onsets,
                                         duration=durations,
                                         description=descriptions,

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -115,12 +115,13 @@ def test_handle_events_reading():
     # We can use any `raw` for this
     raw = mne.io.read_raw_fif(raw_fname)
 
-    # Create an arbitrary events.tsv file
-    events = {'onset': [1, 2, 3],
+    # Create an arbitrary events.tsv file, to test we can deal with 'n/a'
+    events = {'onset': [11, 12, 13],
               'duration': ['n/a', 'n/a', 'n/a']
               }
     tmp_dir = _TempDir()
     events_fname = op.join(tmp_dir, 'sub-01_task-test_events.json')
     _to_tsv(events, events_fname)
 
-    _handle_events_reading(events_fname, raw)
+    raw = _handle_events_reading(events_fname, raw)
+    events, event_id = mne.events_from_annotations(raw)

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -249,8 +249,8 @@ def _read_events(events_data, event_id, raw, ext):
         the MNE events array (shape n_events, 3). If None, events will be
         inferred from the stim channel using `find_events`.
     event_id : dict
-        The event_id dict as provided in write_raw_bids, mapping a
-        description key to an integer valued event code.
+        The event id dict used to create a 'trial_type' column in events.tsv,
+        mapping a description key to an integer valued event code.
     raw : instance of Raw
         The data as MNE-Python Raw object.
     ext : str
@@ -278,7 +278,7 @@ def _read_events(events_data, event_id, raw, ext):
     elif 'stim' in raw:
         events = find_events(raw, min_duration=0.001, initial_event=True)
     elif ext in ['.vhdr', '.set'] and check_version('mne', '0.18'):
-        events, event_id = events_from_annotations(raw)
+        events, event_id = events_from_annotations(raw, event_id)
     else:
         warnings.warn('No events found or provided. Please make sure to'
                       ' set channel type using raw.set_channel_types'


### PR DESCRIPTION
The test I am adding here will break the events reading. Concretely, `'n/a'` strings cannot be dealt with currently.

This will change with this PR.

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [x] All comments resolved
- [ ] This is not your own PR
- [x] All CIs are happy
- [ ] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
- [x] Commit history does not contain any merge commits
