### PR TITLE
Fix reading events from a sidecar json file

### DIFF
--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -101,7 +101,7 @@ def _handle_events_reading(events_fname, raw):
     annot_from_events = mne.Annotations(onset=onsets,
                                         duration=durations,
                                         description=descriptions,
-                                        orig_time=raw.info['meas_date'])
+                                        orig_time=None)
     raw.set_annotations(annot_from_events)
 
     return raw


### PR DESCRIPTION
This PR fixes the onset of the annotations created when reading sidecar `*_events.tsv` files.

Closes #235.

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
- [ ] Commit history does not contain any merge commits
