### PR TITLE
[MRG] ENH added automatic conversion to bv for fif if no meg

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -90,6 +90,7 @@ For full functionality of ``mne-bids``, you will also need to ``pip install``
 the following packages:
 
 - ``nibabel``, for interacting with MRI data
+- ``pybv``, to convert EEG data to BrainVision if input format is not valid according to EEG BIDS specifications
 
 If you want to use the latest development version of ``mne-bids``, use the
 following command:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,14 +36,14 @@ install:
       set PATH="%PATH%;C:\projects\mne-bids\bids-validator\bids-validator\bin\" )
   - CALL "%PYTHON_ROOT%\\Scripts\\activate.bat"
   - "conda install -y python=%PYTHON_VERSION% conda numpy scipy"
-  - "pip install nibabel flake8 pytest pytest-sugar pytest-faulthandler"
+  - "pip install nibabel flake8 pytest pytest-sugar pytest-faulthandler pybv"
   - "pip uninstall -yq mne"
-  - ps: |-
-        cd ..
-        git clone --depth 1 https://github.com/mne-tools/mne-python.git -b $env:MNE_VERSION
-        cd mne-python
-        python setup.py develop
-        cd ..
+  - cmd:
+        cd .. &&
+        git clone --depth 1 https://github.com/mne-tools/mne-python.git -b %MNE_VERSION% &&
+        cd mne-python &&
+        python setup.py develop &&
+        cd .. &&
         cd mne-bids
   - "python setup.py develop"
   - "python -c \"import mne; mne.datasets.testing.data_path()\""

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -22,8 +22,8 @@ Current
 Changelog
 ~~~~~~~~~
 
+- Added automatic conversion of FIF to BrainVision format with warning for EEG only data and conversion to FIF for meg non-FIF data, by `Alex Rockhill` _ (`#237 <https://github.com/mne-tools/mne-bids/pull/237>`_)
 - New feature in :func`mne_bids.write.write_anat` for shear deface of mri, by `Alex Rockhill`_ (`#271 <https://github.com/mne-tools/mne-bids/pull/271>`_)
-
 
 Bug
 ~~~
@@ -186,3 +186,4 @@ People who contributed to this release (in alphabetical order):
 .. _Maximilien Chaumon: https://github.com/dnacombo
 .. _Ezequiel Mikulan: https://github.com/ezemikulan
 .. _Marijn van Vliet: https://github.com/wmvanvliet
+.. _Alex Rockhill: http://github.com/alexrockhill

--- a/environment.yml
+++ b/environment.yml
@@ -13,6 +13,7 @@ dependencies:
 - pip:
   - mne
   - nibabel
+  - pybv
   - nilearn
   - flake8
   - pytest

--- a/mne_bids/config.py
+++ b/mne_bids/config.py
@@ -49,6 +49,6 @@ allowed_extensions_ieeg = ['.vhdr',  # BrainVision, accompanied by .vmrk, .eeg
                            '.nwb',  # Neurodata without borders
                            ]
 
-ALLOWED_EXTENSIONS = (allowed_extensions_meg +
-                      allowed_extensions_eeg +
-                      allowed_extensions_ieeg)
+ALLOWED_EXTENSIONS = {'meg': allowed_extensions_meg,
+                      'eeg': allowed_extensions_eeg,
+                      'ieeg': allowed_extensions_ieeg}


### PR DESCRIPTION
Thanks for contributing. If this is your first time,
make sure to read [contributing.md](https://github.com/mne-tools/mne-bids/blob/master/CONTRIBUTING.md)

PR Description
--------------

I didn't add pybv to the packages automatically installed by pip yet, so I think that still has to be done. I can look into it soon but maybe someone else knows how to add that quicker.

As is this converts a FIF file given to write_raw_bids to BV format if there are no meg channels. It uses both events_from_annotations and find_events for backward compatibility. The conversion is accurate to 1e-9 or greater when taken round trip using a data set I had.

closes

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [x] All comments resolved
- [x] This is not your own PR
- [x] All CIs are happy
- [x] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [x] PR description includes phrase "closes <#issue-number>"
- [x] Commit history does not contain any merge commits
