### PR TITLE
[MRG] add a `maxdepth` arg to print_dir_tree

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -22,6 +22,7 @@ Current
 Changelog
 ~~~~~~~~~
 
+- :func:`mne_bids.utils.print_dir_tree` now accepts an argument :code:`max_depth` which can limit the depth until which the directory tree is printed, by `Stefan Appelhoff`_ (`#245 <https://github.com/mne-tools/mne-bids/pull/245>`_)
 - New command line function exposed :code:`cp` for renaming/copying files including automatic doc generation "CLI", by `Stefan Appelhoff`_ (`#225 <https://github.com/mne-tools/mne-bids/pull/225>`_)
 - :func:`read_raw_bids` now also reads channels.tsv files accompanying a raw BIDS file and sets the channel types accordingly, by `Stefan Appelhoff`_ (`#219 <https://github.com/mne-tools/mne-bids/pull/219>`_)
 - Add example :code:`convert_mri_and_trans` for using :func:`get_head_mri_trans` and :func:`write_anat`, by `Stefan Appelhoff`_ (`#211 <https://github.com/mne-tools/mne-bids/pull/211>`_)

--- a/mne_bids/tests/test_utils.py
+++ b/mne_bids/tests/test_utils.py
@@ -72,10 +72,13 @@ def test_print_dir_tree(capsys):
     """Test printing a dir tree."""
     with pytest.raises(ValueError, match='Directory does not exist'):
         print_dir_tree('i_dont_exist')
+
+    # We check the testing directory
+    test_dir = op.dirname(__file__)
     with pytest.raises(ValueError, match='must be a positive integer'):
-        # We check the testing directory
-        test_dir = op.dirname(__file__)
         print_dir_tree(test_dir, max_depth=-1)
+    with pytest.raises(ValueError, match='must be a positive integer'):
+        print_dir_tree(test_dir, max_depth='bad')
 
     # Do not limit depth
     print_dir_tree(test_dir)

--- a/mne_bids/tests/test_utils.py
+++ b/mne_bids/tests/test_utils.py
@@ -67,13 +67,33 @@ def test_handle_kind():
         _handle_kind(raw)
 
 
-def test_print_dir_tree():
+def test_print_dir_tree(capsys):
     """Test printing a dir tree."""
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='Directory does not exist'):
         print_dir_tree('i_dont_exist')
+    with pytest.raises(ValueError, match='must be a positive integer'):
+        # We check the testing directory
+        test_dir = op.dirname(__file__)
+        print_dir_tree(test_dir, max_depth=-1)
 
-    tmp_dir = _TempDir()
-    assert print_dir_tree(tmp_dir) is None
+    # Do not limit depth
+    print_dir_tree(test_dir)
+    captured = capsys.readouterr()
+    assert '|--- test_utils.py' in captured.out.split('\n')
+    assert '|--- __pycache__/' in captured.out.split('\n')
+    assert '.pyc' in captured.out
+
+    # Now limit depth ... we should not descend into pycache
+    print_dir_tree(test_dir, max_depth=1)
+    captured = capsys.readouterr()
+    assert '|--- test_utils.py' in captured.out.split('\n')
+    assert '|--- __pycache__/' in captured.out.split('\n')
+    assert '.pyc' not in captured.out
+
+    # Limit depth even more
+    print_dir_tree(test_dir, max_depth=0)
+    captured = capsys.readouterr()
+    assert captured.out == '|tests/\n'
 
 
 def test_make_filenames():

--- a/mne_bids/tests/test_utils.py
+++ b/mne_bids/tests/test_utils.py
@@ -4,6 +4,7 @@
 #          Stefan Appelhoff <stefan.appelhoff@mailbox.org>
 #
 # License: BSD (3-clause)
+import os
 import os.path as op
 import pytest
 from datetime import datetime
@@ -80,18 +81,20 @@ def test_print_dir_tree(capsys):
     print_dir_tree(test_dir)
     captured = capsys.readouterr()
     assert '|--- test_utils.py' in captured.out.split('\n')
+    assert '|--- __pycache__{}'.format(os.sep) in captured.out.split('\n')
     assert '.pyc' in captured.out
 
     # Now limit depth ... we should not descend into pycache
     print_dir_tree(test_dir, max_depth=1)
     captured = capsys.readouterr()
     assert '|--- test_utils.py' in captured.out.split('\n')
+    assert '|--- __pycache__{}'.format(os.sep) in captured.out.split('\n')
     assert '.pyc' not in captured.out
 
     # Limit depth even more
     print_dir_tree(test_dir, max_depth=0)
     captured = capsys.readouterr()
-    assert captured.out == '|tests/\n'
+    assert captured.out == '|tests{}\n'.format(os.sep)
 
 
 def test_make_filenames():

--- a/mne_bids/tests/test_utils.py
+++ b/mne_bids/tests/test_utils.py
@@ -80,14 +80,12 @@ def test_print_dir_tree(capsys):
     print_dir_tree(test_dir)
     captured = capsys.readouterr()
     assert '|--- test_utils.py' in captured.out.split('\n')
-    assert '|--- __pycache__/' in captured.out.split('\n')
     assert '.pyc' in captured.out
 
     # Now limit depth ... we should not descend into pycache
     print_dir_tree(test_dir, max_depth=1)
     captured = capsys.readouterr()
     assert '|--- test_utils.py' in captured.out.split('\n')
-    assert '|--- __pycache__/' in captured.out.split('\n')
     assert '.pyc' not in captured.out
 
     # Limit depth even more

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -83,10 +83,17 @@ def _get_ch_type_mapping(fro='mne', to='bids'):
     return ch_type_mapping
 
 
-def print_dir_tree(folder, max_depth=float('inf')):
+def print_dir_tree(folder, max_depth=None):
     """Recursively print dir tree starting from `folder` up to `max_depth`."""
     if not op.exists(folder):
         raise ValueError('Directory does not exist: {}'.format(folder))
+    msg = '`max_depth` must be a positive integer or None'
+    if not isinstance(max_depth, (int, type(None))):
+        raise ValueError(msg)
+    if max_depth is None:
+        max_depth = float('inf')
+    if max_depth < 0:
+        raise ValueError(msg)
 
     # Use max_depth same as the -L param in the unix `tree` command
     max_depth += 1

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -83,20 +83,35 @@ def _get_ch_type_mapping(fro='mne', to='bids'):
     return ch_type_mapping
 
 
-def print_dir_tree(folder):
-    """Recursively print a directory tree starting from `folder`."""
+def print_dir_tree(folder, max_depth=float('inf')):
+    """Recursively print dir tree starting from `folder` up to `max_depth`."""
     if not op.exists(folder):
         raise ValueError('Directory does not exist: {}'.format(folder))
 
-    baselen = len(folder.split(os.sep)) - 1  # makes tree always start at 0 len
+    # Use max_depth same as the -L param in the unix `tree` command
+    max_depth += 1
+
+    # Base length of a tree branch, to normalize each tree's start to 0
+    baselen = len(folder.split(os.sep)) - 1
+
+    # Recursively walk through all directories
     for root, dirs, files in os.walk(folder):
+
+        # Check how far we have walked
         branchlen = len(root.split(os.sep)) - baselen
-        if branchlen <= 1:
-            print('|%s' % (op.basename(root)))
-        else:
-            print('|%s %s' % ((branchlen - 1) * '---', op.basename(root)))  # noqa: E501
-        for file in files:
-            print('|%s %s' % (branchlen * '---', file))
+
+        # Only print, if this is up to the depth we asked
+        if branchlen <= max_depth:
+            if branchlen <= 1:
+                print('|{}'.format(op.basename(root) + os.sep))
+            else:
+                print('|{} {}'.format((branchlen - 1) * '---',
+                                      op.basename(root) + os.sep))
+
+            # Only print files if we are NOT yet up to max_depth or beyond
+            if branchlen < max_depth:
+                for file in files:
+                    print('|{} {}'.format(branchlen * '---', file))
 
 
 def _mkdir_p(path, overwrite=False, verbose=False):


### PR DESCRIPTION
This is handy when we want to visualize a dirtree but not go down recursively until infinity ... e.g., when showing a freesurfer directory.

To Do
- [x] rebase
- [x] add test
- [x] whatsnew

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [x] All comments resolved
- [x] This is not your own PR
- [x] All CIs are happy
- [x] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
- [x] Commit history does not contain any merge commits
