### PR TITLE
[MRG] print help if there are issues

### DIFF
--- a/cli/mne_bids_cp.py
+++ b/cli/mne_bids_cp.py
@@ -37,11 +37,13 @@ def run():
 
     # Check the usage and raise error if invalid
     if len(args) > 0:
+        parser.print_help()
         parser.error('Do not specify arguments without flags. Found: "{}".\n'
                      'Did you forget to provide -i and -o?'
                      .format(args))
 
     if not opt_dict.get('input') or not opt_dict.get('output'):
+        parser.print_help()
         parser.error('Incorrect number of arguments. Supply one input and one '
                      'output file. You supplied: "{}"'.format(opt))
 

--- a/cli/mne_bids_raw_to_bids.py
+++ b/cli/mne_bids_raw_to_bids.py
@@ -64,8 +64,7 @@ def run():
     if not all([opt.subject_id, opt.task, opt.raw_fname, opt.output_path]):
         parser.print_help()
         parser.error('Arguments missing. You need to specify at least the'
-                     'following: --subject_id, --task, --raw data.edf, '
-                     '--output_path.')
+                     'following: --subject_id, --task, --raw, --output_path.')
 
     bids_basename = make_bids_basename(
         subject=opt.subject_id, session=opt.session_id, run=opt.run,

--- a/cli/mne_bids_raw_to_bids.py
+++ b/cli/mne_bids_raw_to_bids.py
@@ -56,6 +56,17 @@ def run():
 
     opt, args = parser.parse_args()
 
+    if len(args) > 0:
+        parser.print_help()
+        parser.error('Do not specify arguments without flags. Found: "{}".\n'
+                     .format(args))
+
+    if not all([opt.subject_id, opt.task, opt.raw_fname, opt.output_path]):
+        parser.print_help()
+        parser.error('Arguments missing. You need to specify at least the'
+                     'following: --subject_id, --task, --raw data.edf, '
+                     '--output_path.')
+
     bids_basename = make_bids_basename(
         subject=opt.subject_id, session=opt.session_id, run=opt.run,
         acquisition=opt.acq, task=opt.task)

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -5,6 +5,7 @@
 # License: BSD (3-clause)
 from os import path as op
 
+import pytest
 from mne.datasets import testing
 from mne.utils import _TempDir, run_tests_if_main, ArgvSetter
 
@@ -34,10 +35,18 @@ def test_raw_to_bids():
     data_path = testing.data_path()
     raw_fname = op.join(data_path, 'MEG', 'sample',
                         'sample_audvis_trunc_raw.fif')
-    # check_usage(mne_bids_raw_to_bids)
+    # Check that help is printed
+    check_usage(mne_bids_raw_to_bids)
+
+    # Should work
     with ArgvSetter(('--subject_id', subject_id, '--task', task, '--raw',
                      raw_fname, '--output_path', output_path)):
         mne_bids_raw_to_bids.run()
+
+    # Too few input args
+    with pytest.raises(SystemExit):
+        with ArgvSetter(('--subject_id', subject_id)):
+            mne_bids_cp.run()
 
 
 def test_cp():
@@ -46,9 +55,18 @@ def test_cp():
     data_path = fetch_brainvision_testing_data()
     raw_fname = op.join(data_path, 'test.vhdr')
     outname = op.join(output_path, 'test2.vhdr')
-    # check_usage(mne_bids_cp)
+
+    # Check that help is printed
+    check_usage(mne_bids_cp)
+
+    # should work
     with ArgvSetter(('--input', raw_fname, '--output', outname)):
         mne_bids_cp.run()
+
+    # too few inputs
+    with pytest.raises(SystemExit):
+        with ArgvSetter(('--input', raw_fname)):
+            mne_bids_cp.run()
 
 
 run_tests_if_main()

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -59,11 +59,11 @@ def test_cp():
     # Check that help is printed
     check_usage(mne_bids_cp)
 
-    # should work
+    # Should work
     with ArgvSetter(('--input', raw_fname, '--output', outname)):
         mne_bids_cp.run()
 
-    # too few inputs
+    # Too few input args
     with pytest.raises(SystemExit):
         with ArgvSetter(('--input', raw_fname)):
             mne_bids_cp.run()


### PR DESCRIPTION
Going back to what @jasmainak told me in https://github.com/mne-tools/mne-bids/pull/225#discussion_r303547777

I know realized myself that displaying the "help" of the CLI whenever it is used incorrectly has some advantages :-)

Here is the PR to fix it.
 
Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [x] All comments resolved
- [x] This is not your own PR
- [x] All CIs are happy
- [x] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [x] PR description includes phrase "closes <#issue-number>"
- [x] Commit history does not contain any merge commits
