### PR TITLE
[MRG] rel imports -> abs imports

### DIFF
--- a/mne_bids/__init__.py
+++ b/mne_bids/__init__.py
@@ -3,6 +3,6 @@
 __version__ = '0.2.dev0'
 
 
-from .write import (write_raw_bids, make_bids_folders, make_bids_basename,  # noqa: E501 F401
-                    make_dataset_description, write_anat)  # noqa: F401
-from .read import read_raw_bids, get_head_mri_trans  # noqa: F401
+from mne_bids.write import (write_raw_bids, make_bids_folders, make_bids_basename,  # noqa: E501 F401
+                            make_dataset_description, write_anat)  # noqa: F401
+from mne_bids.read import read_raw_bids, get_head_mri_trans  # noqa: F401

--- a/mne_bids/copyfiles.py
+++ b/mne_bids/copyfiles.py
@@ -21,7 +21,7 @@ import shutil as sh
 
 from scipy.io import loadmat, savemat
 
-from .read import _parse_ext
+from mne_bids.read import _parse_ext
 
 
 def _copytree(src, dst, **kwargs):

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -17,10 +17,11 @@ from mne.utils import has_nibabel, logger
 from mne.coreg import fit_matched_points
 from mne.transforms import apply_trans
 
-from .tsv_handler import _from_tsv, _drop
-from .config import ALLOWED_EXTENSIONS
-from .utils import (_parse_bids_filename, _extract_landmarks,
-                    _find_matching_sidecar, _parse_ext, _get_ch_type_mapping)
+from mne_bids.tsv_handler import _from_tsv, _drop
+from mne_bids.config import ALLOWED_EXTENSIONS
+from mne_bids.utils import (_parse_bids_filename, _extract_landmarks,
+                            _find_matching_sidecar, _parse_ext,
+                            _get_ch_type_mapping)
 
 reader = {'.con': io.read_raw_kit, '.sqd': io.read_raw_kit,
           '.fif': io.read_raw_fif, '.pdf': io.read_raw_bti,

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -25,7 +25,7 @@ from mne.io.pick import pick_types
 from mne.io.kit.kit import get_kit_info
 from mne.io.constants import FIFF
 
-from .tsv_handler import _to_tsv, _tsv_to_str
+from mne_bids.tsv_handler import _to_tsv, _tsv_to_str
 
 
 def _get_ch_type_mapping(fro='mne', to='bids'):

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -24,19 +24,21 @@ from mne.io import BaseRaw
 from mne.channels.channels import _unit2human
 from mne.utils import check_version, has_nibabel
 
-from .pick import coil_type
-from .utils import (_write_json, _write_tsv, _read_events, _mkdir_p,
-                    _age_on_date, _infer_eeg_placement_scheme, _check_key_val,
-                    _parse_bids_filename, _handle_kind, _check_types,
-                    _get_mrk_meas_date, _extract_landmarks, _parse_ext,
-                    _get_ch_type_mapping)
-from .copyfiles import (copyfile_brainvision, copyfile_eeglab, copyfile_ctf,
-                        copyfile_bti)
-from .read import reader
-from .tsv_handler import _from_tsv, _combine, _drop, _contains_row
+from mne_bids.pick import coil_type
+from mne_bids.utils import (_write_json, _write_tsv, _read_events, _mkdir_p,
+                            _age_on_date, _infer_eeg_placement_scheme,
+                            _check_key_val,
+                            _parse_bids_filename, _handle_kind, _check_types,
+                            _get_mrk_meas_date, _extract_landmarks, _parse_ext,
+                            _get_ch_type_mapping)
+from mne_bids.copyfiles import (copyfile_brainvision, copyfile_eeglab,
+                                copyfile_ctf, copyfile_bti)
+from mne_bids.read import reader
+from mne_bids.tsv_handler import _from_tsv, _combine, _drop, _contains_row
 
-from .config import (ORIENTATION, UNITS, MANUFACTURERS,
-                     IGNORED_CHANNELS, ALLOWED_EXTENSIONS, BIDS_VERSION)
+from mne_bids.config import (ORIENTATION, UNITS, MANUFACTURERS,
+                             IGNORED_CHANNELS, ALLOWED_EXTENSIONS,
+                             BIDS_VERSION)
 
 
 def _channels_tsv(raw, fname, overwrite=False, verbose=True):


### PR DESCRIPTION
previously, implicit and explicit import policies have been mixed in mne-bids

- use only explicit, because they are nicer ([PEP8](https://www.python.org/dev/peps/pep-0008/#imports))

> Absolute imports are recommended, as they are usually more readable and tend to be better behaved (or at least give better error messages) if the import system is incorrectly configured

- now consistent across mne-bids