### PR TITLE
[MRG] Add fetch function for eeg_matchingpennies dataset

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -59,5 +59,6 @@ Datasets (:py:mod:`mne_bids.datasets`)
 .. autosummary::
     :toctree: generated/
 
+    fetch_matchingpennies
     fetch_faces_data
     fetch_brainvision_testing_data

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -22,6 +22,7 @@ Current
 Changelog
 ~~~~~~~~~
 
+- Add new dataset fetcher :func:`mne_bids.datasets.fetch_matchingpennies`, by `Stefan Appelhoff`_ (`#249 <https://github.com/mne-tools/mne-bids/pull/249>`_)
 - :func:`mne_bids.utils.print_dir_tree` now accepts an argument :code:`max_depth` which can limit the depth until which the directory tree is printed, by `Stefan Appelhoff`_ (`#245 <https://github.com/mne-tools/mne-bids/pull/245>`_)
 - New command line function exposed :code:`cp` for renaming/copying files including automatic doc generation "CLI", by `Stefan Appelhoff`_ (`#225 <https://github.com/mne-tools/mne-bids/pull/225>`_)
 - :func:`read_raw_bids` now also reads channels.tsv files accompanying a raw BIDS file and sets the channel types accordingly, by `Stefan Appelhoff`_ (`#219 <https://github.com/mne-tools/mne-bids/pull/219>`_)

--- a/mne_bids/datasets.py
+++ b/mne_bids/datasets.py
@@ -89,7 +89,7 @@ def fetch_matchingpennies(data_path=None, download_dataset_data=True,
                     '11': ('6p8vr', 'ywnpg', 'p7xk2', '8u5fm', 'rjzhy'),
                     }
 
-    for subject in subjects:
+    for subject in subjects:  # pragma: no cover
         file_keys = file_key_map.get(subject, None)
 
         # If wrong subject, do not attempt to download
@@ -113,7 +113,7 @@ def fetch_matchingpennies(data_path=None, download_dataset_data=True,
         _download_data(data, overwrite, verbose)
 
     # If requested, download general data
-    if download_dataset_data:
+    if download_dataset_data:  # pragma: no cover
         file_key_map = {
             '.bidsignore': '6thgf',
             'CHANGES': 'ckmbf',

--- a/mne_bids/datasets.py
+++ b/mne_bids/datasets.py
@@ -16,9 +16,12 @@ from mne.utils import _fetch_file
 from mne_bids import make_bids_basename, make_bids_folders
 
 
-def _download_data(data, overwrite, verbose):
+def _download_data(data, overwrite, verbose, dry=False):
     """Iterate over `data`, a dict with fpath, url and download."""
     for fpath, url in data.items():
+        if dry:
+            print(fpath, url)
+            continue
         if op.exists(fpath) and not overwrite:
             continue
         _fetch_file(url=url, file_name=fpath, print_destination=verbose,
@@ -26,7 +29,8 @@ def _download_data(data, overwrite, verbose):
 
 
 def fetch_matchingpennies(data_path=None, subjects=None, dataset_data=True,
-                          sourcedata=False, overwrite=False, verbose=True):
+                          sourcedata=False, overwrite=False, verbose=True,
+                          dry=False):
     """Fetch the eeg_matchingpennies dataset [1]_.
 
     Parameters
@@ -47,6 +51,8 @@ def fetch_matchingpennies(data_path=None, subjects=None, dataset_data=True,
         Whether or not to overwrite data. Defaults to False.
     verbose : bool
         Whether or not to print output. Defaults to True.
+    dry : bool
+        If True, will only print filepaths and urls instead of downloading.
 
     Returns
     -------
@@ -60,7 +66,7 @@ def fetch_matchingpennies(data_path=None, subjects=None, dataset_data=True,
            https://doi.org/10.17605/OSF.IO/CJ2DR
 
     """
-    if data_path is None:
+    if data_path is None:  # pragma: no cover
         data_path = op.join(op.expanduser('~'), 'mne_data',
                             'mne_bids_examples')
     data_path = op.join(data_path, 'eeg_matchingpennies')
@@ -120,7 +126,7 @@ def fetch_matchingpennies(data_path=None, subjects=None, dataset_data=True,
             data[fpath] = base_url.format(key)
 
         # Download
-        _download_data(data, overwrite, verbose)
+        _download_data(data, overwrite, verbose, dry)
 
     # If requested, download general data
     if dataset_data:
@@ -145,7 +151,7 @@ def fetch_matchingpennies(data_path=None, subjects=None, dataset_data=True,
             data[fpath] = base_url.format(key)
 
         # Download
-        _download_data(data, overwrite, verbose)
+        _download_data(data, overwrite, verbose, dry)
 
     return data_path
 
@@ -170,7 +176,7 @@ def fetch_faces_data(data_path=None, repo='ds000117', subject_ids=[1]):
         data is stored.
 
     """
-    if not data_path:
+    if not data_path:  # pragma: no cover
         data_path = os.path.join(os.path.expanduser('~'), 'mne_data',
                                  'mne_bids_examples')
     os.makedirs(data_path, exist_ok=True)

--- a/mne_bids/datasets.py
+++ b/mne_bids/datasets.py
@@ -127,7 +127,7 @@ def fetch_matchingpennies(data_path=None, download_dataset_data=True,
         }
         # Compile data
         data = dict()
-        for name, key in file_key_map:
+        for fname, key in file_key_map.items():
             fpath = op.join(data_path, fname)
             data[fpath] = base_url.format(key)
 

--- a/mne_bids/datasets.py
+++ b/mne_bids/datasets.py
@@ -5,11 +5,11 @@
 #          Stefan Appelhoff <stefan.appelhoff@mailbox.org>
 #
 # License: BSD (3-clause)
-
 import os
 import os.path as op
 import shutil
 import tarfile
+import urllib
 
 from mne.utils import _fetch_file
 
@@ -68,13 +68,13 @@ def fetch_matchingpennies(data_path=None, download_dataset_data=True,
     data_path = op.join(data_path, 'eeg_matchingpennies')
     os.makedirs(data_path, exist_ok=True)
 
-    if not isinstance(subjects, [list, tuple, type(None)]):
+    if not isinstance(subjects, (list, tuple, type(None))):
         raise ValueError('Specify `subjects` as a list of str, or None.')
     if subjects is None:
         subjects = [str(ii) for ii in range(5, 12)]
 
     task = 'matchingpennies'
-    base_url = 'https://osf.io/{}/'
+    base_url = 'https://osf.io/{}/download'
 
     # Download subject data
     file_suffixes = ('channels.tsv', 'eeg.eeg', 'eeg.vhdr', 'eeg.vmrk',
@@ -191,8 +191,6 @@ def fetch_brainvision_testing_data(data_path=None, overwrite=False,
         be stored. Defaults to '~/mne_data/mne_bids_examples'
     overwrite : bool
         Whether or not to overwrite data. Defaults to False.
-    verbose : bool
-        Whether or not to print output. Defaults to True.
 
     Returns
     -------
@@ -207,7 +205,7 @@ def fetch_brainvision_testing_data(data_path=None, overwrite=False,
     os.makedirs(data_path, exist_ok=True)
 
     base_url = 'https://github.com/mne-tools/mne-python/'
-    base_url += 'tree/master/mne/io/brainvision/tests/data/test{}'
+    base_url += 'raw/master/mne/io/brainvision/tests/data/test{}'
     file_endings = ['.vhdr', '.vmrk', '.eeg', ]
 
     # Compile data
@@ -217,6 +215,11 @@ def fetch_brainvision_testing_data(data_path=None, overwrite=False,
         data[fname] = base_url.format(f_ending)
 
     # Download
-    _download_data(data, overwrite, verbose)
+    for fpath, url in data.items():
+        if op.exists(fpath) and not overwrite:
+            continue
+        response = urllib.request.urlopen(url)
+        with open(fpath, 'wb') as fout:
+            fout.write(response.read())
 
     return data_path

--- a/mne_bids/datasets.py
+++ b/mne_bids/datasets.py
@@ -113,7 +113,7 @@ def fetch_matchingpennies(data_path=None, download_dataset_data=True,
         _download_data(data, overwrite, verbose)
 
     # If requested, download general data
-    if download_dataset_data:  # pragma: no cover
+    if download_dataset_data:
         file_key_map = {
             '.bidsignore': '6thgf',
             'CHANGES': 'ckmbf',

--- a/mne_bids/datasets.py
+++ b/mne_bids/datasets.py
@@ -34,7 +34,7 @@ def fetch_matchingpennies(data_path=None, download_dataset_data=True,
     data_path : str
         Path to a directory into which to place the "eeg_matchingpennies"
         directory. Defaults to "~/mne_data/mne_bids_examples"
-    dataset_data : bool
+    download_dataset_data : bool
         If True, download the dataset metadata. Defaults to True.
     subjects : list of str | None
         The subject identifiers to download data from. Subjects identifiers

--- a/mne_bids/datasets.py
+++ b/mne_bids/datasets.py
@@ -114,6 +114,7 @@ def fetch_matchingpennies(data_path=None, download_dataset_data=True,
 
     # If requested, download general data
     if download_dataset_data:
+        os.makedirs(op.join(data_path, 'stimuli'), exist_ok=True)
         file_key_map = {
             '.bidsignore': '6thgf',
             'CHANGES': 'ckmbf',
@@ -124,6 +125,8 @@ def fetch_matchingpennies(data_path=None, download_dataset_data=True,
             'README': 'k8hjf',
             'task-matchingpennies_eeg.json': 'qf5d8',
             'task-matchingpennies_events.json': '3qztv',
+            'stimuli{}left_hand.png'.format(os.sep): 'g45de',
+            'stimuli{}right_hand.png'.format(os.sep): '2r9zd',
         }
         # Compile data
         data = dict()

--- a/mne_bids/datasets.py
+++ b/mne_bids/datasets.py
@@ -10,9 +10,131 @@ import os
 import os.path as op
 import shutil
 import tarfile
-import urllib.request
 
 from mne.utils import _fetch_file
+
+from mne_bids import make_bids_basename, make_bids_folders
+
+
+def _download_data(data, overwrite, verbose):
+    """Iterate over `data`, a dict with fpath, url and download."""
+    for fpath, url in data.items():
+        if op.exists(fpath) and not overwrite:
+            continue
+        _fetch_file(url=url, file_name=fpath, print_destination=verbose,
+                    resume=True, timeout=10., verbose=verbose)
+
+
+def fetch_matchingpennies(data_path=None, download_dataset_data=True,
+                          subjects=None, overwrite=False, verbose=True):
+    """Fetch the eeg_matchingpennies dataset [1]_.
+
+    Parameters
+    ----------
+    data_path : str
+        Path to a directory into which to place the "eeg_matchingpennies"
+        directory. Defaults to "~/mne_data/mne_bids_examples"
+    dataset_data : bool
+        If True, download the dataset metadata. Defaults to True.
+    subjects : list of str | None
+        The subject identifiers to download data from. Subjects identifiers
+        that are invalid will be ignored. Defaults to downloading from all
+        subjects. Specify an empty list to not download any subject data.
+    overwrite : bool
+        Whether or not to overwrite data. Defaults to False.
+    verbose : bool
+        Whether or not to print output. Defaults to True.
+
+    Returns
+    -------
+    data_path : str
+        The path to the eeg_matchingpennies dataset.
+
+    Notes
+    -----
+    Download of the "/sourcedata" directory containing the original .xdf files
+    is not supported.
+
+    References
+    ----------
+    .. [1] Appelhoff, S., Sauer, D., & Gill, S. S. (2018, July 22). Matching
+           Pennies: A Brain Computer Interface Implementation Dataset.
+           https://doi.org/10.17605/OSF.IO/CJ2DR
+
+    """
+    if data_path is None:
+        data_path = op.join(op.expanduser('~'), 'mne_data',
+                            'mne_bids_examples')
+    data_path = op.join(data_path, 'eeg_matchingpennies')
+    os.makedirs(data_path, exist_ok=True)
+
+    if not isinstance(subjects, [list, tuple, type(None)]):
+        raise ValueError('Specify `subjects` as a list of str, or None.')
+    if subjects is None:
+        subjects = [str(ii) for ii in range(5, 12)]
+
+    task = 'matchingpennies'
+    base_url = 'https://osf.io/{}/'
+
+    # Download subject data
+    file_suffixes = ('channels.tsv', 'eeg.eeg', 'eeg.vhdr', 'eeg.vmrk',
+                     'events.tsv')
+    # Mapping subjects to the identifier url suffixes
+    file_key_map = {'05': ('wdb42', '3at5h', '3m8et', '7gq4s', '9q8r2'),
+                    '06': ('256sk', 'p52dn', 'jk649', 'wdjk9', '5br27'),
+                    '07': ('qvze6', 'z792x', '2an4r', 'u7v2g', 'uyhtd'),
+                    '08': ('4safg', 'dg9b4', 'w6kn2', 'mrkag', 'u76fs'),
+                    '09': ('nqjfm', '6m5ez', 'btv7d', 'daz4f', 'ue7ah'),
+                    '10': ('5cfmh', 'ya8kr', 'he3c2', 'bw6fp', 'r5ydt'),
+                    '11': ('6p8vr', 'ywnpg', 'p7xk2', '8u5fm', 'rjzhy'),
+                    }
+
+    for subject in subjects:
+        file_keys = file_key_map.get(subject, None)
+
+        # If wrong subject, do not attempt to download
+        if file_keys is None:
+            continue
+
+        bids_sub_dir = make_bids_folders(subject, kind='eeg',
+                                         output_path=data_path,
+                                         make_dir=True, verbose=verbose,
+                                         overwrite=overwrite)
+
+        # Compile download data
+        data = dict()
+        for suffix, key in zip(file_suffixes, file_keys):
+            fname = make_bids_basename(subject=subject, task=task,
+                                       suffix=suffix)
+            fpath = op.join(bids_sub_dir, fname)
+            data[fpath] = base_url.format(key)
+
+        # Download
+        _download_data(data, overwrite, verbose)
+
+    # If requested, download general data
+    if download_dataset_data:
+        file_key_map = {
+            '.bidsignore': '6thgf',
+            'CHANGES': 'ckmbf',
+            'dataset_description.json': 'tsy4c',
+            'LICENSE': 'mkhd4',
+            'participants.tsv': '6mceu',
+            'participants.json': 'ku2dn',
+            'README': 'k8hjf',
+            'task-matchingpennies_eeg.json': 'qf5d8',
+            'task-matchingpennies_events.json': '3qztv',
+        }
+        # Compile data
+        data = dict()
+        for name, key in file_key_map:
+            fpath = op.join(data_path, fname)
+            data[fpath] = base_url.format(key)
+
+        # Download
+        _download_data(data, overwrite, verbose)
+
+    return data_path
 
 
 def fetch_faces_data(data_path=None, repo='ds000117', subject_ids=[1]):
@@ -36,10 +158,9 @@ def fetch_faces_data(data_path=None, repo='ds000117', subject_ids=[1]):
 
     """
     if not data_path:
-        home = os.path.expanduser('~')
-        data_path = os.path.join(home, 'mne_data', 'mne_bids_examples')
-        if not os.path.exists(data_path):
-            os.makedirs(data_path)
+        data_path = os.path.join(os.path.expanduser('~'), 'mne_data',
+                                 'mne_bids_examples')
+    os.makedirs(data_path, exist_ok=True)
 
     for subject_id in subject_ids:  # pragma: no cover
         src_url = ('http://openfmri.s3.amazonaws.com/tarballs/'
@@ -59,14 +180,19 @@ def fetch_faces_data(data_path=None, repo='ds000117', subject_ids=[1]):
     return data_path
 
 
-def fetch_brainvision_testing_data(data_path=None):
+def fetch_brainvision_testing_data(data_path=None, overwrite=False,
+                                   verbose=True):
     """Download the MNE-Python testing data for the BrainVision format.
 
     Parameters
     ----------
     data_path : str | None
-        Path to the folder where data is stored. Defaults to
-        '~/mne_data/mne_bids_examples/testing_data_BrainVision'
+        Path to the folder where the "testing_data_BrainVision" folder will
+        be stored. Defaults to '~/mne_data/mne_bids_examples'
+    overwrite : bool
+        Whether or not to overwrite data. Defaults to False.
+    verbose : bool
+        Whether or not to print output. Defaults to True.
 
     Returns
     -------
@@ -75,21 +201,22 @@ def fetch_brainvision_testing_data(data_path=None):
 
     """
     if not data_path:
-        home = os.path.expanduser('~')
-        data_path = os.path.join(home, 'mne_data', 'mne_bids_examples',
-                                 'testing_data_BrainVision')
-        if not os.path.exists(data_path):
-            os.makedirs(data_path)
+        data_path = os.path.join(os.path.expanduser('~'), 'mne_data',
+                                 'mne_bids_examples')
+    data_path = op.join(data_path, 'testing_data_BrainVision')
+    os.makedirs(data_path, exist_ok=True)
 
     base_url = 'https://github.com/mne-tools/mne-python/'
-    base_url += 'raw/master/mne/io/brainvision/tests/data/test'
+    base_url += 'tree/master/mne/io/brainvision/tests/data/test{}'
     file_endings = ['.vhdr', '.vmrk', '.eeg', ]
-    for f_ending in file_endings:
-        url = base_url + f_ending
-        response = urllib.request.urlopen(url)
 
-        fname = os.path.join(data_path, 'test' + f_ending)
-        with open(fname, 'wb') as fout:
-            fout.write(response.read())
+    # Compile data
+    data = dict()
+    for f_ending in file_endings:
+        fname = os.path.join(data_path, 'test{}'.format(f_ending))
+        data[fname] = base_url.format(f_ending)
+
+    # Download
+    _download_data(data, overwrite, verbose)
 
     return data_path

--- a/mne_bids/datasets.py
+++ b/mne_bids/datasets.py
@@ -71,7 +71,7 @@ def fetch_matchingpennies(data_path=None, download_dataset_data=True,
     if not isinstance(subjects, (list, tuple, type(None))):
         raise ValueError('Specify `subjects` as a list of str, or None.')
     if subjects is None:  # pragma: no cover
-        subjects = [str(ii) for ii in range(5, 12)]
+        subjects = ['{:02}'.format(ii) for ii in range(5, 12)]
 
     task = 'matchingpennies'
     base_url = 'https://osf.io/{}/download'

--- a/mne_bids/datasets.py
+++ b/mne_bids/datasets.py
@@ -70,7 +70,7 @@ def fetch_matchingpennies(data_path=None, download_dataset_data=True,
 
     if not isinstance(subjects, (list, tuple, type(None))):
         raise ValueError('Specify `subjects` as a list of str, or None.')
-    if subjects is None:
+    if subjects is None:  # pragma: no cover
         subjects = [str(ii) for ii in range(5, 12)]
 
     task = 'matchingpennies'

--- a/mne_bids/tests/test_datasets.py
+++ b/mne_bids/tests/test_datasets.py
@@ -40,6 +40,8 @@ def test_fetch_matchingpennies(tmpdir):
     with pytest.raises(ValueError, match='Specify `subjects` as a list'):
         fetch_matchingpennies(tmpdir, subjects=1)
 
+    fetch_matchingpennies(tmpdir, sourcedata=True, dry=True)
+
 
 def test_fetch_faces_data(tmpdir):
     """Dry test fetch_faces_data (Will not download anything)."""

--- a/mne_bids/tests/test_datasets.py
+++ b/mne_bids/tests/test_datasets.py
@@ -3,6 +3,7 @@
 #
 # License: BSD (3-clause)
 import os.path as op
+import time
 
 import pytest
 
@@ -29,7 +30,7 @@ def test_fetch_matchingpennies():
 
     # Overwrite is False, so it should only download ".bidsignore"
     fetch_matchingpennies(data_path, download_dataset_data=True, subjects=[])
-    assert op.exists(data_path)
+    assert op.exists(op.join(data_path, 'eeg_matchingpennies', '.bidsignore'))
 
 
 def test_fetch_faces_data():
@@ -40,6 +41,13 @@ def test_fetch_faces_data():
 
 def test_fetch_brainvision_testing_data():
     """Test downloading of BrainVision testing data (~500kB)."""
+    start = time.time()
     data_path = fetch_brainvision_testing_data(overwrite=True)
+    tdownload = time.time() - start
     raw = read_raw_brainvision(op.join(data_path, 'test.vhdr'))
     assert raw
+
+    # This should return without downloading: The files are all there
+    start = time.time()
+    data_path = fetch_brainvision_testing_data(overwrite=False)
+    assert time.time() - start < tdownload

--- a/mne_bids/tests/test_datasets.py
+++ b/mne_bids/tests/test_datasets.py
@@ -4,6 +4,8 @@
 # License: BSD (3-clause)
 import os.path as op
 
+import pytest
+
 from mne.io import read_raw_brainvision
 
 from mne_bids.datasets import (fetch_matchingpennies, fetch_faces_data,
@@ -15,7 +17,19 @@ def test_fetch_matchingpennies():
     with pytest.raises(ValueError, match=''):
         data_path = fetch_matchingpennies(subjects=1)
 
-    data_path = fetch_matchingpennies(subjects=[], download_dataset_data=False)
+    # Write some mock data so we don't download too much in the test
+    data_path = op.join(op.expanduser('~'), 'mne_data', 'mne_bids_examples',
+                        'eeg_matchingpennies')
+    for ff in ['CHANGES', 'README', 'participants.tsv', 'participants.json',
+               'LICENSE', 'dataset_description.json',
+               'task-matchingpennies_eeg.json',
+               'task-matchingpennies_events.json']:
+        with open(op.join(data_path, ff), 'w') as fout:
+            fout.write('test file. Re-run fetch_matchingpennies with '
+                       'overwrite=True')
+
+    # Overwrite is False, so it should only download ".bidsignore"
+    fetch_matchingpennies(data_path, download_dataset_data=True, subjects=[])
     assert op.exists(data_path)
 
 

--- a/mne_bids/tests/test_datasets.py
+++ b/mne_bids/tests/test_datasets.py
@@ -33,7 +33,7 @@ def test_fetch_matchingpennies(tmpdir):
 
     # Overwrite is False, so it should only download ".bidsignore"
     assert not op.exists(op.join(mp_path, '.bidsignore'))
-    fetch_matchingpennies(tmpdir, download_dataset_data=True, subjects=[])
+    fetch_matchingpennies(tmpdir, dataset_data=True, subjects=[])
     assert op.exists(op.join(mp_path, '.bidsignore'))
 
     # Test we raise an error due to wrong subject, no downloading

--- a/mne_bids/tests/test_datasets.py
+++ b/mne_bids/tests/test_datasets.py
@@ -6,7 +6,14 @@ import os.path as op
 
 from mne.io import read_raw_brainvision
 
-from mne_bids.datasets import fetch_faces_data, fetch_brainvision_testing_data
+from mne_bids.datasets import (fetch_matchingpennies, fetch_faces_data,
+                               fetch_brainvision_testing_data)
+
+
+def test_fetch_matchingpennies():
+    """Dry test fetch matchingpennies."""
+    data_path = fetch_matchingpennies(subjects=[], download_dataset_data=False)
+    assert op.exists(data_path)
 
 
 def test_fetch_faces_data():
@@ -17,6 +24,6 @@ def test_fetch_faces_data():
 
 def test_fetch_brainvision_testing_data():
     """Test downloading of BrainVision testing data (~500kB)."""
-    data_path = fetch_brainvision_testing_data()
+    data_path = fetch_brainvision_testing_data(overwrite=True)
     raw = read_raw_brainvision(op.join(data_path, 'test.vhdr'))
     assert raw

--- a/mne_bids/tests/test_datasets.py
+++ b/mne_bids/tests/test_datasets.py
@@ -12,6 +12,9 @@ from mne_bids.datasets import (fetch_matchingpennies, fetch_faces_data,
 
 def test_fetch_matchingpennies():
     """Dry test fetch matchingpennies."""
+    with pytest.raises(ValueError, match=''):
+        data_path = fetch_matchingpennies(subjects=1)
+
     data_path = fetch_matchingpennies(subjects=[], download_dataset_data=False)
     assert op.exists(data_path)
 

--- a/mne_bids/tests/test_datasets.py
+++ b/mne_bids/tests/test_datasets.py
@@ -18,13 +18,12 @@ def test_fetch_matchingpennies():
         data_path = fetch_matchingpennies(subjects=1)
 
     # Write some mock data so we don't download too much in the test
-    data_path = op.join(op.expanduser('~'), 'mne_data', 'mne_bids_examples',
-                        'eeg_matchingpennies')
+    data_path = op.join(op.expanduser('~'), 'mne_data', 'mne_bids_examples')
     for ff in ['CHANGES', 'README', 'participants.tsv', 'participants.json',
                'LICENSE', 'dataset_description.json',
                'task-matchingpennies_eeg.json',
                'task-matchingpennies_events.json']:
-        with open(op.join(data_path, ff), 'w') as fout:
+        with open(op.join(data_path, 'eeg_matchingpennies', ff), 'w') as fout:
             fout.write('test file. Re-run fetch_matchingpennies with '
                        'overwrite=True')
 


### PR DESCRIPTION
Instead of adding a matchingpennies fetcher to the mne-study-template, I thought it could be a nice addition to mne-bids.

We can then easily import it at mne-study-template and make it run.

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [x] All CIs are happy
- [x] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- ~PR description includes phrase "closes <#issue-number>"~
- [x] Commit history does not contain any merge commits
