### PR TITLE
add coveragerc and stop covering test files

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,12 @@
+# .coveragerc to control coverage.py
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Have to re-enable the standard pragma
+    pragma: no cover
+
+    # Don't complain if non-runnable code isn't run:
+    if __name__ == .__main__.:
+
+# Do not include test script in coverage report
+omit = *tests*


### PR DESCRIPTION
quick PR ... while working on some other project I realized that including one's own test files in the coverage report, it distorts the actual % of coverage.

So good practice: Don't cover your test scripts in the report