### PR TITLE
[MRG] enh: add func to get kinds of bids_dir

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -38,6 +38,7 @@ Utils (:py:mod:`mne_bids.utils`)
 
    print_dir_tree
    get_values_for_key
+   get_kinds
 
 Copyfiles (:py:mod:`mne_bids.copyfiles`)
 ========================================

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -22,6 +22,7 @@ Current
 Changelog
 ~~~~~~~~~
 
+- New function :func:`mne_bids.utils.get_kinds` for getting data types from a BIDS dataset, by `Stefan Appelhoff`_ (`#253 <https://github.com/mne-tools/mne-bids/pull/253>`_)
 - New function :func:`mne_bids.utils.get_values_for_key` allows to get a list of instances of a certain entity in a BIDS directory, by `Mainak Jas`_ and `Stefan Appelhoff`_ (`#252 <https://github.com/mne-tools/mne-bids/pull/252>`_)
 - :func:`mne_bids.utils.print_dir_tree` now accepts an argument :code:`max_depth` which can limit the depth until which the directory tree is printed, by `Stefan Appelhoff`_ (`#245 <https://github.com/mne-tools/mne-bids/pull/245>`_)
 - New command line function exposed :code:`cp` for renaming/copying files including automatic doc generation "CLI", by `Stefan Appelhoff`_ (`#225 <https://github.com/mne-tools/mne-bids/pull/225>`_)

--- a/mne_bids/tests/test_utils.py
+++ b/mne_bids/tests/test_utils.py
@@ -19,7 +19,8 @@ from mne_bids.utils import (_check_types, print_dir_tree, _age_on_date,
                             _infer_eeg_placement_scheme, _handle_kind,
                             _find_matching_sidecar, _parse_ext,
                             _get_ch_type_mapping, _parse_bids_filename,
-                            _find_best_candidates, get_values_for_key)
+                            _find_best_candidates, get_values_for_key,
+                            get_kinds)
 
 
 base_path = op.join(op.dirname(mne.__file__), 'io')
@@ -59,6 +60,12 @@ def return_bids_test_dir(tmpdir_factory):
                            overwrite=True)
 
     return output_path
+
+
+def test_get_keys(return_bids_test_dir):
+    """Test getting the datatypes (=kinds) of a dir."""
+    kinds = get_kinds(return_bids_test_dir)
+    assert kinds == ['meg']
 
 
 def test_get_values_for_key(return_bids_test_dir):

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -29,6 +29,32 @@ from mne.io.constants import FIFF
 from mne_bids.tsv_handler import _to_tsv, _tsv_to_str
 
 
+def get_kinds(bids_root):
+    """Get list of data types ("kinds") present in a BIDS dataset.
+
+    Parameters
+    ----------
+    bids_root : str
+        Path to the root of the BIDS directory.
+
+    Returns
+    -------
+    kinds : list of str
+        List of the data types present in the BIDS dataset pointed to by
+        `bids_root`.
+
+    """
+    # Take all possible kinds from "entity" table (Appendix in BIDS spec)
+    kind_list = ('anat', 'func', 'dwi', 'fmap', 'beh', 'meg', 'eeg', 'ieeg')
+    kinds = list()
+    for root, dirs, files in os.walk(bids_root):
+        for dir in dirs:
+            if dir in kind_list and dir not in kinds:
+                kinds.append(dir)
+
+    return kinds
+
+
 def get_values_for_key(bids_root, key):
     """Get list of values for a key in a BIDS dataset.
 


### PR DESCRIPTION
This is needed to completely replace pybids in the mne-study-template.

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [x] All comments resolved
- [x] This is not your own PR
- [x] All CIs are happy
- [x] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
-  ~PR description includes phrase "closes <#issue-number>"~
- [x] Commit history does not contain any merge commits
