### PR TITLE
REL: 0.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
                 name: github pages deployment
                 command: |
                   source activate testenv
-                  if [ "${CIRCLE_BRANCH}" == "maint/0.2" ]; then
+                  if [ "${CIRCLE_BRANCH}" == "maint/0.3" ]; then
                     echo "Deploying stable docs for ${CIRCLE_BRANCH}.";
                     git config --global user.email "circle@mne.com";
                     git config --global user.name "Circle Ci";

--- a/README.rst
+++ b/README.rst
@@ -33,11 +33,11 @@ MNE-BIDS
 
 This is a repository for creating
 `BIDS <http://bids.neuroimaging.io/>`_\ -compatible datasets with
-`MNE <https://mne-tools.github.io/stable/index.html>`_.
+`MNE <https://mne.tools/stable/index.html>`_.
 
 The documentation can be found under the following links:
 
-- for the `stable release <https://mne-tools.github.io/mne-bids/>`_
+- for the `stable release <https://mne.tools/mne-bids/>`_
 - for the `latest (development) version <https://circleci.com/api/v1.1/project/github/mne-tools/mne-bids/latest/artifacts/0/html/index.html?branch=master>`_
 
 Installation

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -108,7 +108,7 @@ html_theme_options = {
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
-    'mne': ('http://mne.tools/stable/', None),
+    'mne': ('https://mne.tools/stable/', None),
     'numpy': ('https://www.numpy.org/devdocs', None),
     'scipy': ('https://scipy.github.io/devdocs', None),
     'matplotlib': ('https://matplotlib.org', None),

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -108,7 +108,7 @@ html_theme_options = {
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
-    'mne': ('http://mne-tools.github.io/stable/', None),
+    'mne': ('http://mne.tools/stable/', None),
     'numpy': ('https://www.numpy.org/devdocs', None),
     'scipy': ('https://scipy.github.io/devdocs', None),
     'matplotlib': ('https://matplotlib.org', None),

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -14,10 +14,10 @@ Here we list a changelog of MNE-BIDS.
 
 .. currentmodule:: mne_bids
 
-.. _current:
+.. _changes_0_3:
 
-Current
--------
+Version 0.3
+-----------
 
 Changelog
 ~~~~~~~~~
@@ -44,6 +44,18 @@ API
 ~~~
 
 - :func:`read_raw_bids` no longer optionally returns :code:`events` and :code:`event_id` but returns the raw object with :code:`mne.Annotations`, whenever an :code:`events.tsv` file is present, by `Stefan Appelhoff`_ (`#209 <https://github.com/mne-tools/mne-bids/pull/209>`_)
+
+Authors
+~~~~~~~
+
+People who contributed to this release (in alphabetical order):
+
+* Alexandre Gramfort
+* Mainak Jas
+* Marijn van Vliet
+* Matt Sanderson
+* Stefan Appelhoff
+* Teon Brooks
 
 .. _changes_0_2:
 

--- a/mne_bids/__init__.py
+++ b/mne_bids/__init__.py
@@ -1,6 +1,6 @@
 """MNE software for easily interacting with BIDS compatible datasets."""
 
-__version__ = '0.2.dev0'
+__version__ = '0.3'
 
 
 from mne_bids.write import (write_raw_bids, make_bids_folders, make_bids_basename,  # noqa: E501 F401

--- a/setup.py
+++ b/setup.py
@@ -21,9 +21,9 @@ DISTNAME = 'mne-bids'
 DESCRIPTION = descr
 MAINTAINER = 'Mainak Jas'
 MAINTAINER_EMAIL = 'mainakjas@gmail.com'
-URL = 'https://mne-tools.github.io/mne-bids/'
+URL = 'https://mne.tools/mne-bids/'
 LICENSE = 'BSD (3-clause)'
-DOWNLOAD_URL = 'http://github.com/mne-tools/mne-bids'
+DOWNLOAD_URL = 'https://github.com/mne-tools/mne-bids.git'
 VERSION = version
 
 if __name__ == "__main__":
@@ -51,5 +51,10 @@ if __name__ == "__main__":
           ],
           platforms='any',
           packages=find_packages(),
-          scripts=['bin/mne_bids']
+          scripts=['bin/mne_bids'],
+          project_urls={
+              'Documentation': 'https://mne.tools/mne-bids',
+              'Bug Reports': 'https://github.com/mne-tools/mne-bids/issues',
+              'Source': 'https://github.com/mne-tools/mne-bids',
+          },
           )


### PR DESCRIPTION
This will mark the release commit for MNE-BIDS version `0.3`.

I am following our release protocol in the WIKI: https://github.com/mne-tools/mne-bids/wiki/How-to-make-a-release

Note that for "contributing authors", I ran the following and got the following output:

```Shell
git shortlog v0.2..HEAD --summary --numbered
    75  Stefan Appelhoff
    19  Marijn van Vliet
     7  monkeyman192
     4  Mainak Jas

```

I manually added @agramfort and @teonbrooks to the list because they performed reviews and gave advise. 

Let me know if there is somebody else that I am forgetting who contributed but never submitted a PR.

# To do

- [x] merged #260 
- [x] merged #262 
- [x] rebased this PR
