### PR TITLE
[MRG] Fix fetcher for ds000117 data

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -36,6 +36,7 @@ Changelog
 Bug
 ~~~
 
+- Fixed bug in :func:`mne_bids.datasets.fetch_faces_data` where downloading multiple subjects was impossible, by `Stefan Appelhoff`_ (`#262 <https://github.com/mne-tools/mne-bids/pull/262>`_)
 - Fixed bug where :func:`read_raw_bids` would throw a ValueError upon encountering strings in the "onset" or "duration" column of events.tsv files, by `Stefan Appelhoff`_ (`#234 <https://github.com/mne-tools/mne-bids/pull/234>`_)
 - Allow raw data from KIT systems to have two marker files specified, by `Matt Sanderson`_ (`#173 <https://github.com/mne-tools/mne-bids/pull/173>`_)
 

--- a/mne_bids/datasets.py
+++ b/mne_bids/datasets.py
@@ -54,7 +54,9 @@ def fetch_faces_data(data_path=None, repo='ds000117', subject_ids=[1]):
         src_url = ('http://openfmri.s3.amazonaws.com/tarballs/'
                    'ds117_R0.1.1_{}_raw.tgz'.format(sub_str))
         tar_fname = op.join(data_path, repo, sub_str + '.tgz')
-        _fetch_file(url=src_url, file_name=tar_fname, print_destination=True)
+        if not op.exists(tar_fname):
+            _fetch_file(url=src_url, file_name=tar_fname,
+                        print_destination=True)
 
         # Unpack the downloaded archive to the correct location
         tf = tarfile.open(tar_fname)


### PR DESCRIPTION
As described in detail [here](https://gitter.im/mne-tools/mne-gsoc-2019-BIDS?at=5d5a99f095071824770b2b07), the fetch_faces function had a logical error that made it **impossible** to download multiple subjects.

There was another bug that lead to errors when the `data_path` argument was NOT `None`, but the path did not exist.

both bugs are fixed, I tested the fix locally and now it works :-)

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [x] All CIs are happy
- [x] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- ~~PR description includes phrase "closes <#issue-number>"~~
- [x] Commit history does not contain any merge commits
