### PR TITLE
[WIP] ENH: add func to write elec tsv

### DIFF
--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -22,7 +22,7 @@ from mne.io.constants import FIFF
 from mne.io.pick import channel_type
 from mne.io import BaseRaw
 from mne.channels.channels import _unit2human
-from mne.utils import check_version, has_nibabel
+from mne.utils import check_version, has_nibabel, _check_ch_locs
 
 from mne_bids.pick import coil_type
 from mne_bids.utils import (_write_json, _write_tsv, _read_events, _mkdir_p,
@@ -325,6 +325,45 @@ def _scans_tsv(raw, raw_fname, fname, overwrite=False, verbose=True):
     # been handled by this point
     _write_tsv(fname, data, True, verbose)
 
+    return fname
+
+
+def _electrodes_tsv(raw, fname, overwrite=False, verbose=True):
+    """Create an electrodes.tsv file and save it.
+
+    Parameters
+    ----------
+    raw : instance of Raw
+        The data as MNE-Python Raw object.
+    fname : str
+        Filename to save the electrodes.tsv to.
+    overwrite : bool
+        Defaults to False.
+        Whether to overwrite the existing data in the file.
+        If there is already data for the given `fname` and overwrite is False,
+        an error will be raised.
+    verbose : bool
+        Set verbose output to true or false.
+
+    """
+    x, y, z, names, sizes = list(), list(), list(), list(), list()
+    for ch in raw.info['chs']:
+        if _check_ch_locs([ch]):
+            x.append(ch['loc'][0])
+            y.append(ch['loc'][1])
+            z.append(ch['loc'][2])
+        else:
+            x.append('n/a')
+            y.append('n/a')
+            z.append('n/a')
+        names.append(ch['ch_name'])
+        sizes.append('n/a')  # need sizes even if we don't know: iEEG REQUIRED
+    data = OrderedDict([('name', names),
+                        ('x', x),
+                        ('y', y),
+                        ('z', z)
+                        ('size', sizes)])
+    _write_tsv(fname, data, overwrite=overwrite, verbose=verbose)
     return fname
 
 


### PR DESCRIPTION
salvages parts from #244 
closes #89 
closes #264 

PR Description
--------------

EEG data use an [electrodes.tsv](https://bids-specification.readthedocs.io/en/stable/04-modality-specific-files/03-electroencephalography.html#electrodes-description-_electrodestsv) file where x,y,z coords of electrodes are written down. If `electrodes.tsv` files are written, a `coordsystem.json` file MUST be supplied to interpret the TSV.

This PR adds that functionality to mne-bids

must read: https://github.com/mne-tools/mne-bids/issues/264

# Caveat

for EEG data, electrode locations are not commonly written into the raw data files (as is the case for MEG data) ... thus, users would have to call `raw.set_dig_montage()` before passing that `raw` to `mne-bids` if they want `electrodes.tsv` and `coordsystem.json` to be written.

Verify this is true for:
- [x] BrainVision ... "coordinates" CAN be included --> but this is a "montage", not a "DigMontage" - no LPA, RPA, and NAS included
- [x] EDF, EDF+ --> header does not permit position data
- [x] BDF --> same header as EDF and EDF+, so no position data
- ~~[x]~~ Set (EEGLAB) --> can contain channel locations in the `EEG.chanlocs` struct array
    - however: which coordinate system? which units? --> always rescaled to the same?

References:
- https://github.com/bids-standard/pyedf/issues/7
- https://sccn.ucsd.edu/wiki/A05:_Data_Structures#EEG.chanlocs
- https://sccn.ucsd.edu/wiki/Chapter_02:_Channel_Locations

Note: We will only write electrodes and coordsystem.json if we know LPA, RPA, and NAS --> because only then we can transform to the ElektaNeuromag system and actually know what kind of data we are writing. --> this is because MNE-Python handles all digitizer space as either "head"(=Neuromag/Elekta) ... or "unknown"

Due to this behavior we are aiming for, we should make sure that no other digitized locations are saved in the raw files (see list above) ... else, there could be a duplication of the digitized location information in `electrodes.tsv` and in the raw data `raw` --> and potentially in different coordinate system formats 

# To do

- [x] gather knowledge about all data formats regarding native capability to save digitization data
- [ ] add check that ascertains that the raw file under scrutiny does not already contain digitization data ... if it does: don't write electrodes.tsv
- [ ] revamp the whole PR to adhere to what is described in https://github.com/mne-tools/mne-bids/issues/264
- [ ] add tests


Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
- [ ] Commit history does not contain any merge commits
