### PR TITLE
[MRG] Deface mri during write_anat

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -22,7 +22,7 @@ Current
 Changelog
 ~~~~~~~~~
 
--New feature in :func`mne_bids.write.write_anat` for shear deface of mri, by `Alex Rockhill`_ (`#271 <https://github.com/mne-tools/mne-bids/pull/271>`_)
+- New feature in :func`mne_bids.write.write_anat` for shear deface of mri, by `Alex Rockhill`_ (`#271 <https://github.com/mne-tools/mne-bids/pull/271>`_)
 
 
 Bug

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -22,6 +22,9 @@ Current
 Changelog
 ~~~~~~~~~
 
+-New feature in :func`mne_bids.write.write_anat` for shear deface of mri, by `Alex Rockhill`_ (`#271 <https://github.com/mne-tools/mne-bids/pull/271>`_)
+
+
 Bug
 ~~~
 

--- a/examples/convert_mri_and_trans.py
+++ b/examples/convert_mri_and_trans.py
@@ -157,7 +157,6 @@ plt.show()
 
 ###############################################################################
 # We can deface the MRI for anonymization
-#
 anat_dir = write_anat(bids_root=output_path,  # the BIDS dir we wrote earlier
                       subject=sub,
                       t1w=t1_mgh_fname,  # path to the MRI scan

--- a/examples/convert_mri_and_trans.py
+++ b/examples/convert_mri_and_trans.py
@@ -155,6 +155,27 @@ for point_idx, label in enumerate(('LPA', 'NAS', 'RPA')):
               title=label)
 plt.show()
 
+#
+# We can deface the MRI for anonymization
+#
+anat_dir = write_anat(bids_root=output_path,  # the BIDS dir we wrote earlier
+                      subject=sub,
+                      t1w=t1_mgh_fname,  # path to the MRI scan
+                      session=ses,
+                      raw=raw,  # the raw MEG data file connected to the MRI
+                      trans=trans,  # our transformation matrix
+                      deface=True,
+                      verbose=True  # this will print out the sidecar file
+                      )
+
+# Our MRI written to BIDS, we got `anat_dir` from our `write_anat` function
+t1_nii_fname = op.join(anat_dir, 'sub-01_ses-01_T1w.nii.gz')
+
+# Plot it
+fig, ax = plt.subplots()
+plot_anat(t1_nii_fname, axes=ax,
+          title='Defaced')
+plt.show()
 
 ###############################################################################
 # .. LINKS

--- a/examples/convert_mri_and_trans.py
+++ b/examples/convert_mri_and_trans.py
@@ -165,6 +165,7 @@ anat_dir = write_anat(bids_root=output_path,  # the BIDS dir we wrote earlier
                       raw=raw,  # the raw MEG data file connected to the MRI
                       trans=trans,  # our transformation matrix
                       deface=True,
+                      overwrite=True,
                       verbose=True  # this will print out the sidecar file
                       )
 
@@ -173,8 +174,7 @@ t1_nii_fname = op.join(anat_dir, 'sub-01_ses-01_T1w.nii.gz')
 
 # Plot it
 fig, ax = plt.subplots()
-plot_anat(t1_nii_fname, axes=ax,
-          title='Defaced')
+plot_anat(t1_nii_fname, axes=ax, title='Defaced')
 plt.show()
 
 ###############################################################################

--- a/examples/convert_mri_and_trans.py
+++ b/examples/convert_mri_and_trans.py
@@ -155,7 +155,7 @@ for point_idx, label in enumerate(('LPA', 'NAS', 'RPA')):
               title=label)
 plt.show()
 
-#
+###############################################################################
 # We can deface the MRI for anonymization
 #
 anat_dir = write_anat(bids_root=output_path,  # the BIDS dir we wrote earlier

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -675,7 +675,7 @@ def test_write_anat(_bids_validate):
     assert vox_sum > vox_sum3
 
     with pytest.raises(ValueError,
-                       match='The raw object and trans must be provided'):
+                       match='The raw object, trans and raw must be provided'):
         write_anat(output_path, subject_id, t1w_mgh, session_id, raw=raw,
                    trans=None, verbose=True, deface=dict(inset=2),
                    overwrite=True)

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -543,6 +543,7 @@ def test_set(_bids_validate):
 def test_write_anat(_bids_validate):
     """Test writing anatomical data."""
     # Get the MNE testing sample data
+    import nibabel as nib
     output_path = _TempDir()
     data_path = testing.data_path()
     raw_fname = op.join(data_path, 'MEG', 'sample',
@@ -647,9 +648,6 @@ def test_write_anat(_bids_validate):
                    trans=trans, verbose=True, deface=False, overwrite=True)
 
     # test deface
-    if not has_nibabel():  # pragma: no cover
-        raise ImportError('This function requires nibabel.')
-    import nibabel as nib
     anat_dir = write_anat(output_path, subject_id, t1w_mgh,
                           session_id, raw=raw, trans=trans_fname,
                           verbose=True, deface=True, overwrite=True)

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -656,7 +656,7 @@ def test_write_anat(_bids_validate):
 
     anat_dir2 = write_anat(output_path, subject_id, t1w_mgh,
                            session_id, raw=raw, trans=trans_fname,
-                           verbose=True, deface=dict(inset=20.),
+                           verbose=True, deface=dict(inset=25.),
                            overwrite=True)
     t1w2 = nib.load(op.join(anat_dir2, 'sub-01_ses-01_T1w.nii.gz'))
     vox_sum2 = t1w2.get_data().sum()
@@ -675,7 +675,7 @@ def test_write_anat(_bids_validate):
     with pytest.raises(ValueError,
                        match='The raw object, trans and raw must be provided'):
         write_anat(output_path, subject_id, t1w_mgh, session_id, raw=raw,
-                   trans=None, verbose=True, deface=dict(inset=20.),
+                   trans=None, verbose=True, deface=True,
                    overwrite=True)
 
     with pytest.raises(ValueError, match='inset must be numeric'):
@@ -683,12 +683,12 @@ def test_write_anat(_bids_validate):
                    trans=trans, verbose=True, deface=dict(inset='small'),
                    overwrite=True)
 
-    with pytest.raises(ValueError, match='inset should positive'):
+    with pytest.raises(ValueError, match='inset should be positive'):
         write_anat(output_path, subject_id, t1w_mgh, session_id, raw=raw,
-                   trans=trans, verbose=True, deface=dict(inset=-2),
+                   trans=trans, verbose=True, deface=dict(inset=-2.),
                    overwrite=True)
 
-    with pytest.raises(ValueError, match='theta must be float'):
+    with pytest.raises(ValueError, match='theta must be numeric'):
         write_anat(output_path, subject_id, t1w_mgh, session_id, raw=raw,
                    trans=trans, verbose=True, deface=dict(theta='big'),
                    overwrite=True)

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -656,7 +656,7 @@ def test_write_anat(_bids_validate):
 
     anat_dir2 = write_anat(output_path, subject_id, t1w_mgh,
                            session_id, raw=raw, trans=trans_fname,
-                           verbose=True, deface=dict(inset=0.3),
+                           verbose=True, deface=dict(inset=20.),
                            overwrite=True)
     t1w2 = nib.load(op.join(anat_dir2, 'sub-01_ses-01_T1w.nii.gz'))
     vox_sum2 = t1w2.get_data().sum()
@@ -675,17 +675,17 @@ def test_write_anat(_bids_validate):
     with pytest.raises(ValueError,
                        match='The raw object, trans and raw must be provided'):
         write_anat(output_path, subject_id, t1w_mgh, session_id, raw=raw,
-                   trans=None, verbose=True, deface=dict(inset=2),
+                   trans=None, verbose=True, deface=dict(inset=20.),
                    overwrite=True)
 
-    with pytest.raises(ValueError, match='inset must be float'):
+    with pytest.raises(ValueError, match='inset must be numeric'):
         write_anat(output_path, subject_id, t1w_mgh, session_id, raw=raw,
                    trans=trans, verbose=True, deface=dict(inset='small'),
                    overwrite=True)
 
-    with pytest.raises(ValueError, match='inset should be between 0 and 1'):
+    with pytest.raises(ValueError, match='inset should positive'):
         write_anat(output_path, subject_id, t1w_mgh, session_id, raw=raw,
-                   trans=trans, verbose=True, deface=dict(inset=2.),
+                   trans=trans, verbose=True, deface=dict(inset=-2),
                    overwrite=True)
 
     with pytest.raises(ValueError, match='theta must be float'):

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -25,7 +25,7 @@ from numpy.testing import assert_array_equal
 import mne
 from mne.datasets import testing
 from mne.utils import (_TempDir, run_subprocess, check_version,
-                       requires_nibabel, has_nibabel)
+                       requires_nibabel)
 from mne.io.constants import FIFF
 from mne.io.kit.kit import get_kit_info
 

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -24,7 +24,8 @@ import numpy as np
 from numpy.testing import assert_array_equal
 import mne
 from mne.datasets import testing
-from mne.utils import _TempDir, run_subprocess, check_version, requires_nibabel
+from mne.utils import (_TempDir, run_subprocess, check_version,
+                       requires_nibabel, has_nibabel)
 from mne.io.constants import FIFF
 from mne.io.kit.kit import get_kit_info
 
@@ -599,13 +600,13 @@ def test_write_anat(_bids_validate):
     # We already have some MRI data there
     with pytest.raises(IOError, match='`overwrite` is set to False'):
         write_anat(output_path, subject_id, t1w_mgh, session_id, acq,
-                   raw=raw, trans=trans, verbose=True, deface=True,
+                   raw=raw, trans=trans, verbose=True, deface=False,
                    overwrite=False)
 
     # pass some invalid type as T1 MRI
     with pytest.raises(ValueError, match='must be a path to a T1 weighted'):
         write_anat(output_path, subject_id, 9999999999999, session_id, raw=raw,
-                   trans=trans, verbose=True, deface=True, overwrite=True)
+                   trans=trans, verbose=True, deface=False, overwrite=True)
 
     # Return without writing sidecar
     sh.rmtree(anat_dir)
@@ -620,7 +621,7 @@ def test_write_anat(_bids_validate):
     match = 'transform type {} not known, must be'.format(type(wrong_type))
     with pytest.raises(ValueError, match=match):
         write_anat(output_path, subject_id, t1w_mgh, session_id, raw=raw,
-                   trans=wrong_type, verbose=True, deface=True,
+                   trans=wrong_type, verbose=True, deface=False,
                    overwrite=True)
 
     # trans is a str, but file does not exist
@@ -632,7 +633,8 @@ def test_write_anat(_bids_validate):
 
     # However, reading trans if it is a string pointing to trans is fine
     write_anat(output_path, subject_id, t1w_mgh, session_id, raw=raw,
-               trans=trans_fname, verbose=True, overwrite=True)
+               trans=trans_fname, verbose=True, deface=False,
+               overwrite=True)
 
     # Writing without a session does NOT yield "ses-None" anywhere
     anat_dir2 = write_anat(output_path, subject_id, t1w_mgh, None)
@@ -642,4 +644,59 @@ def test_write_anat(_bids_validate):
     # specify trans but not raw
     with pytest.raises(ValueError, match='must be specified if `trans`'):
         write_anat(output_path, subject_id, t1w_mgh, session_id, raw=None,
-                   trans=trans, verbose=True, overwrite=True)
+                   trans=trans, verbose=True, deface=False, overwrite=True)
+
+    # test deface
+    if not has_nibabel():  # pragma: no cover
+        raise ImportError('This function requires nibabel.')
+    import nibabel as nib
+    anat_dir = write_anat(output_path, subject_id, t1w_mgh,
+                          session_id, raw=raw, trans=trans_fname,
+                          verbose=True, deface=True, overwrite=True)
+    t1w = nib.load(op.join(anat_dir, 'sub-01_ses-01_T1w.nii.gz'))
+    vox_sum = t1w.get_data().sum()
+
+    anat_dir2 = write_anat(output_path, subject_id, t1w_mgh,
+                           session_id, raw=raw, trans=trans_fname,
+                           verbose=True, deface=dict(inset=0.3),
+                           overwrite=True)
+    t1w2 = nib.load(op.join(anat_dir2, 'sub-01_ses-01_T1w.nii.gz'))
+    vox_sum2 = t1w2.get_data().sum()
+
+    assert vox_sum > vox_sum2
+
+    anat_dir3 = write_anat(output_path, subject_id, t1w_mgh,
+                           session_id, raw=raw, trans=trans_fname,
+                           verbose=True, deface=dict(theta=25),
+                           overwrite=True)
+    t1w3 = nib.load(op.join(anat_dir3, 'sub-01_ses-01_T1w.nii.gz'))
+    vox_sum3 = t1w3.get_data().sum()
+
+    assert vox_sum > vox_sum3
+
+    with pytest.raises(ValueError,
+                       match='The raw object and trans must be provided'):
+        write_anat(output_path, subject_id, t1w_mgh, session_id, raw=raw,
+                   trans=None, verbose=True, deface=dict(inset=2),
+                   overwrite=True)
+
+    with pytest.raises(ValueError, match='inset must be float'):
+        write_anat(output_path, subject_id, t1w_mgh, session_id, raw=raw,
+                   trans=trans, verbose=True, deface=dict(inset=2),
+                   overwrite=True)
+
+    with pytest.raises(ValueError, match='inset should be between 0 and 1'):
+        write_anat(output_path, subject_id, t1w_mgh, session_id, raw=raw,
+                   trans=trans, verbose=True, deface=dict(inset=2.),
+                   overwrite=True)
+
+    with pytest.raises(ValueError, match='theta must be float'):
+        write_anat(output_path, subject_id, t1w_mgh, session_id, raw=raw,
+                   trans=trans, verbose=True, deface=dict(theta='big'),
+                   overwrite=True)
+
+    with pytest.raises(ValueError,
+                       match='theta should be between 0 and 90 degrees'):
+        write_anat(output_path, subject_id, t1w_mgh, session_id, raw=raw,
+                   trans=trans, verbose=True, deface=dict(theta=100),
+                   overwrite=True)

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -565,7 +565,8 @@ def test_write_anat(_bids_validate):
     t1w_mgh = op.join(data_path, 'subjects', 'sample', 'mri', 'T1.mgz')
 
     anat_dir = write_anat(output_path, subject_id, t1w_mgh, session_id, acq,
-                          raw=raw, trans=trans, verbose=True)
+                          raw=raw, trans=trans, deface=True, verbose=True,
+                          overwrite=True)
     _bids_validate(output_path)
 
     # Validate that files are as expected
@@ -598,12 +599,13 @@ def test_write_anat(_bids_validate):
     # We already have some MRI data there
     with pytest.raises(IOError, match='`overwrite` is set to False'):
         write_anat(output_path, subject_id, t1w_mgh, session_id, acq,
-                   raw=raw, trans=trans, verbose=True, overwrite=False)
+                   raw=raw, trans=trans, verbose=True, deface=True,
+                   overwrite=False)
 
     # pass some invalid type as T1 MRI
     with pytest.raises(ValueError, match='must be a path to a T1 weighted'):
         write_anat(output_path, subject_id, 9999999999999, session_id, raw=raw,
-                   trans=trans, verbose=True, overwrite=True)
+                   trans=trans, verbose=True, deface=True, overwrite=True)
 
     # Return without writing sidecar
     sh.rmtree(anat_dir)
@@ -618,7 +620,8 @@ def test_write_anat(_bids_validate):
     match = 'transform type {} not known, must be'.format(type(wrong_type))
     with pytest.raises(ValueError, match=match):
         write_anat(output_path, subject_id, t1w_mgh, session_id, raw=raw,
-                   trans=wrong_type, verbose=True, overwrite=True)
+                   trans=wrong_type, verbose=True, deface=True,
+                   overwrite=True)
 
     # trans is a str, but file does not exist
     wrong_fname = 'not_a_trans'

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -682,7 +682,7 @@ def test_write_anat(_bids_validate):
 
     with pytest.raises(ValueError, match='inset must be float'):
         write_anat(output_path, subject_id, t1w_mgh, session_id, raw=raw,
-                   trans=trans, verbose=True, deface=dict(inset=2),
+                   trans=trans, verbose=True, deface=dict(inset='small'),
                    overwrite=True)
 
     with pytest.raises(ValueError, match='inset should be between 0 and 1'):

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1024,9 +1024,9 @@ def write_anat(bids_root, subject, t1w, session=None, acquisition=None,
             theta = deface['theta']
 
     if not 0 < inset < 1.0:
-        raise ValueError('Inset should be between 0 and 1')
+        raise ValueError('inset should be between 0 and 1')
     if not 0 < theta < 90:
-        raise ValueError('Theta should be between 0 and 90 degrees')
+        raise ValueError('theta should be between 0 and 90 degrees')
 
     if not isinstance(inset, float):
         raise ValueError('inset must be float. Got %s' % type(inset))

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -492,6 +492,66 @@ def _sidecar_json(raw, task, manufacturer, fname, kind, overwrite=False,
     return fname
 
 
+def _deface(t1w, mri_landmarks, deface, trans, raw):
+    if not has_nibabel():  # pragma: no cover
+        raise ImportError('This function requires nibabel.')
+    import nibabel as nib
+
+    inset, theta = (0.2, 35.)
+    if isinstance(deface, dict):
+        if 'inset' in deface:
+            inset = deface['inset']
+        if 'theta' in deface:
+            theta = deface['theta']
+
+    if not isinstance(inset, float):
+        raise ValueError('inset must be float. Got %s' % type(inset))
+
+    if not (isinstance(theta, float) or isinstance(theta, int)):
+        raise ValueError('theta must be float. Got %s' % type(theta))
+
+    if not 0 < inset < 1.0:
+        raise ValueError('inset should be between 0 and 1')
+
+    if not 0 < theta < 90:
+        raise ValueError('theta should be between 0 and 90 degrees')
+
+    # x: L/R L+, y: S/I I+, z: A/P A+
+    t1w_data = t1w.get_data().copy()
+    idxs_vox = np.meshgrid(np.arange(t1w_data.shape[0]),
+                           np.arange(t1w_data.shape[1]),
+                           np.arange(t1w_data.shape[2]),
+                           indexing='ij')
+    idxs_vox = np.array(idxs_vox)  # (3, *t1w_data.shape)
+    idxs_vox = np.transpose(idxs_vox,
+                            [1, 2, 3, 0])  # (*t1w_data.shape, 3)
+    idxs_vox = idxs_vox.reshape(-1, 3)  # (n_voxels, 3)
+
+    mri_landmarks_ras = apply_trans(t1w.affine, mri_landmarks)
+    ras_meg_t = \
+        get_ras_to_neuromag_trans(*mri_landmarks_ras[[1, 0, 2]])
+
+    idxs_ras = apply_trans(t1w.affine, idxs_vox)
+    idxs_meg = apply_trans(ras_meg_t, idxs_ras)
+
+    # now comes the actual defacing
+    # 1. move center of voxels to (nasion - inset)
+    # 2. rotate the head by theta from the normal to the plane passing
+    # through anatomical coordinates
+    trans_y = -mri_landmarks_ras[1, 1] + t1w_data.shape[2] * inset
+    idxs_meg = apply_trans(translation(y=trans_y), idxs_meg)
+    idxs_meg = apply_trans(rotation(x=-np.deg2rad(theta)), idxs_meg)
+    coords = idxs_meg.reshape(t1w.shape + (3,))  # (*t1w_data.shape, 3)
+    mask = (coords[..., 2] < 0)   # z < 0
+
+    t1w_data[mask] = 0.
+    # smooth decided against for potential lack of anonymizaton
+    # https://gist.github.com/alexrockhill/15043928b716a432db3a84a050b241ae
+
+    t1w = nib.Nifti1Image(t1w_data, t1w.affine, t1w.header)
+    return t1w
+
+
 def make_bids_basename(subject=None, session=None, task=None,
                        acquisition=None, run=None, processing=None,
                        recording=None, space=None, prefix=None, suffix=None):
@@ -1012,28 +1072,9 @@ def write_anat(bids_root, subject, t1w, session=None, acquisition=None,
         raise ImportError('This function requires nibabel.')
     import nibabel as nib
 
-    if deface and trans is None:
-        raise ValueError('The raw object and trans must be provided to '
+    if deface and (trans is None or raw is None):
+        raise ValueError('The raw object, trans and raw must be provided to '
                          'deface the T1')
-
-    inset, theta = (0.2, 35.)
-    if isinstance(deface, dict):
-        if 'inset' in deface:
-            inset = deface['inset']
-        if 'theta' in deface:
-            theta = deface['theta']
-
-    if not isinstance(inset, float):
-        raise ValueError('inset must be float. Got %s' % type(inset))
-
-    if not (isinstance(theta, float) or isinstance(theta, int)):
-        raise ValueError('theta must be float. Got %s' % type(theta))
-
-    if not 0 < inset < 1.0:
-        raise ValueError('inset should be between 0 and 1')
-
-    if not 0 < theta < 90:
-        raise ValueError('theta should be between 0 and 90 degrees')
 
     # Make directory for anatomical data
     anat_dir = op.join(bids_root, 'sub-{}'.format(subject))
@@ -1103,39 +1144,7 @@ def write_anat(bids_root, subject, t1w, session=None, acquisition=None,
         _write_json(fname, t1w_json, overwrite, verbose)
 
         if deface:
-            # x: L/R L+, y: S/I I+, z: A/P A+
-            t1w_data = t1w.get_data().copy()
-            idxs_vox = np.meshgrid(np.arange(t1w_data.shape[0]),
-                                   np.arange(t1w_data.shape[1]),
-                                   np.arange(t1w_data.shape[2]),
-                                   indexing='ij')
-            idxs_vox = np.array(idxs_vox)  # (3, *t1w_data.shape)
-            idxs_vox = np.transpose(idxs_vox,
-                                    [1, 2, 3, 0])  # (*t1w_data.shape, 3)
-            idxs_vox = idxs_vox.reshape(-1, 3)  # (n_voxels, 3)
-
-            mri_landmarks_ras = apply_trans(t1w.affine, mri_landmarks)
-            ras_meg_t = \
-                get_ras_to_neuromag_trans(*mri_landmarks_ras[[1, 0, 2]])
-
-            idxs_ras = apply_trans(t1w.affine, idxs_vox)
-            idxs_meg = apply_trans(ras_meg_t, idxs_ras)
-
-            # now comes the actual defacing
-            # 1. move center of voxels to (nasion - inset)
-            # 2. rotate the head by theta from the normal to the plane passing
-            # through anatomical coordinates
-            trans_y = -mri_landmarks_ras[1, 1] + t1w_data.shape[2] * inset
-            idxs_meg = apply_trans(translation(y=trans_y), idxs_meg)
-            idxs_meg = apply_trans(rotation(x=-np.deg2rad(theta)), idxs_meg)
-            coords = idxs_meg.reshape(t1w.shape + (3,))  # (*t1w_data.shape, 3)
-            mask = (coords[..., 2] < 0)   # z < 0
-
-            t1w_data[mask] = 0.
-            # smooth decided against for potential lack of anonymizaton
-            # https://gist.github.com/alexrockhill/15043928b716a432db3a84a050b241ae
-
-            t1w = nib.Nifti1Image(t1w_data, t1w.affine, t1w.header)
+            t1w = _deface(t1w, mri_landmarks, deface, trans, raw)
 
     # Save anatomical data
     if op.exists(t1w_basename):

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -42,6 +42,10 @@ from mne_bids.config import (ORIENTATION, UNITS, MANUFACTURERS,
                              BIDS_VERSION)
 
 
+def _is_numeric(n):
+    return isinstance(n, (np.integer, np.floating, int, float))
+
+
 def _channels_tsv(raw, fname, overwrite=False, verbose=True):
     """Create a channels.tsv file and save it.
 
@@ -504,17 +508,21 @@ def _deface(t1w, mri_landmarks, deface, trans, raw):
         if 'theta' in deface:
             theta = deface['theta']
 
-    if not isinstance(inset, float):
-        raise ValueError('inset must be float. Got %s' % type(inset))
+    if not _is_numeric(inset):
+        raise ValueError('inset must be numeric (float, int). '
+                         'Got %s' % type(inset))
 
-    if not (isinstance(theta, float) or isinstance(theta, int)):
-        raise ValueError('theta must be float. Got %s' % type(theta))
+    if not _is_numeric(theta):
+        raise ValueError('theta must be numeric (float, int). '
+                         'Got %s' % type(theta))
 
-    if not 0 < inset < 1.0:
-        raise ValueError('inset should be between 0 and 1')
+    if inset < 0:
+        raise ValueError('inset should be positive, '
+                         'Got %s' % inset)
 
     if not 0 < theta < 90:
-        raise ValueError('theta should be between 0 and 90 degrees')
+        raise ValueError('theta should be between 0 and 90 '
+                         'degrees. Got %s' % theta)
 
     # x: L/R L+, y: S/I I+, z: A/P A+
     t1w_data = t1w.get_data().copy()

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1051,6 +1051,7 @@ def write_anat(bids_root, subject, t1w, session=None, acquisition=None,
     deface : bool | dict
         If False, no defacing is performed.
         If True, deface with default parameters.
+        `trans` and `raw` must not be `None` if True.
         If dict, accepts the following keys:
             `inset`: how far back in millimeters to start defacing
                      relative to the nasion (default 20)

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1023,16 +1023,17 @@ def write_anat(bids_root, subject, t1w, session=None, acquisition=None,
         if 'theta' in deface:
             theta = deface['theta']
 
-    if not 0 < inset < 1.0:
-        raise ValueError('inset should be between 0 and 1')
-    if not 0 < theta < 90:
-        raise ValueError('theta should be between 0 and 90 degrees')
-
     if not isinstance(inset, float):
         raise ValueError('inset must be float. Got %s' % type(inset))
 
     if not (isinstance(theta, float) or isinstance(theta, int)):
         raise ValueError('theta must be float. Got %s' % type(theta))
+
+    if not 0 < inset < 1.0:
+        raise ValueError('inset should be between 0 and 1')
+
+    if not 0 < theta < 90:
+        raise ValueError('theta should be between 0 and 90 degrees')
 
     # Make directory for anatomical data
     anat_dir = op.join(bids_root, 'sub-{}'.format(subject))

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -497,7 +497,7 @@ def _deface(t1w, mri_landmarks, deface, trans, raw):
         raise ImportError('This function requires nibabel.')
     import nibabel as nib
 
-    inset, theta = (0.2, 35.)
+    inset, theta = (20, 35.)
     if isinstance(deface, dict):
         if 'inset' in deface:
             inset = deface['inset']
@@ -538,7 +538,7 @@ def _deface(t1w, mri_landmarks, deface, trans, raw):
     # 1. move center of voxels to (nasion - inset)
     # 2. rotate the head by theta from the normal to the plane passing
     # through anatomical coordinates
-    trans_y = -mri_landmarks_ras[1, 1] + t1w_data.shape[2] * inset
+    trans_y = -mri_landmarks_ras[1, 1] + inset
     idxs_meg = apply_trans(translation(y=trans_y), idxs_meg)
     idxs_meg = apply_trans(rotation(x=-np.deg2rad(theta)), idxs_meg)
     coords = idxs_meg.reshape(t1w.shape + (3,))  # (*t1w_data.shape, 3)
@@ -1044,8 +1044,8 @@ def write_anat(bids_root, subject, t1w, session=None, acquisition=None,
         If False, no defacing is performed.
         If True, deface with default parameters.
         If dict, accepts the following keys:
-            `inset`: how far back as a fraction of mri space to start
-                     defacing relative to the nasion (default 0.2)
+            `inset`: how far back in millimeters to start defacing
+                     defacing relative to the nasion (default 20)
             `theta`: is the angle of the defacing shear in degrees relative
                      to the normal to the plane passing through the anatomical
                      landmarks (default 35).

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1053,7 +1053,7 @@ def write_anat(bids_root, subject, t1w, session=None, acquisition=None,
         If True, deface with default parameters.
         If dict, accepts the following keys:
             `inset`: how far back in millimeters to start defacing
-                     defacing relative to the nasion (default 20)
+                     relative to the nasion (default 20)
             `theta`: is the angle of the defacing shear in degrees relative
                      to the normal to the plane passing through the anatomical
                      landmarks (default 35).

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1048,7 +1048,7 @@ def write_anat(bids_root, subject, t1w, session=None, acquisition=None,
                      defacing relative to the nasion (default 0.2)
             `theta`: is the angle of the defacing shear in degrees relative
                      to the normal to the plane passing through the anatomical
-                     landmarks (default 35)
+                     landmarks (default 35).
     overwrite : bool
         Whether to overwrite existing files or data in files.
         Defaults to False.


### PR DESCRIPTION
PR Description
--------------

Using a numpy/scipy implementation, a shear method will be applied to erase the face for T1 data.

closes https://github.com/mne-tools/mne-bids/issues/239

progress on https://github.com/mne-tools/mne-bids/issues/269 

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [x] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [x] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [x] PR description includes phrase "closes <#issue-number>"
- [x] Commit history does not contain any merge commits
