### PR TITLE
Add Keyword Conversion to FIF for MEG and BV for EEG & iEEG

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -22,6 +22,7 @@ Current
 Changelog
 ~~~~~~~~~
 
+- Added option to convert files to FIF for MEG and BV for EEG/iEEG, forcing not to convert when not a BIDS-acceptable format is also added, by `Alex Rockhill`_ (`#285 https://github.com/mne-tools/mne-bids/pull/285>`_)
 - Added option to anonymize by shifting measurement date with `anonymize` parameter, in accordance with BIDS specifications, by `Alex Rockhill`_ (`#280 <https://github.com/mne-tools/mne-bids/pull/280>`_)
 - Added automatic conversion of FIF to BrainVision format with warning for EEG only data and conversion to FIF for meg non-FIF data, by `Alex Rockhill`_ (`#237 <https://github.com/mne-tools/mne-bids/pull/237>`_)
 - Add possibility to pass raw readers parameters (e.g. `allow_maxshield`) to :func:`read_raw_bids` to allow reading BIDS-formatted data before applying maxfilter, by  `Sophie Herbst`_

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -544,12 +544,9 @@ def test_bti(_bids_validate):
         output_path = _test_anonymize(raw, bids_basename)
     _bids_validate(output_path)
 
-<<<<<<< HEAD
-=======
     output_path = _test_convert(raw, bids_basename)
     _bids_validate(output_path)
 
->>>>>>> anonymize keyword argument for write_raw_bids
 
 # XXX: vhdr test currently passes only on MNE master. Skip until next release.
 # see: https://github.com/mne-tools/mne-python/pull/6558
@@ -674,12 +671,9 @@ def test_edf(_bids_validate):
     output_path = _test_anonymize(raw, bids_basename)
     _bids_validate(output_path)
 
-<<<<<<< HEAD
-=======
     output_path = _test_convert(raw, bids_basename)
     _bids_validate(output_path)
 
->>>>>>> anonymize keyword argument for write_raw_bids
 
 def test_bdf(_bids_validate):
     """Test write_raw_bids conversion for Biosemi data."""
@@ -725,12 +719,9 @@ def test_bdf(_bids_validate):
     output_path = _test_anonymize(raw, bids_basename)
     _bids_validate(output_path)
 
-<<<<<<< HEAD
-=======
     output_path = _test_convert(raw, bids_basename)
     _bids_validate(output_path)
 
->>>>>>> anonymize keyword argument for write_raw_bids
 
 def test_set(_bids_validate):
     """Test write_raw_bids conversion for EEGLAB data."""
@@ -786,12 +777,9 @@ def test_set(_bids_validate):
     output_path = _test_anonymize(raw, bids_basename)
     _bids_validate(output_path)
 
-<<<<<<< HEAD
-=======
     output_path = _test_convert(raw, bids_basename)
     _bids_validate(output_path)
 
->>>>>>> anonymize keyword argument for write_raw_bids
 
 @requires_nibabel()
 def test_write_anat(_bids_validate):

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -207,6 +207,12 @@ def test_fif(_bids_validate):
     output_path2 = _test_convert(raw2, bids_basename, events_fname, event_id)
     _bids_validate(output_path2)
 
+    with pytest.warns(UserWarning, match='not supported by BIDS'):
+        write_raw_bids(raw2, bids_basename, output_path2,
+                       events_data=events_fname,
+                       event_id=event_id, convert=False,
+                       overwrite=True, verbose=True)
+
     os.remove(op.join(output_path, 'test-raw.fif'))
     bids_dir = op.join(output_path, 'sub-%s' % subject_id,
                        'ses-%s' % session_id, 'eeg')

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -96,6 +96,21 @@ def _test_anonymize(raw, bids_basename, events_fname=None, event_id=None):
     return output_path
 
 
+@requires_version('pybv', '0.2.0')
+def _test_convert(raw, bids_basename, events_fname=None, event_id=None):
+    output_path = _TempDir()
+    if mne.pick_types(raw.info, meg=True).size > 0:
+        match = 'Converting data files to FIF format'
+    else:
+        match = 'Converting data files to BrainVision format'
+    with pytest.warns(UserWarning, match=match):
+        write_raw_bids(raw, bids_basename, output_path,
+                       events_data=events_fname,
+                       event_id=event_id, convert=True,
+                       overwrite=False, verbose=True)
+    return output_path
+
+
 def test_stamp_to_dt():
     """Test conversions of meas_date to datetime objects."""
     meas_date = (1346981585, 835782)
@@ -188,6 +203,10 @@ def test_fif(_bids_validate):
         write_raw_bids(raw2, bids_basename, output_path,
                        events_data=events_fname, event_id=event_id,
                        verbose=True, overwrite=False)
+
+    output_path2 = _test_convert(raw2, bids_basename, events_fname, event_id)
+    _bids_validate(output_path2)
+
     os.remove(op.join(output_path, 'test-raw.fif'))
     bids_dir = op.join(output_path, 'sub-%s' % subject_id,
                        'ses-%s' % session_id, 'eeg')
@@ -447,6 +466,18 @@ def test_kit(_bids_validate):
             output_path, events_data=events_fname, event_id=event_id,
             overwrite=True)
 
+    # test anonymize and convert
+    raw = mne.io.read_raw_kit(
+        raw_fname, mrk=hpi_fname, elp=electrode_fname,
+        hsp=headshape_fname)
+    output_path = _test_anonymize(raw, kit_bids_basename,
+                                  events_fname, event_id)
+    _bids_validate(output_path)
+
+    output_path = _test_convert(raw, bids_basename,
+                                events_fname, event_id)
+    _bids_validate(output_path)
+
 
 def test_ctf(_bids_validate):
     """Test functionality of the write_raw_bids conversion for CTF data."""
@@ -479,6 +510,9 @@ def test_ctf(_bids_validate):
     with pytest.raises(ValueError, match='All measurement dates are None'):
         get_anonymization_daysback(raw)
 
+    output_path = _test_convert(raw, bids_basename)
+    _bids_validate(output_path)
+
 
 def test_bti(_bids_validate):
     """Test functionality of the write_raw_bids conversion for BTi data."""
@@ -510,6 +544,12 @@ def test_bti(_bids_validate):
         output_path = _test_anonymize(raw, bids_basename)
     _bids_validate(output_path)
 
+<<<<<<< HEAD
+=======
+    output_path = _test_convert(raw, bids_basename)
+    _bids_validate(output_path)
+
+>>>>>>> anonymize keyword argument for write_raw_bids
 
 # XXX: vhdr test currently passes only on MNE master. Skip until next release.
 # see: https://github.com/mne-tools/mne-python/pull/6558
@@ -634,6 +674,12 @@ def test_edf(_bids_validate):
     output_path = _test_anonymize(raw, bids_basename)
     _bids_validate(output_path)
 
+<<<<<<< HEAD
+=======
+    output_path = _test_convert(raw, bids_basename)
+    _bids_validate(output_path)
+
+>>>>>>> anonymize keyword argument for write_raw_bids
 
 def test_bdf(_bids_validate):
     """Test write_raw_bids conversion for Biosemi data."""
@@ -679,6 +725,12 @@ def test_bdf(_bids_validate):
     output_path = _test_anonymize(raw, bids_basename)
     _bids_validate(output_path)
 
+<<<<<<< HEAD
+=======
+    output_path = _test_convert(raw, bids_basename)
+    _bids_validate(output_path)
+
+>>>>>>> anonymize keyword argument for write_raw_bids
 
 def test_set(_bids_validate):
     """Test write_raw_bids conversion for EEGLAB data."""
@@ -734,6 +786,12 @@ def test_set(_bids_validate):
     output_path = _test_anonymize(raw, bids_basename)
     _bids_validate(output_path)
 
+<<<<<<< HEAD
+=======
+    output_path = _test_convert(raw, bids_basename)
+    _bids_validate(output_path)
+
+>>>>>>> anonymize keyword argument for write_raw_bids
 
 @requires_nibabel()
 def test_write_anat(_bids_validate):

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -207,7 +207,7 @@ def test_fif(_bids_validate):
     output_path2 = _test_convert(raw2, bids_basename, events_fname, event_id)
     _bids_validate(output_path2)
 
-    with pytest.warns(UserWarning, match='not supported by BIDS'):
+    with pytest.raises(ValueError, match='Not converting'):
         write_raw_bids(raw2, bids_basename, output_path2,
                        events_data=events_fname,
                        event_id=event_id, convert=False,

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -929,12 +929,6 @@ def write_raw_bids(raw, bids_basename, output_path, events_data=None,
                    for the manufacturer, please update the manufacturer field
                    in the sidecars manually.
 
-                 * If `convert` is False, files will not be BIDS compatible
-                   unless they were already in a BIDS compatible file type for
-                   that modality. Once all issues with converting are fixed
-                   and the conversion is known to be stable, this is strongly
-                   recommended not to be used.
-
     Parameters
     ----------
     raw : instance of mne.io.Raw
@@ -995,7 +989,7 @@ def write_raw_bids(raw, bids_basename, output_path, events_data=None,
         for MEG data if the data file is not already in that format.
         Defaults to None in which case conversion will be done only if
         the file type is not compatible (e.g. an EEG-only FIF file). If
-        anonymize is used, the file must be converted.
+        anonymize is used, the file must be converted. False is not allowed.
     overwrite : bool
         Whether to overwrite existing files or data in files.
         Defaults to False.
@@ -1062,14 +1056,11 @@ def write_raw_bids(raw, bids_basename, output_path, events_data=None,
 
     bids_fname = bids_basename + '_%s%s' % (kind, ext)
 
-    if not convert:
-        if convert is None:
-            convert = ext not in ALLOWED_EXTENSIONS[kind]
-        else:
-            if ext not in ALLOWED_EXTENSIONS[kind] and verbose:
-                warn('The format %s is not supported by BIDS, unless ' % ext +
-                     'there are issues with the conversion, it is strongly ' +
-                     'recommended that you do not use `convert=False`')
+    if convert is None:
+        convert = ext not in ALLOWED_EXTENSIONS[kind]
+    elif not convert:
+        raise ValueError('Not converting could result in a non-BIDS ' +
+                         'compatible dataset')
 
     # check whether the info provided indicates that the data is emptyroom
     # data

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1056,6 +1056,9 @@ def write_raw_bids(raw, bids_basename, output_path, events_data=None,
 
     bids_fname = bids_basename + '_%s%s' % (kind, ext)
 
+    if convert is None:
+        convert = ext not in ALLOWED_EXTENSIONS[kind]
+
     # check whether the info provided indicates that the data is emptyroom
     # data
     emptyroom = False
@@ -1108,6 +1111,7 @@ def write_raw_bids(raw, bids_basename, output_path, events_data=None,
 
     # Anonymize
     if anonymize is not None:
+<<<<<<< HEAD
         # if info['meas_date'] None, then the dates are not stored
         if raw.info['meas_date'] is None:
             daysback = None
@@ -1126,6 +1130,22 @@ def write_raw_bids(raw, bids_basename, output_path, events_data=None,
                 raise ValueError('`daysback` exceeds maximum value MNE '
                                  'is able to store in FIF format, must '
                                  'be less than %i' % daysback_max)
+=======
+        if 'daysback' not in anonymize or anonymize['daysback'] is None:
+            raise ValueError('`daysback` argument required to anonymize.')
+        daysback = anonymize['daysback']
+        daysback_min, daysback_max = _get_anonymization_daysback(raw)
+        if daysback < daysback_min:
+            warn('`daysback` is too small; the measurement date '
+                 'is after 1925, which is not recommended by BIDS.'
+                 'The minimum `daysback` value for changing the measurement'
+                 'date of this data to before this date is %i' % daysback_min)
+        if (ext == '.fif' or (kind == 'meg' and convert) and
+                daysback > daysback_max):
+            raise ValueError('`daysback` exceeds maximum value MNE is able '
+                             'to store in FIF format, must be less than %i' %
+                             daysback_max)
+>>>>>>> moved convert up for anonymization daysback not exceeding max
         keep_his = anonymize['keep_his'] if 'keep_his' in anonymize else False
         raw.info = anonymize_info(raw.info, daysback=daysback,
                                   keep_his=keep_his)
@@ -1165,9 +1185,6 @@ def write_raw_bids(raw, bids_basename, output_path, events_data=None,
         raise FileExistsError('"%s" already exists. Please set '  # noqa: F821
                               'overwrite to True.' % bids_fname)
     _mkdir_p(os.path.dirname(bids_fname))
-
-    if convert is None:
-        convert = ext not in ALLOWED_EXTENSIONS[kind]
 
     if not (convert or anonymize) and verbose:
         print('Copying data files to %s' % op.splitext(bids_fname)[0])

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -929,6 +929,12 @@ def write_raw_bids(raw, bids_basename, output_path, events_data=None,
                    for the manufacturer, please update the manufacturer field
                    in the sidecars manually.
 
+                 * If `convert` is False, files will not be BIDS compatible
+                   unless they were already in a BIDS compatible file type for
+                   that modality. Once all issues with converting are fixed
+                   and the conversion is known to be stable, this is strongly
+                   recommended not to be used.
+
     Parameters
     ----------
     raw : instance of mne.io.Raw
@@ -1056,8 +1062,14 @@ def write_raw_bids(raw, bids_basename, output_path, events_data=None,
 
     bids_fname = bids_basename + '_%s%s' % (kind, ext)
 
-    if convert is None:
-        convert = ext not in ALLOWED_EXTENSIONS[kind]
+    if not convert:
+        if convert is None:
+            convert = ext not in ALLOWED_EXTENSIONS[kind]
+        else:
+            if ext not in ALLOWED_EXTENSIONS[kind] and verbose:
+                warn('The format %s is not supported by BIDS, unless ' % ext +
+                     'there are issues with the conversion, it is strongly ' +
+                     'recommended that you do not use `convert=False`')
 
     # check whether the info provided indicates that the data is emptyroom
     # data

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1111,7 +1111,6 @@ def write_raw_bids(raw, bids_basename, output_path, events_data=None,
 
     # Anonymize
     if anonymize is not None:
-<<<<<<< HEAD
         # if info['meas_date'] None, then the dates are not stored
         if raw.info['meas_date'] is None:
             daysback = None
@@ -1130,22 +1129,6 @@ def write_raw_bids(raw, bids_basename, output_path, events_data=None,
                 raise ValueError('`daysback` exceeds maximum value MNE '
                                  'is able to store in FIF format, must '
                                  'be less than %i' % daysback_max)
-=======
-        if 'daysback' not in anonymize or anonymize['daysback'] is None:
-            raise ValueError('`daysback` argument required to anonymize.')
-        daysback = anonymize['daysback']
-        daysback_min, daysback_max = _get_anonymization_daysback(raw)
-        if daysback < daysback_min:
-            warn('`daysback` is too small; the measurement date '
-                 'is after 1925, which is not recommended by BIDS.'
-                 'The minimum `daysback` value for changing the measurement'
-                 'date of this data to before this date is %i' % daysback_min)
-        if (ext == '.fif' or (kind == 'meg' and convert) and
-                daysback > daysback_max):
-            raise ValueError('`daysback` exceeds maximum value MNE is able '
-                             'to store in FIF format, must be less than %i' %
-                             daysback_max)
->>>>>>> moved convert up for anonymization daysback not exceeding max
         keep_his = anonymize['keep_his'] if 'keep_his' in anonymize else False
         raw.info = anonymize_info(raw.info, daysback=daysback,
                                   keep_his=keep_his)


### PR DESCRIPTION
PR Description
--------------

Add the option to convert to more widely used formats (BV and FIF) so that BIDS supported files can be more standardized. Contrapositively, add the option not to force a conversion for files that are not BIDS compliant (EEG-only data stored in FIF for instance, for an example, see https://openneuro.org/datasets/ds001784)


Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
- [ ] Commit history does not contain any merge commits
