### PR TITLE
[BUG] [MRG] Pybv event saving bug and adding tests

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -31,7 +31,7 @@ Changelog
 Bug
 ~~~
 
-- Fixed broken event timing broken by conversion to BV in :func:`write_raw_bids`, by `Alex Rockhill`_ (`# <https://github.com/mne-tools/mne-bids/pull/>`_)
+- Fixed broken event timing broken by conversion to BV in :func:`write_raw_bids`, by `Alex Rockhill`_ (`#294 <https://github.com/mne-tools/mne-bids/pull/294>`_)
 
 API
 ~~~

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -31,6 +31,8 @@ Changelog
 Bug
 ~~~
 
+- Fixed broken event timing broken by conversion to BV in :func:`write_raw_bids`, by `Alex Rockhill`_ (`# <https://github.com/mne-tools/mne-bids/pull/>`_)
+
 API
 ~~~
 

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -180,6 +180,7 @@ def test_fif(_bids_validate):
     output_path = _TempDir()
     raw = mne.io.read_raw_fif(raw_fname)
     raw.load_data()
+    events = mne.find_events(raw)
     raw2 = raw.pick_types(meg=False, eeg=True, stim=True, eog=True, ecg=True)
     raw2.save(op.join(output_path, 'test-raw.fif'), overwrite=True)
     raw2 = mne.io.Raw(op.join(output_path, 'test-raw.fif'), preload=False)
@@ -195,10 +196,13 @@ def test_fif(_bids_validate):
                     'eeg.vmrk', 'events.tsv']:
         assert op.isfile(op.join(bids_dir, bids_basename + '_' + sidecar))
 
-    raw2 = mne.io.read_raw_brainvision(op.join(bids_dir,
-                                               bids_basename + '_eeg.vhdr'))
+    raw2 = read_raw_bids(bids_basename + '_eeg.vhdr', output_path)
 
+    events2 = mne.find_events(raw2)
+    events2[:, 0] += raw.first_samp
+    # events2, _ = mne.events_from_annotations(raw2)
     assert_array_almost_equal(raw.get_data(), raw2.get_data())
+    assert_array_almost_equal(events, events2)
     _bids_validate(output_path)
 
     # write the same data but pretend it is empty room data:

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -609,14 +609,16 @@ def _write_raw_brainvision(raw, bids_fname):
                           'file to Brainvision format')
     from pybv import write_brainvision
     events, _ = events_from_annotations(raw)
-    events[:, 0] -= 2334  # raw.first_samp
+    meas_date = raw.info['meas_date']
+    if meas_date is not None:
+        meas_date = _stamp_to_dt(meas_date)
     write_brainvision(raw.get_data(), raw.info['sfreq'],
                       raw.ch_names,
                       op.splitext(op.basename(bids_fname))[0],
                       op.dirname(bids_fname),
                       events=events[:, [0, 2]],
-                      resolution=1e-7,
-                      meas_date=_stamp_to_dt(raw.info['meas_date']))
+                      resolution=1e-9,
+                      meas_date=meas_date)
 
 
 def _get_anonymization_daysback(raw):

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -18,7 +18,7 @@ import numpy as np
 from numpy.testing import assert_array_equal
 from mne.transforms import (_get_trans, apply_trans, get_ras_to_neuromag_trans,
                             rotation, translation)
-from mne import Epochs, events_from_annotations
+from mne import Epochs, events_from_annotations, pick_types
 from mne.io.constants import FIFF
 from mne.io.pick import channel_type
 from mne.io import BaseRaw, anonymize_info
@@ -608,12 +608,15 @@ def _write_raw_brainvision(raw, bids_fname):
         raise ImportError('pybv >=0.2.0 is required for converting ' +
                           'file to Brainvision format')
     from pybv import write_brainvision
-    events, event_id = events_from_annotations(raw)
+    events, _ = events_from_annotations(raw)
+    events[:, 0] -= 2334  # raw.first_samp
     write_brainvision(raw.get_data(), raw.info['sfreq'],
                       raw.ch_names,
                       op.splitext(op.basename(bids_fname))[0],
-                      op.dirname(bids_fname), events[:, [0, 2]],
-                      resolution=1e-6)
+                      op.dirname(bids_fname),
+                      events=events[:, [0, 2]],
+                      resolution=1e-7,
+                      meas_date=_stamp_to_dt(raw.info['meas_date']))
 
 
 def _get_anonymization_daysback(raw):

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -609,6 +609,7 @@ def _write_raw_brainvision(raw, bids_fname):
                           'file to Brainvision format')
     from pybv import write_brainvision
     events, _ = events_from_annotations(raw)
+    events[:, 0] -= raw.first_samp
     meas_date = raw.info['meas_date']
     if meas_date is not None:
         meas_date = _stamp_to_dt(meas_date)

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -609,6 +609,8 @@ def _write_raw_brainvision(raw, bids_fname):
                           'file to Brainvision format')
     from pybv import write_brainvision
     events, _ = events_from_annotations(raw)
+    # Subtract raw.fist_samp because brainvision marks events starting from
+    # the first available data point and ignores the raw.first_samp
     events[:, 0] -= raw.first_samp
     meas_date = raw.info['meas_date']
     if meas_date is not None:

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -18,7 +18,7 @@ import numpy as np
 from numpy.testing import assert_array_equal
 from mne.transforms import (_get_trans, apply_trans, get_ras_to_neuromag_trans,
                             rotation, translation)
-from mne import Epochs, events_from_annotations
+from mne import Epochs
 from mne.io.constants import FIFF
 from mne.io.pick import channel_type
 from mne.io import BaseRaw, anonymize_info
@@ -608,7 +608,7 @@ def _write_raw_brainvision(raw, bids_fname, events):
         raise ImportError('pybv >=0.2.0 is required for converting ' +
                           'file to Brainvision format')
     from pybv import write_brainvision
-    # Subtract raw.fist_samp because brainvision marks events starting from
+    # Subtract raw.first_samp because brainvision marks events starting from
     # the first available data point and ignores the raw.first_samp
     if events is not None:
         events[:, 0] -= raw.first_samp

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -18,7 +18,7 @@ import numpy as np
 from numpy.testing import assert_array_equal
 from mne.transforms import (_get_trans, apply_trans, get_ras_to_neuromag_trans,
                             rotation, translation)
-from mne import Epochs, events_from_annotations, pick_types
+from mne import Epochs, events_from_annotations
 from mne.io.constants import FIFF
 from mne.io.pick import channel_type
 from mne.io import BaseRaw, anonymize_info


### PR DESCRIPTION
Ok, here's the state of what I know, hopefully someone can help: 1) I can use mne.find_events on the sample data but not mne.read_events_from_annotations, this is weird, I thought the second would work (see the issue below for a minimally reproducible example). 2) When I convert to BV and then read the raw back in, it's off by raw.first_samp, this is not good but I thought fixable. 3) This is where is gets weird and I don't understand how find_events and events_from_annotations work well enough to debug it: when I pass any offset to the time stamp column of events (events[:, 0]) the events from find_events do not change and the events from events_from_annotation have the event_id second column off by 10001, i.e. 2 becomes 10003 but the zeroth column events don't change in this one either. So I'm a bit stuck on this BV conversion.

Related to https://github.com/mne-tools/mne-bids/issues/293.

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [x] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [x] PR description includes phrase "closes <#issue-number>"
- [ ] Commit history does not contain any merge commits
