### PR TITLE
[MRG] use mne-bids for binder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
                   conda update --yes --quiet conda
                   conda env create -f environment.yml --name=testenv
                   source activate testenv
-                  pip install -U https://api.github.com/repos/mne-tools/mne-python/zipball/master
+                  pip install mne==0.18.2
                   python setup.py develop
 
             - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
                   conda update --yes --quiet conda
                   conda env create -f environment.yml --name=testenv
                   source activate testenv
-                  pip install mne==0.18.2
+                  pip install mne==0.19
                   python setup.py develop
 
             - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
                   conda update --yes --quiet conda
                   conda env create -f environment.yml --name=testenv
                   source activate testenv
-                  pip install mne==0.19
+                  pip install mne~=0.19.0
                   python setup.py develop
 
             - run:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ language: python
 env:
   global:
     # can be "stable", or anything that can be used with git checkout
-    - VALIDATOR_VERSION="master"
+    - VALIDATOR_VERSION="9d8a6ffae5e0ee117b97bc8c978fe34ec3c13af4"
     # can be any branch of MNE-Python (e.g., "maint/0.18", "master", ...)
-    - MNE_VERSION="master"
+    - MNE_VERSION="maint/0.18"
 
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
     # can be "stable", or anything that can be used with git checkout
     - VALIDATOR_VERSION="9d8a6ffae5e0ee117b97bc8c978fe34ec3c13af4"
     # can be any branch of MNE-Python (e.g., "maint/0.18", "master", ...)
-    - MNE_VERSION="maint/0.18"
+    - MNE_VERSION="maint/0.19"
 
 
 before_install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,7 +36,7 @@ install:
   - "powershell ci-helpers/appveyor/install-miniconda.ps1"
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
   - "activate test"
-  - "conda install numpy'>1.14' scipy'>0.18.1'"
+  - "conda install numpy scipy"
   - "pip install nibabel flake8 pytest pytest-sugar pytest-faulthandler"
   - "pip uninstall -yq mne"
   - ps: |-

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,9 +4,9 @@ environment:
         # latter case, you MUST adjust VALIDATOR_EXECUTABLE to the following value:
         # "C:\\projects\\mne-bids\\bids-validator\\bids-validator\\bin\\bids-validator"
         # ... whereas for "stable", VALIDATOR_EXECUTABLE MUST be set to "n/a"
-        VALIDATOR_VERSION: "master"
+        VALIDATOR_VERSION: "9d8a6ffae5e0ee117b97bc8c978fe34ec3c13af4"
         # can be any branch of MNE-Python (e.g., "maint/0.18", "master", ...)
-        MNE_VERSION: "master"
+        MNE_VERSION: "maint/0.18"
         VALIDATOR_EXECUTABLE: "C:\\projects\\mne-bids\\bids-validator\\bids-validator\\bin\\bids-validator"
         NODEJS_VERSION: "10.16.1"
         PYTHON: "C:\\conda"
@@ -36,7 +36,7 @@ install:
   - "powershell ci-helpers/appveyor/install-miniconda.ps1"
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
   - "activate test"
-  - "conda install numpy scipy"
+  - "conda install numpy'<=1.14' scipy'<=0.18.1'"
   - "pip install nibabel flake8 pytest pytest-sugar pytest-faulthandler"
   - "pip uninstall -yq mne"
   - ps: |-

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ environment:
         # ... whereas for "stable", VALIDATOR_EXECUTABLE MUST be set to "n/a"
         VALIDATOR_VERSION: "9d8a6ffae5e0ee117b97bc8c978fe34ec3c13af4"
         # can be any branch of MNE-Python (e.g., "maint/0.18", "master", ...)
-        MNE_VERSION: "maint/0.18"
+        MNE_VERSION: "maint/0.19"
         VALIDATOR_EXECUTABLE: "C:\\projects\\mne-bids\\bids-validator\\bids-validator\\bin\\bids-validator"
         NODEJS_VERSION: "10.16.1"
         PYTHON: "C:\\conda"
@@ -36,7 +36,7 @@ install:
   - "powershell ci-helpers/appveyor/install-miniconda.ps1"
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
   - "activate test"
-  - "conda install numpy'<=1.14' scipy'<=0.18.1'"
+  - "conda install numpy'>1.14' scipy'>0.18.1'"
   - "pip install nibabel flake8 pytest pytest-sugar pytest-faulthandler"
   - "pip uninstall -yq mne"
   - ps: |-

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,6 +14,8 @@ environment:
       - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
         PYTHON_VERSION: "3.6"
         PYTHON_ARCH: "64"
+        PYTHON_ROOT: "C:\\Miniconda36-x64"
+        CONDA_INSTRUMENTATION_ENABLED: "true"
 
 install:
   # https://www.appveyor.com/docs/lang/nodejs-iojs/
@@ -32,11 +34,8 @@ install:
       yarn &&
       cd .. &&
       set PATH="%PATH%;C:\projects\mne-bids\bids-validator\bids-validator\bin\" )
-  - "git clone --depth 1 git://github.com/astropy/ci-helpers.git"
-  - "powershell ci-helpers/appveyor/install-miniconda.ps1"
-  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
-  - "activate test"
-  - "conda install numpy scipy"
+  - CALL "%PYTHON_ROOT%\\Scripts\\activate.bat"
+  - "conda install -y python=%PYTHON_VERSION% conda numpy scipy"
   - "pip install nibabel flake8 pytest pytest-sugar pytest-faulthandler"
   - "pip uninstall -yq mne"
   - ps: |-

--- a/doc/binder-requirements.txt
+++ b/doc/binder-requirements.txt
@@ -1,0 +1,1 @@
+mne_bids

--- a/doc/binder-requirements.txt
+++ b/doc/binder-requirements.txt
@@ -1,1 +1,1 @@
-mne_bids
+mne_bids<0.4

--- a/doc/binder-requirements.txt
+++ b/doc/binder-requirements.txt
@@ -1,1 +1,1 @@
-mne_bids<0.4
+mne_bids<=0.3

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -127,7 +127,8 @@ sphinx_gallery_conf = {
         'branch': 'gh-pages',  # noqa: E501 Can be any branch, tag, or commit hash. Use a branch that hosts your docs.
         'binderhub_url': 'https://mybinder.org',  # noqa: E501 Any URL of a binderhub deployment. Must be full URL (e.g. https://mybinder.org).
         'dependencies': [
-            '../environment.yml'
+            '../environment.yml',
+            './binder-requirements.txt'
         ],
     }
 }

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
 - scikit-learn
 - matplotlib
 - pip:
-  - mne==0.19
+  - mne~=0.19.0
   - nibabel
   - nilearn
   - flake8

--- a/environment.yml
+++ b/environment.yml
@@ -6,12 +6,12 @@ dependencies:
 - python<3.7
 - pip=19
 - mkl
-- numpy<=1.14
-- scipy<=0.18.1
+- numpy>1.14
+- scipy>0.18
 - scikit-learn
 - matplotlib
 - pip:
-  - mne<0.19
+  - mne=0.19
   - nibabel
   - nilearn
   - flake8

--- a/environment.yml
+++ b/environment.yml
@@ -6,12 +6,12 @@ dependencies:
 - python<3.7
 - pip=19
 - mkl
-- numpy
-- scipy
+- numpy<=1.14
+- scipy<=0.18.1
 - scikit-learn
 - matplotlib
 - pip:
-  - mne
+  - mne<0.19
   - nibabel
   - nilearn
   - flake8

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
 - scikit-learn
 - matplotlib
 - pip:
-  - mne=0.19
+  - mne==0.19
   - nibabel
   - nilearn
   - flake8


### PR DESCRIPTION
potentially replaces #300 

Here I simply add a new requirements file specifically for the binder installation.

The idea would be to merge this into `maint/0.3` and see if it makes our examples work.

If it does, we can do the same for `master`.

Note: Merging this SHOULD trigger an update of the website, see: https://github.com/mne-tools/mne-bids/blob/5809a8204f0fc9f18e772807312ecfd656a6d6d9/.circleci/config.yml#L67-L72

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
- [ ] Commit history does not contain any merge commits
