### PR TITLE
MRG: binder install with distinct env yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,12 @@ jobs:
         steps:
             - checkout
 
+            - run:
+              name: Check environment.yml and doc/environment.yml syncing
+              # doc/environment.yml must be a perfect copy of environment.yml
+              # with a single line "  - mne_bids~=0.X" added in the pip section
+              command: diff <(grep -v '^  - mne_bids~=0.3$' doc/environment.yml) <(cat environment.yml)
+
             # restore cache from last build. Unless __init__.py has changed since then
             - restore_cache:
                 keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,10 +7,10 @@ jobs:
             - checkout
 
             - run:
-              name: Check environment.yml and doc/environment.yml syncing
-              # doc/environment.yml must be a perfect copy of environment.yml
-              # with a single line "  - mne_bids~=0.X" added in the pip section
-              command: diff <(grep -v '^  - mne_bids~=0.3$' doc/environment.yml) <(cat environment.yml)
+                name: Check environment.yml and doc/environment.yml syncing
+                # doc/environment.yml must be a perfect copy of environment.yml
+                # with a single line "  - mne_bids~=0.X" added in the pip section
+                command: diff <(grep -v '^  - mne_bids~=0.3$' doc/environment.yml) <(cat environment.yml)
 
             # restore cache from last build. Unless __init__.py has changed since then
             - restore_cache:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -129,7 +129,7 @@ sphinx_gallery_conf = {
         'branch': 'gh-pages',  # noqa: E501 Can be any branch, tag, or commit hash. Use a branch that hosts your docs.
         'binderhub_url': 'https://mybinder.org',  # noqa: E501 Any URL of a binderhub deployment. Must be full URL (e.g. https://mybinder.org).
         'dependencies': [
-            '../environment.yml'
+            './environment.yml'
         ],
     }
 }

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -1,0 +1,29 @@
+name: mne_bids
+channels:
+- defaults
+- conda-forge
+dependencies:
+- python<3.7
+- pip=19
+- mkl
+- numpy>=1.14
+- scipy>=0.18.1
+- scikit-learn
+- matplotlib
+- pip:
+  - mne_bids~=0.3
+  - mne>=0.19.1
+  - nibabel
+  - pybv
+  - nilearn
+  - flake8
+  - pytest
+  - pytest-cov
+  - pytest-sugar
+  - pytest-faulthandler
+  - check-manifest
+  - sphinx
+  - pillow
+  - numpydoc
+  - sphinx_bootstrap_theme
+  - sphinx_gallery

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -22,6 +22,7 @@ dependencies:
   - pytest-sugar
   - pytest-faulthandler
   - check-manifest
+  - pydocstyle
   - sphinx
   - pillow
   - numpydoc


### PR DESCRIPTION
Running the examples in binder has been fixed for our stable docs in: https://github.com/mne-tools/mne-bids/commit/acd5717a8c3d6c875693e53c8619d77e4f04906e

To make sure that this behavior will also work once we release `0.4`, we need to add the fix to our `master` branch as well.

Currently that fix is only on our `maint/0.3` branch.

Notes:
- before releasing, we will have to update `mne_bids~=0.3` to `mne_bids~=0.X` for every Xth release (perhaps we can find a better way to do this in the future)
- binder examples will only work for stable docs ... not for dev docs (also perhaps something to be improved in the future)


Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
- [ ] Commit history does not contain any merge commits
