### PR TITLE
[MRG] Include 'part' in the entity list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ dist/
 *.egg*
 build
 coverage
-coverage.xml
+*.xml
 
 # Sphinx documentation
 doc/_build/

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -33,6 +33,7 @@ Changelog
 - Add existence check for :func:`write_raw_bids` before :func:`make_dataset_description` is called, by `Adam Li`_ (`#331 <https://github.com/mne-tools/mne-bids/pull/331>`_)
 - Update scans.tsv writer to adhere to MNE-Python v0.20+ where `meas_date` is stored as a `datetime` object, by `Adam Li`_ (`#344 <https://github.com/mne-tools/mne-bids/pull/344>`_)
 - :func:`read_raw_bids` now reads in sidecar json files to set, or estimate Power Line Frequency, by `Adam Li`_ (`#341 <https://github.com/mne-tools/mne-bids/pull/341>`_)
+- Allow FIF files with multiple parts to be read using :func:`read_raw_bids`, by `Teon Brooks`_(`#346 <https://github.com/mne-tools/mne-bids/pull/346>`)
 
 Bug
 ~~~

--- a/mne_bids/tests/test_utils.py
+++ b/mne_bids/tests/test_utils.py
@@ -219,10 +219,10 @@ def test_parse_ext():
 
 
 @pytest.mark.parametrize('fname', [
-    'sub-01_ses-02_task-test_run-3_meg.fif',
-    'sub-01_ses-02_task-test_run-3.fif',
-    'sub-01_ses-02_task-test_run-3',
-    '/bids_root/sub-01/ses-02/meg/sub-01_ses-02_task-test_run-3_meg.fif',
+    'sub-01_ses-02_task-test_run-3_part-01_meg.fif',
+    'sub-01_ses-02_task-test_run-3_part-01.fif',
+    'sub-01_ses-02_task-test_run-3_part-01',
+    '/bids_root/sub-01/ses-02/meg/sub-01_ses-02_task-test_run-3_part-01_meg.fif',
 ])
 def test_parse_bids_filename(fname):
     """Test parsing entities from a bids filename."""
@@ -231,8 +231,9 @@ def test_parse_bids_filename(fname):
     assert params['ses'] == '02'
     assert params['run'] == '3'
     assert params['task'] == 'test'
+    assert params['part'] == '01'
     assert list(params.keys()) == ['sub', 'ses', 'task', 'acq', 'run', 'proc',
-                                   'space', 'recording', 'kind']
+                                   'space', 'recording', 'part', 'kind']
 
 
 def test_age_on_date():

--- a/mne_bids/tests/test_utils.py
+++ b/mne_bids/tests/test_utils.py
@@ -222,7 +222,8 @@ def test_parse_ext():
     'sub-01_ses-02_task-test_run-3_part-01_meg.fif',
     'sub-01_ses-02_task-test_run-3_part-01.fif',
     'sub-01_ses-02_task-test_run-3_part-01',
-    '/bids_root/sub-01/ses-02/meg/sub-01_ses-02_task-test_run-3_part-01_meg.fif',
+    ('/bids_root/sub-01/ses-02/meg/' +
+     'sub-01_ses-02_task-test_run-3_part-01_meg.fif'),
 ])
 def test_parse_bids_filename(fname):
     """Test parsing entities from a bids filename."""

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -302,13 +302,13 @@ param_regex = re.compile(r'([^-_\.\\\/]+)-([^-_\.\\\/]+)')
 def _parse_bids_filename(fname, verbose):
     """Get dict from BIDS fname."""
     keys = ['sub', 'ses', 'task', 'acq', 'run', 'proc', 'run', 'space',
-            'recording', 'kind']
+            'recording', 'part', 'kind']
     params = {key: None for key in keys}
     idx_key = 0
     for match in re.finditer(param_regex, op.basename(fname)):
         key, value = match.groups()
         if key not in keys:
-            raise KeyError('Unexpected entity ''%s'' found in filename ''%s'''
+            raise KeyError('Unexpected entity "%s" found in filename "%s"'
                            % (key, fname))
         if keys.index(key) < idx_key:
             raise ValueError('Entities in filename not ordered correctly.'


### PR DESCRIPTION
Update utils.py


Thanks for contributing. If this is your first time,
make sure to read [contributing.md](https://github.com/mne-tools/mne-bids/blob/master/CONTRIBUTING.md)

PR Description
--------------

`part` is missing from the entity list. It is introduced for the fif files in the appendix but it isn't being captured in our parsing step

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [x] All comments resolved
- [x] This is not your own PR
- [x] All CIs are happy
- [x] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
- [x] Commit history does not contain any merge commits