### PR TITLE
[MRG] Add handedness to participant files

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -22,6 +22,7 @@ Current
 Changelog
 ~~~~~~~~~
 
+- Added handedness to participant files, by `Dominik Welke`_ (`#354 <https://github.com/mne-tools/mne-bids/pull/354>`_)
 - Added automatic conversion of FIF to BrainVision format with warning for EEG only data and conversion to FIF for meg non-FIF data, by `Alex Rockhill`_ (`#237 <https://github.com/mne-tools/mne-bids/pull/237>`_)
 - Add possibility to pass raw readers parameters (e.g. `allow_maxshield`) to :func:`read_raw_bids` to allow reading BIDS-formatted data before applying maxfilter, by  `Sophie Herbst`_
 - New feature in :func`mne_bids.write.write_anat` for shear deface of mri, by `Alex Rockhill`_ (`#271 <https://github.com/mne-tools/mne-bids/pull/271>`_)

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -242,7 +242,7 @@ def test_fif(_bids_validate):
     # give the raw object some fake participant data (potentially overwriting)
     raw = mne.io.read_raw_fif(raw_fname)
     raw.info['subject_info'] = {'his_id': subject_id2,
-                                'birthday': (1993, 1, 26), 'sex': 1}
+                                'birthday': (1993, 1, 26), 'sex': 1, 'hand': 2}
     write_raw_bids(raw, bids_basename, bids_root, events_data=events_fname,
                    event_id=event_id, overwrite=True)
     # assert age of participant is correct
@@ -275,7 +275,7 @@ def test_fif(_bids_validate):
     # data
     # change the gender but don't force overwrite.
     raw.info['subject_info'] = {'his_id': subject_id2,
-                                'birthday': (1994, 1, 26), 'sex': 2}
+                                'birthday': (1994, 1, 26), 'sex': 2, 'hand': 1}
     with pytest.raises(FileExistsError, match="already exists"):  # noqa: F821
         write_raw_bids(raw, bids_basename2, bids_root,
                        events_data=events_fname, event_id=event_id,

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -289,6 +289,10 @@ def _participants_tsv(raw, subject_id, fname, overwrite=False,
         sexes = {0: 'n/a', 1: 'M', 2: 'F'}
         sex = sexes[subject_info.get('sex', 0)]
 
+        # add handedness
+        hand_options = {0: 'n/a', 1: 'R', 2: 'L', 3: 'A'}
+        hand = hand_options[subject_info.get('hand', 0)]
+
         # determine the age of the participant
         age = subject_info.get('birthday', None)
         meas_date = raw.info.get('meas_date', None)
@@ -305,10 +309,6 @@ def _participants_tsv(raw, subject_id, fname, overwrite=False,
             subject_age = _age_on_date(bday, meas_datetime)
         else:
             subject_age = "n/a"
-
-        # add handedness
-        hand_options = {0: 'n/a', 1: 'R', 2: 'L', 3: 'A'}  # not according to mne conventions (only r/l)
-        hand = hand_options[subject_info.get('hand', 0)]
 
     data.update({'age': [subject_age], 'sex': [sex], 'hand': [hand]})
 

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -301,7 +301,7 @@ def _participants_tsv(raw, subject_id, fname, overwrite=False,
             if isinstance(meas_date, datetime):
                 meas_datetime = meas_date
             else:
-                meas_datetime = datetime.fromtimestamp(meas_date)
+                meas_datetime = datetime.fromtimestamp(meas_date, tz=timezone.utc)
             subject_age = _age_on_date(bday, meas_datetime)
         else:
             subject_age = "n/a"
@@ -1155,7 +1155,7 @@ def write_raw_bids(raw, bids_basename, bids_root, events_data=None,
         meas_date = raw.info.get('meas_date', None)
         if meas_date is not None:
             if not isinstance(meas_date, datetime):
-                meas_date = datetime.fromtimestamp(meas_date[0])
+                meas_date = datetime.fromtimestamp(meas_date[0], tz=timezone.utc)
             er_date = meas_date.strftime('%Y%m%d')
             if er_date != session_id:
                 raise ValueError("Date provided for session doesn't match "

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -290,7 +290,8 @@ def _participants_tsv(raw, subject_id, fname, overwrite=False,
         sex = sexes[subject_info.get('sex', 0)]
 
         # add handedness
-        # XXX: MNE currently only handles R/L, follow <https://github.com/mne-tools/mne-python/issues/7347>
+        # XXX: MNE currently only handles R/L,
+        # follow https://github.com/mne-tools/mne-python/issues/7347
         hand_options = {0: 'n/a', 1: 'R', 2: 'L', 3: 'A'}
         hand = hand_options[subject_info.get('hand', 0)]
 
@@ -306,7 +307,8 @@ def _participants_tsv(raw, subject_id, fname, overwrite=False,
             if isinstance(meas_date, datetime):
                 meas_datetime = meas_date
             else:
-                meas_datetime = datetime.fromtimestamp(meas_date, tz=timezone.utc)
+                meas_datetime = datetime.fromtimestamp(meas_date,
+                                                       tz=timezone.utc)
             subject_age = _age_on_date(bday, meas_datetime)
         else:
             subject_age = "n/a"
@@ -1158,7 +1160,8 @@ def write_raw_bids(raw, bids_basename, bids_root, events_data=None,
         meas_date = raw.info.get('meas_date', None)
         if meas_date is not None:
             if not isinstance(meas_date, datetime):
-                meas_date = datetime.fromtimestamp(meas_date[0], tz=timezone.utc)
+                meas_date = datetime.fromtimestamp(meas_date[0],
+                                                   tz=timezone.utc)
             er_date = meas_date.strftime('%Y%m%d')
             if er_date != session_id:
                 raise ValueError("Date provided for session doesn't match "

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -307,7 +307,7 @@ def _participants_tsv(raw, subject_id, fname, overwrite=False,
             subject_age = "n/a"
 
         # add handedness
-        hand_options = {0: 'n/a', 1: 'R', 2: 'L', 3: 'AMBI'}  # not according to mne conventions (only r/l)
+        hand_options = {0: 'n/a', 1: 'R', 2: 'L', 3: 'A'}  # not according to mne conventions (only r/l)
         hand = hand_options[subject_info.get('hand', 0)]
 
     data.update({'age': [subject_age], 'sex': [sex], 'hand': [hand]})
@@ -360,6 +360,8 @@ def _participants_json(fname, overwrite=False, verbose=True):
                    'Units': 'years'}
     cols['sex'] = {'Description': 'Biological sex of the participant',
                    'Levels': {'F': 'female', 'M': 'male'}}
+    cols['hand'] = {'Description': 'Handedness of the participant',
+                    'Levels': {'R': 'right', 'L': 'left', 'A': 'ambidextrous'}}
 
     _write_json(fname, cols, overwrite, verbose)
 

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -290,6 +290,7 @@ def _participants_tsv(raw, subject_id, fname, overwrite=False,
         sex = sexes[subject_info.get('sex', 0)]
 
         # add handedness
+        # XXX: MNE currently only handles R/L, follow <https://github.com/mne-tools/mne-python/issues/7347>
         hand_options = {0: 'n/a', 1: 'R', 2: 'L', 3: 'A'}
         hand = hand_options[subject_info.get('hand', 0)]
 

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -283,6 +283,7 @@ def _participants_tsv(raw, subject_id, fname, overwrite=False,
 
     subject_age = "n/a"
     sex = "n/a"
+    hand = 'n/a'
     subject_info = raw.info['subject_info']
     if subject_info is not None:
         sexes = {0: 'n/a', 1: 'M', 2: 'F'}
@@ -305,7 +306,11 @@ def _participants_tsv(raw, subject_id, fname, overwrite=False,
         else:
             subject_age = "n/a"
 
-    data.update({'age': [subject_age], 'sex': [sex]})
+        # add handedness
+        hand_options = {0: 'n/a', 1: 'R', 2: 'L', 3: 'AMBI'}  # not according to mne conventions (only r/l)
+        hand = hand_options[subject_info.get('hand', 0)]
+
+    data.update({'age': [subject_age], 'sex': [sex], 'hand': [hand]})
 
     if os.path.exists(fname):
         orig_data = _from_tsv(fname)
@@ -313,7 +318,8 @@ def _participants_tsv(raw, subject_id, fname, overwrite=False,
         exact_included = _contains_row(orig_data,
                                        {'participant_id': subject_id,
                                         'age': subject_age,
-                                        'sex': sex})
+                                        'sex': sex,
+                                        'hand': hand})
         # whether the subject id is in the previous data
         sid_included = subject_id in orig_data['participant_id']
         # if the subject data provided is different to the currently existing


### PR DESCRIPTION
PR Description
--------------

hi all - 

here is a small PR that adds the subjects' handedness to the participant files (related to #302) 
i also added generic timezone information to some datetime-objects where it was missing (missing tz-info can caused errors).

cheers, Dominik

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
- [ ] Commit history does not contain any merge commits
