### PR TITLE
Fix typo in write_raw_bids()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ cover
 .pytest_cache
 .ipynb_checkpoints
 .DS_Store
+.vscode/

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1100,7 +1100,7 @@ def write_raw_bids(raw, bids_basename, bids_root, events_data=None,
 
     Notes
     -----
-    For the participants.tsv file, the raw.info['subjects_info'] should be
+    For the participants.tsv file, the raw.info['subject_info'] should be
     updated and raw.info['meas_date'] should not be None to compute the age
     of the participant correctly.
 


### PR DESCRIPTION
PR Description
--------------

Fixes a typo in the `write_raw_bids()` docstring and adds `.vscode` to `.gitignore`.

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
- [ ] Commit history does not contain any merge commits
