### PR TITLE
ENH: Allow for Path-like paths

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -35,7 +35,7 @@ Changelog
 - Update scans.tsv writer to adhere to MNE-Python v0.20+ where `meas_date` is stored as a `datetime` object, by `Adam Li`_ (`#344 <https://github.com/mne-tools/mne-bids/pull/344>`_)
 - :func:`read_raw_bids` now reads in sidecar json files to set, or estimate Power Line Frequency, by `Adam Li`_ (`#341 <https://github.com/mne-tools/mne-bids/pull/341>`_)
 - Allow FIF files with multiple parts to be read using :func:`read_raw_bids`, by `Teon Brooks`_(`#346 <https://github.com/mne-tools/mne-bids/pull/346>`)
-- :func:`write_raw_bids` can now handle a `bids_root` parameters that is a `pathlib.Path`, by `Richard Höchenberger`_(`#362 <https://github.com/mne-tools/mne-bids/pull/362>`)
+- MNE-BIDS can now handle a paths that are `pathlib.Path` objects (in addition to strings), by `Richard Höchenberger`_(`#362 <https://github.com/mne-tools/mne-bids/pull/362>`)
 
 Bug
 ~~~

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -210,4 +210,4 @@ People who contributed to this release (in alphabetical order):
 .. _Sophie Herbst: http://github.com/SophieHerbst
 .. _Adam Li: https://github.com/adam2392
 .. _Fu-Te Wong: https://github.com/zuxfoucault
-.. _Richard Höchenberger: https://githum.com/hoechenberger
+.. _Richard Höchenberger: https://github.com/hoechenberger

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -35,6 +35,7 @@ Changelog
 - Update scans.tsv writer to adhere to MNE-Python v0.20+ where `meas_date` is stored as a `datetime` object, by `Adam Li`_ (`#344 <https://github.com/mne-tools/mne-bids/pull/344>`_)
 - :func:`read_raw_bids` now reads in sidecar json files to set, or estimate Power Line Frequency, by `Adam Li`_ (`#341 <https://github.com/mne-tools/mne-bids/pull/341>`_)
 - Allow FIF files with multiple parts to be read using :func:`read_raw_bids`, by `Teon Brooks`_(`#346 <https://github.com/mne-tools/mne-bids/pull/346>`)
+- :func:`write_raw_bids` can now handle a `bids_root` parameters that is a `pathlib.Path`, by `Richard Höchenberger`_(`#362 <https://github.com/mne-tools/mne-bids/pull/362>`)
 
 Bug
 ~~~
@@ -209,3 +210,4 @@ People who contributed to this release (in alphabetical order):
 .. _Sophie Herbst: http://github.com/SophieHerbst
 .. _Adam Li: https://github.com/adam2392
 .. _Fu-Te Wong: https://github.com/zuxfoucault
+.. _Richard Höchenberger: https://githum.com/hoechenberger

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -291,9 +291,9 @@ def read_raw_bids(bids_fname, bids_root, extra_params=None,
 
     Parameters
     ----------
-    bids_fname : str
+    bids_fname : str | pathlib.Path
         Full name of the data file
-    bids_root : str
+    bids_root : str | pathlib.Path
         Path to root of the BIDS folder
     extra_params : None | dict
         Extra parameters to be passed to MNE read_raw_* functions.
@@ -402,9 +402,9 @@ def get_matched_empty_room(bids_fname, bids_root):
 
     Parameters
     ----------
-    bids_fname : str
+    bids_fname : str | pathlib.Path
         The filename for which to find the matching empty room file.
-    bids_root : str
+    bids_root : str | pathlib.Path
         Path to the BIDS root folder.
 
     Returns
@@ -454,9 +454,9 @@ def get_head_mri_trans(bids_fname, bids_root):
 
     Parameters
     ----------
-    bids_fname : str
+    bids_fname : str | pathlib.Path
         Full name of the MEG data file
-    bids_root : str
+    bids_root : str | pathlib.Path
         Path to root of the BIDS folder
 
     Returns

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -203,9 +203,9 @@ def _handle_electrodes_reading(electrodes_fname, coord_frame, raw, verbose):
     electrodes_dict['z'] = [float(x) for x in electrodes_dict['z']
                             if x != "n/a"]
 
-    ch_locs = list(zip(electrodes_dict['x'],
-                       electrodes_dict['y'],
-                       electrodes_dict['z']))
+    ch_locs = np.array(list(zip(electrodes_dict['x'],
+                                electrodes_dict['y'],
+                                electrodes_dict['z'])))
     ch_pos = dict(zip(ch_names_raw, ch_locs))
 
     # create mne.DigMontage

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -291,7 +291,7 @@ def read_raw_bids(bids_fname, bids_root, extra_params=None,
 
     Parameters
     ----------
-    bids_fname : str | pathlib.Path
+    bids_fname : str
         Full name of the data file
     bids_root : str | pathlib.Path
         Path to root of the BIDS folder
@@ -402,7 +402,7 @@ def get_matched_empty_room(bids_fname, bids_root):
 
     Parameters
     ----------
-    bids_fname : str | pathlib.Path
+    bids_fname : str
         The filename for which to find the matching empty room file.
     bids_root : str | pathlib.Path
         Path to the BIDS root folder.
@@ -454,7 +454,7 @@ def get_head_mri_trans(bids_fname, bids_root):
 
     Parameters
     ----------
-    bids_fname : str | pathlib.Path
+    bids_fname : str
         Full name of the MEG data file
     bids_root : str | pathlib.Path
         Path to root of the BIDS folder

--- a/mne_bids/tests/test_utils.py
+++ b/mne_bids/tests/test_utils.py
@@ -197,7 +197,7 @@ def test_make_folders():
     make_bids_folders(subject='hi', session='foo', kind='ba',
                       bids_root=None)
     assert op.isdir(op.join(os.getcwd(), 'sub-hi', 'ses-foo', 'ba'))
-    
+
     # Check if a pathlib.Path bids_root works.
     bids_root = Path(_TempDir())
     make_bids_folders(subject='hi', session='foo', kind='ba',

--- a/mne_bids/tests/test_utils.py
+++ b/mne_bids/tests/test_utils.py
@@ -205,7 +205,7 @@ def test_ensure_pathlike():
     assert _ensure_pathlike(path_str) == path_str
     assert _ensure_pathlike(Path(path_str)) == path_str
     assert _ensure_pathlike(None) is None
-    
+
     with pytest.raises(ValueError):
         _ensure_pathlike(1)
 

--- a/mne_bids/tests/test_utils.py
+++ b/mne_bids/tests/test_utils.py
@@ -21,7 +21,7 @@ from mne_bids.utils import (_check_types, print_dir_tree, _age_on_date,
                             _find_matching_sidecar, _parse_ext,
                             _get_ch_type_mapping, _parse_bids_filename,
                             _find_best_candidates, get_entity_vals,
-                            _ensure_pathlike, get_kinds)
+                            _path_to_str, get_kinds)
 
 
 base_path = op.join(op.dirname(mne.__file__), 'io')
@@ -199,15 +199,14 @@ def test_check_types():
         _check_types([None, 1, 3.14, 'meg', [1, 2]])
 
 
-def test_ensure_pathlike():
-    """Test if _ensure_pathlike returns str or None with correct input."""
+def test_path_to_str():
+    """Test that _path_to_str returns a string."""
     path_str = 'foo'
-    assert _ensure_pathlike(path_str) == path_str
-    assert _ensure_pathlike(Path(path_str)) == path_str
-    assert _ensure_pathlike(None) is None
+    assert _path_to_str(path_str) == path_str
+    assert _path_to_str(Path(path_str)) == path_str
 
     with pytest.raises(ValueError):
-        _ensure_pathlike(1)
+        _path_to_str(1)
 
 
 def test_parse_ext():

--- a/mne_bids/tests/test_utils.py
+++ b/mne_bids/tests/test_utils.py
@@ -183,13 +183,26 @@ def test_make_folders():
     make_bids_folders(subject='hi', session='foo', kind='ba',
                       bids_root=bids_root)
     assert op.isdir(op.join(bids_root, 'sub-hi', 'ses-foo', 'ba'))
+
     # If we remove a kwarg the folder shouldn't be created
     bids_root = _TempDir()
     make_bids_folders(subject='hi', kind='ba', bids_root=bids_root)
     assert op.isdir(op.join(bids_root, 'sub-hi', 'ba'))
+
     # check overwriting of folders
     make_bids_folders(subject='hi', kind='ba', bids_root=bids_root,
                       overwrite=True, verbose=True)
+
+    # Check if bids_root=None creates folders in the current working directory
+    make_bids_folders(subject='hi', session='foo', kind='ba',
+                      bids_root=None)
+    assert op.isdir(op.join(os.getcwd(), 'sub-hi', 'ses-foo', 'ba'))
+    
+    # Check if a pathlib.Path bids_root works.
+    bids_root = Path(_TempDir())
+    make_bids_folders(subject='hi', session='foo', kind='ba',
+                      bids_root=bids_root)
+    assert op.isdir(op.join(bids_root, 'sub-hi', 'ses-foo', 'ba'))
 
 
 def test_check_types():

--- a/mne_bids/tests/test_utils.py
+++ b/mne_bids/tests/test_utils.py
@@ -8,6 +8,7 @@ import os
 import os.path as op
 import pytest
 from datetime import datetime
+from pathlib import Path
 
 from numpy.random import random
 import mne
@@ -20,7 +21,7 @@ from mne_bids.utils import (_check_types, print_dir_tree, _age_on_date,
                             _find_matching_sidecar, _parse_ext,
                             _get_ch_type_mapping, _parse_bids_filename,
                             _find_best_candidates, get_entity_vals,
-                            get_kinds)
+                            _ensure_pathlike, get_kinds)
 
 
 base_path = op.join(op.dirname(mne.__file__), 'io')
@@ -196,6 +197,17 @@ def test_check_types():
     assert _check_types(['foo', 'bar', None]) is None
     with pytest.raises(ValueError):
         _check_types([None, 1, 3.14, 'meg', [1, 2]])
+
+
+def test_ensure_pathlike():
+    """Test if _ensure_pathlike returns str or None with correct input."""
+    path_str = 'foo'
+    assert _ensure_pathlike(path_str) == path_str
+    assert _ensure_pathlike(Path(path_str)) == path_str
+    assert _ensure_pathlike(None) is None
+    
+    with pytest.raises(ValueError):
+        _ensure_pathlike(1)
 
 
 def test_parse_ext():

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -1098,6 +1098,7 @@ def test_write_raw_pathlike():
     assert bids_root_ == str(bids_root)
 
 
+@requires_nibabel()
 def test_write_anat_pathlike():
     """Test writing anatomical data with pathlib.Paths."""
     data_path = testing.data_path()

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -19,6 +19,7 @@ import platform
 import shutil as sh
 import json
 from distutils.version import LooseVersion
+from pathlib import Path
 
 import numpy as np
 from numpy.testing import assert_array_equal, assert_array_almost_equal
@@ -1075,3 +1076,44 @@ def test_write_anat(_bids_validate):
         anat_dir = write_anat(bids_root, subject_id, t1w_mgh, session_id,
                               acq, deface=True, landmarks=fail_landmarks,
                               verbose=True, overwrite=True)
+
+
+def test_write_raw_pathlike():
+    data_path = testing.data_path()
+    raw_fname = op.join(data_path, 'MEG', 'sample',
+                        'sample_audvis_trunc_raw.fif')
+    event_id = {'Auditory/Left': 1, 'Auditory/Right': 2, 'Visual/Left': 3,
+                'Visual/Right': 4, 'Smiley': 5, 'Button': 32}
+    raw = mne.io.read_raw_fif(raw_fname)
+
+    bids_root = Path(_TempDir())
+    events_fname = (Path(data_path) / 'MEG' / 'sample' /
+                    'sample_audvis_trunc_raw-eve.fif')
+    bids_root_ = write_raw_bids(raw=raw, bids_basename=bids_basename,
+                                bids_root=bids_root, events_data=events_fname,
+                                event_id=event_id, overwrite=False)
+
+    # write_raw_bids() should return a string.
+    assert isinstance(bids_root_, str)
+    assert bids_root_ == str(bids_root)
+
+
+def test_write_anat_pathlike():
+    """Test writing anatomical data with pathlib.Paths."""
+    data_path = testing.data_path()
+    raw_fname = op.join(data_path, 'MEG', 'sample',
+                        'sample_audvis_trunc_raw.fif')
+    trans_fname = raw_fname.replace('_raw.fif', '-trans.fif')
+    raw = mne.io.read_raw_fif(raw_fname)
+    trans = mne.read_trans(trans_fname)
+
+    bids_root = Path(_TempDir())
+    t1w_mgh_fname = Path(data_path) / 'subjects' / 'sample' / 'mri' / 'T1.mgz'
+    anat_dir = write_anat(bids_root=bids_root, subject=subject_id,
+                          t1w=t1w_mgh_fname,
+                          session=session_id, acquisition=acq,
+                          raw=raw, trans=trans, deface=True, verbose=True,
+                          overwrite=True)
+
+    # write_anat() should return a string.
+    assert isinstance(anat_dir, str)

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -242,7 +242,9 @@ def make_bids_folders(subject, session=None, kind=None, bids_root=None,
     path/to/project/sub-sub_01/ses-my_session/meg
 
     """
-    _check_types((subject, kind, session, bids_root))
+    _check_types((subject, kind, session))
+    bids_root = _ensure_pathlike(bids_root)
+
     if session is not None:
         _check_key_val('ses', session)
 
@@ -364,8 +366,21 @@ def _check_types(variables):
     """Make sure all vars are str or None."""
     for var in variables:
         if not isinstance(var, (str, type(None))):
-            raise ValueError("All values must be either None or strings. "
-                             "Found type %s." % type(var))
+            raise ValueError("You supplied a value of type %s, where a "
+                             "string or None was expected." % type(var))
+
+
+def _ensure_pathlike(var):
+    """Make sure the var is None or Path-like, and convert Path to str."""
+    if not isinstance(var, (Path, str, type(None))):
+        raise ValueError("All path parameters must be either None, strings, "
+                         "or pathlib.Path objects. "
+                         "Found type %s." % type(var))
+
+    if var is None:
+        return None
+    else:
+        return str(var)
 
 
 def _write_json(fname, dictionary, overwrite=False, verbose=False):

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -35,7 +35,7 @@ def get_kinds(bids_root):
 
     Parameters
     ----------
-    bids_root : str
+    bids_root : str | pathlib.Path
         Path to the root of the BIDS directory.
 
     Returns
@@ -65,7 +65,7 @@ def get_entity_vals(bids_root, entity_key):
 
     Parameters
     ----------
-    bids_root : str
+    bids_root : str | pathlib.Path
         Path to the root of the BIDS directory.
     entity_key : str
         The name of the entity key to search for. Can be one of
@@ -214,7 +214,7 @@ def make_bids_folders(subject, session=None, kind=None, bids_root=None,
         "anat", "func", etc.
     session : str | None
         The session for a item. Corresponds to "ses".
-    bids_root : str | Path | None
+    bids_root : str | pathlib.Path | None
         The bids_root for the folders to be created. If None, folders will be
         created in the current working directory.
     make_dir : bool
@@ -374,7 +374,7 @@ def _check_types(variables):
 def _path_to_str(var):
     """Make sure var is a string or Path, return string representation."""
     if not isinstance(var, (Path, str)):
-        raise ValueError("All path parameters must be either strings  or "
+        raise ValueError("All path parameters must be either strings or "
                          "pathlib.Path objects. Found type %s." % type(var))
     else:
         return str(var)
@@ -584,7 +584,7 @@ def _find_matching_sidecar(bids_fname, bids_root, suffix, allow_fail=False):
     ----------
     bids_fname : str
         Full name of the data file
-    bids_root : str
+    bids_root : str | pathlib.Path
         Path to root of the BIDS folder
     suffix : str
         The suffix of the sidecar file to be found. E.g., "_coordsystem.json"

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -214,7 +214,7 @@ def make_bids_folders(subject, session=None, kind=None, bids_root=None,
         "anat", "func", etc.
     session : str | None
         The session for a item. Corresponds to "ses".
-    bids_root : str | None
+    bids_root : str | Path | None
         The bids_root for the folders to be created. If None, folders will be
         created in the current working directory.
     make_dir : bool
@@ -243,7 +243,8 @@ def make_bids_folders(subject, session=None, kind=None, bids_root=None,
 
     """
     _check_types((subject, kind, session))
-    bids_root = _path_to_str(bids_root)
+    if bids_root is not None:
+        bids_root = _path_to_str(bids_root)
 
     if session is not None:
         _check_key_val('ses', session)

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -243,7 +243,7 @@ def make_bids_folders(subject, session=None, kind=None, bids_root=None,
 
     """
     _check_types((subject, kind, session))
-    bids_root = _ensure_pathlike(bids_root)
+    bids_root = _path_to_str(bids_root)
 
     if session is not None:
         _check_key_val('ses', session)
@@ -370,15 +370,11 @@ def _check_types(variables):
                              "string or None was expected." % type(var))
 
 
-def _ensure_pathlike(var):
-    """Make sure the var is None or Path-like, and convert Path to str."""
-    if not isinstance(var, (Path, str, type(None))):
-        raise ValueError("All path parameters must be either None, strings, "
-                         "or pathlib.Path objects. "
-                         "Found type %s." % type(var))
-
-    if var is None:
-        return None
+def _path_to_str(var):
+    """Make sure var is a string or Path, return string representation."""
+    if not isinstance(var, (Path, str)):
+        raise ValueError("All path parameters must be either strings  or "
+                         "pathlib.Path objects. Found type %s." % type(var))
     else:
         return str(var)
 

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -13,6 +13,7 @@ from datetime import datetime, date, timedelta, timezone
 from warnings import warn
 import shutil as sh
 from collections import defaultdict, OrderedDict
+from pathlib import Path
 
 import numpy as np
 from scipy import linalg
@@ -1054,7 +1055,7 @@ def write_raw_bids(raw, bids_basename, bids_root, events_data=None,
 
         Note that the modality 'meg' is automatically inferred from the raw
         object and extension '.fif' is copied from raw.filenames.
-    bids_root : str
+    bids_root : str | Path
         The path of the root of the BIDS compatible folder. The session and
         subject specific folders will be populated automatically by parsing
         bids_basename.

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -35,6 +35,7 @@ from mne_bids.utils import (_write_json, _write_tsv, _read_events, _mkdir_p,
                             _age_on_date, _infer_eeg_placement_scheme,
                             _check_key_val,
                             _parse_bids_filename, _handle_kind, _check_types,
+                            _ensure_pathlike,
                             _extract_landmarks, _parse_ext,
                             _get_ch_type_mapping, make_bids_folders,
                             _estimate_line_freq)
@@ -1125,6 +1126,7 @@ def write_raw_bids(raw, bids_basename, bids_root, events_data=None,
     if raw.preload is not False:
         raise ValueError('The data should not be preloaded.')
 
+    bids_root = _ensure_pathlike(bids_root)
     raw = raw.copy()
 
     raw_fname = raw.filenames[0]

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -13,7 +13,6 @@ from datetime import datetime, date, timedelta, timezone
 from warnings import warn
 import shutil as sh
 from collections import defaultdict, OrderedDict
-from pathlib import Path
 
 import numpy as np
 from scipy import linalg
@@ -1055,14 +1054,15 @@ def write_raw_bids(raw, bids_basename, bids_root, events_data=None,
 
         Note that the modality 'meg' is automatically inferred from the raw
         object and extension '.fif' is copied from raw.filenames.
-    bids_root : str | Path
+    bids_root : str | pathlib.Path
         The path of the root of the BIDS compatible folder. The session and
         subject specific folders will be populated automatically by parsing
         bids_basename.
-    events_data : str | array | None
-        The events file. If a string, a path to the events file. If an array,
-        the MNE events array (shape n_events, 3). If None, events will be
-        inferred from the stim channel using `mne.find_events`.
+    events_data : str | pathlib.Path | array | None
+        The events file. If a string or a Path object, specifies the path of
+        the events file. If an array, the MNE events array (shape n_events, 3).
+        If None, events will be inferred from the stim channel using
+        `mne.find_events`.
     event_id : dict | None
         The event id dict used to create a 'trial_type' column in events.tsv
     anonymize : dict | None
@@ -1357,11 +1357,11 @@ def write_anat(bids_root, subject, t1w, session=None, acquisition=None,
 
     Parameters
     ----------
-    bids_root : str
+    bids_root : str | pathlib.Path
         Path to root of the BIDS folder
     subject : str
         Subject label as in 'sub-<label>', for example: '01'
-    t1w : str | nibabel image object
+    t1w : str | pathlib.Path | nibabel image object
         Path to a T1 weighted MRI scan of the subject. Can be in any format
         readable by nibabel. Can also be a nibabel image object of a T1
         weighted MRI scan. Will be written as a .nii.gz file.
@@ -1429,12 +1429,20 @@ def write_anat(bids_root, subject, t1w, session=None, acquisition=None,
         os.makedirs(anat_dir)
 
     # Try to read our T1 file and convert to MGH representation
-    if isinstance(t1w, str):
+    try:
+        t1w = _path_to_str(t1w)
+    except ValueError:
+        # t1w -> str conversion failed, so maybe the user passed an nibabel
+        # object instead of a path.
+        if type(t1w) not in nib.all_image_classes:
+            raise ValueError('`t1w` must be a path to a T1 weighted MRI data '
+                             'file , or a nibabel image object, but it is of '
+                             'type "{}"'.format(type(t1w)))
+    else:
+        # t1w -> str conversion in the try block was successful, so load the
+        # file from the specified location. We do this here and not in the try
+        # block to keep the try block as short as possible.
         t1w = nib.load(t1w)
-    elif type(t1w) not in nib.all_image_classes:
-        raise ValueError('`t1w` must be a path to a T1 weighted MRI data file '
-                         ', or a nibabel image object, but it is of type '
-                         '"{}"'.format(type(t1w)))
 
     t1w = nib.Nifti1Image(t1w.dataobj, t1w.affine)
     # XYZT_UNITS = NIFT_UNITS_MM (10 in binary or 2 in decimal)

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -35,7 +35,7 @@ from mne_bids.utils import (_write_json, _write_tsv, _read_events, _mkdir_p,
                             _age_on_date, _infer_eeg_placement_scheme,
                             _check_key_val,
                             _parse_bids_filename, _handle_kind, _check_types,
-                            _ensure_pathlike,
+                            _path_to_str,
                             _extract_landmarks, _parse_ext,
                             _get_ch_type_mapping, make_bids_folders,
                             _estimate_line_freq)
@@ -1126,7 +1126,7 @@ def write_raw_bids(raw, bids_basename, bids_root, events_data=None,
     if raw.preload is not False:
         raise ValueError('The data should not be preloaded.')
 
-    bids_root = _ensure_pathlike(bids_root)
+    bids_root = _path_to_str(bids_root)
     raw = raw.copy()
 
     raw_fname = raw.filenames[0]


### PR DESCRIPTION
PR Description
--------------
<strike>`bids_root`</strike >All paths in the public API can now be a `pathlib.Path` objects. I've introduced a new function `utils._path_to_str()`, casts `Path` objects to a string. This also ensures that the current behavior of MNE-BIDS is retained (e.g., `write_raw_bids`, which returns `bids_root`, will return a string even if a `Path` `bids_root` was supplied by the user)

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [x] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
<s> - [ ] PR description includes phrase "closes <#issue-number>" </s>
- [x] Commit history does not contain any merge commits
