### PR TITLE
TESTS: test_get_matched_empty_room didn't use UTC

### DIFF
--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -377,8 +377,10 @@ def test_get_matched_empty_room():
         er_bids_basename = make_bids_basename(subject='emptyroom',
                                               task='noise', session=date)
         er_meas_date = datetime.strptime(date, '%Y%m%d')
+        er_meas_date = er_meas_date.replace(tzinfo=timezone.utc)
+
         if check_version('mne', '0.20'):
-            er_raw.set_meas_date(er_meas_date.replace(tzinfo=timezone.utc))
+            er_raw.set_meas_date(er_meas_date)
         else:
             er_raw.info['meas_date'] = (er_meas_date.timestamp(), 0)
         write_raw_bids(er_raw, er_bids_basename, bids_root)


### PR DESCRIPTION
PR Description
---------------

`test_read.test_get_matched_empty_room()` didn't run successfully on my
computer with MNE 0.19.2 as my computer clock is not set to UTC / GMT (but CET),
causing a discrepancy of 1h which lead to changes in the dates the
test assumed (e.g., test would assume `20021204`, but bc of the timezone
offset my computer would generate a timestamp for `20021204` - 1h,
yielding `20021203`, causing the test to fail).

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
- [ ] Commit history does not contain any merge commits
