### PR TITLE
MRG: first step DOC versioning

### DIFF
--- a/doc/_templates/navbar.html
+++ b/doc/_templates/navbar.html
@@ -1,0 +1,16 @@
+{% extends "!navbar.html" %}
+
+{% block navbarsearch %}
+<div class="navbar-form navbar-right navbar-btn dropdown btn-group-sm" style="margin-left: 20px; margin-top: 5px; margin-bottom: 5px">
+  <button type="button" class="btn btn-{% if (build_dev_html|tobool) %}danger{% else %}primary{% endif %} navbar-btn dropdown-toggle" id="dropdownMenu1" data-toggle="dropdown">
+    v{{ release }}
+    <span class="caret"></span>
+  </button>
+  <ul class="dropdown-menu" aria-labelledby="dropdownMenu1">
+    <li><a href="https://circleci.com/api/v1.1/project/github/mne-tools/mne-bids/latest/artifacts/0/html/index.html?branch=master">Development</a></li>
+    <li><a href="https://mne.tools/mne-bids/">Stable</a></li>
+  </ul>
+</div>
+
+{{ super() }}
+{% endblock %}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -106,7 +106,7 @@ intersphinx_mapping = {
     'numpy': ('https://www.numpy.org/devdocs', None),
     'scipy': ('https://scipy.github.io/devdocs', None),
     'matplotlib': ('https://matplotlib.org', None),
-    'nilearn': ('http://nilearn.github.io', None),
+    'nilearn': ('https://nilearn.github.io', None),
 }
 
 sphinx_gallery_conf = {

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -9,13 +9,6 @@ import sphinx_bootstrap_theme
 
 import mne_bids
 
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
-curdir = os.path.dirname(__file__)
-sys.path.append(os.path.abspath(os.path.join(curdir, '..', 'mne_bids')))
-sys.path.append(os.path.abspath(os.path.join(curdir, 'sphinxext')))
-
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -102,7 +95,7 @@ html_theme_options = {
         ("API", "api"),
         ("CLI", "generated/cli"),
         ("What's new", "whats_new"),
-        ("Github", "https://github.com/mne-tools/mne-bids", True),
+        ("GitHub", "https://github.com/mne-tools/mne-bids", True),
     ]}
 
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -81,6 +81,9 @@ html_show_sourcelink = False
 html_theme = 'bootstrap'
 html_theme_path = sphinx_bootstrap_theme.get_html_theme_path()
 
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
@@ -102,12 +105,14 @@ html_theme_options = {
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
-    'mne': ('https://mne.tools/stable/', None),
+    'mne': ('https://mne.tools/dev', None),
     'numpy': ('https://www.numpy.org/devdocs', None),
     'scipy': ('https://scipy.github.io/devdocs', None),
     'matplotlib': ('https://matplotlib.org', None),
     'nilearn': ('https://nilearn.github.io', None),
 }
+intersphinx_timeout = 5
+
 
 sphinx_gallery_conf = {
     'examples_dirs': '../examples',

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -20,7 +20,6 @@ dependencies:
   - pytest<5.4
   - pytest-cov
   - pytest-sugar
-  - pytest-faulthandler
   - check-manifest
   - pydocstyle
   - sphinx

--- a/environment.yml
+++ b/environment.yml
@@ -19,7 +19,6 @@ dependencies:
   - pytest<5.4
   - pytest-cov
   - pytest-sugar
-  - pytest-faulthandler
   - check-manifest
   - pydocstyle
   - sphinx

--- a/examples/convert_empty_room.py
+++ b/examples/convert_empty_room.py
@@ -1,5 +1,5 @@
 """
-.. _ex-convert-mne-sample:
+.. _ex-convert-empty-room:
 
 ======================================
 Storing empty room data in BIDS format

--- a/examples/convert_group_studies.py
+++ b/examples/convert_group_studies.py
@@ -8,7 +8,7 @@ The data from Wakeman et al. [1]_ is available here:
 https://openneuro.org/datasets/ds000117
 
 We recommend that you go through the more basic BIDS conversion example before
-checking out this group conversion example: :ref:`_ex-convert-mne-sample`
+checking out this group conversion example: :ref:`ex-convert-mne-sample`
 
 References
 ----------

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1382,11 +1382,14 @@ def write_anat(bids_root, subject, t1w, session=None, acquisition=None,
         If True, deface with default parameters.
         `trans` and `raw` must not be `None` if True.
         If dict, accepts the following keys:
-            `inset`: how far back in millimeters to start defacing
-                     relative to the nasion (default 20)
-            `theta`: is the angle of the defacing shear in degrees relative
-                     to the normal to the plane passing through the anatomical
-                     landmarks (default 35).
+
+        - `inset`: how far back in millimeters to start defacing
+          relative to the nasion (default 20)
+
+        - `theta`: is the angle of the defacing shear in degrees relative
+          to the normal to the plane passing through the anatomical
+          landmarks (default 35).
+
     landmarks: instance of DigMontage | str
         The DigMontage or filepath to a DigMontage with landmarks that can be
         passed to provide information for defacing. Landmarks can be determined


### PR DESCRIPTION
I started this PR with high hopes of bringing versioned docs to MNE-BIDS (currently we only have one stable version ... and the "latest" version as hosted in CircleCI artifacts)

 ... buuut after too many hours of hacking, there are no news apart from these small fixes I now present in this PR :man_shrugging: 

Anyhow, this is what I tried and why it didn't work:

- [`sphinxcontrib-versioning`](https://github.com/sphinx-contrib/sphinxcontrib-versioning) is what I started with. It's being used in https://poldracklab.github.io/smriprep/ ... as was recommended by one of our JOSS reviewers in December 2019. --> unfortunately, that repo's maintainer is very busy and the code is not being kept well up to date ... see https://github.com/sphinx-contrib/sphinxcontrib-versioning/issues/77 and https://github.com/sphinx-contrib/sphinxcontrib-versioning/issues/78 ... I didn't try to force this package to work and instead moved on to the alternative below:

- [`sphinx_multiversion`](https://github.com/Holzhaus/sphinx-multiversion) ... which seems pretty nice once correctly configured. See this page as an example (click on versions tab in lower left of page): https://mixxx.org/manual/2.3/en/index.html
    - issues: the build seems to copy each branch/tag (can be configured which ones precisely) into *temporary* directories to build one version per branch/tag ... and then there were clashes with Sphinx Gallery that suddenly didn't find it's README.txt anymore. --> This may be resolvable. But given that `sphinx_multiversion` itself seems brand new, it probably means lots of hack work. (edit, helpful link to get sidebars activated in bootstrap [here](https://stackoverflow.com/q/20939598/5201771))

Summary: Neither of the two packages seem very robust ... but they *could* be used for our purposes ... needs more time investment though and I've had enough for an evening :)

If somebody else wants to give this a shot, please do it! 

EDIT: An alternative is of course to do it like in MNE-Python and manually upload the docs for each release: https://github.com/mne-tools/mne-tools.github.io ... and then adding [some html/css templates](https://github.com/mne-tools/mne-python/blob/master/doc/_templates/navbar.html) to link to those

Edit2: Another alternative would be a move to [https://readthedocs.org/](https://readthedocs.org/), but that would mean giving up our current system, relying on GitHub Pages.


Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [x] All comments resolved
- [x] This is not your own PR
- [x] All CIs are happy
- [x] PR title starts with [MRG]
- ~[whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated~
- ~PR description includes phrase "closes <#issue-number>"~
- [x] Commit history does not contain any merge commits
