### PR TITLE
MRG: MAINT/0.1 --> fixes to build old docs without errors

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -49,7 +49,7 @@ People who contributed to this release  (in alphabetical order):
 * Mainak Jas
 * Matt Sanderson
 * Romain Quentin
-* Stefan Appel
+* Stefan Appelhoff
 * Teon Brooks
 
 .. _Mainak Jas: https://perso.telecom-paristech.fr/mjas/

--- a/examples/convert_eeg_to_bids.py
+++ b/examples/convert_eeg_to_bids.py
@@ -25,7 +25,6 @@ import shutil as sh
 
 import mne
 from mne.datasets import eegbci
-from mne.io.edf.edf import read_annotations_edf
 
 from mne_bids import write_raw_bids, make_bids_basename
 from mne_bids.utils import print_dir_tree
@@ -94,7 +93,7 @@ raw = mne.io.read_raw_edf(edf_path, preload=False, stim_channel=None)
 ###############################################################################
 # The annotations stored in the file must be read in separately and converted
 # into a 2D numpy array of events that is compatible with MNE.
-annot = read_annotations_edf(edf_path)
+annot = mne.read_annotations(edf_path)
 raw.set_annotations(annot)
 events, event_id = mne.events_from_annotations(raw)
 
@@ -163,7 +162,7 @@ for subj_idx in [1, 2]:
         edf_path = eegbci.load_data(subject=subj_idx, runs=task_idx)[0]
 
         raw = mne.io.read_raw_edf(edf_path, preload=False, stim_channel=None)
-        annot = read_annotations_edf(edf_path)
+        annot = mne.read_annotations(edf_path)
         raw.set_annotations(annot)
         events, event_id = mne.events_from_annotations(raw)
 

--- a/examples/convert_group_studies.py
+++ b/examples/convert_group_studies.py
@@ -45,6 +45,7 @@ output_path = op.join(data_path, 'ds000117-bids')
 ###############################################################################
 #
 # .. warning:: This will download 7.9 GB of data for one subject!
+#
 # Define event_ids.
 
 event_id = {

--- a/mne_bids/mne_bids.py
+++ b/mne_bids/mne_bids.py
@@ -536,15 +536,21 @@ def write_raw_bids(raw, bids_basename, output_path, events_data=None,
         Example: sub-01_ses-01_task-testing_acq-01_run-01
         This will write the following files in the correct subfolder
         of output_path:
-            sub-01_ses-01_task-testing_acq-01_run-01_meg.fif
-            sub-01_ses-01_task-testing_acq-01_run-01_meg.json
-            sub-01_ses-01_task-testing_acq-01_run-01_channels.tsv
-            sub-01_ses-01_task-testing_acq-01_run-01_coordsystem.json
+
+        - sub-01_ses-01_task-testing_acq-01_run-01_meg.fif
+        - sub-01_ses-01_task-testing_acq-01_run-01_meg.json
+        - sub-01_ses-01_task-testing_acq-01_run-01_channels.tsv
+        - sub-01_ses-01_task-testing_acq-01_run-01_coordsystem.json
+
         and the following one if events_data is not None
-            sub-01_ses-01_task-testing_acq-01_run-01_events.tsv
+
+        - sub-01_ses-01_task-testing_acq-01_run-01_events.tsv
+
         and add a line to the following files:
-            participants.tsv
-            scans.tsv
+
+        - participants.tsv
+        - scans.tsv
+
         Note that the modality 'meg' is automatically inferred from the raw
         object and extension '.fif' is copied from raw.filenames.
     output_path : str


### PR DESCRIPTION
NOTE: This goes into `maint/0.1` ... NOT `master` :-)

I am still trying to get simple versioned docs (see #364)

Doing that, I am going through our old releases and generating the docs as they were then.

Small fixes --> note: this is NOT about fixing past mistakes. Only to get the docs to work without warnings+errors.

I am going to do this for 0.2 and 0.3 as well and then hopefully make a PR to the gh-pages branch with the old docs.

Edit: To recreate the old environment, I started with a fresh conda env and then used the old `.circle/config.yml` file to install the adequate versions. When only `master` was specified, I compared release dates to figure out what version `master` was at that time.



Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [x] This is not your own PR
- [x] All CIs are happy
- [x] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [x] PR description includes phrase "closes <#issue-number>"
- [x] Commit history does not contain any merge commits
