### PR TITLE
MRG: Devdocs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ jobs:
 
       - add_ssh_keys:
         fingerprints:
-          - "bf:ac:92:1d:dc:ca:a0:2d:aa:f6:b2:b6:d5:1c:ac:74"
+          - "7f:74:00:17:2b:1a:7d:68:56:68:6b:64:b5:e0:7f:91"
 
       - run:
         # push built docs to the `gh-pages` branch into the `dev` directory

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,72 +2,71 @@
 version: 2.1
 
 jobs:
-
   docs-build:
     docker:
       - image: circleci/python:3.7.3-stretch
     steps:
-      - checkout
+        - checkout
 
-      - run:
-        name: Check environment.yml and doc/environment.yml syncing
-        # doc/environment.yml must be a perfect copy of environment.yml
-        # with a single line "  - mne_bids~=0.X" added in the pip section
-        command: diff <(grep -v '^  - mne_bids>=0.*,<0.*$' doc/environment.yml) <(cat environment.yml)
+        - run:
+            name: Check environment.yml and doc/environment.yml syncing
+            # doc/environment.yml must be a perfect copy of environment.yml
+            # with a single line "  - mne_bids~=0.X" added in the pip section
+            command: diff <(grep -v '^  - mne_bids~=0.3$' doc/environment.yml) <(cat environment.yml)
 
-      # restore cache from last build. Unless __init__.py has changed since then
-      - restore_cache:
-        keys:
-          - data-cache-0-{{ checksum "./mne_bids/__init__.py" }}
+        # restore cache from last build. Unless __init__.py has changed since then
+        - restore_cache:
+            keys:
+              - data-cache-0-{{ checksum "./mne_bids/__init__.py" }}
 
-      # Also restore pip cache to speed up installations
-      - restore_cache:
-        keys:
-          - pip-cache-0-{{ checksum "./environment.yml" }}
+        # Also restore pip cache to speed up installations
+        - restore_cache:
+            keys:
+              - pip-cache-0-{{ checksum "./environment.yml" }}
 
-      - run:
-        name: Install miniconda
-        command: |
-          wget -q https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh;
-          chmod +x ~/miniconda.sh;
-          ~/miniconda.sh -b -p ~/miniconda;
-          echo "export PATH=~/miniconda/bin:$PATH" >> $BASH_ENV;
+        - run:
+            name: Install miniconda
+            command: |
+              wget -q https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh;
+              chmod +x ~/miniconda.sh;
+              ~/miniconda.sh -b -p ~/miniconda;
+              echo "export PATH=~/miniconda/bin:$PATH" >> $BASH_ENV;
 
-      - run:
-        name: Setup Python environment
-        # ... but use latest version of MNE
-        command: |
-          conda update --yes --quiet conda
-          conda env create -f environment.yml --name=testenv
-          source activate testenv
-          pip install -U https://api.github.com/repos/mne-tools/mne-python/zipball/master
-          python setup.py develop
+        - run:
+            name: Setup Python environment
+            # ... but use latest version of MNE
+            command: |
+              conda update --yes --quiet conda
+              conda env create -f environment.yml --name=testenv
+              source activate testenv
+              pip install -U https://api.github.com/repos/mne-tools/mne-python/zipball/master
+              python setup.py develop
 
-      - run:
-        name: Build the documentation
-        command: |
-            source activate testenv
-            make build-doc
+        - run:
+            name: Build the documentation
+            command: |
+                source activate testenv
+                make build-doc
 
-      - persist_to_workspace:
-        root: doc/_build
-        paths: html
+        - persist_to_workspace:
+            root: doc/_build
+            paths: html
 
-      - store_artifacts:
-        path: doc/_build/html/
-        destination: html
+        - store_artifacts:
+            path: doc/_build/html/
+            destination: html
 
-      # Store the data cache
-      - save_cache:
-        key: data-cache-0-{{ checksum "./mne_bids/__init__.py" }}
-        paths:
-          - ~/mne_data
+        # Store the data cache
+        - save_cache:
+            key: data-cache-0-{{ checksum "./mne_bids/__init__.py" }}
+            paths:
+              - ~/mne_data
 
-      # Store pip cache
-      - save_cache:
-        key: pip-cache-0-{{ checksum "./environment.yml" }}
-        paths:
-          - ~/.cache/pip
+        # Store pip cache
+        - save_cache:
+            key: pip-cache-0-{{ checksum "./environment.yml" }}
+            paths:
+              - ~/.cache/pip
 
   docs-deploy:
     # will only be run on master branch
@@ -77,32 +76,31 @@ jobs:
       - checkout
 
       - attach_workspace:
-        at: doc/_build
+          at: doc/_build
 
       - run:
-        name: Install and configure dependencies
-        command: |
-          npm install -g --silent gh-pages@2.2
-          git config --global user.email "circle@mne.com"
-          git config --global user.name "Circle Ci"
+          name: Install and configure dependencies
+          command: |
+            npm install -g --silent gh-pages@2.2
+            git config --global user.email "circle@mne.com"
+            git config --global user.name "Circle Ci"
 
       - add_ssh_keys:
-        fingerprints:
-          - "7f:74:00:17:2b:1a:7d:68:56:68:6b:64:b5:e0:7f:91"
+          fingerprints:
+            - "7f:74:00:17:2b:1a:7d:68:56:68:6b:64:b5:e0:7f:91"
 
       - run:
-        # push built docs to the `gh-pages` branch into the `dev` directory
-        name: Deploy docs to gh-pages branch
-        command: gh-pages --dotfiles --message "doc updates [skip ci]" --dist doc/_build/html --dest ./dev
+          # push built docs into the `dev` directory on the `gh-pages` branch
+          name: Deploy docs to gh-pages branch
+          command: gh-pages --dotfiles --message "doc updates [skip ci]" --dist doc/_build/html --dest ./dev
 
 workflows:
-  version: 2.1
   build:
     jobs:
       - docs-build
       - docs-deploy:
-        requires:
-          - docs-build
-        filters:
-          branches:
-            only: master
+          requires:
+            - docs-build
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,81 +1,108 @@
-version: 2
+# See: https://circleci.com/blog/deploying-documentation-to-github-pages-with-continuous-integration/
+version: 2.1
+
 jobs:
-    build:
-        docker:
-            - image: circleci/python:3.7.3-stretch
-        steps:
-            - checkout
 
-            - run:
-                name: Check environment.yml and doc/environment.yml syncing
-                # doc/environment.yml must be a perfect copy of environment.yml
-                # with a single line "  - mne_bids~=0.X" added in the pip section
-                command: diff <(grep -v '^  - mne_bids~=0.3$' doc/environment.yml) <(cat environment.yml)
+  docs-build:
+    docker:
+      - image: circleci/python:3.7.3-stretch
+    steps:
+      - checkout
 
-            # restore cache from last build. Unless __init__.py has changed since then
-            - restore_cache:
-                keys:
-                  - data-cache-0-{{ checksum "./mne_bids/__init__.py" }}
+      - run:
+        name: Check environment.yml and doc/environment.yml syncing
+        # doc/environment.yml must be a perfect copy of environment.yml
+        # with a single line "  - mne_bids~=0.X" added in the pip section
+        command: diff <(grep -v '^  - mne_bids~=0.*$' doc/environment.yml) <(cat environment.yml)
 
-            # Also restore pip cache to speed up installations
-            - restore_cache:
-                keys:
-                  - pip-cache-0-{{ checksum "./environment.yml" }}
+      # restore cache from last build. Unless __init__.py has changed since then
+      - restore_cache:
+        keys:
+          - data-cache-0-{{ checksum "./mne_bids/__init__.py" }}
 
-            - run:
-                name: Install miniconda
-                command: |
-                  wget -q https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh;
-                  chmod +x ~/miniconda.sh;
-                  ~/miniconda.sh -b -p ~/miniconda;
-                  echo "export PATH=~/miniconda/bin:$PATH" >> $BASH_ENV;
+      # Also restore pip cache to speed up installations
+      - restore_cache:
+        keys:
+          - pip-cache-0-{{ checksum "./environment.yml" }}
 
-            - run:
-                name: Setup Python environment
-                # ... but use latest version of MNE
-                command: |
-                  conda update --yes --quiet conda
-                  conda env create -f environment.yml --name=testenv
-                  source activate testenv
-                  pip install -U https://api.github.com/repos/mne-tools/mne-python/zipball/master
-                  python setup.py develop
+      - run:
+        name: Install miniconda
+        command: |
+          wget -q https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh;
+          chmod +x ~/miniconda.sh;
+          ~/miniconda.sh -b -p ~/miniconda;
+          echo "export PATH=~/miniconda/bin:$PATH" >> $BASH_ENV;
 
-            - run:
-                name: Build the documentation
-                command: |
-                    source activate testenv
-                    make build-doc
+      - run:
+        name: Setup Python environment
+        # ... but use latest version of MNE
+        command: |
+          conda update --yes --quiet conda
+          conda env create -f environment.yml --name=testenv
+          source activate testenv
+          pip install -U https://api.github.com/repos/mne-tools/mne-python/zipball/master
+          python setup.py develop
 
-            - store_artifacts:
-                path: doc/_build/html/
-                destination: html
+      - run:
+        name: Build the documentation
+        command: |
+            source activate testenv
+            make build-doc
 
-            # Store the data cache
-            - save_cache:
-                key: data-cache-0-{{ checksum "./mne_bids/__init__.py" }}
-                paths:
-                  - ~/mne_data
+      - persist_to_workspace:
+        root: doc/_build
+        paths: html
 
-            # Store pip cache
-            - save_cache:
-                key: pip-cache-0-{{ checksum "./environment.yml" }}
-                paths:
-                  - ~/.cache/pip
+      - store_artifacts:
+        path: doc/_build/html/
+        destination: html
 
-            - add_ssh_keys:
-                fingerprints:
-                  - "bf:ac:92:1d:dc:ca:a0:2d:aa:f6:b2:b6:d5:1c:ac:74"
+      # Store the data cache
+      - save_cache:
+        key: data-cache-0-{{ checksum "./mne_bids/__init__.py" }}
+        paths:
+          - ~/mne_data
 
-            - deploy:
-                name: github pages deployment
-                command: |
-                  source activate testenv
-                  if [ "${CIRCLE_BRANCH}" == "maint/0.3" ]; then
-                    echo "Deploying stable docs for ${CIRCLE_BRANCH}.";
-                    git config --global user.email "circle@mne.com";
-                    git config --global user.name "Circle Ci";
-                    cd doc;
-                    make install;
-                  else
-                    echo "No deployment (build: ${CIRCLE_BRANCH}).";
-                  fi
+      # Store pip cache
+      - save_cache:
+        key: pip-cache-0-{{ checksum "./environment.yml" }}
+        paths:
+          - ~/.cache/pip
+
+  docs-deploy:
+    # will only be run on master branch
+    docker:
+      - image: node:8.10.0
+    steps:
+      - checkout
+
+      - attach_workspace:
+        at: doc/_build
+
+      - run:
+        name: Install and configure dependencies
+        command: |
+          npm install -g --silent gh-pages@2.2
+          git config --global user.email "circle@mne.com"
+          git config --global user.name "Circle Ci"
+
+      - add_ssh_keys:
+        fingerprints:
+          - "bf:ac:92:1d:dc:ca:a0:2d:aa:f6:b2:b6:d5:1c:ac:74"
+
+      - run:
+        # push built docs to the `gh-pages` branch into the `dev` directory
+        name: Deploy docs to gh-pages branch
+        command: gh-pages --dotfiles --message "doc updates [skip ci]" --dist doc/_build/html --dest ./dev
+
+workflows:
+  version: 2.1
+  build:
+    jobs:
+      - docs-build
+      - docs-deploy:
+        requires:
+          - docs-build
+        filters:
+          branches:
+            only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
         name: Check environment.yml and doc/environment.yml syncing
         # doc/environment.yml must be a perfect copy of environment.yml
         # with a single line "  - mne_bids~=0.X" added in the pip section
-        command: diff <(grep -v '^  - mne_bids~=0.*$' doc/environment.yml) <(cat environment.yml)
+        command: diff <(grep -v '^  - mne_bids>=0.*,<0.*$' doc/environment.yml) <(cat environment.yml)
 
       # restore cache from last build. Unless __init__.py has changed since then
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,8 +11,8 @@ jobs:
         - run:
             name: Check environment.yml and doc/environment.yml syncing
             # doc/environment.yml must be a perfect copy of environment.yml
-            # with a single line "  - mne_bids~=0.X" added in the pip section
-            command: diff <(grep -v '^  - mne_bids~=0.3$' doc/environment.yml) <(cat environment.yml)
+            # with a single line "  - mne_bids>=0.X,<0.Y" added in the pip section
+            command: diff <(grep -v '^  - mne_bids>=0.*,<0.*$' doc/environment.yml) <(cat environment.yml)
 
         # restore cache from last build. Unless __init__.py has changed since then
         - restore_cache:

--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,7 @@ Documentation
 The documentation can be found under the following links:
 
 - for the `stable release <https://mne.tools/mne-bids/>`_
-- for the `latest (development) version <https://circleci.com/api/v1.1/project/github/mne-tools/mne-bids/latest/artifacts/0/html/index.html?branch=master>`_
+- for the `latest (development) version <https://mne.tools/mne-bids/dev/index.html>`_
 
 Dependencies
 ------------

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -130,21 +130,3 @@ coverage:
 	$(SPHINXBUILD) -b coverage $(ALLSPHINXOPTS) $(BUILDDIR)/coverage
 	@echo "Testing of coverage in the sources finished, look at the " \
 		  "results in $(BUILDDIR)/coverage/python.txt."
-
-install:
-	rm -rf _build/doctrees _build/mne_bids.github.io
-	# first clone the mne-tools/mne_bids.github.io repo because it may ask
-	# for password and we don't want to delay this long build in
-	# the middle of it
-	# --no-checkout just fetches the root folder without content
-	# --depth 1 is a speed optimization since we don't need the
-	# history prior to the last commit
-	# -b gh-pages fetches only the branch for the gh-pages
-	git clone -b gh-pages --single-branch --no-checkout --depth 1 https://github.com/mne-tools/mne-bids _build/mne_bids.github.io
-	make html
-	cd _build/ && \
-	cp -r html/* mne_bids.github.io && \
-	cd mne_bids.github.io && \
-	git add * && \
-	git commit -a -m 'Make install' && \
-	git push

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -141,12 +141,10 @@ install:
 	# history prior to the last commit
 	# -b gh-pages fetches only the branch for the gh-pages
 	git clone -b gh-pages --single-branch --no-checkout --depth 1 https://github.com/mne-tools/mne-bids _build/mne_bids.github.io
-	touch _build/mne_bids.github.io/.nojekyll
 	make html
 	cd _build/ && \
 	cp -r html/* mne_bids.github.io && \
 	cd mne_bids.github.io && \
 	git add * && \
-	git add .nojekyll && \
 	git commit -a -m 'Make install' && \
 	git push

--- a/doc/_templates/navbar.html
+++ b/doc/_templates/navbar.html
@@ -7,8 +7,11 @@
     <span class="caret"></span>
   </button>
   <ul class="dropdown-menu" aria-labelledby="dropdownMenu1">
-    <li><a href="https://circleci.com/api/v1.1/project/github/mne-tools/mne-bids/latest/artifacts/0/html/index.html?branch=master">Development</a></li>
-    <li><a href="https://mne.tools/mne-bids/">Stable</a></li>
+    <li><a href="https://mne.tools/mne-bids/dev/index.html">Development</a></li>
+    <li><a href="https://mne.tools/mne-bids/stable/index.html">Stable</a></li>
+    <li><a href="https://mne.tools/mne-bids/v0.3/index.html">v0.3</a></li>
+    <li><a href="https://mne.tools/mne-bids/v0.2/index.html">v0.2</a></li>
+    <li><a href="https://mne.tools/mne-bids/v0.1/index.html">v0.1</a></li>
   </ul>
 </div>
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -114,10 +114,20 @@ intersphinx_mapping = {
 }
 intersphinx_timeout = 5
 
+# Resolve binder filepath_prefix. From the docs:
+# "A prefix to append to the filepath in the Binder links. You should use this
+# if you will store your built documentation in a sub-folder of a repository,
+# instead of in the root."
+# we will store dev docs in a `dev` subdirectory and all other docs in a
+# directory "v" + version_str. E.g., "v0.3"
+if 'dev' in version:
+    filepath_prefix = 'dev'
+else:
+    assert version
+    filepath_prefix = 'v{}'.format(version)
 
 sphinx_gallery_conf = {
     'examples_dirs': '../examples',
-    'within_subsection_order': ExampleTitleSortKey,
     'gallery_dirs': 'auto_examples',
     'filename_pattern': '^((?!sgskip).)*$',
     'backreferences_dir': 'generated',
@@ -127,8 +137,9 @@ sphinx_gallery_conf = {
         'repo': 'mne-bids',
         'branch': 'gh-pages',  # noqa: E501 Can be any branch, tag, or commit hash. Use a branch that hosts your docs.
         'binderhub_url': 'https://mybinder.org',  # noqa: E501 Any URL of a binderhub deployment. Must be full URL (e.g. https://mybinder.org).
+        'filepath_prefix': filepath_prefix,  # noqa: E501 A prefix to prepend to any filepaths in Binder links.
         'dependencies': [
-            './environment.yml'
+            './environment.yml',
         ],
     }
 }

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -54,8 +54,8 @@ master_doc = 'index'
 # General information about the project.
 project = u'mne_bids'
 td = date.today()
-copyright = u'%s, MNE Developers. Last updated on %s' % (td.year,
-                                                         td.isoformat())
+copyright = u'2017-%s, MNE Developers. Last updated on %s' % (td.year,
+                                                              td.isoformat())
 
 author = u'MNE Developers'
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -123,11 +123,11 @@ intersphinx_timeout = 5
 if 'dev' in version:
     filepath_prefix = 'dev'
 else:
-    assert version
     filepath_prefix = 'v{}'.format(version)
 
 sphinx_gallery_conf = {
     'examples_dirs': '../examples',
+    'within_subsection_order': ExampleTitleSortKey,
     'gallery_dirs': 'auto_examples',
     'filename_pattern': '^((?!sgskip).)*$',
     'backreferences_dir': 'generated',

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -28,6 +28,7 @@ sys.path.append(os.path.abspath(os.path.join(curdir, 'sphinxext')))
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    'sphinx.ext.githubpages',
     'sphinx.ext.autodoc',
     'sphinx.ext.mathjax',
     'sphinx.ext.viewcode',

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -11,8 +11,8 @@ dependencies:
 - scikit-learn
 - matplotlib
 - pip:
-  - mne_bids~=0.3
-  - mne>=0.19.1
+  - mne_bids>=0.3,<0.4
+  - mne>=0.19.1,<0.20
   - nibabel
   - pybv
   - nilearn

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -12,7 +12,7 @@ dependencies:
 - matplotlib
 - pip:
   - mne_bids>=0.3,<0.4
-  - mne>=0.19.1,<0.20
+  - mne>=0.19.1
   - nibabel
   - pybv
   - nilearn

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -22,7 +22,6 @@ Current
 Changelog
 ~~~~~~~~~
 
-- Added handedness to participant files, by `Dominik Welke`_ (`#354 <https://github.com/mne-tools/mne-bids/pull/354>`_)
 - Added automatic conversion of FIF to BrainVision format with warning for EEG only data and conversion to FIF for meg non-FIF data, by `Alex Rockhill`_ (`#237 <https://github.com/mne-tools/mne-bids/pull/237>`_)
 - Add possibility to pass raw readers parameters (e.g. `allow_maxshield`) to :func:`read_raw_bids` to allow reading BIDS-formatted data before applying maxfilter, by  `Sophie Herbst`_
 - New feature in :func`mne_bids.write.write_anat` for shear deface of mri, by `Alex Rockhill`_ (`#271 <https://github.com/mne-tools/mne-bids/pull/271>`_)
@@ -35,7 +34,9 @@ Changelog
 - Update scans.tsv writer to adhere to MNE-Python v0.20+ where `meas_date` is stored as a `datetime` object, by `Adam Li`_ (`#344 <https://github.com/mne-tools/mne-bids/pull/344>`_)
 - :func:`read_raw_bids` now reads in sidecar json files to set, or estimate Power Line Frequency, by `Adam Li`_ (`#341 <https://github.com/mne-tools/mne-bids/pull/341>`_)
 - Allow FIF files with multiple parts to be read using :func:`read_raw_bids`, by `Teon Brooks`_ (`#346 <https://github.com/mne-tools/mne-bids/pull/346>`)
+- Added handedness to participant files, by `Dominik Welke`_ (`#354 <https://github.com/mne-tools/mne-bids/pull/354>`_)
 - MNE-BIDS can now handle a paths that are `pathlib.Path` objects (in addition to strings), by `Richard Höchenberger`_ (`#362 <https://github.com/mne-tools/mne-bids/pull/362>`)
+- The documentation is now available for all MNE-BIDS versions via a dropdown menu, by `Stefan Appelhoff`_(`#370 <https://github.com/mne-tools/mne-bids/pull/370>`)
 
 Bug
 ~~~

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
 - scikit-learn
 - matplotlib
 - pip:
-  - mne>=0.19.1,<0.20
+  - mne>=0.19.1
   - nibabel
   - pybv
   - nilearn

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
 - scikit-learn
 - matplotlib
 - pip:
-  - mne>=0.19.1
+  - mne>=0.19.1,<0.20
   - nibabel
   - pybv
   - nilearn


### PR DESCRIPTION
Main point of this PR: Make CircleCI build devdocs. See point 3 in #369 

accompanying PR: https://github.com/mne-tools/mne-bids/pull/371 ... #371 MUST BE MERGED BEFORE THIS ONE 

**binder**

I said before that Binder will only work for the stable docs ... fortunately I was wrong!

With the addition in this PR (`filepath_prefix`)  binder links are enabled for all versions:
- dev
- stable
- v0.3
- the versions prior to v0.3 did not have binder when they were released ... so they also don't have it now

**circleCI key**

I securely added a new CircleCI SSH key so that Circle can push the docs to our branch. Following [this tutorial](https://circleci.com/blog/deploying-documentation-to-github-pages-with-continuous-integration/)

**WIKI**

I updated the release post, and added a new post to document the changes I made:
- https://github.com/mne-tools/mne-bids/wiki/How-to-make-a-release
- https://github.com/mne-tools/mne-bids/wiki/Explanation-of-Documentation-Setup

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [x] All comments resolved
- [ ] This is not your own PR
- [x] All CIs are happy
- [x] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [x] PR description includes phrase "closes <#issue-number>"
- [x] Commit history does not contain any merge commits
