### PR TITLE
MRG: TESTS: Remove RuntimeWarnings

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -48,6 +48,7 @@ Bug
 - Fix :func:`read_raw_bids` to properly read in sidecar json even if a similarly named copy lives inside "derivatives/" sub-folder, by `Adam Li`_  (`#350 <https://github.com/mne-tools/mne-bids/pull/350>`_)
 - Fix :func:`read_raw_bids` to properly read in events.tsv sidecar if the 'trial_type' description has a "#" character in it by `Adam Li`_ (`#355 <https://github.com/mne-tools/mne-bids/pull/355>`_)
 - Avoid cases in which NumPy would raise a `FutureWarning` when populating TSV files, by `Richard Höchenberger`_ (`#372 <https://github.com/mne-tools/mne-bids/pull/372>`)
+- Remove events with an unknown onset, and assume unknown event durations to be zero, when reading BIDS data via :func:`read_raw_bids`, by `Richard Höchenberger`_ (`#375 <https://github.com/mne-tools/mne-bids/pull/375>`)
 
 API
 ~~~

--- a/mne_bids/commands/tests/test_cli.py
+++ b/mne_bids/commands/tests/test_cli.py
@@ -16,6 +16,10 @@ base_path = op.join(op.dirname(mne.__file__), 'io')
 subject_id = '01'
 task = 'testing'
 
+# Silence NumPy warnings
+# See https://stackoverflow.com/a/40846742
+pytestmark = pytest.mark.filterwarnings('ignore:numpy.ufunc size changed')
+
 
 def check_usage(module, force_help=False):
     """Ensure we print usage."""

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -10,9 +10,7 @@ import os.path as op
 from datetime import datetime
 import glob
 import json
-import warnings
 from warnings import warn
-from copy import deepcopy
 
 import numpy as np
 import mne

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -149,9 +149,9 @@ def _handle_events_reading(events_fname, raw):
 
     # Keep only events where onset is known
     good_events_idx = ~np.isnan(onsets)
+    onsets = onsets[good_events_idx]
     durations = durations[good_events_idx]
     descriptions = descriptions[good_events_idx]
-    onsets = onsets[good_events_idx]
     del good_events_idx
 
     # Add Events to raw as annotations

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -143,11 +143,18 @@ def _handle_events_reading(events_fname, raw):
 
     # Deal with "n/a" strings before converting to float
     ons = [np.nan if on == 'n/a' else on for on in events_dict['onset']]
-    dus = [np.nan if du == 'n/a' else du for du in events_dict['duration']]
-
-    # Add Events to raw as annotations
+    dus = [0 if du == 'n/a' else du for du in events_dict['duration']]
     onsets = np.asarray(ons, dtype=float)
     durations = np.asarray(dus, dtype=float)
+
+    # Keep only events where onset is known
+    good_events_idx = ~np.isnan(onsets)
+    durations = durations[good_events_idx]
+    descriptions = descriptions[good_events_idx]
+    onsets = onsets[good_events_idx]
+    del good_events_idx
+
+    # Add Events to raw as annotations
     annot_from_events = mne.Annotations(onset=onsets,
                                         duration=durations,
                                         description=descriptions,

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -10,7 +10,9 @@ import os.path as op
 from datetime import datetime
 import glob
 import json
+import warnings
 from warnings import warn
+from copy import deepcopy
 
 import numpy as np
 import mne

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -195,6 +195,8 @@ def test_line_freq_estimation():
         somato_raw = mne_bids.read_raw_bids(bids_fname, bids_root)
         assert somato_raw.info['line_freq'] == 50
 
+    # assert that line_freq should be None when
+    # all picks are not meg/eeg/ecog/seeg
     somato_raw.info['line_freq'] = None
     somato_raw.set_channel_types({somato_raw.ch_names[i]: 'bio'
                                   for i in range(len(somato_raw.ch_names))})

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -53,6 +53,13 @@ somato_raw_fname = op.join(somato_path, 'sub-01', 'meg',
 # See https://stackoverflow.com/a/40846742
 pytestmark = pytest.mark.filterwarnings('ignore:numpy.ufunc size changed')
 
+warning_str = dict(
+    channel_unit_changed='ignore:The unit for chann*.:RuntimeWarning:mne',
+    meas_date_set_to_none="ignore:.*'meas_date' set to None:RuntimeWarning:"
+                          "mne",
+    nasion_not_found='ignore:.*nasion not found:RuntimeWarning:mne',
+)
+
 
 def test_read_raw():
     """Test the raw reading."""
@@ -75,10 +82,7 @@ def test_not_implemented():
 
 
 @requires_nibabel()
-@pytest.mark.filterwarnings(r'ignore:The unit for channel\(s\) STI 001, '
-                            'STI 002, STI 003, STI 004, STI 005, STI 006, '
-                            'STI 014, STI 015, STI 016 has changed from V to '
-                            'NA.:RuntimeWarning:mne')
+@pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
 def test_get_head_mri_trans():
     """Test getting a trans object from BIDS data."""
     import nibabel as nib
@@ -155,8 +159,7 @@ def test_handle_events_reading():
     events, event_id = mne.events_from_annotations(raw)
 
 
-@pytest.mark.filterwarnings(r'ignore:The unit for channel\(s\)'
-                            ':RuntimeWarning:mne')  # meg -> bio
+@pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
 def test_line_freq_estimation():
     """Test estimating line frequency."""
     bids_root = _TempDir()
@@ -204,10 +207,7 @@ def test_line_freq_estimation():
     assert somato_raw.info['line_freq'] is None
 
 
-@pytest.mark.filterwarnings(r'ignore:The unit for channel\(s\) STI 001, '
-                            'STI 002, STI 003, STI 004, STI 005, STI 006, '
-                            'STI 014, STI 015, STI 016 has changed from V to '
-                            'NA.:RuntimeWarning:mne')
+@pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
 def test_handle_info_reading():
     """Test reading information from a BIDS sidecar.json file."""
     bids_root = _TempDir()
@@ -267,10 +267,8 @@ def test_handle_info_reading():
         raw = mne_bids.read_raw_bids(bids_fname, bids_root)
 
 
-@pytest.mark.filterwarnings('ignore:Fiducial point nasion not found'
-                            ':RuntimeWarning:mne')
-@pytest.mark.filterwarnings(r'ignore:The unit for channel\(s\) Status has '
-                            'changed from NA to V.:RuntimeWarning:mne')
+@pytest.mark.filterwarnings(warning_str['nasion_not_found'])
+@pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
 def test_handle_coords_reading():
     """Test reading coordinates from BIDS files."""
     bids_root = _TempDir()
@@ -318,9 +316,7 @@ def test_handle_coords_reading():
 
 
 @requires_nibabel()
-@pytest.mark.filterwarnings(r'ignore:The unit for channel\(s\) UDIO001, '
-                            'UPPT001, UPPT002 has changed from V to NA.'
-                            ':RuntimeWarning:mne')
+@pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
 def test_get_head_mri_trans_ctf():
     """Test getting a trans object from BIDS data in CTF."""
     import nibabel as nib
@@ -353,12 +349,8 @@ def test_get_head_mri_trans_ctf():
     assert_almost_equal(trans['trans'], estimated_trans['trans'])
 
 
-@pytest.mark.filterwarnings("ignore:Input info has 'meas_date' set to None."
-                            ":RuntimeWarning:mne")
-@pytest.mark.filterwarnings(r'ignore:The unit for channel\(s\) STI 001, '
-                            'STI 002, STI 003, STI 004, STI 005, STI 006, '
-                            'STI 014, STI 015, STI 016 has changed from V to '
-                            'NA.:RuntimeWarning:mne')
+@pytest.mark.filterwarnings(warning_str['meas_date_set_to_none'])
+@pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
 def test_get_matched_empty_room():
     """Test reading of empty room data."""
     bids_root = _TempDir()
@@ -429,10 +421,7 @@ def test_get_matched_empty_room():
         get_matched_empty_room(bids_basename + '_meg.fif', bids_root)
 
 
-@pytest.mark.filterwarnings(r'ignore:The unit for channel\(s\) STI 001, '
-                            'STI 002, STI 003, STI 004, STI 005, STI 006, '
-                            'STI 014, STI 015, STI 016 has changed from V to '
-                            'NA.:RuntimeWarning:mne')
+@pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
 def test_read_raw_bids_pathlike():
     """Test that read_raw_bids() can handle a Path-like bids_root."""
     bids_root = _TempDir()

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -143,7 +143,7 @@ def test_handle_events_reading():
 
     # Create an arbitrary events.tsv file, to test we can deal with 'n/a'
     # make sure we can deal w/ "#" characters
-    events = {'onset': [11, 12, 13],
+    events = {'onset': [11, 12, 'n/a'],
               'duration': ['n/a', 'n/a', 'n/a'],
               'trial_type': ["rec start", "trial #1", "trial #2!"]
               }

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -49,6 +49,10 @@ somato_path = somato.data_path()
 somato_raw_fname = op.join(somato_path, 'sub-01', 'meg',
                            'sub-01_task-somato_meg.fif')
 
+# Silence NumPy warnings
+# See https://stackoverflow.com/a/40846742
+pytestmark = pytest.mark.filterwarnings('ignore:numpy.ufunc size changed')
+
 
 def test_read_raw():
     """Test the raw reading."""
@@ -71,6 +75,10 @@ def test_not_implemented():
 
 
 @requires_nibabel()
+@pytest.mark.filterwarnings(r'ignore:The unit for channel\(s\) STI 001, '
+                            'STI 002, STI 003, STI 004, STI 005, STI 006, '
+                            'STI 014, STI 015, STI 016 has changed from V to '
+                            'NA.:RuntimeWarning:mne')
 def test_get_head_mri_trans():
     """Test getting a trans object from BIDS data."""
     import nibabel as nib
@@ -147,6 +155,8 @@ def test_handle_events_reading():
     events, event_id = mne.events_from_annotations(raw)
 
 
+@pytest.mark.filterwarnings(r'ignore:The unit for channel\(s\)'
+                            ':RuntimeWarning:mne')  # meg -> bio
 def test_line_freq_estimation():
     """Test estimating line frequency."""
     bids_root = _TempDir()
@@ -185,8 +195,6 @@ def test_line_freq_estimation():
         somato_raw = mne_bids.read_raw_bids(bids_fname, bids_root)
         assert somato_raw.info['line_freq'] == 50
 
-    # assert that line_freq should be None when
-    # all picks are not meg/eeg/ecog/seeg
     somato_raw.info['line_freq'] = None
     somato_raw.set_channel_types({somato_raw.ch_names[i]: 'bio'
                                   for i in range(len(somato_raw.ch_names))})
@@ -194,6 +202,10 @@ def test_line_freq_estimation():
     assert somato_raw.info['line_freq'] is None
 
 
+@pytest.mark.filterwarnings(r'ignore:The unit for channel\(s\) STI 001, '
+                            'STI 002, STI 003, STI 004, STI 005, STI 006, '
+                            'STI 014, STI 015, STI 016 has changed from V to '
+                            'NA.:RuntimeWarning:mne')
 def test_handle_info_reading():
     """Test reading information from a BIDS sidecar.json file."""
     bids_root = _TempDir()
@@ -253,6 +265,10 @@ def test_handle_info_reading():
         raw = mne_bids.read_raw_bids(bids_fname, bids_root)
 
 
+@pytest.mark.filterwarnings('ignore:Fiducial point nasion not found'
+                            ':RuntimeWarning:mne')
+@pytest.mark.filterwarnings(r'ignore:The unit for channel\(s\) Status has '
+                            'changed from NA to V.:RuntimeWarning:mne')
 def test_handle_coords_reading():
     """Test reading coordinates from BIDS files."""
     bids_root = _TempDir()
@@ -300,6 +316,9 @@ def test_handle_coords_reading():
 
 
 @requires_nibabel()
+@pytest.mark.filterwarnings(r'ignore:The unit for channel\(s\) UDIO001, '
+                            'UPPT001, UPPT002 has changed from V to NA.'
+                            ':RuntimeWarning:mne')
 def test_get_head_mri_trans_ctf():
     """Test getting a trans object from BIDS data in CTF."""
     import nibabel as nib
@@ -332,6 +351,12 @@ def test_get_head_mri_trans_ctf():
     assert_almost_equal(trans['trans'], estimated_trans['trans'])
 
 
+@pytest.mark.filterwarnings("ignore:Input info has 'meas_date' set to None."
+                            ":RuntimeWarning:mne")
+@pytest.mark.filterwarnings(r'ignore:The unit for channel\(s\) STI 001, '
+                            'STI 002, STI 003, STI 004, STI 005, STI 006, '
+                            'STI 014, STI 015, STI 016 has changed from V to '
+                            'NA.:RuntimeWarning:mne')
 def test_get_matched_empty_room():
     """Test reading of empty room data."""
     bids_root = _TempDir()
@@ -402,6 +427,10 @@ def test_get_matched_empty_room():
         get_matched_empty_room(bids_basename + '_meg.fif', bids_root)
 
 
+@pytest.mark.filterwarnings(r'ignore:The unit for channel\(s\) STI 001, '
+                            'STI 002, STI 003, STI 004, STI 005, STI 006, '
+                            'STI 014, STI 015, STI 016 has changed from V to '
+                            'NA.:RuntimeWarning:mne')
 def test_read_raw_bids_pathlike():
     """Test that read_raw_bids() can handle a Path-like bids_root."""
     bids_root = _TempDir()

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -53,6 +53,10 @@ bids_basename = make_bids_basename(
     task=task)
 bids_basename_minimal = make_bids_basename(subject=subject_id, task=task)
 
+# Silence NumPy warnings
+# See https://stackoverflow.com/a/40846742
+pytestmark = pytest.mark.filterwarnings('ignore:numpy.ufunc size changed')
+
 
 # WINDOWS issues:
 # the bids-validator development version does not work properly on Windows as
@@ -138,6 +142,17 @@ def test_get_anonymization_daysback():
 
 
 @requires_version('pybv', '0.2.0')
+# XXX check next marker if legit!
+@pytest.mark.filterwarnings('ignore:Omitted 50 annotation\(s\) that were '
+                            'outside data range.:RuntimeWarning:mne')
+@pytest.mark.filterwarnings(r'ignore:The unit for channel\(s\) STI 001, '
+                            'STI 002, STI 003, STI 004, STI 005, STI 006, '
+                            'STI 014, STI 015, STI 016 has changed from V to '
+                            'NA.:RuntimeWarning:mne')
+@pytest.mark.filterwarnings(r'ignore:The unit for channel\(s\) STI 001, '
+                            'STI 002, STI 003, STI 004, STI 005, STI 006, '
+                            'STI 015, STI 016 has changed from V to '
+                            'NA.:RuntimeWarning:mne')
 def test_fif(_bids_validate):
     """Test functionality of the write_raw_bids conversion for fif."""
     bids_root = _TempDir()
@@ -507,6 +522,8 @@ def test_kit(_bids_validate):
             overwrite=True)
 
 
+@pytest.mark.filterwarnings("ignore:Input info has 'meas_date' set to None."
+                            ":RuntimeWarning:mne")
 def test_ctf(_bids_validate):
     """Test functionality of the write_raw_bids conversion for CTF data."""
     bids_root = _TempDir()
@@ -542,6 +559,8 @@ def test_ctf(_bids_validate):
             get_anonymization_daysback(raw)
 
 
+@pytest.mark.filterwarnings(r'ignore:The unit for channel\(s\) STI 014 '
+                            'has changed from V to NA.:RuntimeWarning:mne')
 def test_bti(_bids_validate):
     """Test functionality of the write_raw_bids conversion for BTi data."""
     bids_root = _TempDir()
@@ -579,7 +598,12 @@ def test_bti(_bids_validate):
 # XXX: vhdr test currently passes only on MNE master. Skip until next release.
 # see: https://github.com/mne-tools/mne-python/pull/6558
 @pytest.mark.skipif(LooseVersion(mne.__version__) < LooseVersion('0.19'),
-                    reason="requires mne 0.19.dev0 or higher")
+                    reason='requires mne 0.19.dev0 or higher')
+@pytest.mark.filterwarnings('ignore:The unit for channel\(s\) CP5, CP6, HL, '
+                            'HR, Vb has changed from NA to V.'
+                            ':RuntimeWarning:mne')
+@pytest.mark.filterwarnings('ignore:The unit for channel\(s\) ReRef has '
+                            'changed from C to V.:RuntimeWarning:mne')
 def test_vhdr(_bids_validate):
     """Test write_raw_bids conversion for BrainVision data."""
     bids_root = _TempDir()
@@ -643,6 +667,8 @@ def test_vhdr(_bids_validate):
     _bids_validate(bids_root)
 
 
+@pytest.mark.filterwarnings('ignore:Fiducial point nasion not found'
+                            ':RuntimeWarning:mne')
 def test_edf(_bids_validate):
     """Test write_raw_bids conversion for European Data Format data."""
     bids_root = _TempDir()
@@ -793,6 +819,8 @@ def test_bdf(_bids_validate):
         _bids_validate(output_path)
 
 
+@pytest.mark.filterwarnings("ignore:Input info has 'meas_date' set to None."
+                            ":RuntimeWarning:mne")
 def test_set(_bids_validate):
     """Test write_raw_bids conversion for EEGLAB data."""
     # standalone .set file

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -149,7 +149,7 @@ def test_get_anonymization_daysback():
 
 
 @requires_version('pybv', '0.2.0')
-@pytest.mark.filterwarnings(warning_str['annotations_omitted'])  # XXX legit??
+@pytest.mark.filterwarnings(warning_str['annotations_omitted'])
 @pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
 def test_fif(_bids_validate):
     """Test functionality of the write_raw_bids conversion for fif."""

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -57,6 +57,13 @@ bids_basename_minimal = make_bids_basename(subject=subject_id, task=task)
 # See https://stackoverflow.com/a/40846742
 pytestmark = pytest.mark.filterwarnings('ignore:numpy.ufunc size changed')
 
+warning_str = dict(
+    channel_unit_changed='ignore:The unit for chann*.:RuntimeWarning:mne',
+    meas_date_set_to_none="ignore:.*'meas_date' set to None:RuntimeWarning:"
+                          "mne",
+    nasion_not_found='ignore:.*nasion not found:RuntimeWarning:mne',
+    annotations_omitted='ignore:Omitted .* annot.*:RuntimeWarning:mne',
+)
 
 # WINDOWS issues:
 # the bids-validator development version does not work properly on Windows as
@@ -142,17 +149,8 @@ def test_get_anonymization_daysback():
 
 
 @requires_version('pybv', '0.2.0')
-# XXX check next marker if legit!
-@pytest.mark.filterwarnings(r'ignore:Omitted 50 annotation\(s\) that were '
-                            'outside data range.:RuntimeWarning:mne')
-@pytest.mark.filterwarnings(r'ignore:The unit for channel\(s\) STI 001, '
-                            'STI 002, STI 003, STI 004, STI 005, STI 006, '
-                            'STI 014, STI 015, STI 016 has changed from V to '
-                            'NA.:RuntimeWarning:mne')
-@pytest.mark.filterwarnings(r'ignore:The unit for channel\(s\) STI 001, '
-                            'STI 002, STI 003, STI 004, STI 005, STI 006, '
-                            'STI 015, STI 016 has changed from V to '
-                            'NA.:RuntimeWarning:mne')
+@pytest.mark.filterwarnings(warning_str['annotations_omitted'])  # XXX legit??
+@pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
 def test_fif(_bids_validate):
     """Test functionality of the write_raw_bids conversion for fif."""
     bids_root = _TempDir()
@@ -522,8 +520,7 @@ def test_kit(_bids_validate):
             overwrite=True)
 
 
-@pytest.mark.filterwarnings("ignore:Input info has 'meas_date' set to None."
-                            ":RuntimeWarning:mne")
+@pytest.mark.filterwarnings(warning_str['meas_date_set_to_none'])
 def test_ctf(_bids_validate):
     """Test functionality of the write_raw_bids conversion for CTF data."""
     bids_root = _TempDir()
@@ -559,8 +556,7 @@ def test_ctf(_bids_validate):
             get_anonymization_daysback(raw)
 
 
-@pytest.mark.filterwarnings(r'ignore:The unit for channel\(s\) STI 014 '
-                            'has changed from V to NA.:RuntimeWarning:mne')
+@pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
 def test_bti(_bids_validate):
     """Test functionality of the write_raw_bids conversion for BTi data."""
     bids_root = _TempDir()
@@ -599,11 +595,7 @@ def test_bti(_bids_validate):
 # see: https://github.com/mne-tools/mne-python/pull/6558
 @pytest.mark.skipif(LooseVersion(mne.__version__) < LooseVersion('0.19'),
                     reason='requires mne 0.19.dev0 or higher')
-@pytest.mark.filterwarnings(r'ignore:The unit for channel\(s\) CP5, CP6, HL, '
-                            'HR, Vb has changed from NA to V.'
-                            ':RuntimeWarning:mne')
-@pytest.mark.filterwarnings(r'ignore:The unit for channel\(s\) ReRef has '
-                            'changed from C to V.:RuntimeWarning:mne')
+@pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
 def test_vhdr(_bids_validate):
     """Test write_raw_bids conversion for BrainVision data."""
     bids_root = _TempDir()
@@ -667,8 +659,7 @@ def test_vhdr(_bids_validate):
     _bids_validate(bids_root)
 
 
-@pytest.mark.filterwarnings('ignore:Fiducial point nasion not found'
-                            ':RuntimeWarning:mne')
+@pytest.mark.filterwarnings(warning_str['nasion_not_found'])
 def test_edf(_bids_validate):
     """Test write_raw_bids conversion for European Data Format data."""
     bids_root = _TempDir()
@@ -819,8 +810,7 @@ def test_bdf(_bids_validate):
         _bids_validate(output_path)
 
 
-@pytest.mark.filterwarnings("ignore:Input info has 'meas_date' set to None."
-                            ":RuntimeWarning:mne")
+@pytest.mark.filterwarnings(warning_str['meas_date_set_to_none'])
 def test_set(_bids_validate):
     """Test write_raw_bids conversion for EEGLAB data."""
     # standalone .set file

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -143,7 +143,7 @@ def test_get_anonymization_daysback():
 
 @requires_version('pybv', '0.2.0')
 # XXX check next marker if legit!
-@pytest.mark.filterwarnings('ignore:Omitted 50 annotation\(s\) that were '
+@pytest.mark.filterwarnings(r'ignore:Omitted 50 annotation\(s\) that were '
                             'outside data range.:RuntimeWarning:mne')
 @pytest.mark.filterwarnings(r'ignore:The unit for channel\(s\) STI 001, '
                             'STI 002, STI 003, STI 004, STI 005, STI 006, '
@@ -599,10 +599,10 @@ def test_bti(_bids_validate):
 # see: https://github.com/mne-tools/mne-python/pull/6558
 @pytest.mark.skipif(LooseVersion(mne.__version__) < LooseVersion('0.19'),
                     reason='requires mne 0.19.dev0 or higher')
-@pytest.mark.filterwarnings('ignore:The unit for channel\(s\) CP5, CP6, HL, '
+@pytest.mark.filterwarnings(r'ignore:The unit for channel\(s\) CP5, CP6, HL, '
                             'HR, Vb has changed from NA to V.'
                             ':RuntimeWarning:mne')
-@pytest.mark.filterwarnings('ignore:The unit for channel\(s\) ReRef has '
+@pytest.mark.filterwarnings(r'ignore:The unit for channel\(s\) ReRef has '
                             'changed from C to V.:RuntimeWarning:mne')
 def test_vhdr(_bids_validate):
     """Test write_raw_bids conversion for BrainVision data."""

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,6 @@ addopts =
     --ignore=doc
 filterwarnings =
     error
-    # ignore::RuntimeWarning
     ignore::UserWarning
     ignore::ImportWarning
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ addopts =
     --ignore=doc
 filterwarnings =
     error
-    ignore::RuntimeWarning
+    # ignore::RuntimeWarning
     ignore::UserWarning
     ignore::ImportWarning
 


### PR DESCRIPTION
PR Description
--------------

Make `pytest` fail on `RuntimeWarnings`, and only allow "legit", explicitly specified warnings in tests.

At first, I wanted to "fix" or silence all warnings, but I quickly realized that maybe this wasn't the best idea – also because I ran into some weird interactions between the `warnings` module
and pytest being configured to fail on warnings, which cost me hours to figure out.

That's why I've now decided to filter warnings that a test is expected to raise via `pytest.mark.filterwarnings`. This allows us not only to specify a warning message and category, but also from which module to expect the warning, e.g. `mne_bids` or `mne`. I've been very careful to check if all warnings that are silenced this way are actually legit; there's only one warning in `test_write.test_fif()` about which I'm unsure (marked via `XXX`).

Wondering if the warning match strings should be put into a global dict to make tests look cleaner. Could also think of adding regexps, however I'm not the one capable of writing those ;)

#### Update
This PR also fixes an issue with MNE-Python 0.19:

`mne_bids.read._handle_events_reading()` would produce a warning when event onsets or durations are `'n/a'`. This is because it replaces all `'n/a'` strings with `np.nan` before creating  annotations. When this Annotation object is then passed to `Raw.set_annotations()`, MNE calls
`Annotations.crop()`, which executes the following line:

```python
out_of_bounds = (absolute_onset > tmax) | (absolute_offset < tmin)
```

Since there's now `np.nan` in `absolute_onset` and / or `absolute_offset`, the desired behavior is unclear, and NumPy will emit a `RuntimeWarning`. This warning, however, only occurs with MNE-Python 0.19; with MNE `master`, the behavior of`Annotations.crop()` has obviously changed.

To make things work without warning even with MNE-Python 0.19, we now drop events with an unknown (`'n/a'` or `np.nan`) onset before creating Annotations. And unknown durations are now simply assumed to be zero.


x-ref #374


Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [x] All CIs are happy
- [x] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
- [ ] Commit history does not contain any merge commits
