### PR TITLE
TESTS, PKG: Remove DeprecationWarnings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,7 +77,7 @@ Dependencies
 * numpy (>=1.14)
 * scipy (>=0.18.1)
 * mne (>=0.19.1)
-* nibabel (optional)
+* nibabel (>=2.2, optional)
 * pybv (optional)
 
 Installation

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -13,7 +13,7 @@ dependencies:
 - pip:
   - mne_bids>=0.3,<0.4
   - mne>=0.19.1
-  - nibabel
+  - nibabel>=2.2
   - pybv
   - nilearn
   - flake8

--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,7 @@ dependencies:
 - matplotlib
 - pip:
   - mne>=0.19.1
-  - nibabel
+  - nibabel>=2.2
   - pybv
   - nilearn
   - flake8

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -943,14 +943,14 @@ def test_write_anat(_bids_validate):
                           session_id, raw=raw, trans=trans_fname,
                           verbose=True, deface=True, overwrite=True)
     t1w = nib.load(op.join(anat_dir, 'sub-01_ses-01_T1w.nii.gz'))
-    vox_sum = t1w.get_data().sum()
+    vox_sum = t1w.get_fdata().sum()
 
     anat_dir2 = write_anat(bids_root, subject_id, t1w_mgh,
                            session_id, raw=raw, trans=trans_fname,
                            verbose=True, deface=dict(inset=25.),
                            overwrite=True)
     t1w2 = nib.load(op.join(anat_dir2, 'sub-01_ses-01_T1w.nii.gz'))
-    vox_sum2 = t1w2.get_data().sum()
+    vox_sum2 = t1w2.get_fdata().sum()
 
     assert vox_sum > vox_sum2
 
@@ -959,7 +959,7 @@ def test_write_anat(_bids_validate):
                            verbose=True, deface=dict(theta=25),
                            overwrite=True)
     t1w3 = nib.load(op.join(anat_dir3, 'sub-01_ses-01_T1w.nii.gz'))
-    vox_sum3 = t1w3.get_data().sum()
+    vox_sum3 = t1w3.get_fdata().sum()
 
     assert vox_sum > vox_sum3
 
@@ -1016,7 +1016,7 @@ def test_write_anat(_bids_validate):
     _bids_validate(bids_root)
 
     t1w1 = nib.load(op.join(anat_dir, 'sub-01_ses-01_acq-01_T1w.nii.gz'))
-    vox1 = t1w1.get_data()
+    vox1 = t1w1.get_fdata()
 
     # test mri landmarks
     anat_dir = write_anat(bids_root, subject_id, t1w_mgh, session_id,
@@ -1026,7 +1026,7 @@ def test_write_anat(_bids_validate):
     _bids_validate(bids_root)
 
     t1w2 = nib.load(op.join(anat_dir, 'sub-01_ses-01_acq-01_T1w.nii.gz'))
-    vox2 = t1w2.get_data()
+    vox2 = t1w2.get_fdata()
 
     # because of significant rounding errors the voxels are fairly different
     # but the deface works in all three cases and was checked
@@ -1056,7 +1056,7 @@ def test_write_anat(_bids_validate):
     _bids_validate(bids_root)
 
     t1w3 = nib.load(op.join(anat_dir, 'sub-01_ses-01_acq-01_T1w.nii.gz'))
-    vox3 = t1w3.get_data()
+    vox3 = t1w3.get_fdata()
 
     assert abs(vox1 - vox3).sum() / abs(vox1).sum() < 0.2
 

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -671,7 +671,7 @@ def _deface(t1w, mri_landmarks, deface):
                          'degrees. Got %s' % theta)
 
     # x: L/R L+, y: S/I I+, z: A/P A+
-    t1w_data = t1w.get_data().copy()
+    t1w_data = t1w.get_fdata().copy()
     idxs_vox = np.meshgrid(np.arange(t1w_data.shape[0]),
                            np.arange(t1w_data.shape[1]),
                            np.arange(t1w_data.shape[2]),

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,6 @@ filterwarnings =
     error
     ignore::RuntimeWarning
     ignore::UserWarning
-    ignore::DeprecationWarning
     ignore::ImportWarning
 
 [pydocstyle]


### PR DESCRIPTION
PR Description
--------------

`nibabel` threw `DeprecationWarnings`  on calls to `t1w.get_data()`: the `get_data()` method has been deprecated since release 3.0 (December 2019), and one should use `get_fdata()` instead, see e.g. https://git.fmrib.ox.ac.uk/samh/profumo/commit/82cde929f04a581c2c6984d7fa280a37868d082b

`get_fdata()` was introduced in `nibabel` 2.2 (October 2017), therefore I felt incouraged to simply switch `mne-bids` to `get_fdata()` without adding a fallback to `get_data()`, and bumping the min. required `nibabel` version to 2.2.

x-ref #374 

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [x] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
- [x] Commit history does not contain any merge commits
