### PR TITLE
TESTS: Fix timestamp bug in tests, extract FIF anonymization tests to separate function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,13 @@ matrix:
                MNE_VERSION="maint/0.19"
           name: "Linux pip minimal"
 
+        # Linux with timezone = Berlin, i.e. UTC+1 (CET) or UTC+2 (CEST)
+        - os: linux
+          env: CONDA_ENV="environment.yml"
+               MNE_VERSION="master"
+               TZ="Europe/Berlin"
+          name: "Linux conda full, timezone Europe/Berlin"
+
 # Specify version of BIDS-validator to be used, 'master', or 'stable'
 env:
   global:
@@ -89,6 +96,10 @@ install:
 cache:
     - pip
     - yarn
+
+before_script:
+    - echo $TZ
+    - date
 
 script:
     - pytest . --cov=./mne_bids --cov-report=xml --verbose --ignore mne-python

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -222,17 +222,19 @@ def test_fif(_bids_validate):
     raw = mne.io.read_raw_fif(raw_fname)
     meas_date = raw.info['meas_date']
     if not isinstance(meas_date, datetime):
-        meas_date = datetime.fromtimestamp(meas_date[0])
+        meas_date = datetime.fromtimestamp(meas_date[0], tz=timezone.utc)
     er_date = meas_date.strftime('%Y%m%d')
     er_bids_basename = 'sub-emptyroom_ses-{0}_task-noise'.format(str(er_date))
     write_raw_bids(raw, er_bids_basename, bids_root, overwrite=False)
     assert op.exists(op.join(
         bids_root, 'sub-emptyroom', 'ses-{0}'.format(er_date), 'meg',
         'sub-emptyroom_ses-{0}_task-noise_meg.json'.format(er_date)))
+
     # test that an incorrect date raises an error.
     er_bids_basename_bad = 'sub-emptyroom_ses-19000101_task-noise'
     with pytest.raises(ValueError, match='Date provided'):
         write_raw_bids(raw, er_bids_basename_bad, bids_root, overwrite=False)
+
     # test that the acquisition time was written properly
     scans_tsv = make_bids_basename(
         subject=subject_id, session=session_id, suffix='scans.tsv',


### PR DESCRIPTION
PR Description
--------------
- Fixes timestamp handling in a test, which closes #378.
- Moves anonymization tests for FIF files to their own function, which can now be easily skipped (via the `@pytest.mark.skipif` decorator) on MNE-Python <0.20, where this feature is not available.
- Adds a test with time zone set to Berlin to Travis test matrix.

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
- [ ] Commit history does not contain any merge commits
