### PR TITLE
MAINT: add .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,24 @@
+Adam Li <adam2392@gmail.com>
+Alex Rockhill <aprockhill206@gmail.com>
+Alex Rockhill <aprockhill206@gmail.com> <aprock@uw.edu>
+Alexandre Gramfort <alexandre.gramfort@m4x.org>
+Ariel Rokem <arokem@gmail.com>
+Chris Holdgraf <choldgraf@gmail.com>
+Chris Holdgraf <choldgraf@gmail.com> <choldgraf@berkeley.edu>
+Clemens Brunner <clemens.brunner@gmail.com>
+Kambiz Tavabi <ktavabi@gmail.com>
+Mainak Jas <mainakjas@gmail.com>
+Mainak Jas <mainakjas@gmail.com> <jasmainak@users.noreply.github.com>
+Marijn van Vliet <w.m.vanvliet@gmail.com>
+Maximilien Chaumon <maximilien.chaumon@gmail.com>
+Maximilien Chaumon <maximilien.chaumon@gmail.com> <maximilien.chaumon@icm-institute.org>
+Romain Quentin <rom.quentin@gmail.com>
+Richard Höchenberger <richard.hoechenberger@gmail.com>
+Sophie Herbst <ksherbst@gmail.com>
+Stefan Appelhoff <stefan.appelhoff@mailbox.org>
+Teon Brooks <teon.brooks@gmail.com>
+Dominik Welke <dominik.welke@ae.mpg.de>
+Dominik Welke <dominik.welke@ae.mpg.de> dominikwelke <33089761+dominikwelke@users.noreply.github.com>
+Ezequiel Mikulan <e.mikulan@gmail.com>
+Fu-Te Wong <zuxfoucault@yahoo.com.tw>
+Matt Sanderson <monkey_man_192@yahoo.com.au>


### PR DESCRIPTION
closes #384 

`.mailmap` is there to merge *your* `git` identities.

Example:
-      `dwelke <dominik.welke@ae.mpg.de>`
-      `dominikwelke <33089761+dominikwelke@users.noreply.github.com>`

become:  `Dominik Welke <dominik.welke@ae.mpg.de>` with this PR (and all contributions are properly attributed)

read more about it here: https://blog.developer.atlassian.com/aliasing-authors-in-git/

---

I did a first pass at `.mailmap` the following people need to confirm that they are satisfied with how they are represented in `.mailmap`:

@alexrockhill @choldgraf @jasmainak @dnacombo @dominikwelke

if you want to be represented differently, please comment or make a code suggestion.