### PR TITLE
[MRG] Allow exclusion of emptyroom  in get_entitty_vals

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -23,7 +23,7 @@ Changelog
 ~~~~~~~~~
 
 - :func:`read_raw_bids` now reads in participants tsv data, by `Adam Li`_ (`#392 <https://github.com/mne-tools/mne-bids/pull/392>`_)
-- :func:`mne_bids.utils.get_entity_vals` has gained ``ignore_*`` keyword arguments to exclude specific datasets from the list of results, by `Richard Höchenberger`_ (`#409 <https://github.com/mne-tools/mne-bids/pull/409>`_)
+- :func:`mne_bids.utils.get_entity_vals` has gained ``ignore_*`` keyword arguments to exclude specific values from the list of results, e.g. the entities for a particular subject or task, by `Richard Höchenberger`_ (`#409 <https://github.com/mne-tools/mne-bids/pull/409>`_)
 
 Bug
 ~~~

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -23,6 +23,7 @@ Changelog
 ~~~~~~~~~
 
 - :func:`read_raw_bids` now reads in participants tsv data, by `Adam Li`_ (`#392 <https://github.com/mne-tools/mne-bids/pull/392>`_)
+- :func:`mne_bids.utils.get_entity_vals` has gained ``ignore_*`` keyword arguments to exclude specific datasets from the list of results, by `Richard Höchenberger`_ (`#409 <https://github.com/mne-tools/mne-bids/pull/409>`_)
 
 Bug
 ~~~

--- a/mne_bids/tests/test_utils.py
+++ b/mne_bids/tests/test_utils.py
@@ -77,17 +77,31 @@ def test_get_keys(return_bids_test_dir):
     assert kinds == ['meg']
 
 
-def test_get_entity_vals(return_bids_test_dir):
+@pytest.mark.parametrize('entity, expected_vals, kwargs',
+                         [('bogus', None, None),
+                          ('sub', [subject_id], None),
+                          ('ses', [session_id], None),
+                          ('run', [run, '02'], None),
+                          ('acq', [], None),
+                          ('task', [task], None),
+                          ('sub', [], dict(ignore_sub=[subject_id])),
+                          ('ses', [], dict(ignore_ses=[session_id])),
+                          ('run', [run], dict(ignore_run=['02'])),
+                          ('task', [], dict(ignore_task=[task])),
+                          ('run', [run, '02'], dict(ignore_run=['bogus']))])
+def test_get_entity_vals(entity, expected_vals, kwargs, return_bids_test_dir):
     """Test getting a list of entities."""
     bids_root = return_bids_test_dir
-    with pytest.raises(ValueError, match='`key` must be one of'):
-        get_entity_vals(bids_root, entity_key='bogus')
+    if kwargs is None:
+        kwargs = dict()
 
-    assert get_entity_vals(bids_root, 'sub') == [subject_id]
-    assert get_entity_vals(bids_root, 'ses') == [session_id]
-    assert get_entity_vals(bids_root, 'run') == [run, '02']
-    assert get_entity_vals(bids_root, 'acq') == []
-    assert get_entity_vals(bids_root, 'task') == [task]
+    if entity == 'bogus':
+        with pytest.raises(ValueError, match='`key` must be one of'):
+            get_entity_vals(bids_root=bids_root, entity_key=entity, **kwargs)
+    else:
+        vals = get_entity_vals(bids_root=bids_root, entity_key=entity,
+                               **kwargs)
+        assert vals == expected_vals
 
 
 def test_get_ch_type_mapping():

--- a/mne_bids/tests/test_utils.py
+++ b/mne_bids/tests/test_utils.py
@@ -85,9 +85,13 @@ def test_get_keys(return_bids_test_dir):
                           ('acq', [], None),
                           ('task', [task], None),
                           ('sub', [], dict(ignore_sub=[subject_id])),
+                          ('sub', [], dict(ignore_sub=subject_id)),
                           ('ses', [], dict(ignore_ses=[session_id])),
+                          ('ses', [], dict(ignore_ses=session_id)),
                           ('run', [run], dict(ignore_run=['02'])),
+                          ('run', [run], dict(ignore_run='02')),
                           ('task', [], dict(ignore_task=[task])),
+                          ('task', [], dict(ignore_task=task)),
                           ('run', [run, '02'], dict(ignore_run=['bogus']))])
 def test_get_entity_vals(entity, expected_vals, kwargs, return_bids_test_dir):
     """Test getting a list of entities."""

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -69,6 +69,7 @@ warning_str = dict(
     annotations_omitted='ignore:Omitted .* annot.*:RuntimeWarning:mne',
 )
 
+
 # WINDOWS issues:
 # the bids-validator development version does not work properly on Windows as
 # of 2019-06-25 --> https://github.com/bids-standard/bids-validator/issues/790

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -55,7 +55,7 @@ def get_kinds(bids_root):
     return kinds
 
 
-def get_entity_vals(bids_root, entity_key, ignore_sub=('emptyroom',),
+def get_entity_vals(bids_root, entity_key, *, ignore_sub=('emptyroom',),
                     ignore_task=None, ignore_ses=None, ignore_run=None,
                     ignore_acq=None):
     """Get list of values associated with an `entity_key` in a BIDS dataset.

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -73,15 +73,15 @@ def get_entity_vals(bids_root, entity_key, *, ignore_sub=('emptyroom',),
         ['sub', 'ses', 'task', 'run', 'acq'].
     ignore_sub : iterable | None
         Subjects to ignore. By default, entities from the ``emptyroom``
-        mock-subject are not returned.
+        mock-subject are not returned. If ``None``, include all subjects.
     ignore_task : iterable | None
-        Tasks to ignore.
+        Tasks to ignore. If ``None``, include all tasks.
     ignore_ses : iterable | None
-        Sessions to ignore.
+        Sessions to ignore. If ``None``, include all sessions.
     ignore_run : iterable | None
-        Runs to ignore.
+        Runs to ignore. If ``None``, include all runs.
     ignore_acq : iterable | None
-        Acquisitions to ignore.
+        Acquisitions to ignore. If ``None``, include all acquisitions.
 
     Returns
     -------

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -55,6 +55,16 @@ def get_kinds(bids_root):
     return kinds
 
 
+def _ensure_tuple(x):
+    """Always return a tuple."""
+    if x is None:
+        return tuple()
+    elif isinstance(x, str):
+        return (x,)
+    else:
+        return tuple(x)
+
+
 def get_entity_vals(bids_root, entity_key, *, ignore_sub=('emptyroom',),
                     ignore_task=None, ignore_ses=None, ignore_run=None,
                     ignore_acq=None):
@@ -71,17 +81,17 @@ def get_entity_vals(bids_root, entity_key, *, ignore_sub=('emptyroom',),
     entity_key : str
         The name of the entity key to search for. Can be one of
         ['sub', 'ses', 'task', 'run', 'acq'].
-    ignore_sub : iterable | None
-        Subjects to ignore. By default, entities from the ``emptyroom``
+    ignore_sub : str | iterable | None
+        Subject(s) to ignore. By default, entities from the ``emptyroom``
         mock-subject are not returned. If ``None``, include all subjects.
-    ignore_task : iterable | None
-        Tasks to ignore. If ``None``, include all tasks.
-    ignore_ses : iterable | None
-        Sessions to ignore. If ``None``, include all sessions.
-    ignore_run : iterable | None
-        Runs to ignore. If ``None``, include all runs.
-    ignore_acq : iterable | None
-        Acquisitions to ignore. If ``None``, include all acquisitions.
+    ignore_task : str | iterable | None
+        Task(s) to ignore. If ``None``, include all tasks.
+    ignore_ses : str | iterable | None
+        Session(s) to ignore. If ``None``, include all sessions.
+    ignore_run : str | iterable | None
+        Run(s) to ignore. If ``None``, include all runs.
+    ignore_acq : str | iterable | None
+        Acquisition(s) to ignore. If ``None``, include all acquisitions.
 
     Returns
     -------
@@ -106,6 +116,12 @@ def get_entity_vals(bids_root, entity_key, *, ignore_sub=('emptyroom',),
     if entity_key not in entities:
         raise ValueError('`key` must be one of "{}". Got "{}"'
                          .format(entities, entity_key))
+
+    ignore_sub = _ensure_tuple(ignore_sub)
+    ignore_task = _ensure_tuple(ignore_task)
+    ignore_ses = _ensure_tuple(ignore_ses)
+    ignore_run = _ensure_tuple(ignore_run)
+    ignore_acq = _ensure_tuple(ignore_acq)
 
     p = re.compile(r'{}-(.*?)_'.format(entity_key))
     value_list = list()

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -55,7 +55,9 @@ def get_kinds(bids_root):
     return kinds
 
 
-def get_entity_vals(bids_root, entity_key, include_emptyroom=False):
+def get_entity_vals(bids_root, entity_key, ignore_sub=('emptyroom',),
+                    ignore_task=None, ignore_ses=None, ignore_run=None,
+                    ignore_acq=None):
     """Get list of values associated with an `entity_key` in a BIDS dataset.
 
     BIDS file names are organized by key-value pairs called "entities" [1]_.
@@ -68,10 +70,18 @@ def get_entity_vals(bids_root, entity_key, include_emptyroom=False):
         Path to the root of the BIDS directory.
     entity_key : str
         The name of the entity key to search for. Can be one of
-        ['sub', 'ses', 'run', 'acq'].
-    include_emptyroom : bool
-        Whether to extract the entity values from empty-room recordings in the
-        dataset as well.
+        ['sub', 'ses', 'task', 'run', 'acq'].
+    ignore_sub : iterable | None
+        Subjects to ignore. By default, entities from the ``emptyroom``
+        mock-subject are not returned.
+    ignore_task : iterable | None
+        Tasks to ignore.
+    ignore_ses : iterable | None
+        Sessions to ignore.
+    ignore_run : iterable | None
+        Runs to ignore.
+    ignore_acq : iterable | None
+        Acquisitions to ignore.
 
     Returns
     -------
@@ -100,8 +110,20 @@ def get_entity_vals(bids_root, entity_key, include_emptyroom=False):
     p = re.compile(r'{}-(.*?)_'.format(entity_key))
     value_list = list()
     for filename in Path(bids_root).rglob('*{}-*_*'.format(entity_key)):
-        if (filename.stem.startswith('sub-emptyroom_') and
-                not include_emptyroom):
+        if ignore_sub and any([filename.stem.startswith(f'sub-{s}_')
+                               for s in ignore_sub]):
+            continue
+        if ignore_task and any([f'_task-{t}_' in filename.stem
+                                for t in ignore_task]):
+            continue
+        if ignore_ses and any([f'_ses-{s}_' in filename.stem
+                               for s in ignore_ses]):
+            continue
+        if ignore_run and any([f'_run-{r}_' in filename.stem
+                               for r in ignore_run]):
+            continue
+        if ignore_acq and any([f'_acq-{a}_' in filename.stem
+                               for a in ignore_acq]):
             continue
 
         match = p.search(filename.stem)

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -55,7 +55,7 @@ def get_kinds(bids_root):
     return kinds
 
 
-def get_entity_vals(bids_root, entity_key):
+def get_entity_vals(bids_root, entity_key, include_emptyroom=False):
     """Get list of values associated with an `entity_key` in a BIDS dataset.
 
     BIDS file names are organized by key-value pairs called "entities" [1]_.
@@ -69,6 +69,9 @@ def get_entity_vals(bids_root, entity_key):
     entity_key : str
         The name of the entity key to search for. Can be one of
         ['sub', 'ses', 'run', 'acq'].
+    include_emptyroom : bool
+        Whether to extract the entity values from empty-room recordings in the
+        dataset as well.
 
     Returns
     -------
@@ -97,6 +100,10 @@ def get_entity_vals(bids_root, entity_key):
     p = re.compile(r'{}-(.*?)_'.format(entity_key))
     value_list = list()
     for filename in Path(bids_root).rglob('*{}-*_*'.format(entity_key)):
+        if (filename.stem.startswith('sub-emptyroom_') and
+                not include_emptyroom):
+            continue
+
         match = p.search(filename.stem)
         value = match.group(1)
         if value not in value_list:

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -65,7 +65,7 @@ def _ensure_tuple(x):
         return tuple(x)
 
 
-def get_entity_vals(bids_root, entity_key, *, ignore_sub=('emptyroom',),
+def get_entity_vals(bids_root, entity_key, *, ignore_sub='emptyroom',
                     ignore_task=None, ignore_ses=None, ignore_run=None,
                     ignore_acq=None):
     """Get list of values associated with an `entity_key` in a BIDS dataset.

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -56,7 +56,7 @@ def get_kinds(bids_root):
 
 
 def _ensure_tuple(x):
-    """Always return a tuple."""
+    """Return a tuple."""
     if x is None:
         return tuple()
     elif isinstance(x, str):


### PR DESCRIPTION
PR Description
--------------

This PR adds an `include_emptyroom` kwarg to `utils.get_entity_vals()`, allowing the user to specify whether information from empty-room recordings should be included in the returned entity values.

Closes GH-407.

**Changes default behavior of `utils.get_entity_vals()` to NOT incude emptyroom information.**

**Need advice on how to best add a test.**

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [x] All comments resolved
- [x] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [x] PR description includes phrase "closes <#issue-number>"
- [x] Commit history does not contain any merge commits
