### PR TITLE
[MRG] RF: Accept bids_basename in read_raw_bids(), get_matched_empty_room(), get_head_mri_trans(), and drop their bids_fname param

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -38,7 +38,9 @@ Bug
 API
 ~~~
 
-- no entries yet
+- :func:`read_raw_bids` now expects `bids_basename` as the first argument and gains a `kind` parameter. The name of the file to read will be inferred automatically, and can no longer be passed to the function directly. This ensures better API consistency with :func:`write_raw_bids`, by `Richard Höchenberger`_ (`#410 <https://github.com/mne-tools/mne-bids/pull/410>`_)
+- :func:`get_matched_empty_room` now expects `bids_basename` as the first argument and returns the `bids_basename` of the best-matching empty-room recording (instead of its filename before). The `bids_fname` argument has been dropped, by `Richard Höchenberger`_ (`#410 <https://github.com/mne-tools/mne-bids/pull/410>`_)
+- :func:`get_head_mri_trans` now expects `bids_basename` as the first argument. The `bids_fname` argument has been dropped, by `Richard Höchenberger`_ (`#410 <https://github.com/mne-tools/mne-bids/pull/410>`_)
 
 .. _changes_0_4:
 

--- a/examples/convert_empty_room.py
+++ b/examples/convert_empty_room.py
@@ -91,8 +91,8 @@ print_dir_tree(bids_path)
 # file that is closest in time to the measurement file using MNE-BIDS.
 from mne_bids import get_matched_empty_room # noqa
 
-bids_fname = bids_basename + '_meg.fif'
-best_er_fname = get_matched_empty_room(bids_fname, bids_path)
+best_er_fname = get_matched_empty_room(bids_basename=bids_basename,
+                                       bids_root=bids_path)
 print(best_er_fname)
 
 ###############################################################################

--- a/examples/convert_empty_room.py
+++ b/examples/convert_empty_room.py
@@ -87,14 +87,14 @@ print_dir_tree(bids_path)
 ###############################################################################
 # To get an accurate estimate of the noise, it is important that the empty
 # room recording be as close in date as the raw data.
-# We can retrieve the filename corresponding to the empty room
-# file that is closest in time to the measurement file using MNE-BIDS.
+# We can retrieve the basename corresponding to the empty room
+# recording that is closest in time to the experimental measurement.
 from mne_bids import get_matched_empty_room # noqa
 
-best_er_fname = get_matched_empty_room(bids_basename=bids_basename,
-                                       bids_root=bids_path)
-print(best_er_fname)
+best_er_basename = get_matched_empty_room(bids_basename=bids_basename,
+                                          bids_root=bids_path)
+print(best_er_basename)
 
 ###############################################################################
 # Finally, we can read the empty room file using
-raw = read_raw_bids(best_er_fname, bids_path)
+raw = read_raw_bids(bids_basename=best_er_basename, bids_root=bids_path)

--- a/examples/convert_ieeg_to_bids.py
+++ b/examples/convert_ieeg_to_bids.py
@@ -203,8 +203,7 @@ print_dir_tree(bids_root)
 # :func:`read_raw_bids` to read in the data.
 
 # read in the BIDS dataset and plot the coordinates
-bids_fname = bids_basename + "_ieeg.vhdr"
-raw = read_raw_bids(bids_fname, bids_root=bids_root)
+raw = read_raw_bids(bids_basename=bids_basename, bids_root=bids_root)
 
 # get the first 5 channels and show their locations
 # this should match what was printed earlier.

--- a/examples/convert_mne_sample.py
+++ b/examples/convert_mne_sample.py
@@ -75,8 +75,7 @@ print_dir_tree(output_path)
 # packages can automate your workflow. For example, reading the data back
 # into MNE-Python can easily be done using :func:`read_raw_bids`.
 
-bids_fname = bids_basename + '_meg.fif'
-raw = read_raw_bids(bids_fname, output_path)
+raw = read_raw_bids(bids_basename=bids_basename, bids_root=output_path)
 
 ###############################################################################
 # The resulting data is already in a convenient form to create epochs and

--- a/examples/convert_mri_and_trans.py
+++ b/examples/convert_mri_and_trans.py
@@ -114,11 +114,7 @@ print_dir_tree(output_path)
 ###############################################################################
 # Our BIDS dataset is now ready to be shared. We can easily estimate the
 # transformation matrix using ``MNE-BIDS`` and the BIDS dataset.
-
-bids_fname = bids_basename + '_meg.fif'
-
-# reproduce our trans
-estim_trans = get_head_mri_trans(bids_fname=bids_fname,  # name of the MEG file
+estim_trans = get_head_mri_trans(bids_basename=bids_basename,
                                  bids_root=output_path  # root of our BIDS dir
                                  )
 

--- a/examples/read_bids_datasets.py
+++ b/examples/read_bids_datasets.py
@@ -43,12 +43,9 @@ from mne_bids.utils import print_dir_tree
 #
 # Get the MNE somato data
 bids_root = somato.data_path()
-somato_raw_fname = os.path.join(bids_root, 'sub-01', 'meg',
-                                'sub-01_task-somato_meg.fif')
-
 subject_id = '01'
 task = 'somato'
-kind = "meg"
+kind = 'meg'
 
 bids_basename = make_bids_basename(subject=subject_id, task=task)
 
@@ -65,8 +62,8 @@ print_dir_tree(bids_root)
 #
 # Let's read in the dataset and show off a few features of the
 # loading function `read_raw_bids`. Note, this is just one line of code.
-bids_fname = bids_basename + "_{}.fif".format(kind)
-raw = read_raw_bids(bids_fname, bids_root, verbose=True)
+raw = read_raw_bids(bids_basename=bids_basename, bids_root=bids_root,
+                    kind=kind, verbose=True)
 
 ###############################################################################
 # `raw.info` has the basic subject metadata

--- a/examples/read_bids_datasets.py
+++ b/examples/read_bids_datasets.py
@@ -24,8 +24,6 @@ and to display the data that is saved within the accompanying sidecars.
 
 ###############################################################################
 # We are importing everything we need for this example:
-import os
-
 from mne.datasets import somato
 
 from mne_bids import make_bids_basename, read_raw_bids

--- a/mne_bids/__init__.py
+++ b/mne_bids/__init__.py
@@ -7,6 +7,7 @@ from mne_bids.write import (write_raw_bids, make_bids_basename,  # noqa: E501 F4
                             make_dataset_description, write_anat,  # noqa: F401
                             get_anonymization_daysback,  # noqa: F401
                             _stamp_to_dt, _get_anonymization_daysback)
-from mne_bids.read import read_raw_bids, get_head_mri_trans, get_matched_empty_room  # noqa: F401
+from mne_bids.read import (read_raw_bids, get_head_mri_trans,  # noqa: F401
+                           get_matched_empty_room)  # noqa: F401
 from mne_bids.utils import make_bids_folders  # noqa: F401
 from mne_bids import commands  # noqa: F401

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -402,8 +402,8 @@ def _get_bids_fname_from_filesystem(*, bids_basename, bids_root, sub, ses,
     return bids_fname
 
 
-def make_bids_fname(bids_basename, bids_root=None, kind=None, extension=None,
-                    verbose=False):
+def _make_bids_fname(bids_basename, bids_root=None, kind=None, extension=None,
+                     verbose=False):
     """
     Construct the filename of a BIDS data file.
 
@@ -515,8 +515,8 @@ def read_raw_bids(bids_basename, bids_root, kind=None, extra_params=None,
 
     data_dir = make_bids_folders(subject=sub, session=ses, kind=kind,
                                  make_dir=False)
-    bids_fname = make_bids_fname(bids_basename=bids_basename,
-                                 bids_root=bids_root, kind=kind)
+    bids_fname = _make_bids_fname(bids_basename=bids_basename,
+                                  bids_root=bids_root, kind=kind)
 
     if op.splitext(bids_fname)[1] == '.pdf':
         bids_raw_folder = op.join(bids_root, data_dir,
@@ -660,8 +660,8 @@ def get_matched_empty_room(bids_basename, bids_root):
         Returns None if no file found.
     """
     kind = 'meg'
-    bids_fname = make_bids_fname(bids_basename=bids_basename,
-                                 bids_root=bids_root, kind=kind)
+    bids_fname = _make_bids_fname(bids_basename=bids_basename,
+                                  bids_root=bids_root, kind=kind)
     _, ext = _parse_ext(bids_fname)
 
     raw = read_raw_bids(bids_basename=bids_basename, bids_root=bids_root,
@@ -720,8 +720,8 @@ def get_head_mri_trans(bids_basename, bids_root):
     import nibabel as nib
 
     # Get the sidecar file for MRI landmarks
-    bids_fname = make_bids_fname(bids_basename=bids_basename,
-                                 bids_root=bids_root, kind='meg')
+    bids_fname = _make_bids_fname(bids_basename=bids_basename,
+                                  bids_root=bids_root, kind='meg')
     t1w_json_path = _find_matching_sidecar(bids_fname, bids_root, 'T1w.json')
 
     # Get MRI landmarks from the JSON sidecar

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -404,8 +404,7 @@ def _get_bids_fname_from_filesystem(*, bids_basename, bids_root, sub, ses,
 
 def _make_bids_fname(bids_basename, bids_root=None, kind=None, extension=None,
                      verbose=False):
-    """
-    Construct the filename of a BIDS data file.
+    """Construct the filename of a BIDS data file.
 
     Parameters
     ----------

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -347,8 +347,12 @@ def _infer_kind(*, bids_basename, bids_root, sub, ses):
 
     kinds = _get_kinds_for_sub(bids_basename=bids_basename,
                                bids_root=bids_root, sub=sub, ses=ses)
+
+    # We only want to handle electrophysiological data here.
+    allowed_kinds = set(['meg', 'eeg', 'ieeg'])
+    kinds = list(set(kinds) & allowed_kinds)
     if not kinds:
-        raise ValueError('No data found.')
+        raise ValueError('No electrophysiological data found.')
     elif len(kinds) >= 2:
         msg = (f'Found data of more than one recording modality. Please '
                f'pass the `kind` parameter to specify which data to load. '

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -28,7 +28,7 @@ from mne_bids.utils import (_parse_bids_filename, _extract_landmarks,
                             _find_matching_sidecar, _parse_ext,
                             _get_ch_type_mapping, make_bids_folders,
                             _estimate_line_freq, _scale_coord_to_meters,
-                            _get_kinds_for_sub)
+                            _get_kinds_for_sub, make_bids_basename)
 
 reader = {'.con': io.read_raw_kit, '.sqd': io.read_raw_kit,
           '.fif': io.read_raw_fif, '.pdf': io.read_raw_bti,
@@ -658,9 +658,9 @@ def get_matched_empty_room(bids_basename, bids_root):
 
     Returns
     -------
-    er_fname : str | None.
-        The filename corresponding to the empty-room measurement.
-        Returns None if no file found.
+    er_basename : str | None.
+        The basename corresponding to the best-matching empty-room measurement.
+        Returns None if none was found.
     """
     kind = 'meg'
     bids_fname = _make_bids_fname(bids_basename=bids_basename,
@@ -693,7 +693,22 @@ def get_matched_empty_room(bids_basename, bids_root):
             min_seconds = abs(delta_t.total_seconds())
             best_er_fname = er_fname
 
-    return best_er_fname
+    if best_er_fname is None:
+        er_basename = None
+    else:
+        params = _parse_bids_filename(best_er_fname)
+        er_basename = make_bids_basename(
+            subject=params.get('sub', None),
+            session=params.get('ses', None),
+            task=params.get('task', None),
+            acquisition=params.get('acq', None),
+            run=params.get('run', None),
+            processing=params.get('proc', None),
+            recording=params.get('recording', None),
+            space=params.get('space', None)
+        )
+
+    return er_basename
 
 
 def get_head_mri_trans(bids_basename, bids_root):

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -369,8 +369,8 @@ def _get_bids_fname_from_filesystem(*, bids_basename, bids_root, sub, ses,
     data_dir = make_bids_folders(subject=sub, session=ses, kind=kind,
                                  make_dir=False)
 
-    if op.isdir(op.join(bids_root, data_dir, f'{bids_basename}_{kind}')):
-        bti_dir = op.join(bids_root, data_dir, f'{bids_basename}_{kind}')
+     bti_dir = op.join(bids_root, data_dir, f'{bids_basename}_{kind}')
+     if op.isdir(bti_dir):
         logger.info(f'Assuming BTi data in {bti_dir}')
         bids_fname = f'{bti_dir}.pdf'
     else:

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -28,7 +28,7 @@ from mne_bids.utils import (_parse_bids_filename, _extract_landmarks,
                             _find_matching_sidecar, _parse_ext,
                             _get_ch_type_mapping, make_bids_folders,
                             _estimate_line_freq, _scale_coord_to_meters,
-                            _get_kinds_for_sub, make_bids_basename)
+                            _get_kinds_for_sub)
 
 reader = {'.con': io.read_raw_kit, '.sqd': io.read_raw_kit,
           '.fif': io.read_raw_fif, '.pdf': io.read_raw_bti,
@@ -696,7 +696,9 @@ def get_matched_empty_room(bids_basename, bids_root):
     if best_er_fname is None:
         er_basename = None
     else:
-        params = _parse_bids_filename(best_er_fname)
+        from mne_bids import make_bids_basename  # Avoid circular import.
+
+        params = _parse_bids_filename(best_er_fname, verbose='warning')
         er_basename = make_bids_basename(
             subject=params.get('sub', None),
             session=params.get('ses', None),

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -350,7 +350,7 @@ def _infer_kind(*, bids_basename, bids_root, sub, ses):
 
     # We only want to handle electrophysiological data here.
     allowed_kinds = ['meg', 'eeg', 'ieeg']
-    kinds = set(kinds) & set(allowed_kinds)
+    kinds = list(set(kinds) & set(allowed_kinds))
     if not kinds:
         raise ValueError('No electrophysiological data found.')
     elif len(kinds) >= 2:
@@ -358,10 +358,9 @@ def _infer_kind(*, bids_basename, bids_root, sub, ses):
                f'pass the `kind` parameter to specify which data to load. '
                f'Found the following kinds: {kinds}')
         raise RuntimeError(msg)
-    elif len(kinds) == 1:
-        kind = kinds[0]
 
-    return kind
+    assert len(kinds) == 1
+    return kinds[0]
 
 
 def _get_bids_fname_from_filesystem(*, bids_basename, bids_root, sub, ses,
@@ -504,17 +503,8 @@ def read_raw_bids(bids_basename, bids_root, kind=None, extra_params=None,
     ses = params['ses']
 
     if kind is None:
-        kinds = _get_kinds_for_sub(bids_basename=bids_basename,
-                                   bids_root=bids_root, sub=sub, ses=ses)
-        if not kinds:
-            raise ValueError('No data found.')
-        elif kind is None and len(kinds) == 1:
-            kind = kinds[0]
-        elif kind is None and len(kinds) >= 2:
-            msg = (f'Found data of more than one recording modality. Please '
-                   f'pass the `kind` parameter to specify which data to load. '
-                   f'Found the following kinds: {kinds}')
-            raise RuntimeError(msg)
+        kind = _infer_kind(bids_basename=bids_basename, bids_root=bids_root,
+                           sub=sub, ses=ses)
 
     data_dir = make_bids_folders(subject=sub, session=ses, kind=kind,
                                  make_dir=False)

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -349,8 +349,8 @@ def _infer_kind(*, bids_basename, bids_root, sub, ses):
                                bids_root=bids_root, sub=sub, ses=ses)
 
     # We only want to handle electrophysiological data here.
-    allowed_kinds = set(['meg', 'eeg', 'ieeg'])
-    kinds = list(set(kinds) & allowed_kinds)
+    allowed_kinds = ['meg', 'eeg', 'ieeg']
+    kinds = set(kinds) & set(allowed_kinds)
     if not kinds:
         raise ValueError('No electrophysiological data found.')
     elif len(kinds) >= 2:

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -27,7 +27,8 @@ from mne_bids.config import (ALLOWED_EXTENSIONS, _convert_hand_options,
 from mne_bids.utils import (_parse_bids_filename, _extract_landmarks,
                             _find_matching_sidecar, _parse_ext,
                             _get_ch_type_mapping, make_bids_folders,
-                            _estimate_line_freq, _scale_coord_to_meters)
+                            _estimate_line_freq, _scale_coord_to_meters,
+                            _get_kinds_for_sub)
 
 reader = {'.con': io.read_raw_kit, '.sqd': io.read_raw_kit,
           '.fif': io.read_raw_fif, '.pdf': io.read_raw_bti,
@@ -340,7 +341,118 @@ def _handle_channels_reading(channels_fname, bids_fname, raw):
     return raw
 
 
-def read_raw_bids(bids_fname, bids_root, extra_params=None, verbose=True):
+def _infer_kind(*, bids_basename, bids_root, sub, ses):
+    # Check which kind is available for this particular
+    # subject & session. If we get no or multiple hits, throw an error.
+
+    kinds = _get_kinds_for_sub(bids_basename=bids_basename,
+                               bids_root=bids_root, sub=sub, ses=ses)
+    if not kinds:
+        raise ValueError('No data found.')
+    elif len(kinds) >= 2:
+        msg = (f'Found data of more than one recording modality. Please '
+               f'pass the `kind` parameter to specify which data to load. '
+               f'Found the following kinds: {kinds}')
+        raise RuntimeError(msg)
+    elif len(kinds) == 1:
+        kind = kinds[0]
+
+    return kind
+
+
+def _get_bids_fname_from_filesystem(*, bids_basename, bids_root, sub, ses,
+                                    kind):
+    if kind is None:
+        kind = _infer_kind(bids_basename=bids_basename, bids_root=bids_root,
+                           sub=sub, ses=ses)
+
+    data_dir = make_bids_folders(subject=sub, session=ses, kind=kind,
+                                 make_dir=False)
+
+    if op.isdir(op.join(bids_root, data_dir, f'{bids_basename}_{kind}')):
+        bti_dir = op.join(bids_root, data_dir, f'{bids_basename}_{kind}')
+        logger.info(f'Assuming BTi data in {bti_dir}')
+        bids_fname = f'{bti_dir}.pdf'
+    else:
+        # Find all matching files in all supported formats.
+        valid_exts = list(reader.keys())
+        matching_paths = glob.glob(op.join(bids_root, data_dir,
+                                           f'{bids_basename}_{kind}.*'))
+        matching_paths = [p for p in matching_paths
+                          if _parse_ext(p)[1] in valid_exts]
+
+        if not matching_paths:
+            msg = ('Could not locate a data file of a supported format. This '
+                   'is likely a problem with your BIDS dataset. Please run '
+                   'the BIDS validator on your data.')
+            raise RuntimeError(msg)
+
+        # FIXME This will break e.g. with FIFF data split across multiple
+        # FIXME files.
+        if len(matching_paths) > 1:
+            msg = ('Found more than one matching data file for the requested '
+                   'recording. Cannot proceed due to the ambiguity. This is '
+                   'likely a problem with your BIDS dataset. Please run the '
+                   'BIDS validator on your data.')
+            raise RuntimeError(msg)
+
+        matching_path = matching_paths[0]
+        bids_fname = op.basename(matching_path)
+
+    return bids_fname
+
+
+def make_bids_fname(bids_basename, bids_root=None, kind=None, extension=None,
+                    verbose=False):
+    """
+    Construct the filename of a BIDS data file.
+
+    Parameters
+    ----------
+    bids_basename : str
+        The base filename of the BIDS-compatible files. Typically, this can be
+        generated using :func:`mne_bids.make_bids_basename`.
+    bids_root : str | pathlib.Path | None
+        Path to root of the BIDS folder
+    kind : str | None
+        The kind of recording to read. If ``None`` and only one kind (e.g.,
+        only EEG or only MEG data) is present in the dataset, it will be
+        selected automatically.
+    extra_params : None | dict
+        Extra parameters to be passed to MNE read_raw_* functions.
+        If a dict, for example: ``extra_params=dict(allow_maxshield=True)``.
+    extension : None | str
+        If ``None``, try to infer the filename extension by searching for the
+        file on disk. If the file cannot be found, an error will be raised. To
+        disable this automatic inference attempt, pass a string (like
+        ``'.fif'`` or ``'.vhdr'``). If an empty string is passed, no extension
+        will be added to the filename.
+    verbose : bool
+        The verbosity level.
+
+    """
+    # Get the BIDS parameters (=entities)
+    params = _parse_bids_filename(bids_basename, verbose)
+    sub = params['sub']
+    ses = params['ses']
+
+    if extension is None and bids_root is None:
+        msg = ('No filename extension was provided, and it cannot be '
+               'automatically inferred because no bids_root was passed.')
+        raise ValueError(msg)
+
+    if extension is None:
+        bids_fname = _get_bids_fname_from_filesystem(
+            bids_basename=bids_basename, bids_root=bids_root, sub=sub, ses=ses,
+            kind=kind)
+    else:
+        bids_fname = f'{bids_basename}_{kind}.{extension}'
+
+    return bids_fname
+
+
+def read_raw_bids(bids_basename, bids_root, kind=None, extra_params=None,
+                  verbose=True):
     """Read BIDS compatible data.
 
     Will attempt to read associated events.tsv and channels.tsv files to
@@ -348,50 +460,72 @@ def read_raw_bids(bids_fname, bids_root, extra_params=None, verbose=True):
 
     Parameters
     ----------
-    bids_fname : str
-        Full name of the data file
+    bids_basename : str
+        The base filename of the BIDS compatible files. Typically, this can be
+        generated using :func:`mne_bids.make_bids_basename`.
     bids_root : str | pathlib.Path
         Path to root of the BIDS folder
+    kind : str | None
+        The kind of recording to read. If ``None`` and only one kind (e.g.,
+        only EEG or only MEG data) is present in the dataset, it will be
+        selected automatically.
     extra_params : None | dict
         Extra parameters to be passed to MNE read_raw_* functions.
         If a dict, for example: ``extra_params=dict(allow_maxshield=True)``.
     verbose : bool
-        The verbosity level
+        The verbosity level.
 
     Returns
     -------
     raw : instance of Raw
         The data as MNE-Python Raw object.
 
+    Raises
+    ------
+    RuntimeError
+        If multiple recording kinds are present in the dataset, but
+        ``kind=None``.
+
+    RuntimeError
+        If more than one data files exist for the specified recording.
+
+    RuntimeError
+        If no data file in a supported format can be located.
+
+    ValueError
+        If the specified ``kind`` cannot be found in the dataset.
+
     """
-    # Full path to data file is needed so that mne-bids knows
-    # what is the modality -- meg, eeg, ieeg to read
-    bids_fname = op.basename(bids_fname)
-    bids_basename = '_'.join(bids_fname.split('_')[:-1])
-    kind = bids_fname.split('_')[-1].split('.')[0]
-    _, ext = _parse_ext(bids_fname)
+    params = _parse_bids_filename(bids_basename, verbose='warning')
+    sub = params['sub']
+    ses = params['ses']
 
-    # Get the BIDS parameters (=entities)
-    params = _parse_bids_filename(bids_basename, verbose)
+    if kind is None:
+        kinds = _get_kinds_for_sub(bids_basename=bids_basename,
+                                   bids_root=bids_root, sub=sub, ses=ses)
+        if not kinds:
+            raise ValueError('No data found.')
+        elif kind is None and len(kinds) == 1:
+            kind = kinds[0]
+        elif kind is None and len(kinds) >= 2:
+            msg = (f'Found data of more than one recording modality. Please '
+                   f'pass the `kind` parameter to specify which data to load. '
+                   f'Found the following kinds: {kinds}')
+            raise RuntimeError(msg)
 
-    # Construct the path to the "kind" where the data is stored
-    # Subject is mandatory ...
-    kind_dir = op.join(bids_root, 'sub-{}'.format(params['sub']))
-    # Session is optional ...
-    if params['ses'] is not None:
-        kind_dir = op.join(kind_dir, 'ses-{}'.format(params['ses']))
-    # Kind is mandatory
-    kind_dir = op.join(kind_dir, kind)
+    data_dir = make_bids_folders(subject=sub, session=ses, kind=kind,
+                                 make_dir=False)
+    bids_fname = make_bids_fname(bids_basename=bids_basename,
+                                 bids_root=bids_root, kind=kind)
 
-    config = None
-    if ext in ('.fif', '.ds', '.vhdr', '.edf', '.bdf', '.set', '.sqd', '.con'):
-        bids_fpath = op.join(kind_dir,
-                             bids_basename + '_{}{}'.format(kind, ext))
-
-    elif ext == '.pdf':
-        bids_raw_folder = op.join(kind_dir, bids_basename + '_{}'.format(kind))
+    if op.splitext(bids_fname)[1] == '.pdf':
+        bids_raw_folder = op.join(bids_root, data_dir,
+                                  f'{bids_basename}_{kind}')
         bids_fpath = glob.glob(op.join(bids_raw_folder, 'c,rf*'))[0]
         config = op.join(bids_raw_folder, 'config')
+    else:
+        bids_fpath = op.join(bids_root, data_dir, bids_fname)
+        config = None
 
     if extra_params is None:
         extra_params = dict()
@@ -496,7 +630,8 @@ def read_raw_bids(bids_fname, bids_root, extra_params=None, verbose=True):
 
     # read in associated subject info from participants.tsv
     participants_tsv_fpath = op.join(bids_root, 'participants.tsv')
-    subject = "sub-" + params['sub']
+    params = _parse_bids_filename(bids_basename, verbose='warning')
+    subject = f"sub-{params['sub']}"
     if op.exists(participants_tsv_fpath):
         raw = _handle_participants_reading(participants_tsv_fpath, raw,
                                            subject, verbose=verbose)
@@ -507,26 +642,30 @@ def read_raw_bids(bids_fname, bids_root, extra_params=None, verbose=True):
     return raw
 
 
-def get_matched_empty_room(bids_fname, bids_root):
-    """Get matching empty room file.
+def get_matched_empty_room(bids_basename, bids_root):
+    """Get matching empty-room file for an MEG recording.
 
     Parameters
     ----------
-    bids_fname : str
-        The filename for which to find the matching empty room file.
+    bids_basename : str
+        The base filename of the BIDS-compatible file. Typically, this can be
+        generated using :func:`mne_bids.make_bids_basename`.
     bids_root : str | pathlib.Path
         Path to the BIDS root folder.
 
     Returns
     -------
     er_fname : str | None.
-        The filename corresponding to the empty room.
+        The filename corresponding to the empty-room measurement.
         Returns None if no file found.
     """
-    bids_fname = op.basename(bids_fname)
+    kind = 'meg'
+    bids_fname = make_bids_fname(bids_basename=bids_basename,
+                                 bids_root=bids_root, kind=kind)
     _, ext = _parse_ext(bids_fname)
 
-    raw = read_raw_bids(bids_fname, bids_root)
+    raw = read_raw_bids(bids_basename=bids_basename, bids_root=bids_root,
+                        kind='meg')
     if raw.info['meas_date'] is None:
         raise ValueError('Measurement date not available. Cannot get matching'
                          ' empty room file')
@@ -554,7 +693,7 @@ def get_matched_empty_room(bids_fname, bids_root):
     return best_er_fname
 
 
-def get_head_mri_trans(bids_fname, bids_root):
+def get_head_mri_trans(bids_basename, bids_root):
     """Produce transformation matrix from MEG and MRI landmark points.
 
     Will attempt to read the landmarks of Nasion, LPA, and RPA from the sidecar
@@ -564,8 +703,9 @@ def get_head_mri_trans(bids_fname, bids_root):
 
     Parameters
     ----------
-    bids_fname : str
-        Full name of the MEG data file
+    bids_basename : str
+        The base filename of the BIDS-compatible file. Typically, this can be
+        generated using :func:`mne_bids.make_bids_basename`.
     bids_root : str | pathlib.Path
         Path to root of the BIDS folder
 
@@ -580,7 +720,8 @@ def get_head_mri_trans(bids_fname, bids_root):
     import nibabel as nib
 
     # Get the sidecar file for MRI landmarks
-    bids_fname = op.basename(bids_fname)
+    bids_fname = make_bids_fname(bids_basename=bids_basename,
+                                 bids_root=bids_root, kind='meg')
     t1w_json_path = _find_matching_sidecar(bids_fname, bids_root, 'T1w.json')
 
     # Get MRI landmarks from the JSON sidecar
@@ -623,7 +764,8 @@ def get_head_mri_trans(bids_fname, bids_root):
     if ext == '.fif':
         extra_params = dict(allow_maxshield=True)
 
-    raw = read_raw_bids(bids_fname, bids_root, extra_params=extra_params)
+    raw = read_raw_bids(bids_basename=bids_basename, bids_root=bids_root,
+                        extra_params=extra_params, kind='meg')
     meg_coords_dict = _extract_landmarks(raw.info['dig'])
     meg_landmarks = np.asarray((meg_coords_dict['LPA'],
                                 meg_coords_dict['NAS'],

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -369,8 +369,8 @@ def _get_bids_fname_from_filesystem(*, bids_basename, bids_root, sub, ses,
     data_dir = make_bids_folders(subject=sub, session=ses, kind=kind,
                                  make_dir=False)
 
-     bti_dir = op.join(bids_root, data_dir, f'{bids_basename}_{kind}')
-     if op.isdir(bti_dir):
+    bti_dir = op.join(bids_root, data_dir, f'{bids_basename}_{kind}')
+    if op.isdir(bti_dir):
         logger.info(f'Assuming BTi data in {bti_dir}')
         bids_fname = f'{bti_dir}.pdf'
     else:

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -616,4 +616,3 @@ def test_read_raw_kind():
 
     assert raw_1 == raw_2
     assert raw_1 == raw_3
-

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -588,3 +588,26 @@ def test_read_raw_bids_pathlike():
                    verbose=False)
     raw = read_raw_bids(bids_basename=bids_basename, bids_root=Path(bids_root),
                         kind='meg')
+
+
+@pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
+def test_read_raw_kind():
+    """Test that read_raw_bids() can infer the kind if need be."""
+    bids_root = _TempDir()
+    raw = mne.io.read_raw_fif(raw_fname, verbose=False)
+    write_raw_bids(raw, bids_basename, bids_root, overwrite=True,
+                   verbose=False)
+
+    raw_1 = read_raw_bids(bids_basename=bids_basename, bids_root=bids_root,
+                          kind='meg')
+    raw_2 = read_raw_bids(bids_basename=bids_basename, bids_root=bids_root,
+                          kind=None)
+    raw_3 = read_raw_bids(bids_basename=bids_basename, bids_root=bids_root)
+
+    raw_1.crop(0, 2).load_data()
+    raw_2.crop(0, 2).load_data()
+    raw_3.crop(0, 2).load_data()
+
+    assert raw_1 == raw_2
+    assert raw_1 == raw_3
+

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -361,7 +361,8 @@ def test_handle_ieeg_coords_reading():
                        overwrite=True, verbose=False)
         # read in raw file w/ updated coordinate frame
         # and make sure all digpoints are correct coordinate frames
-        raw_test = read_raw_bids(bids_fname, bids_root)
+        raw_test = read_raw_bids(bids_basename=bids_basename,
+                                 bids_root=bids_root, verbose=False)
         coord_frame_int = MNE_IEEG_COORD_FRAME_DICT[coord_frame]
         for digpoint in raw_test.info['dig']:
             assert digpoint['coord_frame'] == coord_frame_int
@@ -403,7 +404,8 @@ def test_handle_ieeg_coords_reading():
     _to_tsv(electrodes_dict, electrodes_fname)
     with pytest.warns(RuntimeWarning, match='Coordinate unit '
                                             'is not an accepted BIDS'):
-        raw_test = read_raw_bids(bids_fname, bids_root, verbose=False)
+        raw_test = read_raw_bids(bids_basename=bids_basename,
+                                 bids_root=bids_root, verbose=False)
 
     # correct BIDS units should scale to meters properly
     for coord_unit, scaling in scalings.items():
@@ -417,7 +419,8 @@ def test_handle_ieeg_coords_reading():
         _to_tsv(electrodes_dict, electrodes_fname)
 
         # read in raw file w/ updated montage
-        raw_test = read_raw_bids(bids_fname, bids_root, verbose=False)
+        raw_test = read_raw_bids(bids_basename=bids_basename,
+                                 bids_root=bids_root, verbose=False)
 
         # obtain the sensor positions and make sure they're the same
         assert_dig_allclose(raw.info, raw_test.info)
@@ -433,12 +436,14 @@ def test_handle_ieeg_coords_reading():
         # and make sure all digpoints are MRI coordinate frame
         with pytest.warns(RuntimeWarning, match="Coordinate frame is "
                                                 "not accepted BIDS keyword"):
-            raw_test = read_raw_bids(bids_fname, bids_root, verbose=False)
+            raw_test = read_raw_bids(bids_basename=bids_basename,
+                                     bids_root=bids_root, verbose=False)
             assert raw_test.info['dig'] is None
 
     # ACPC should be read in as RAS for iEEG
     _update_sidecar(coordsystem_fname, 'iEEGCoordinateSystem', 'acpc')
-    raw_test = read_raw_bids(bids_fname, bids_root, verbose=False)
+    raw_test = read_raw_bids(bids_basename=bids_basename, bids_root=bids_root,
+                             verbose=False)
     coord_frame_int = MNE_IEEG_COORD_FRAME_DICT['ras']
     for digpoint in raw_test.info['dig']:
         assert digpoint['coord_frame'] == coord_frame_int
@@ -453,7 +458,7 @@ def test_handle_ieeg_coords_reading():
     _to_tsv(electrodes_dict, electrodes_fname)
     with pytest.raises(RuntimeError, match='Channels do not correspond'):
         raw_test = read_raw_bids(bids_basename=bids_basename,
-                                 bids_root=bids_root)
+                                 bids_root=bids_root, verbose=False)
 
     # make sure montage is set if there are coordinates w/ 'n/a'
     raw.info['bads'] = []
@@ -471,7 +476,8 @@ def test_handle_ieeg_coords_reading():
     nan_chs = [electrodes_dict['name'][i] for i in [0, 3]]
     with pytest.warns(RuntimeWarning, match='There are channels '
                                             'without locations'):
-        raw = read_raw_bids(bids_basename=bids_basename, bids_root=bids_root)
+        raw = read_raw_bids(bids_basename=bids_basename, bids_root=bids_root,
+                            verbose=False)
         for idx, ch in enumerate(raw.info['chs']):
             if ch['ch_name'] in nan_chs:
                 assert all(np.isnan(ch['loc'][:3]))

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -528,9 +528,9 @@ def test_get_matched_empty_room():
                                        task='audiovisual', run='01')
     write_raw_bids(raw, bids_basename, bids_root, overwrite=True)
 
-    er_fname = get_matched_empty_room(bids_basename=bids_basename,
-                                      bids_root=bids_root)
-    assert er_fname is None
+    er_basename = get_matched_empty_room(bids_basename=bids_basename,
+                                         bids_root=bids_root)
+    assert er_basename is None
 
     # testing data has no noise recording, so save the actual data
     # as if it were noise
@@ -547,9 +547,9 @@ def test_get_matched_empty_room():
                                           task='noise', session=er_date)
     write_raw_bids(er_raw, er_bids_basename, bids_root, overwrite=True)
 
-    er_fname = get_matched_empty_room(bids_basename=bids_basename,
-                                      bids_root=bids_root)
-    assert er_bids_basename in er_fname
+    recovered_er_basename = get_matched_empty_room(bids_basename=bids_basename,
+                                                   bids_root=bids_root)
+    assert er_bids_basename == recovered_er_basename
 
     # assert that we get best emptyroom if there are multiple available
     sh.rmtree(op.join(bids_root, 'sub-emptyroom'))
@@ -566,9 +566,9 @@ def test_get_matched_empty_room():
             er_raw.info['meas_date'] = (er_meas_date.timestamp(), 0)
         write_raw_bids(er_raw, er_bids_basename, bids_root)
 
-    best_er_fname = get_matched_empty_room(bids_basename=bids_basename,
-                                           bids_root=bids_root)
-    assert '20021204' in best_er_fname
+    best_er_basename = get_matched_empty_room(bids_basename=bids_basename,
+                                              bids_root=bids_root)
+    assert '20021204' in best_er_basename
 
     # assert that we get error if meas_date is not available.
     raw = read_raw_bids(bids_basename=bids_basename, bids_root=bids_root,

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -55,6 +55,20 @@ def get_kinds(bids_root):
     return kinds
 
 
+def _get_kinds_for_sub(*, bids_basename, bids_root, sub, ses=None):
+    """Retrieve available data kinds for a specific subject and session."""
+    subject_dir = op.join(bids_root, f'sub-{sub}')
+    if ses is not None:
+        subject_dir = op.join(subject_dir, f'ses-{ses}')
+
+    # TODO We do this to ensure we don't accidentally pick up any "spurious"
+    # TODO sub-directories. But is that really necessary with valid BIDS data?
+    kinds_in_dataset = get_kinds(bids_root=bids_root)
+    subdirs = [f.name for f in os.scandir(subject_dir) if f.is_dir()]
+    available_kinds = [s for s in subdirs if s in kinds_in_dataset]
+    return available_kinds
+
+
 def _ensure_tuple(x):
     """Return a tuple."""
     if x is None:


### PR DESCRIPTION
<strike>And drop `bids_fname` in favor of `bids_basename`. The filename is automatically populated based on `bids_basename`, `bids_root` and `kind`.

**This is still WIP, as it's already working, but not all tests have been adjusted yet, so CI will fail.**</strike>

See https://github.com/mne-tools/mne-bids/pull/410#issuecomment-629804329

Closes #408.

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [x] All comments resolved
- [x] This is not your own PR
- [x] All CIs are happy
- [x] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [x] PR description includes phrase "closes <#issue-number>"
- [x] Commit history does not contain any merge commits
