### PR TITLE
TESTS: Support non-global bids-validator in test_write.py; fix one test to work with mne-python:master

### DIFF
--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -81,17 +81,18 @@ warning_str = dict(
 @pytest.fixture(scope="session")
 def _bids_validate():
     """Fixture to run BIDS validator."""
-    shell = False
-    bids_validator_exe = ['bids-validator', '--config.error=41',
-                          '--config.error=41']
+    vadlidator_args = ['--config.error=41']
+    exe = os.getenv('VALIDATOR_EXECUTABLE', 'bids-validator')
+
     if platform.system() == 'Windows':
         shell = True
-        exe = os.getenv('VALIDATOR_EXECUTABLE', 'n/a')
-        if 'VALIDATOR_EXECUTABLE' != 'n/a':
-            bids_validator_exe = ['node', exe]
+        bids_validator_exe = ['node', exe, *vadlidator_args]
+    else:
+        shell = False
+        bids_validator_exe = [exe, *vadlidator_args]
 
     def _validate(bids_root):
-        cmd = bids_validator_exe + [bids_root]
+        cmd = [*bids_validator_exe, bids_root]
         run_subprocess(cmd, shell=shell)
 
     return _validate

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -953,8 +953,14 @@ def test_write_anat(_bids_validate):
 
     # trans has a wrong type
     wrong_type = 1
-    match = f'trans must be an instance of .*, got {type(wrong_type)} instead'
-    with pytest.raises(TypeError, match=match):
+    if check_version('mne', min_version='0.21'):
+        match = f'trans must be an instance of .*, got {type(wrong_type)} '
+        ex = TypeError
+    else:
+        match = f'transform type {type(wrong_type)} not known, must be'
+        ex = ValueError
+
+    with pytest.raises(ex, match=match):
         write_anat(bids_root, subject_id, t1w_mgh, session_id, raw=raw,
                    trans=wrong_type, verbose=True, deface=False,
                    overwrite=True)

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -953,8 +953,8 @@ def test_write_anat(_bids_validate):
 
     # trans has a wrong type
     wrong_type = 1
-    match = 'transform type {} not known, must be'.format(type(wrong_type))
-    with pytest.raises(ValueError, match=match):
+    match = f'trans must be an instance of .*, got {type(wrong_type)} instead'
+    with pytest.raises(TypeError, match=match):
         write_anat(bids_root, subject_id, t1w_mgh, session_id, raw=raw,
                    trans=wrong_type, verbose=True, deface=False,
                    overwrite=True)


### PR DESCRIPTION
PR Description
--------------
- I cannot install `bids-validator` (or node) globally, so I'm now leveraging the `VALIDATOR_EXECUTABLE` environment variable from `test_write.py` to allow the user to pass a custom executable path to the test
- After was able run the tests thanks to this adjustment, I realized one of them kept failing <strike>because it expected an exception (from MNE) that simply has a different type and phrasing upstream. So I fixed this. Makes me wonder why our CI never caught this, and</strike> with `mne-python:master`. Wonder if we shouldn't remove this particular test altogether anyway, because it just checks if MNE raises a certain exception. That should be ensured through unit tests upstream…

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
- [ ] Commit history does not contain any merge commits
