### PR TITLE
TESTS: Support non-global validator in test_write

### DIFF
--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -81,17 +81,18 @@ warning_str = dict(
 @pytest.fixture(scope="session")
 def _bids_validate():
     """Fixture to run BIDS validator."""
-    shell = False
-    bids_validator_exe = ['bids-validator', '--config.error=41',
-                          '--config.error=41']
+    vadlidator_args = ['--config.error=41']
+    exe = os.getenv('VALIDATOR_EXECUTABLE', 'bids-validator')
+
     if platform.system() == 'Windows':
         shell = True
-        exe = os.getenv('VALIDATOR_EXECUTABLE', 'n/a')
-        if 'VALIDATOR_EXECUTABLE' != 'n/a':
-            bids_validator_exe = ['node', exe]
+        bids_validator_exe = ['node', exe, *vadlidator_args]
+    else:
+        shell = False
+        bids_validator_exe = [exe, *vadlidator_args]
 
     def _validate(bids_root):
-        cmd = bids_validator_exe + [bids_root]
+        cmd = [*bids_validator_exe, bids_root]
         run_subprocess(cmd, shell=shell)
 
     return _validate


### PR DESCRIPTION
PR Description
--------------

I cannot install `bids-validator `(or node) globally on our Linux server, so I'm now leveraging the `VALIDATOR_EXECUTABLE` environment variable from `test_write.py` to allow the user to pass a custom executable path to the test

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
- [ ] Commit history does not contain any merge commits
