### PR TITLE
TESTS: Fix a test to work with MNE master

### DIFF
--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -952,8 +952,14 @@ def test_write_anat(_bids_validate):
 
     # trans has a wrong type
     wrong_type = 1
-    match = 'transform type {} not known, must be'.format(type(wrong_type))
-    with pytest.raises(ValueError, match=match):
+    if check_version('mne', min_version='0.21'):
+        match = f'trans must be an instance of .*, got {type(wrong_type)} '
+        ex = TypeError
+    else:
+        match = f'transform type {type(wrong_type)} not known, must be'
+        ex = ValueError
+
+    with pytest.raises(ex, match=match):
         write_anat(bids_root, subject_id, t1w_mgh, session_id, raw=raw,
                    trans=wrong_type, verbose=True, deface=False,
                    overwrite=True)


### PR DESCRIPTION
PR Description
--------------

`mne-python:master` has changed an exception, breaking one of our tests.

Makes you wonder whether this particular test should maybe be dropped anyway, as it's essentially testing MNE functionality that should be tested upstream! (We're not catching this exception in `mne-bids`. So, when the test is run, it will simply retrieve and test the exception raised by `mne-python`)

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
- [ ] Commit history does not contain any merge commits
