### PR TITLE
[MRG] propagate `verbose` in `write_raw_bids` to `utils._read_events`

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -270,3 +270,4 @@ People who contributed to this release (in alphabetical order):
 .. _Richard Höchenberger: https://github.com/hoechenberger
 .. _Alexandre Gramfort: http://alexandre.gramfort.net
 .. _Ariel Rokem: https://github.com/arokem
+.. _Evgenii Kalenkovich: https://github.com/kalenkovich

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -30,7 +30,6 @@ Changelog
 - :func:`mne_bids.write_raw_bids` now writes CoordinateSystemDescription as specified in BIDS Specification if CoordinateSystem is MNE-compatible, by `Adam Li`_ (`#416 <https://github.com/mne-tools/mne-bids/pull/416>`_)
 - :func:`mne_bids.write_raw_bids` and :func:`mne_bids.read_raw_bids` now handle scalp EEG if Captrak coordinate system and NAS/LPA/RPA landmarks are present, by `Adam Li`_ (`#416 <https://github.com/mne-tools/mne-bids/pull/416>`_)
 - :func:`mne_bids.get_matched_empty_room` now implements an algorithm for discovering empty-room recordings that do not have the recording date set as their session, by `Richard Höchenberger`_ (`#421 <https://github.com/mne-tools/mne-bids/pull/421>`_)
-- :func:`mne_bids.write_raw_bids` now applies `verbose` to the functions that read events, by `Evgenii Kalenkovich`_ (`#453 <https://github.com/mne-tools/mne-bids/pull/453>`_)
 
 Bug
 ~~~
@@ -42,6 +41,7 @@ Bug
 - fix coordystem reading in :func:`mne_bids.read_raw_bids` for cases where the ``acq`` is undefined, by `Stefan Appelhoff`_ (`#440 <https://github.com/mne-tools/mne-bids/pull/440>`_)
 - Calling :func:`write_raw_bids` with `overwrite==True` will preserve existing entries in ``participants.tsv`` and ``participants.json`` if the **new** dataset does not contain these entries, by `Adam Li`_ (`#442 <https://github.com/mne-tools/mne-bids/pull/442>`_)
 - Fix BIDS entity using 'recording' to be 'rec' in filenames, as in specification by `Adam Li`_ (`#446 <https://github.com/mne-tools/mne-bids/pull/446>`_)
+- :func:`mne_bids.write_raw_bids` now applies `verbose` to the functions that read events, by `Evgenii Kalenkovich`_ (`#453 <https://github.com/mne-tools/mne-bids/pull/453>`_)
 
 API
 ~~~

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -30,6 +30,7 @@ Changelog
 - :func:`mne_bids.write_raw_bids` now writes CoordinateSystemDescription as specified in BIDS Specification if CoordinateSystem is MNE-compatible, by `Adam Li`_ (`#416 <https://github.com/mne-tools/mne-bids/pull/416>`_)
 - :func:`mne_bids.write_raw_bids` and :func:`mne_bids.read_raw_bids` now handle scalp EEG if Captrak coordinate system and NAS/LPA/RPA landmarks are present, by `Adam Li`_ (`#416 <https://github.com/mne-tools/mne-bids/pull/416>`_)
 - :func:`mne_bids.get_matched_empty_room` now implements an algorithm for discovering empty-room recordings that do not have the recording date set as their session, by `Richard Höchenberger`_ (`#421 <https://github.com/mne-tools/mne-bids/pull/421>`_)
+- :func:`mne_bids.write_raw_bids` now applies `verbose` to the functions that read events, by `Evgenii Kalenkovich`_ (`#453 <https://github.com/mne-tools/mne-bids/pull/453>`_)
 
 Bug
 ~~~

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -20,7 +20,7 @@ from copy import deepcopy
 
 import numpy as np
 from mne import read_events, find_events, events_from_annotations
-from mne.utils import check_version, warn, logger
+from mne.utils import check_version, warn, logger, verbose
 from mne.channels import make_standard_montage
 from mne.io.pick import pick_types
 from mne.io.kit.kit import get_kit_info
@@ -710,6 +710,7 @@ def _check_key_val(key, val):
     return key, val
 
 
+@verbose
 def _read_events(events_data, event_id, raw, ext, verbose=False):
     """Read in events data.
 

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -727,8 +727,7 @@ def _read_events(events_data, event_id, raw, ext, verbose=None):
     ext : str
         The extension of the original data file.
     verbose : bool | str | int | None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        and :ref:`Logging documentation <tut_logging>` for more).
+        If not None, override default verbose level (see :func:`mne.verbose`).
 
     Returns
     -------

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -20,7 +20,7 @@ from copy import deepcopy
 
 import numpy as np
 from mne import read_events, find_events, events_from_annotations
-from mne.utils import check_version, warn, logger, verbose
+from mne.utils import check_version, warn, logger
 from mne.channels import make_standard_montage
 from mne.io.pick import pick_types
 from mne.io.kit.kit import get_kit_info

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -710,7 +710,6 @@ def _check_key_val(key, val):
     return key, val
 
 
-@verbose
 def _read_events(events_data, event_id, raw, ext, verbose=False):
     """Read in events data.
 
@@ -727,7 +726,9 @@ def _read_events(events_data, event_id, raw, ext, verbose=False):
         The data as MNE-Python Raw object.
     ext : str
         The extension of the original data file.
-    %(verbose)s
+    verbose : bool | str | int | None
+        If not None, override default verbose level (see :func:`mne.verbose`
+        and :ref:`Logging documentation <tut_logging>` for more).
 
     Returns
     -------

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -749,9 +749,11 @@ def _read_events(events_data, event_id, raw, ext, verbose=False):
                              'found %s' % events_data.shape[1])
         events = events_data
     elif 'stim' in raw:
-        events = find_events(raw, min_duration=0.001, initial_event=True, verbose=verbose)
+        events = find_events(raw, min_duration=0.001, initial_event=True,
+                             verbose=verbose)
     elif ext in ['.vhdr', '.set'] and check_version('mne', '0.18'):
-        events, event_id = events_from_annotations(raw, event_id, verbose=verbose)
+        events, event_id = events_from_annotations(raw, event_id,
+                                                   verbose=verbose)
     else:
         warn('No events found or provided. Please make sure to'
              ' set channel type using raw.set_channel_types'

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -710,7 +710,7 @@ def _check_key_val(key, val):
     return key, val
 
 
-def _read_events(events_data, event_id, raw, ext, verbose=False):
+def _read_events(events_data, event_id, raw, ext, verbose=None):
     """Read in events data.
 
     Parameters

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -710,7 +710,7 @@ def _check_key_val(key, val):
     return key, val
 
 
-def _read_events(events_data, event_id, raw, ext):
+def _read_events(events_data, event_id, raw, ext, verbose=False):
     """Read in events data.
 
     Parameters
@@ -726,6 +726,7 @@ def _read_events(events_data, event_id, raw, ext):
         The data as MNE-Python Raw object.
     ext : str
         The extension of the original data file.
+    %(verbose)s
 
     Returns
     -------
@@ -737,7 +738,7 @@ def _read_events(events_data, event_id, raw, ext):
 
     """
     if isinstance(events_data, str):
-        events = read_events(events_data).astype(int)
+        events = read_events(events_data, verbose=verbose).astype(int)
     elif isinstance(events_data, np.ndarray):
         if events_data.ndim != 2:
             raise ValueError('Events must have two dimensions, '
@@ -747,9 +748,9 @@ def _read_events(events_data, event_id, raw, ext):
                              'found %s' % events_data.shape[1])
         events = events_data
     elif 'stim' in raw:
-        events = find_events(raw, min_duration=0.001, initial_event=True)
+        events = find_events(raw, min_duration=0.001, initial_event=True, verbose=verbose)
     elif ext in ['.vhdr', '.set'] and check_version('mne', '0.18'):
-        events, event_id = events_from_annotations(raw, event_id)
+        events, event_id = events_from_annotations(raw, event_id, verbose=verbose)
     else:
         warn('No events found or provided. Please make sure to'
              ' set channel type using raw.set_channel_types'

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1107,7 +1107,8 @@ def write_raw_bids(raw, bids_basename, bids_root, events_data=None,
                        'is not supported for kind "{}". '
                        'Skipping ...'.format(kind))
 
-    events, event_id = _read_events(events_data, event_id, raw, ext, verbose=verbose)
+    events, event_id = _read_events(events_data, event_id, raw, ext,
+                                    verbose=verbose)
     if events is not None and len(events) > 0 and not emptyroom:
         _events_tsv(events, raw, events_fname, event_id, overwrite, verbose)
 

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1107,7 +1107,7 @@ def write_raw_bids(raw, bids_basename, bids_root, events_data=None,
                        'is not supported for kind "{}". '
                        'Skipping ...'.format(kind))
 
-    events, event_id = _read_events(events_data, event_id, raw, ext)
+    events, event_id = _read_events(events_data, event_id, raw, ext, verbose=verbose)
     if events is not None and len(events) > 0 and not emptyroom:
         _events_tsv(events, raw, events_fname, event_id, overwrite, verbose)
 


### PR DESCRIPTION
PR Description
--------------

The parameter `verbose` of `write_raw_bids` was not passed to `utils._read_raw_bids` which didn't have the `verbose` parameter at all. Consequently, `utils._read_raw_bids` did not pass the non-existent parameter to `read_events`, `find_events`, and `events_from_annotations`.

What has been done:

- added `verbose` parameter to `utils._read_raw_bids`,
- passed `verbose` in `write_raw_bids` to `utils._read_raw_bids`
- passed `verbose` in `utils._read_raw_bids` to `read_events`, `find_events`, and `events_from_annotations`

closes #448 

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [x] All comments resolved
- [x] This is not your own PR
- [x] All CIs are happy
- [x] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [x] PR description includes phrase "closes <#issue-number>"
- [x] Commit history does not contain any merge commits
