### PR TITLE
[MRG] Fixed kwargs issue breaking raw_to_bids

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -43,6 +43,8 @@ Bug
 - Fix BIDS entity using 'recording' to be 'rec' in filenames, as in specification by `Adam Li`_ (`#446 <https://github.com/mne-tools/mne-bids/pull/446>`_)
 - Fix :func:`write_raw_bids` when `info['dig']` is `None` by `Alexandre Gramfort`_ (`#452 <https://github.com/mne-tools/mne-bids/pull/452>`_)
 - :func:`mne_bids.write_raw_bids` now applies `verbose` to the functions that read events, by `Evgenii Kalenkovich`_ (`#453 <https://github.com/mne-tools/mne-bids/pull/453>`_)
+- Fix `raw_to_bids` CLI tool to work with non-FIF files, by `Austin Hurst`_ (`#456 <https://github.com/mne-tools/mne-bids/pull/456>`_)
+
 
 API
 ~~~
@@ -272,3 +274,4 @@ People who contributed to this release (in alphabetical order):
 .. _Alexandre Gramfort: http://alexandre.gramfort.net
 .. _Ariel Rokem: https://github.com/arokem
 .. _Evgenii Kalenkovich: https://github.com/kalenkovich
+.. _Austin Hurst: https://github.com/a-hurst

--- a/mne_bids/commands/tests/test_cli.py
+++ b/mne_bids/commands/tests/test_cli.py
@@ -51,6 +51,13 @@ def test_raw_to_bids(tmpdir):
                      raw_fname, '--bids_root', output_path)):
         mne_bids_raw_to_bids.run()
 
+    # Test EDF files as well
+    edf_data_path = op.join(base_path, 'edf', 'tests', 'data')
+    edf_fname = op.join(edf_data_path, 'test.edf')
+    with ArgvSetter(('--subject_id', subject_id, '--task', task, '--raw',
+                     edf_fname, '--bids_root', output_path)):
+        mne_bids_raw_to_bids.run()
+
     # Too few input args
     with pytest.raises(SystemExit):
         with ArgvSetter(('--subject_id', subject_id)):

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -50,14 +50,8 @@ def _read_raw(raw_fpath, electrode=None, hsp=None, hpi=None, config=None,
     elif ext == '.fif':
         raw = reader[ext](raw_fpath, allow_maxshield, **kwargs)
 
-    elif ext in ['.ds', '.vhdr', '.set']:
+    elif ext in ['.ds', '.vhdr', '.set', '.edf', '.bdf']:
         raw = reader[ext](raw_fpath, **kwargs)
-
-    # EDF (european data format) or BDF (biosemi) format
-    # TODO: integrate with lines above once MNE can read
-    # annotations with preload=False
-    elif ext in ['.edf', '.bdf']:
-        raw = reader[ext](raw_fpath, preload=True, **kwargs)
 
     # MEF and NWB are allowed, but not yet implemented
     elif ext in ['.mef', '.nwb']:

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -31,7 +31,7 @@ from mne_bids.utils import (_parse_bids_filename, _extract_landmarks,
 
 
 def _read_raw(raw_fpath, electrode=None, hsp=None, hpi=None, config=None,
-              verbose=None, **kwargs):
+              verbose=None, allow_maxshield=False, **kwargs):
     """Read a raw file into MNE, making inferences based on extension."""
     _, ext = _parse_ext(raw_fpath)
 
@@ -48,7 +48,7 @@ def _read_raw(raw_fpath, electrode=None, hsp=None, hpi=None, config=None,
                               **kwargs)
 
     elif ext == '.fif':
-        raw = reader[ext](raw_fpath, **kwargs)
+        raw = reader[ext](raw_fpath, allow_maxshield, **kwargs)
 
     elif ext in ['.ds', '.vhdr', '.set']:
         raw = reader[ext](raw_fpath, **kwargs)

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -30,7 +30,7 @@ from mne_bids.utils import (_parse_bids_filename, _extract_landmarks,
                             _estimate_line_freq, _infer_kind)
 
 
-def _read_raw(raw_fpath, electrode=None, hsp=None, hpi=None, 
+def _read_raw(raw_fpath, electrode=None, hsp=None, hpi=None,
               allow_maxshield=False, config=None, verbose=None, **kwargs):
     """Read a raw file into MNE, making inferences based on extension."""
     _, ext = _parse_ext(raw_fpath)

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -30,8 +30,8 @@ from mne_bids.utils import (_parse_bids_filename, _extract_landmarks,
                             _estimate_line_freq, _infer_kind)
 
 
-def _read_raw(raw_fpath, electrode=None, hsp=None, hpi=None, config=None,
-              verbose=None, allow_maxshield=False, **kwargs):
+def _read_raw(raw_fpath, electrode=None, hsp=None, hpi=None, 
+              allow_maxshield=False, config=None, verbose=None, **kwargs):
     """Read a raw file into MNE, making inferences based on extension."""
     _, ext = _parse_ext(raw_fpath)
 


### PR DESCRIPTION
PR Description
--------------

Fixes #455 by making `allow_maxshield` an actual argument to `_read_raw`, preventing it from getting passed via kwargs to reader functions that don't support it.

Note that this doesn't fix `raw_to_bids` completely for EDF and BDF files. The writer code has a check that raises an exception if data has been preloaded, and "preload=True" is explicitly set for the ".edf" and ".bdf" readers in `_read_raw`:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/mne_bids/commands/mne_bids_raw_to_bids.py", line 81, in <module>
    run()
  File "/usr/local/lib/python3.7/site-packages/mne_bids/commands/mne_bids_raw_to_bids.py", line 77, in run
    verbose=True)
  File "/usr/local/lib/python3.7/site-packages/mne_bids/write.py", line 1128, in write_raw_bids
    raise ValueError('The data should not be preloaded.')
ValueError: The data should not be preloaded.
```

The relevant chunks of code are here:

https://github.com/mne-tools/mne-bids/blob/237b3badab5fe8c28b64bf68b398780d1b53fa7d/mne_bids/read.py#L56-L60

https://github.com/mne-tools/mne-bids/blob/237b3badab5fe8c28b64bf68b398780d1b53fa7d/mne_bids/write.py#L944-L945

Looking at the Git blame, that TODO comment in read.py two years old, and setting "preload=False" fixes the issue completely for me, suggesting that the mentioned MNE feature has since been added.

Is it fine for me to drop the `preload` argument from those readers as part of this PR as well, or would that accidentally break compatibility with older MNE versions or something?


Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [x] All comments resolved
- [x] This is not your own PR
- [x] All CIs are happy
- [x] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [x] PR description includes phrase "closes <#issue-number>"
- [x] Commit history does not contain any merge commits
