### PR TITLE
ENH: Allow concatenation of BIDSPath with  string

### DIFF
--- a/mne_bids/tests/test_utils.py
+++ b/mne_bids/tests/test_utils.py
@@ -426,3 +426,8 @@ def test_bids_path(return_bids_test_dir):
     bids_path = make_bids_basename(subject='01', session='02',
                                    task='03', suffix='ieeg.edf')
     assert repr(bids_path) == 'BIDSPath(sub-01_ses-02_task-03_ieeg.edf)'
+
+    # test string concatenation
+    bids_path = make_bids_basename(subject='01', session='A')
+    other_string = 'foo'
+    assert bids_path + other_string == str(bids_path) + other_string

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -157,6 +157,9 @@ class BIDSPath(object):
         """Compare str representations."""
         return str(self) != str(other)
 
+    def __add__(self, other):
+        return str(self) + other
+
     def copy(self):
         """Copy the instance.
 


### PR DESCRIPTION
PR Description
--------------
In the mne-study-template we constantly create derivatives, which are currently
not or not sufficiently specified in the BIDS standard. Hence, the way
we derive their filenames is typically something like:

```python
basename = make_bids_basename(...)
fname =  op.join(bids_basename + '_processing_step.fif')
```

Yet, this concatenation doesn't work with BIDSPath anymore. Instead, we'd have to convert the BIDSPath to a string first, which seems cumbersome.

This PR, therefore, adds an `__add__()` method to BIDSPath, which will allow for the above code to work unchanged.

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
- [ ] Commit history does not contain any merge commits
