### PR TITLE
[MRG] ENH: Ignore entities from `derivatives` subfolder

### DIFF
--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -358,6 +358,10 @@ def get_entity_vals(bids_root, entity_key, *, ignore_sub='emptyroom',
     >>> get_entity_vals(bids_root, entity_key)
     ['05', '06', '07', '08', '09', '10', '11']
 
+    Notes
+    -----
+    This function will scan the entire ``bids_root``, except for a
+    ``derivatives`` subfolder placed directly under ``bids_root``.
 
     References
     ----------
@@ -378,6 +382,10 @@ def get_entity_vals(bids_root, entity_key, *, ignore_sub='emptyroom',
     p = re.compile(r'{}-(.*?)_'.format(entity_key))
     value_list = list()
     for filename in Path(bids_root).rglob('*{}-*_*'.format(entity_key)):
+        # Ignore `derivatives` folder.
+        if str(filename).startswith(op.join(bids_root, 'derivatives')):
+            continue
+
         if ignore_sub and any([filename.stem.startswith(f'sub-{s}_')
                                for s in ignore_sub]):
             continue


### PR DESCRIPTION
PR Description
--------------

When calling `get_entity_vals()`,  we now ignore the `derivatives` folder in the BIDS root directory. This is important as the
derivatives may, for example, contain "mock" subjects like "sub-grand_average" or similar things, which we are typically
not interested in when looking at the BIDS root. If the users wants to process the data in `derivatives/`, they can just set the `bids_root` kwarg to `bids_root/derivatives`, and everything will work as expected.

The way I've coded the solution is not elegant at all, but it's simple and does do the trick… 

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [x] All comments resolved
- [x] This is not your own PR
- [x] All CIs are happy
- [x] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
- [x] Commit history does not contain any merge commits
