### PR TITLE
[MRG] add DatasetType field to make_dataset_description

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -31,8 +31,7 @@ Changelog
 - :func:`mne_bids.write_raw_bids` and :func:`mne_bids.read_raw_bids` now handle scalp EEG if Captrak coordinate system and NAS/LPA/RPA landmarks are present, by `Adam Li`_ (`#416 <https://github.com/mne-tools/mne-bids/pull/416>`_)
 - :func:`mne_bids.get_matched_empty_room` now implements an algorithm for discovering empty-room recordings that do not have the recording date set as their session, by `Richard Höchenberger`_ (`#421 <https://github.com/mne-tools/mne-bids/pull/421>`_)
 - :func:`write_raw_bids` now adds citations to the README, by `Alex Rockhill`_ (`#463 <https://github.com/mne-tools/mne-bids/pull/463>`_)
-- :func:`write_raw_bids` now adds citations to the README, by `Alex Rockhill`_ (`#463 <https://github.com/mne-tools/mne-bids/pull/463>`_)
-- :func:`make_dataset_description` now adds the recommended field DatasetType with a defauls value "raw" automatically, by `Stefan Appelhoff`_ (`#472 <https://github.com/mne-tools/mne-bids/pull/472>`_)
+- :func:`make_dataset_description` now has an additional parameter ``datasettype`` to set the recommended field ``DatasetType`` (defaults to ``"raw"``), by `Stefan Appelhoff`_ (`#472 <https://github.com/mne-tools/mne-bids/pull/472>`_)
 
 Bug
 ~~~

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -31,7 +31,7 @@ Changelog
 - :func:`mne_bids.write_raw_bids` and :func:`mne_bids.read_raw_bids` now handle scalp EEG if Captrak coordinate system and NAS/LPA/RPA landmarks are present, by `Adam Li`_ (`#416 <https://github.com/mne-tools/mne-bids/pull/416>`_)
 - :func:`mne_bids.get_matched_empty_room` now implements an algorithm for discovering empty-room recordings that do not have the recording date set as their session, by `Richard Höchenberger`_ (`#421 <https://github.com/mne-tools/mne-bids/pull/421>`_)
 - :func:`write_raw_bids` now adds citations to the README, by `Alex Rockhill`_ (`#463 <https://github.com/mne-tools/mne-bids/pull/463>`_)
-- :func:`make_dataset_description` now has an additional parameter ``datasettype`` to set the recommended field ``DatasetType`` (defaults to ``"raw"``), by `Stefan Appelhoff`_ (`#472 <https://github.com/mne-tools/mne-bids/pull/472>`_)
+- :func:`make_dataset_description` now has an additional parameter ``dataset_type`` to set the recommended field ``DatasetType`` (defaults to ``"raw"``), by `Stefan Appelhoff`_ (`#472 <https://github.com/mne-tools/mne-bids/pull/472>`_)
 
 Bug
 ~~~

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -31,6 +31,8 @@ Changelog
 - :func:`mne_bids.write_raw_bids` and :func:`mne_bids.read_raw_bids` now handle scalp EEG if Captrak coordinate system and NAS/LPA/RPA landmarks are present, by `Adam Li`_ (`#416 <https://github.com/mne-tools/mne-bids/pull/416>`_)
 - :func:`mne_bids.get_matched_empty_room` now implements an algorithm for discovering empty-room recordings that do not have the recording date set as their session, by `Richard Höchenberger`_ (`#421 <https://github.com/mne-tools/mne-bids/pull/421>`_)
 - :func:`write_raw_bids` now adds citations to the README, by `Alex Rockhill`_ (`#463 <https://github.com/mne-tools/mne-bids/pull/463>`_)
+- :func:`write_raw_bids` now adds citations to the README, by `Alex Rockhill`_ (`#463 <https://github.com/mne-tools/mne-bids/pull/463>`_)
+- :func:`make_dataset_description` now adds the recommended field DatasetType with a defauls value "raw" automatically, by `Stefan Appelhoff`_ (`#472 <https://github.com/mne-tools/mne-bids/pull/472>`_)
 
 Bug
 ~~~

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -116,6 +116,16 @@ def _test_anonymize(raw, bids_basename, events_fname=None, event_id=None):
     return bids_root
 
 
+def test_make_dataset_description():
+    """Test making a dataset_description.json."""
+    tmp_dir = _TempDir()
+    with pytest.raises(ValueError, match='`datasettype` must be either "raw"'):
+        make_dataset_description(path=tmp_dir, name='thing', datasettype='src')
+
+    make_dataset_description(path=tmp_dir, name='thing',
+                             datasettype='derivative', verbose=True)
+
+
 def test_stamp_to_dt():
     """Test conversions of meas_date to datetime objects."""
     meas_date = (1346981585, 835782)

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -119,11 +119,11 @@ def _test_anonymize(raw, bids_basename, events_fname=None, event_id=None):
 def test_make_dataset_description():
     """Test making a dataset_description.json."""
     tmp_dir = _TempDir()
-    with pytest.raises(ValueError, match='`datasettype` must be either "raw"'):
-        make_dataset_description(path=tmp_dir, name='thing', datasettype='src')
+    with pytest.raises(ValueError, match='`dataset_type` must be either "raw"'):
+        make_dataset_description(path=tmp_dir, name='thing', dataset_type='src')
 
     make_dataset_description(path=tmp_dir, name='thing',
-                             datasettype='derivative', verbose=True)
+                             dataset_type='derivative', verbose=True)
 
 
 def test_stamp_to_dt():

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -119,11 +119,16 @@ def _test_anonymize(raw, bids_basename, events_fname=None, event_id=None):
 def test_make_dataset_description():
     """Test making a dataset_description.json."""
     tmp_dir = _TempDir()
-    with pytest.raises(ValueError, match='`dataset_type` must be either "raw"'):
-        make_dataset_description(path=tmp_dir, name='thing', dataset_type='src')
+    with pytest.raises(ValueError, match='`dataset_type` must be either "raw" '
+                                         'or "derivative."'):
+        make_dataset_description(path=tmp_dir, name='tst', dataset_type='src')
 
-    make_dataset_description(path=tmp_dir, name='thing',
-                             dataset_type='derivative', verbose=True)
+    make_dataset_description(
+        path=tmp_dir, name='tst', authors='MNE B., MNE P.',
+        funding='GSOC2019, GSOC2021',
+        references_and_links='https://doi.org/10.21105/joss.01896',
+        dataset_type='derivative', verbose=True
+    )
 
 
 def test_stamp_to_dt():

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -793,7 +793,7 @@ def make_dataset_description(path, name, data_license=None,
                              authors=None, acknowledgements=None,
                              how_to_acknowledge=None, funding=None,
                              references_and_links=None, doi=None,
-                             datasettype='raw',
+                             dataset_type='raw',
                              verbose=False):
     """Create json for a dataset description.
 

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -793,6 +793,7 @@ def make_dataset_description(path, name, data_license=None,
                              authors=None, acknowledgements=None,
                              how_to_acknowledge=None, funding=None,
                              references_and_links=None, doi=None,
+                             datasettype='raw',
                              verbose=False):
     """Create json for a dataset description.
 
@@ -828,11 +829,14 @@ def make_dataset_description(path, name, data_license=None,
         separated str like ['a', 'b', 'c'].
     doi : str | None
         The DOI for the dataset.
+    datasettype : str
+        Must be either "raw" or "derivative". Defaults to "raw".
+    verbose : bool
+        Set verbose output to True or False.
 
     Notes
     -----
     The required field BIDSVersion will be automatically filled by mne_bids.
-    The recommended field DatasetType will be automatically filled to be "raw".
 
     """
     # default author to make dataset description BIDS compliant
@@ -847,11 +851,13 @@ def make_dataset_description(path, name, data_license=None,
         funding = funding.split(', ')
     if isinstance(references_and_links, str):
         references_and_links = references_and_links.split(', ')
+    if datasettype not in ['raw', 'derivative']:
+        raise ValueError('`datasettype` must be either "raw" or "derivative."')
 
     fname = op.join(path, 'dataset_description.json')
     description = OrderedDict([('Name', name),
                                ('BIDSVersion', BIDS_VERSION),
-                               ('DatasetType', 'raw'),
+                               ('DatasetType', datasettype),
                                ('License', data_license),
                                ('Authors', authors),
                                ('Acknowledgements', acknowledgements),

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -829,7 +829,7 @@ def make_dataset_description(path, name, data_license=None,
         separated str like ['a', 'b', 'c'].
     doi : str | None
         The DOI for the dataset.
-    datasettype : str
+    dataset_type : str
         Must be either "raw" or "derivative". Defaults to "raw".
     verbose : bool
         Set verbose output to True or False.
@@ -851,13 +851,13 @@ def make_dataset_description(path, name, data_license=None,
         funding = funding.split(', ')
     if isinstance(references_and_links, str):
         references_and_links = references_and_links.split(', ')
-    if datasettype not in ['raw', 'derivative']:
-        raise ValueError('`datasettype` must be either "raw" or "derivative."')
+    if dataset_type not in ['raw', 'derivative']:
+        raise ValueError('`dataset_type` must be either "raw" or "derivative."')
 
     fname = op.join(path, 'dataset_description.json')
     description = OrderedDict([('Name', name),
                                ('BIDSVersion', BIDS_VERSION),
-                               ('DatasetType', datasettype),
+                               ('DatasetType', dataset_type),
                                ('License', data_license),
                                ('Authors', authors),
                                ('Acknowledgements', acknowledgements),

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -832,6 +832,7 @@ def make_dataset_description(path, name, data_license=None,
     Notes
     -----
     The required field BIDSVersion will be automatically filled by mne_bids.
+    The recommended field DatasetType will be automatically filled to be "raw".
 
     """
     # default author to make dataset description BIDS compliant
@@ -850,6 +851,7 @@ def make_dataset_description(path, name, data_license=None,
     fname = op.join(path, 'dataset_description.json')
     description = OrderedDict([('Name', name),
                                ('BIDSVersion', BIDS_VERSION),
+                               ('DatasetType', 'raw'),
                                ('License', data_license),
                                ('Authors', authors),
                                ('Acknowledgements', acknowledgements),

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -852,7 +852,8 @@ def make_dataset_description(path, name, data_license=None,
     if isinstance(references_and_links, str):
         references_and_links = references_and_links.split(', ')
     if dataset_type not in ['raw', 'derivative']:
-        raise ValueError('`dataset_type` must be either "raw" or "derivative."')
+        raise ValueError('`dataset_type` must be either "raw" or '
+                         '"derivative."')
 
     fname = op.join(path, 'dataset_description.json')
     description = OrderedDict([('Name', name),


### PR DESCRIPTION
The `DatasetType` field in `dataset_description.json` is a new, RECOMMENDED field in BIDS that can be either "raw" or "derivative". [spec link](https://bids-specification.readthedocs.io/en/stable/03-modality-agnostic-files.html#dataset_descriptionjson)

For now I think it's reasonable for us to fill this with `"raw"` automatically.



Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [x] All comments resolved
- [ ] This is not your own PR
- [x] All CIs are happy
- [x] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- ~[ ] PR description includes phrase "closes <#issue-number>"~
- [x] Commit history does not contain any merge commits
