### PR TITLE
[MRG] DOC: Add electrode coordinates to EEG conversion example

### DIFF
--- a/examples/convert_eeg_to_bids.py
+++ b/examples/convert_eeg_to_bids.py
@@ -85,7 +85,7 @@ print_dir_tree(data_dir)
 # We will do exactly that in the next step.
 
 ###############################################################################
-# Formatting to BIDS
+# Converting to BIDS
 # ------------------
 #
 # Let's start with loading the data and extracting the events.

--- a/examples/convert_eeg_to_bids.py
+++ b/examples/convert_eeg_to_bids.py
@@ -9,12 +9,11 @@ data. Specifically, we will follow these steps:
 1. Download some EEG data from the
    `PhysioBank database <https://physionet.org/physiobank/database>`_.
 
-2. Load the data, extract information, and save in a new BIDS directory ...
-   once for a single subject, and then while looping over different subjects.
+2. Load the data, extract information, and save it in a new BIDS directory.
 
-3. Check the result and compare it with the standard
+3. Check the result and compare it with the standard.
 
-4. Cite ``mne-bids``
+4. Cite ``mne-bids``.
 
 .. currentmodule:: mne_bids
 

--- a/examples/convert_eeg_to_bids.py
+++ b/examples/convert_eeg_to_bids.py
@@ -85,8 +85,8 @@ print_dir_tree(data_dir)
 # We will do exactly that in the next step.
 
 ###############################################################################
-# Converting to BIDS
-# ------------------
+# Convert to BIDS
+# ---------------
 #
 # Let's start with loading the data and extracting the events.
 # We are reading the data using MNE-Python's ``io`` module and the

--- a/examples/convert_eeg_to_bids.py
+++ b/examples/convert_eeg_to_bids.py
@@ -9,9 +9,12 @@ data. Specifically, we will follow these steps:
 1. Download some EEG data from the
    `PhysioBank database <https://physionet.org/physiobank/database>`_.
 
-2. Load the data, extract information, and save in a new BIDS directory
+2. Load the data, extract information, and save in a new BIDS directory ...
+   once for a single subject, and then while looping over different subjects.
 
 3. Check the result and compare it with the standard
+
+4. Cite ``mne-bids``
 
 .. currentmodule:: mne_bids
 """
@@ -38,41 +41,45 @@ from mne_bids.utils import print_dir_tree
 # `EEG Motor Movement/Imagery Dataset <https://doi.org/10.13026/C28G6P>`_
 # available on the PhysioBank database.
 #
-# The data consists of 109 volunteers performing 14 experimental runs each. For
-# each subject, there were two baseline tasks (1. eyes open, 2. eyes closed) as
-# well as four different motor imagery tasks. For the present example, we will
-# show how to format the data for two subjects and selected tasks to comply
-# with the Brain Imaging Data Structure
+# The data consists of 109 volunteers performing 14 experimental runs each.
+# For each subject, there were two baseline tasks (i) eyes open, (ii) eyes
+# closed, as well as four different motor imagery tasks.
+# For the present example, we will show how to format the data for two subjects
+# and selected tasks to comply with the Brain Imaging Data Structure
 # (`BIDS <http://bids.neuroimaging.io/>`_).
 #
 # Conveniently, there is already a data loading function available with
 # MNE-Python:
 
 # Define which tasks we want to download.
-tasks = [2,  # This is 2 minutes of eyes closed rest
-         4,  # This is run #1 of imagining to close left or right fist
-         12]  # This is run #2 of imagining to close left or right fist
+tasks = [
+    2,  # This is 2 minutes of eyes closed rest
+    4,  # This is run #1 of imagining to close left or right fist
+    12  # This is run #2 of imagining to close left or right fist
+]
 
 # Download the data for subjects 1 and 2
-for subj_idx in [1, 2]:
-    eegbci.load_data(subject=subj_idx, runs=tasks, update_path=True)
+subjects = [1, 2]
+for subj in subjects:
+    eegbci.load_data(subject=subj, runs=tasks, update_path=True)
 
 ###############################################################################
 # Let's see whether the data has been downloaded using a quick visualization
 # of the directory tree.
 
-# get MNE directory w/ example data
+# get MNE directory with example data
 mne_data_dir = mne.get_config('MNE_DATASETS_EEGBCI_PATH')
-
 data_dir = os.path.join(mne_data_dir, 'MNE-eegbci-data')
+
 print_dir_tree(data_dir)
 
 ###############################################################################
-# The data are in the `European Data Format <https://www.edfplus.info/>`_
-# '.edf', which is good for us because next to the BrainVision format, EDF is
-# one of the recommended file formats for EEG BIDS. However, apart from the
-# data format, we need to build a directory structure and supply meta data
-# files to properly *bidsify* this data.
+# The data are in the `European Data Format <https://www.edfplus.info/>`_ with
+# the ``.edf`` extension, which is good for us because next to the
+# `BrainVision format`_, EDF is one of the recommended file formats for EEG
+# data in BIDS format.
+# However, apart from the data format, we need to build a directory structure
+# and supply meta data files to properly *bidsify* this data.
 
 ###############################################################################
 # Step 2: Formatting as BIDS
@@ -82,20 +89,47 @@ print_dir_tree(data_dir)
 # MNE-Python's io module and the :func:`mne.io.read_raw_edf` function. Note
 # that we must use `preload=False`, the default in MNE-Python. It prevents the
 # data from being loaded and modified when converting to BIDS.
+
+# Load the data from "2 minutes eyes closed rest"
 edf_path = eegbci.load_data(subject=1, runs=2)[0]
 raw = mne.io.read_raw_edf(edf_path, preload=False)
 
-###############################################################################
-# The annotations stored in the file must be read in separately and converted
-# into a 2D numpy array of events that is compatible with MNE.
-annot = mne.read_annotations(edf_path)
-raw.set_annotations(annot)
+# For converting the data to BIDS, we need to convert the the annotations
+# stored in the file to a 2D numpy array of events.
 events, event_id = mne.events_from_annotations(raw)
 
-print(raw)
+###############################################################################
+# For the sake of the example we will also pretend that we have the electrode
+# coordinates for the data recordings.
+# We will use a coordinates file from the MNE testing data in `CapTrak`_
+# format.
+#
+# .. note:: The ``*electrodes.tsv`` and ``*coordsystem.json`` files in BIDS are
+#           intended to carry information about digitized (i.e., *measured*)
+#           electrode positions on the scalp of the research subject. Do *not*
+#           (!) use these files to store "template" or "idealized" electrode
+#           positions, like those that can be obtained from
+#           :func:`mne.channels.make_standard_montage`!
+#
+
+# Get the electrode coordinates
+testing_data = mne.datasets.testing.data_path()
+captrak_path = os.path.join(testing_data, 'montage', 'captrak_coords.bvct')
+montage = mne.channels.read_dig_captrak(captrak_path)
+
+# Rename the montage channel names only for this example, because as said
+# before, coordinate and EEG data were not actually collected together
+# Do *not* do this for your own data.
+montage.rename_channels(dict(zip(montage.ch_names, raw.ch_names)))
+
+# "attach" the electrode coordinates to the `raw` object
+raw.set_montage(montage)
+
+# show the electrode positions
+raw.plot_sensors()
 
 ###############################################################################
-# With this step, we have everything to start a new BIDS directory using
+# With these steps, we have everything to start a new BIDS directory using
 # our data. To do that, we can use :func:`write_raw_bids`
 # Generally, :func:`write_raw_bids` tries to extract as much
 # meta data as possible from the raw data and then formats it in a BIDS
@@ -110,25 +144,28 @@ print(raw)
 print(write_raw_bids.__doc__)
 
 ###############################################################################
-# We loaded 'S001R02.edf', which corresponds to subject 1 in the second task.
+# We loaded ``S001R02.edf``, which corresponds to subject 1 in the second task.
 # The second task was to rest with closed eyes.
 subject_id = '001'  # zero padding to account for >100 subjects in this dataset
 task = 'resteyesclosed'
-raw_file = raw
 bids_root = os.path.join(mne_data_dir, 'eegmmidb_bids')
+
+# Start with a clean directory in case the directory existed beforehand
+sh.rmtree(bids_root, ignore_errors=True)
 
 ###############################################################################
 # Now we just need to specify a few more EEG details to get something sensible:
 
 # Brief description of the event markers present in the data. This will become
 # the `trial_type` column in our BIDS `events.tsv`. We know about the event
-# meaning from the documentation on PhysioBank
+# meaning from the documentation on PhysioBank.
 trial_type = {'rest': 0, 'imagine left fist': 1, 'imagine right fist': 2}
 
 # Now convert our data to be in a new BIDS dataset.
 bids_basename = make_bids_basename(subject=subject_id, task=task)
-write_raw_bids(raw_file, bids_basename, bids_root, event_id=trial_type,
+write_raw_bids(raw, bids_basename, bids_root, event_id=trial_type,
                events_data=events, overwrite=True)
+
 ###############################################################################
 # What does our fresh BIDS directory look like?
 print_dir_tree(bids_root)
@@ -140,30 +177,41 @@ print_dir_tree(bids_root)
 sh.rmtree(bids_root)
 
 # Some initial information that we found in the PhysioBank documentation
-task_names = {2: 'resteyesclosed',
-              4: 'imaginefists',  # run 1
-              12: 'imaginefists'  # run 2
-              }
+task_names = {
+    2: 'resteyesclosed',
+    4: 'imaginefists',  # run 1
+    12: 'imaginefists'  # run 2
+}
 
-run_mapping = {2: None,  # for resting eyes closed task, there was only one run
-               4: '1',
-               12: '2'
-               }
+run_mapping = {
+    2: None,  # for resting eyes closed task, there was only one run
+    4: '1',
+    12: '2'
+}
+
+# The electrode coordinate files would be different for each subject, but in
+# our example they are all the same
+subj2electrode_files = {subj: captrak_path for subj in subjects}
 
 # Now go over subjects and *bidsify*
-for subj_idx in [1, 2]:
-    for task_idx in [2, 4, 12]:
+for subj in subjects:
+    for task in tasks:
         # Load the data
-        edf_path = eegbci.load_data(subject=subj_idx, runs=task_idx)[0]
-
+        edf_path = eegbci.load_data(subject=subj, runs=task)[0]
         raw = mne.io.read_raw_edf(edf_path, preload=False, stim_channel=None)
-        annot = mne.read_annotations(edf_path)
-        raw.set_annotations(annot)
+
+        # get events
         events, event_id = mne.events_from_annotations(raw)
 
-        bids_basename = make_bids_basename(subject='{:03}'.format(subj_idx),
-                                           task=task_names[task_idx],
-                                           run=run_mapping[task_idx])
+        # attach electrode coordinates depending on subject
+        montage = mne.channels.read_dig_captrak(subj2electrode_files[subj])
+        montage.rename_channels(dict(zip(montage.ch_names, raw.ch_names)))
+        raw.set_montage(montage)
+
+        # convert
+        bids_basename = make_bids_basename(subject='{:03}'.format(subj),
+                                           task=task_names[task],
+                                           run=run_mapping[task])
         write_raw_bids(raw, bids_basename, bids_root, event_id=trial_type,
                        events_data=events, overwrite=True)
 
@@ -201,3 +249,6 @@ print(text)
 # Web version: https://bids-standard.github.io/bids-validator/
 #
 # Command line tool: https://www.npmjs.com/package/bids-validator
+#
+# .. _BrainVision format: https://www.brainproducts.com/productdetails.php?id=21&tab=5
+# .. _CapTrak: http://www.fieldtriptoolbox.org/faq/how_are_the_different_head_and_mri_coordinate_systems_defined/#details-of-the-captrak-coordinate-system

--- a/examples/convert_ieeg_to_bids.py
+++ b/examples/convert_ieeg_to_bids.py
@@ -15,7 +15,9 @@ data. Specifically, we will follow these steps:
 
 3. Check the result and compare it with the standard.
 
-4. Confirm that written iEEG coordinates are the
+4. Cite MNE-BIDS
+
+5. Confirm that written iEEG coordinates are the
    same before :func:`write_raw_bids` was called.
 
 The iEEG data will be written by :func:`write_raw_bids` with

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -683,6 +683,8 @@ def _write_raw_brainvision(raw, bids_fname, events):
     bids_fname : str
         The name of the BIDS-specified file where the raw object
         should be saved.
+    events : ndarray
+        The events as MNE-Python format ndaray.
 
     """
     if not check_version('pybv', '0.2'):


### PR DESCRIPTION
closes #468 

to do:

- ~[ ] fix CapTrak units to mm~ --> decided against it, `m` should be fine.
- [x] show electrodes TSV and coordsystem.json in example
- [x] fix long links --> pep issue
- [x] do not show group conversion ... there is another example for that


Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [x] All comments resolved
- [ ] This is not your own PR
- [x] All CIs are happy
- [x] PR title starts with [MRG]
- ~[ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated~
- [x] PR description includes phrase "closes <#issue-number>"
- [x] Commit history does not contain any merge commits
