### PR TITLE
[MRG] ENH: Allow copyfile_brainvision to anonymize data in-place

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -32,7 +32,7 @@ Changelog
 - :func:`mne_bids.get_matched_empty_room` now implements an algorithm for discovering empty-room recordings that do not have the recording date set as their session, by `Richard Höchenberger`_ (`#421 <https://github.com/mne-tools/mne-bids/pull/421>`_)
 - :func:`write_raw_bids` now adds citations to the README, by `Alex Rockhill`_ (`#463 <https://github.com/mne-tools/mne-bids/pull/463>`_)
 - :func:`make_dataset_description` now has an additional parameter ``dataset_type`` to set the recommended field ``DatasetType`` (defaults to ``"raw"``), by `Stefan Appelhoff`_ (`#472 <https://github.com/mne-tools/mne-bids/pull/472>`_)
-- :func:`mne_bids.copyfiles.copyfile_brainvison` now has ``anonymize`` and ``date`` parameters to control anonymization, by `Stefan Appelhoff`_ (`#475 <https://github.com/mne-tools/mne-bids/pull/475>`_)
+- :func:`mne_bids.copyfiles.copyfile_brainvision` now has ``anonymize`` and ``date`` parameters to control anonymization, by `Stefan Appelhoff`_ (`#475 <https://github.com/mne-tools/mne-bids/pull/475>`_)
 
 Bug
 ~~~

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -32,7 +32,7 @@ Changelog
 - :func:`mne_bids.get_matched_empty_room` now implements an algorithm for discovering empty-room recordings that do not have the recording date set as their session, by `Richard Höchenberger`_ (`#421 <https://github.com/mne-tools/mne-bids/pull/421>`_)
 - :func:`write_raw_bids` now adds citations to the README, by `Alex Rockhill`_ (`#463 <https://github.com/mne-tools/mne-bids/pull/463>`_)
 - :func:`make_dataset_description` now has an additional parameter ``dataset_type`` to set the recommended field ``DatasetType`` (defaults to ``"raw"``), by `Stefan Appelhoff`_ (`#472 <https://github.com/mne-tools/mne-bids/pull/472>`_)
-- :func:`mne_bids.copyfiles.copyfile_brainvision` now has ``anonymize`` and ``date`` parameters to control anonymization, by `Stefan Appelhoff`_ (`#475 <https://github.com/mne-tools/mne-bids/pull/475>`_)
+- :func:`mne_bids.copyfiles.copyfile_brainvision` now has an ``anonymize`` parameter to control anonymization, by `Stefan Appelhoff`_ (`#475 <https://github.com/mne-tools/mne-bids/pull/475>`_)
 
 Bug
 ~~~

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -32,6 +32,7 @@ Changelog
 - :func:`mne_bids.get_matched_empty_room` now implements an algorithm for discovering empty-room recordings that do not have the recording date set as their session, by `Richard Höchenberger`_ (`#421 <https://github.com/mne-tools/mne-bids/pull/421>`_)
 - :func:`write_raw_bids` now adds citations to the README, by `Alex Rockhill`_ (`#463 <https://github.com/mne-tools/mne-bids/pull/463>`_)
 - :func:`make_dataset_description` now has an additional parameter ``dataset_type`` to set the recommended field ``DatasetType`` (defaults to ``"raw"``), by `Stefan Appelhoff`_ (`#472 <https://github.com/mne-tools/mne-bids/pull/472>`_)
+- :func:`mne_bids.copyfiles.copyfile_brainvison` now has ``anonymize`` and ``date`` parameters to control anonymization, by `Stefan Appelhoff`_ (`#475 <https://github.com/mne-tools/mne-bids/pull/475>`_)
 
 Bug
 ~~~

--- a/examples/rename_brainvision_files.py
+++ b/examples/rename_brainvision_files.py
@@ -70,7 +70,8 @@ examples_dir = op.join(data_path, 'Brainvision')
 # --------------------
 # Above, at the top of the example, we imported
 # :func:`mne_bids.copyfiles.copyfile_brainvision` from
-# the MNE-BIDS :mod:`copyfiles.py` module. This function takes two main inputs:
+# the MNE-BIDS ``mne_bids.copyfiles.py`` module. This function takes two
+# main inputs:
 # First, the path to the existing ``.vhdr`` file. And second, the path to
 # the future ``.vhdr`` file.
 #

--- a/examples/rename_brainvision_files.py
+++ b/examples/rename_brainvision_files.py
@@ -48,7 +48,6 @@ References
 import os.path as op
 import datetime
 
-from numpy.testing import assert_array_equal
 import mne
 
 from mne_bids.copyfiles import copyfile_brainvision
@@ -90,12 +89,9 @@ vhdr_file_renamed = op.join(examples_dir, 'test_renamed.vhdr')
 copyfile_brainvision(vhdr_file, vhdr_file_renamed, verbose=True)
 
 # Check that MNE-Python can read in both, the original as well as the renamed
-# data. They should be the same.
+# data (two files: their contents are the same apart from the name)
 raw = mne.io.read_raw_brainvision(vhdr_file)
 raw_renamed = mne.io.read_raw_brainvision(vhdr_file_renamed)
-
-# If we can run the following without error, everything is fine
-assert_array_equal(raw.get_data(), raw_renamed.get_data())
 
 ###############################################################################
 # Anonymize the recording

--- a/examples/rename_brainvision_files.py
+++ b/examples/rename_brainvision_files.py
@@ -1,7 +1,7 @@
 """
-======================================================
-06. Rename and/or anonymize BrainVision EEG data files
-======================================================
+=====================================
+06. Rename BrainVision EEG data files
+=====================================
 
 According to the EEG extension to BIDS [1]_, the `BrainVision data format`_ is
 one of the recommended formats to store EEG data within a BIDS dataset.
@@ -20,12 +20,8 @@ each recording:
           references will corrupt the dataset! But relax, MNE-BIDS can take
           care of this for you.
 
-We may also wish to *anonymize* the data. MNE-BIDS can automate this task, too.
-
-In this example, we use MNE-BIDS to:
-
-1. Rename BrainVision data files including a repair of the internal file links
-2. Anonymize (overwrite) all recording dates
+In this example, we use MNE-BIDS to rename BrainVision data files including a
+repair of the internal file links
 
 For the command line version of this tool, see the :code:`cp` tool in the docs
 for the :ref:`Python Command Line Interface <python_cli>`.
@@ -46,7 +42,6 @@ References
 ###############################################################################
 # We are importing everything we need for this example:
 import os.path as op
-import datetime
 
 import mne
 
@@ -94,39 +89,8 @@ raw = mne.io.read_raw_brainvision(vhdr_file)
 raw_renamed = mne.io.read_raw_brainvision(vhdr_file_renamed)
 
 ###############################################################################
-# Anonymize the recording
-# -----------------------
-# We successfully renamed our file. But we can use
-# :func:`mne_bids.copyfiles.copyfile_brainvision` also to anonymize the
-# recording.
-#
-# In the example below, we overwrite our previously renamed file. But this time
-# we specify the ``anonymize`` and ``date`` parameters, to overwrite the
-# existing dates with our new one.
-
-# Get the original recording date
-original_date = raw.info['meas_date']
-print(f'The original date was {original_date}\n')
-
-# Make up a new date to anonymize the original one. 1900-05-06 at 00:00:00
-# seems fine
-new_date = datetime.datetime(1924, 5, 6)
-
-# Now anonymize using `new_date`
-copyfile_brainvision(vhdr_file, vhdr_file_renamed, anonymize=True,
-                     date=new_date, verbose=True)
-
-# Check that the freshly renamed and anonymized file has the new date
-raw_renamed = mne.io.read_raw_brainvision(vhdr_file_renamed)
-anonymized_date = raw_renamed.info['meas_date']
-print(f'After anonymization, the date is now {anonymized_date}.\n')
-
-###############################################################################
 # Further information
 # -------------------
-# You can also anonymize BrainVision files without specifying the ``date``
-# parameter. If you just specify ``anonymize=True``, MNE-BIDS will overwrite
-# all dates with a default datetime of 1924-01-01T00:00:00.
 #
 # For converting data files, or writing new data to the BrainVision format, you
 # can use the `pybv`_ Python package.

--- a/examples/rename_brainvision_files.py
+++ b/examples/rename_brainvision_files.py
@@ -37,7 +37,7 @@ References
        electroencephalography. Sci Data 6, 103 (2019).
        https://doi.org/10.1038/s41597-019-0104-8
 .. _BrainVision data format: https://www.brainproducts.com/productdetails.php?id=21&tab=5
-"""
+"""  # noqa:E501
 
 # Authors: Stefan Appelhoff <stefan.appelhoff@mailbox.org>
 #

--- a/examples/rename_brainvision_files.py
+++ b/examples/rename_brainvision_files.py
@@ -4,23 +4,24 @@
 ======================================================
 
 According to the EEG extension to BIDS [1]_, the `BrainVision data format`_ is
-one of the recommended formats to store EEG data within a BIDS directory.
+one of the recommended formats to store EEG data within a BIDS dataset.
 
 To organize EEG data in BIDS format, it is often necessary to rename the files.
 In the case of BrainVision files, we would have to rename multiple files for
-each dataset instance (i.e., once per recording):
+each recording:
 
 1. A text header file (``.vhdr``) containing meta data
 2. A text marker file (``.vmrk``) containing information about events in the
    data
 3. A binary data file (``.eeg``) containing the voltage values of the EEG
 
-.. Note:: The three files contain internal links that guide the data reading
-          software. Renaming the three files without adjusting the internal
-          links will corrupt the file format! But relax, MNE-BIDS can take care
+.. Note:: The three files contain references that guide the data reading
+          software. Simply *renaming* the files without adjusting these
+          references will corrupt the dataset! But relax, MNE-BIDS can take
+          care
           of this for you.
 
-Next to renaming files for BIDS, we often will also have to anonymize the data.
+We may also wish to *anonymize* the data. MNE-BIDS can automate this task, too.
 
 In this example, we use MNE-BIDS to:
 

--- a/examples/rename_brainvision_files.py
+++ b/examples/rename_brainvision_files.py
@@ -70,7 +70,7 @@ examples_dir = op.join(data_path, 'Brainvision')
 # --------------------
 # Above, at the top of the example, we imported
 # :func:`mne_bids.copyfiles.copyfile_brainvision` from
-# the MNE-BIDS ``mne_bids.copyfiles.py`` module. This function takes two
+# the MNE-BIDS ``mne_bids/copyfiles.py`` module. This function takes two
 # main inputs:
 # First, the path to the existing ``.vhdr`` file. And second, the path to
 # the future ``.vhdr`` file.

--- a/examples/rename_brainvision_files.py
+++ b/examples/rename_brainvision_files.py
@@ -18,8 +18,7 @@ each recording:
 .. Note:: The three files contain references that guide the data reading
           software. Simply *renaming* the files without adjusting these
           references will corrupt the dataset! But relax, MNE-BIDS can take
-          care
-          of this for you.
+          care of this for you.
 
 We may also wish to *anonymize* the data. MNE-BIDS can automate this task, too.
 

--- a/examples/rename_brainvision_files.py
+++ b/examples/rename_brainvision_files.py
@@ -1,35 +1,52 @@
 """
-=====================================
-06. Rename BrainVision EEG data files
-=====================================
+======================================================
+06. Rename and/or anonymize BrainVision EEG data files
+======================================================
 
-The BrainVision file format is one of the recommended formats to store EEG data
-within a BIDS directory. To organize EEG data in BIDS format, it is often
-necessary to rename the files. In the case of BrainVision files, we would have
-to rename multiple files for each dataset instance (i.e., once per recording):
+According to the EEG extension to BIDS [1]_, the `BrainVision data format`_ is
+one of the recommended formats to store EEG data within a BIDS directory.
+
+To organize EEG data in BIDS format, it is often necessary to rename the files.
+In the case of BrainVision files, we would have to rename multiple files for
+each dataset instance (i.e., once per recording):
 
 1. A text header file (``.vhdr``) containing meta data
 2. A text marker file (``.vmrk``) containing information about events in the
    data
 3. A binary data file (``.eeg``) containing the voltage values of the EEG
 
-The problem is that the three files contain internal links that guide a
-potential data reading software. If we just rename the three files without also
-adjusting the internal links, we corrupt the file format.
+.. Note:: The three files contain internal links that guide the data reading
+          software. Renaming the three files without adjusting the internal
+          links will corrupt the file format! But relax, MNE-BIDS can take care
+          of this for you.
 
-In this example, we use MNE-BIDS to rename BrainVision data files including a
-repair of the internal file pointers.
+Next to renaming files for BIDS, we often will also have to anonymize the data.
+
+In this example, we use MNE-BIDS to:
+
+1. Rename BrainVision data files including a repair of the internal file links
+2. Anonymize (overwrite) all recording dates
 
 For the command line version of this tool, see the :code:`cp` tool in the docs
 for the :ref:`Python Command Line Interface <python_cli>`.
+
+References
+----------
+.. [1] Pernet, C.R., Appelhoff, S., Gorgolewski, K.J. et al. EEG-BIDS, an
+       extension to the brain imaging data structure for
+       electroencephalography. Sci Data 6, 103 (2019).
+       https://doi.org/10.1038/s41597-019-0104-8
+.. _BrainVision data format: https://www.brainproducts.com/productdetails.php?id=21&tab=5
 """
 
 # Authors: Stefan Appelhoff <stefan.appelhoff@mailbox.org>
+#
 # License: BSD (3-clause)
 
 ###############################################################################
 # We are importing everything we need for this example:
 import os.path as op
+import datetime
 
 from numpy.testing import assert_array_equal
 import mne
@@ -37,8 +54,8 @@ import mne
 from mne_bids.copyfiles import copyfile_brainvision
 
 ###############################################################################
-# Step 1: Download some example data
-# ----------------------------------
+# Download some example data
+# --------------------------
 # To demonstrate the MNE-BIDS functions, we need some testing data. Here, we
 # will use the MNE-Python testing data. Feel free to use your own BrainVision
 # data.
@@ -49,45 +66,76 @@ data_path = mne.datasets.testing.data_path()
 examples_dir = op.join(data_path, 'Brainvision')
 
 ###############################################################################
-# Step 2: Rename the recording
-# ----------------------------------
+# Rename the recording
+# --------------------
 # Above, at the top of the example, we imported
 # :func:`mne_bids.copyfiles.copyfile_brainvision` from
-# the MNE-BIDS ``utils.py`` module. This function takes two arguments as
-# input: First, the path to the existing .vhdr file. And second, the path to
-# the future .vhdr file.
+# the MNE-BIDS :mod:`copyfiles.py` module. This function takes two main inputs:
+# First, the path to the existing ``.vhdr`` file. And second, the path to
+# the future ``.vhdr`` file.
+#
+# With the optional ``verbose`` parameter you can furthermore determine how
+# much information you want to get during the procedure.
 #
 # :func:`mne_bids.copyfiles.copyfile_brainvision` will then create three new
-# files (.vhdr, .vmrk, and .eeg) with the new names as provided with the second
-# argument.
+# files (``.vhdr``, ``.vmrk``, and ``.eeg``) with the new names as provided
+# with the second argument.
 #
 # Here, we rename a test file name:
 
-vhdr_file = op.join(examples_dir, 'test_NO.vhdr')
+# Rename the file
+vhdr_file = op.join(examples_dir, 'Analyzer_nV_Export.vhdr')
 vhdr_file_renamed = op.join(examples_dir, 'test_renamed.vhdr')
-copyfile_brainvision(vhdr_file, vhdr_file_renamed)
+copyfile_brainvision(vhdr_file, vhdr_file_renamed, verbose=True)
 
-###############################################################################
-# Step 3: Assert that the renamed data can be read by a software
-# --------------------------------------------------------------
-# Finally, let's use MNE-Python to read in both, the original BrainVision data
-# as well as the renamed data. They should be the same.
+# Check that MNE-Python can read in both, the original as well as the renamed
+# data. They should be the same.
 raw = mne.io.read_raw_brainvision(vhdr_file)
 raw_renamed = mne.io.read_raw_brainvision(vhdr_file_renamed)
 
+# If we can run the following without error, everything is fine
 assert_array_equal(raw.get_data(), raw_renamed.get_data())
+
+###############################################################################
+# Anonymize the recording
+# -----------------------
+# We successfully renamed our file. But we can use
+# :func:`mne_bids.copyfiles.copyfile_brainvision` also to anonymize the
+# recording.
+#
+# In the example below, we overwrite our previously renamed file. But this time
+# we specify the ``anonymize`` and ``date`` parameters, to overwrite the
+# existing dates with our new one.
+
+# Get the original recording date
+original_date = raw.info['meas_date']
+print(f'The original date was {original_date}\n')
+
+# Make up a new date to anonymize the original one. 1900-05-06 at 00:00:00
+# seems fine
+new_date = datetime.datetime(1924, 5, 6)
+
+# Now anonymize using `new_date`
+copyfile_brainvision(vhdr_file, vhdr_file_renamed, anonymize=True,
+                     date=new_date, verbose=True)
+
+# Check that the freshly renamed and anonymized file has the new date
+raw_renamed = mne.io.read_raw_brainvision(vhdr_file_renamed)
+anonymized_date = raw_renamed.info['meas_date']
+print(f'After anonymization, the date is now {anonymized_date}.\n')
 
 ###############################################################################
 # Further information
 # -------------------
-# There are alternative options to rename your BrainVision files. You could
-# for example check out the
-# `BVARENAMER <https://github.com/stefanSchinkel/bvarenamer>`_ by Stefan
-# Schinkel.
+# You can also anonymize BrainVision files without specifying the ``date``
+# parameter. If you just specify ``anonymize=True``, MNE-BIDS will overwrite
+# all dates with a default datetime of 1924-01-01T00:00:00.
 #
-# Lastly, there is a tool to check the integrity of your BrainVision files.
+# For converting data files, or writing new data to the BrainVision format, you
+# can use the `pybv`_ Python package.
+#
+# There is node JS tool to check the integrity of your BrainVision files.
 # For that, see the `BrainVision Validator <bv-validator_>`_
 #
-# .. LINKS
-#
+# .. _`pybv`: https://github.com/bids-standard/pybv
 # .. _`bv-validator`: https://github.com/sappelhoff/brainvision-validator

--- a/mne_bids/__init__.py
+++ b/mne_bids/__init__.py
@@ -1,13 +1,11 @@
 """MNE software for easily interacting with BIDS compatible datasets."""
 
 __version__ = '0.5.dev0'
-
-
-from mne_bids.write import (write_raw_bids,  # noqa: E501 F401
-                            make_dataset_description, write_anat,  # noqa: F401
-                            get_anonymization_daysback,  # noqa: F401
-                            _stamp_to_dt, _get_anonymization_daysback)
-from mne_bids.read import (read_raw_bids, get_head_mri_trans,  # noqa: F401
-                           get_matched_empty_room)  # noqa: F401
-from mne_bids.utils import make_bids_folders, make_bids_basename  # noqa: F401
 from mne_bids import commands  # noqa: F401
+from mne_bids.read import get_matched_empty_room  # noqa: F401; noqa: F401
+from mne_bids.read import get_head_mri_trans, read_raw_bids
+from mne_bids.utils import (_get_anonymization_daysback,  # noqa: F401
+                            _stamp_to_dt, get_anonymization_daysback,
+                            make_bids_basename, make_bids_folders)
+from mne_bids.write import write_raw_bids  # noqa: F401; noqa: E501 F401
+from mne_bids.write import make_dataset_description, write_anat

--- a/mne_bids/__init__.py
+++ b/mne_bids/__init__.py
@@ -2,10 +2,10 @@
 
 __version__ = '0.5.dev0'
 from mne_bids import commands  # noqa: F401
-from mne_bids.read import get_matched_empty_room  # noqa: F401; noqa: F401
 from mne_bids.read import get_head_mri_trans, read_raw_bids
-from mne_bids.utils import (_get_anonymization_daysback,  # noqa: F401
-                            _stamp_to_dt, get_anonymization_daysback,
+from mne_bids.utils import (get_anonymization_daysback,  # noqa: F401
                             make_bids_basename, make_bids_folders)
-from mne_bids.write import write_raw_bids  # noqa: F401; noqa: E501 F401
 from mne_bids.write import make_dataset_description, write_anat
+
+from mne_bids.read import get_matched_empty_room  # noqa: F401; noqa: F401
+from mne_bids.write import write_raw_bids  # noqa: F401; noqa: E501 F401

--- a/mne_bids/__init__.py
+++ b/mne_bids/__init__.py
@@ -1,11 +1,10 @@
 """MNE software for easily interacting with BIDS compatible datasets."""
 
 __version__ = '0.5.dev0'
-from mne_bids import commands  # noqa: F401
-from mne_bids.read import get_head_mri_trans, read_raw_bids
-from mne_bids.utils import (get_anonymization_daysback,  # noqa: F401
+from mne_bids import commands
+from mne_bids.read import (get_head_mri_trans, read_raw_bids,
+                           get_matched_empty_room)
+from mne_bids.utils import (get_anonymization_daysback,
                             make_bids_basename, make_bids_folders)
-from mne_bids.write import make_dataset_description, write_anat
-
-from mne_bids.read import get_matched_empty_room  # noqa: F401; noqa: F401
-from mne_bids.write import write_raw_bids  # noqa: F401; noqa: E501 F401
+from mne_bids.write import (make_dataset_description, write_anat,
+                            write_raw_bids)

--- a/mne_bids/copyfiles.py
+++ b/mne_bids/copyfiles.py
@@ -17,7 +17,7 @@ due to internal pointers that are not being updated.
 import os
 import os.path as op
 import re
-import datetime
+
 import shutil as sh
 
 from mne.io import read_raw_brainvision, anonymize_info

--- a/mne_bids/copyfiles.py
+++ b/mne_bids/copyfiles.py
@@ -209,12 +209,13 @@ def copyfile_kit(src, dest, subject_id, session_id,
             sh.copyfile(position_file, position_fname)
 
 
-def _anonymize_brainvision(vmrk_file):
+def _anonymize_brainvision(vmrk_file, date=None):
     """Operates in place."""
     pass
 
 
-def copyfile_brainvision(vhdr_src, vhdr_dest, anonymize=False, verbose=False):
+def copyfile_brainvision(vhdr_src, vhdr_dest, anonymize=False, date=None,
+                         verbose=False):
     """Copy a BrainVision file triplet to a new location and repair links.
 
     The BrainVision file format consists of three files: .vhdr, .eeg, and .vmrk
@@ -228,9 +229,12 @@ def copyfile_brainvision(vhdr_src, vhdr_dest, anonymize=False, verbose=False):
         The src path of the .vhdr file to be copied.
     vhdr_dest : str
         The destination path of the .vhdr file.
-    anonymize : bool | datetime
-        If True, zero out all date strings in the copied .vmrk file. If a
-        datetime is supplied, all existing date strings will be replaced.
+    anonymize : bool
+        If False, leave dates in .vmrk file as they are. If True, replace all
+        date strings with zeros.
+    date : datetime | None
+        If `anonymize` is True, `date` will be used to replace all date strings
+        in the .vmrk file.
 
     """
     # Get extenstion of the brainvision file
@@ -273,7 +277,7 @@ def copyfile_brainvision(vhdr_src, vhdr_dest, anonymize=False, verbose=False):
                 fout.write(line)
 
     if anonymize:
-        _anonymize_brainvision(fname_dest + '.vmrk')
+        _anonymize_brainvision(fname_dest + '.vmrk', date)
 
     if verbose:
         for ext in ['.eeg', '.vhdr', '.vmrk']:

--- a/mne_bids/copyfiles.py
+++ b/mne_bids/copyfiles.py
@@ -224,13 +224,8 @@ def _replace_file(fname, pattern, replace):
         fout.writelines(new_content)
 
 
-def _anonymize_brainvision(vhdr_file, date=None):
-    """Anonymize a vmrk and vhdr file in place."""
-    if date is None:
-        date = datetime.datetime(1924, 1, 1)
-    if not isinstance(date, datetime.datetime):
-        raise ValueError('`date` must be None or datetime.datetime.')
-
+def _anonymize_brainvision(vhdr_file, date):
+    """Anonymize vmrk and vhdr files in place using `date` datetime object."""
     _, vmrk_file = _get_brainvision_paths(vhdr_file)
 
     # Go through VMRK
@@ -267,7 +262,7 @@ def copyfile_brainvision(vhdr_src, vhdr_dest, anonymize=None, verbose=False):
             Number of days by which to move back the recording date in time.
             In studies with multiple subjects the relative recording date
             differences between subjects can be kept by using the same number
-            of `daysback` for all subject anonymizations. `daysback` must be
+            of `daysback` for all subject anonymizations. `daysback` should be
             great enough to shift the date prior to 1925 to conform with BIDS
             anonymization rules.
 
@@ -279,7 +274,7 @@ def copyfile_brainvision(vhdr_src, vhdr_dest, anonymize=None, verbose=False):
     verbose : bool
         Determine whether results should be logged. Defaults to False.
 
-    See also
+    See Also
     --------
     mne.io.anonymize_info
 

--- a/mne_bids/copyfiles.py
+++ b/mne_bids/copyfiles.py
@@ -220,7 +220,7 @@ def _replace_file(fname, pattern, replace):
         new_content.append(line)
 
     with open(fname, 'w') as fout:
-        fout.write_lines(new_content)
+        fout.writelines(new_content)
 
 
 def _anonymize_brainvision(vhdr_file, date=None):
@@ -239,7 +239,7 @@ def _anonymize_brainvision(vhdr_file, date=None):
 
     # Go through VHDR
     pattern = re.compile(r'^Impedance \[kOhm\] at \d\d:\d\d:\d\d :$')
-    replace = f'at {date.strftime('%H:%M:%S')} :'
+    replace = f'at {date.strftime("%H:%M:%S")} :'
     _replace_file(vhdr_file, pattern, replace)
 
 

--- a/mne_bids/copyfiles.py
+++ b/mne_bids/copyfiles.py
@@ -24,8 +24,7 @@ from mne.io import read_raw_brainvision, anonymize_info
 from scipy.io import loadmat, savemat
 
 from mne_bids.read import _parse_ext
-from mne_bids.utils import _get_mrk_meas_date
-from mne_bids.write import _check_anonymize
+from mne_bids.utils import _get_mrk_meas_date, _check_anonymize
 
 
 def _copytree(src, dst, **kwargs):
@@ -260,23 +259,29 @@ def copyfile_brainvision(vhdr_src, vhdr_dest, anonymize=None, verbose=False):
     vhdr_dest : str
         The destination path of the .vhdr file.
     anonymize : dict | None
-        If None is provided (default) no anonymization is performed.
-        If a dictionary is passed, data will be anonymized; identifying data
-        structures such as study date and time will be changed.
-        `daysback` is a required argument and `keep_his` is optional, these
-        arguments are passed to :func:`mne.io.anonymize_info`.
+        If None (default), no anonymization is performed.
+        If dict, data will be anonymized depending on the keys provided with
+        the dict: `daysback` is a required key, `keep_his` is an optional key.
 
         `daysback` : int
-            Number of days to move back the date. To keep relative dates for
-            a subject use the same `daysback`. According to BIDS
-            specifications, the number of days back must be great enough
-            that the date is before 1925.
+            Number of days by which to move back the recording date in time.
+            In studies with multiple subjects the relative recording date
+            differences between subjects can be kept by using the same number
+            of `daysback` for all subject anonymizations. `daysback` must be
+            great enough to shift the date prior to 1925 to conform with BIDS
+            anonymization rules.
 
         `keep_his` : bool
-            If True info['subject_info']['his_id'] of subject_info will NOT be
-            overwritten. Defaults to False.
+            By default (False), all subject information next to the recording
+            date will be overwritten as well. If True, keep subject information
+            apart from the recording date.
+
     verbose : bool
         Determine whether results should be logged. Defaults to False.
+
+    See also
+    --------
+    mne.io.anonymize_info
 
     """
     # Get extenstion of the brainvision file

--- a/mne_bids/copyfiles.py
+++ b/mne_bids/copyfiles.py
@@ -312,9 +312,11 @@ def copyfile_brainvision(vhdr_src, vhdr_dest, anonymize=False, date=None,
 
     if verbose:
         for ext in ['.eeg', '.vhdr', '.vmrk']:
-            print('Created "{}" in "{}"'
-                  .format(fname_dest + ext,
-                          op.dirname(op.realpath(vhdr_dest))))
+            _, fname = os.path.split(fname_dest + ext)
+            dirname = op.dirname(op.realpath(vhdr_dest))
+            print(f'Created "{fname}" in "{dirname}".')
+        if anonymize:
+            print('Anonymized all dates in VHDR and VMRK.')
 
 
 def copyfile_eeglab(src, dest):

--- a/mne_bids/copyfiles.py
+++ b/mne_bids/copyfiles.py
@@ -209,7 +209,12 @@ def copyfile_kit(src, dest, subject_id, session_id,
             sh.copyfile(position_file, position_fname)
 
 
-def copyfile_brainvision(vhdr_src, vhdr_dest, verbose=False):
+def _anonymize_brainvision(vmrk_file):
+    """Operates in place."""
+    pass
+
+
+def copyfile_brainvision(vhdr_src, vhdr_dest, anonymize=False, verbose=False):
     """Copy a BrainVision file triplet to a new location and repair links.
 
     The BrainVision file format consists of three files: .vhdr, .eeg, and .vmrk
@@ -223,6 +228,9 @@ def copyfile_brainvision(vhdr_src, vhdr_dest, verbose=False):
         The src path of the .vhdr file to be copied.
     vhdr_dest : str
         The destination path of the .vhdr file.
+    anonymize : bool | datetime
+        If True, zero out all date strings in the copied .vmrk file. If a
+        datetime is supplied, all existing date strings will be replaced.
 
     """
     # Get extenstion of the brainvision file
@@ -263,6 +271,9 @@ def copyfile_brainvision(vhdr_src, vhdr_dest, verbose=False):
                 if line.strip() in search_lines:
                     line = line.replace(basename_src, basename_dest)
                 fout.write(line)
+
+    if anonymize:
+        _anonymize_brainvision(fname_dest + '.vmrk')
 
     if verbose:
         for ext in ['.eeg', '.vhdr', '.vmrk']:

--- a/mne_bids/tests/test_copyfiles.py
+++ b/mne_bids/tests/test_copyfiles.py
@@ -101,10 +101,6 @@ def test_copyfile_brainvision():
     raw = mne.io.read_raw_brainvision(new_name)
     assert raw.filenames[0] == (op.join(head, 'tested_conversion.eeg'))
 
-    # Date should not have changed from original
-    date = raw.info['meas_date'].strftime('%Y%m%d%H%M%S%f')
-    assert date == '20131113161403794232'
-
     # Test with anonymization
     raw = mne.io.read_raw_brainvision(raw_fname)
     prev_date = raw.info['meas_date']

--- a/mne_bids/tests/test_copyfiles.py
+++ b/mne_bids/tests/test_copyfiles.py
@@ -5,6 +5,7 @@
 #
 # License: BSD (3-clause)
 import os.path as op
+import datetime
 import pytest
 
 from scipy.io import savemat
@@ -99,6 +100,33 @@ def test_copyfile_brainvision():
     # Try to read with MNE - if this works, the links are correct
     raw = mne.io.read_raw_brainvision(new_name)
     assert raw.filenames[0] == (op.join(head, 'tested_conversion.eeg'))
+
+    # Date should not have changed from original
+    date = raw.info['meas_date'].strftime('%Y%m%d%H%M%S%f')
+    assert date == '20131113161403794232'
+
+    # Test with anonymization
+    copyfile_brainvision(raw_fname, new_name, anonymize=True, verbose=True)
+    raw = mne.io.read_raw_brainvision(new_name)
+    date = raw.info['meas_date'].strftime('%Y%m%d%H%M%S%f')
+    assert date == '19240101000000000000'
+
+    with pytest.raises(ValueError, match='`date` must be None or datetime'):
+        copyfile_brainvision(raw_fname, new_name, anonymize=True, date='12.02')
+
+    newdate = datetime.datetime(1955, 5, 6, 12, 23, 11)
+    copyfile_brainvision(raw_fname, new_name, anonymize=True, date=newdate)
+    raw = mne.io.read_raw_brainvision(new_name)
+    date = raw.info['meas_date'].strftime('%Y%m%d%H%M%S%f')
+    assert date == newdate.strftime('%Y%m%d%H%M%S%f')
+
+    for line in open(new_name):
+        # The original time should no longer be in the file
+        if 'Impedance [kOhm] at 16:12:27 :' in line:
+            raise AssertionError()
+        # if we find the new time, we're good
+        if 'Impedance [kOhm] at 12:23:11 :' in line:
+            break
 
 
 def test_copyfile_eeglab():

--- a/mne_bids/tests/test_copyfiles.py
+++ b/mne_bids/tests/test_copyfiles.py
@@ -106,27 +106,13 @@ def test_copyfile_brainvision():
     assert date == '20131113161403794232'
 
     # Test with anonymization
-    copyfile_brainvision(raw_fname, new_name, anonymize=True, verbose=True)
+    raw = mne.io.read_raw_brainvision(raw_fname)
+    prev_date = raw.info['meas_date']
+    anonymize = {'daysback': 32459}
+    copyfile_brainvision(raw_fname, new_name, anonymize, verbose=True)
     raw = mne.io.read_raw_brainvision(new_name)
-    date = raw.info['meas_date'].strftime('%Y%m%d%H%M%S%f')
-    assert date == '19240101000000000000'
-
-    with pytest.raises(ValueError, match='`date` must be None or datetime'):
-        copyfile_brainvision(raw_fname, new_name, anonymize=True, date='12.02')
-
-    newdate = datetime.datetime(1955, 5, 6, 12, 23, 11)
-    copyfile_brainvision(raw_fname, new_name, anonymize=True, date=newdate)
-    raw = mne.io.read_raw_brainvision(new_name)
-    date = raw.info['meas_date'].strftime('%Y%m%d%H%M%S%f')
-    assert date == newdate.strftime('%Y%m%d%H%M%S%f')
-
-    for line in open(new_name):
-        # The original time should no longer be in the file
-        if 'Impedance [kOhm] at 16:12:27 :' in line:
-            raise AssertionError()
-        # if we find the new time, we're good
-        if 'Impedance [kOhm] at 12:23:11 :' in line:
-            break
+    new_date = raw.info['meas_date']
+    assert new_date == (prev_date - datetime.timedelta(days=32459))
 
 
 def test_copyfile_eeglab():

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -41,7 +41,7 @@ from mne.io.kit.kit import get_kit_info
 
 from mne_bids import (write_raw_bids, read_raw_bids, make_bids_basename,
                       make_bids_folders, write_anat, make_dataset_description)
-from mne_bids.write import (_stamp_to_dt, _get_anonymization_daysback,
+from mne_bids.utils import (_stamp_to_dt, _get_anonymization_daysback,
                             get_anonymization_daysback)
 from mne_bids.tsv_handler import _from_tsv, _to_tsv
 from mne_bids.utils import _find_matching_sidecar, _update_sidecar

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -12,7 +12,7 @@ import glob
 import json
 import shutil as sh
 import re
-from datetime import datetime
+from datetime import datetime, date, timedelta, timezone
 from collections import defaultdict, OrderedDict
 from os import path as op
 from pathlib import Path
@@ -1206,3 +1206,125 @@ def _infer_kind(*, bids_basename, bids_root, sub, ses):
 
     assert len(kinds) == 1
     return kinds[0]
+
+
+def _check_anonymize(anonymize, raw, ext):
+    """Check the `anonymize` dict."""
+    # if info['meas_date'] None, then the dates are not stored
+    if raw.info['meas_date'] is None:
+        daysback = None
+    else:
+        if 'daysback' not in anonymize or anonymize['daysback'] is None:
+            raise ValueError('`daysback` argument required to anonymize.')
+        daysback = anonymize['daysback']
+        daysback_min, daysback_max = _get_anonymization_daysback(raw)
+        if daysback < daysback_min:
+            warn('`daysback` is too small; the measurement date '
+                 'is after 1925, which is not recommended by BIDS.'
+                 'The minimum `daysback` value for changing the '
+                 'measurement date of this data to before this date '
+                 'is %s' % daysback_min)
+        if ext == '.fif' and daysback > daysback_max:
+            raise ValueError('`daysback` exceeds maximum value MNE '
+                             'is able to store in FIF format, must '
+                             'be less than %i' % daysback_max)
+    keep_his = anonymize['keep_his'] if 'keep_his' in anonymize else False
+    return daysback, keep_his
+
+
+def _get_anonymization_daysback(raw):
+    """Get the min and max number of daysback necessary to satisfy BIDS specs.
+
+    .. warning:: It is important that you remember the anonymization
+                 number if you would ever like to de-anonymize but
+                 that it is not included in the code publication
+                 as that would break the anonymization.
+
+    BIDS requires that anonymized dates be before 1925. In order to
+    preserve the longitudinal structure and ensure anonymization, the
+    user is asked to provide the same `daysback` argument to each call
+    of `write_raw_bids`. To determine the miniumum number of daysback
+    necessary, this function will calculate the minimum number based on
+    the most recent measurement date of raw objects.
+
+    Parameters
+    ----------
+    raw : instance of mne.io.Raw
+        The raw data. It must be an instance or list of instances of mne.Raw.
+
+    Returns
+    -------
+    daysback_min : int
+        The minimum number of daysback necessary to be compatible with BIDS.
+    daysback_max : int
+        The maximum number of daysback that MNE can store.
+    """
+    this_date = _stamp_to_dt(raw.info['meas_date']).date()
+    daysback_min = (this_date - date(year=1924, month=12, day=31)).days
+    daysback_max = (this_date - datetime.fromtimestamp(0).date() +
+                    timedelta(seconds=np.iinfo('>i4').max)).days
+    return daysback_min, daysback_max
+
+
+def get_anonymization_daysback(raws):
+    """Get the group min and max number of daysback necessary for BIDS specs.
+
+    .. warning:: It is important that you remember the anonymization
+                 number if you would ever like to de-anonymize but
+                 that it is not included in the code publication
+                 as that would break the anonymization.
+
+    BIDS requires that anonymized dates be before 1925. In order to
+    preserve the longitudinal structure and ensure anonymization, the
+    user is asked to provide the same `daysback` argument to each call
+    of `write_raw_bids`. To determine the miniumum number of daysback
+    necessary, this function will calculate the minimum number based on
+    the most recent measurement date of raw objects.
+
+    Parameters
+    ----------
+    raw : mne.io.Raw | list of Raw
+        The group raw data. It must be a list of instances of mne.Raw.
+
+    Returns
+    -------
+    daysback_min : int
+        The minimum number of daysback necessary to be compatible with BIDS.
+    daysback_max : int
+        The maximum number of daysback that MNE can store.
+    """
+    if not isinstance(raws, list):
+        raws = list([raws])
+    daysback_min_list = list()
+    daysback_max_list = list()
+    for raw in raws:
+        if raw.info['meas_date'] is not None:
+            daysback_min, daysback_max = _get_anonymization_daysback(raw)
+            daysback_min_list.append(daysback_min)
+            daysback_max_list.append(daysback_max)
+    if not daysback_min_list or not daysback_max_list:
+        raise ValueError('All measurement dates are None, ' +
+                         'pass any `daysback` value to anonymize.')
+    daysback_min = max(daysback_min_list)
+    daysback_max = min(daysback_max_list)
+    if daysback_min > daysback_max:
+        raise ValueError('The dataset spans more time than can be ' +
+                         'accomodated by MNE, you may have to ' +
+                         'not follow BIDS recommendations and use' +
+                         'anonymized dates after 1925')
+    return daysback_min, daysback_max
+
+
+def _stamp_to_dt(utc_stamp):
+    """Convert POSIX timestamp to datetime object in Windows-friendly way."""
+    # This is a windows datetime bug for timestamp < 0. A negative value
+    # is needed for anonymization which requires the date to be moved back
+    # to before 1925. This then requires a negative value of daysback
+    # compared the 1970 reference date.
+    if isinstance(utc_stamp, datetime):
+        return utc_stamp
+    stamp = [int(s) for s in utc_stamp]
+    if len(stamp) == 1:  # In case there is no microseconds information
+        stamp.append(0)
+    return (datetime.fromtimestamp(0, tz=timezone.utc) +
+            timedelta(0, stamp[0], stamp[1]))  # day, sec, μs

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -1235,22 +1235,10 @@ def _check_anonymize(anonymize, raw, ext):
 def _get_anonymization_daysback(raw):
     """Get the min and max number of daysback necessary to satisfy BIDS specs.
 
-    .. warning:: It is important that you remember the anonymization
-                 number if you would ever like to de-anonymize but
-                 that it is not included in the code publication
-                 as that would break the anonymization.
-
-    BIDS requires that anonymized dates be before 1925. In order to
-    preserve the longitudinal structure and ensure anonymization, the
-    user is asked to provide the same `daysback` argument to each call
-    of `write_raw_bids`. To determine the miniumum number of daysback
-    necessary, this function will calculate the minimum number based on
-    the most recent measurement date of raw objects.
-
     Parameters
     ----------
-    raw : instance of mne.io.Raw
-        The raw data. It must be an instance or list of instances of mne.Raw.
+    raw : mne.io.Raw
+        Subject raw data.
 
     Returns
     -------
@@ -1284,7 +1272,7 @@ def get_anonymization_daysback(raws):
     Parameters
     ----------
     raw : mne.io.Raw | list of Raw
-        The group raw data. It must be a list of instances of mne.Raw.
+        Subject raw data or list of raw data from several subjects.
 
     Returns
     -------

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -10,7 +10,7 @@
 import json
 import os
 import os.path as op
-from datetime import datetime, date, timedelta, timezone
+from datetime import datetime, timezone
 import shutil as sh
 from collections import defaultdict, OrderedDict
 
@@ -39,7 +39,7 @@ from mne_bids.utils import (_write_json, _write_tsv, _write_text,
                             _path_to_str, _parse_ext,
                             _get_ch_type_mapping, make_bids_folders,
                             _estimate_line_freq, make_bids_basename,
-                            BIDSPath)
+                            BIDSPath, _check_anonymize, _stamp_to_dt)
 from mne_bids.copyfiles import (copyfile_brainvision, copyfile_eeglab,
                                 copyfile_ctf, copyfile_bti, copyfile_kit)
 from mne_bids.tsv_handler import (_from_tsv, _drop, _contains_row,
@@ -51,47 +51,8 @@ from mne_bids.config import (ORIENTATION, UNITS, MANUFACTURERS,
                              _convert_sex_options, reader)
 
 
-def _check_anonymize(anonymize, raw, ext):
-    """Check the `anonymize` dict."""
-    # if info['meas_date'] None, then the dates are not stored
-    if raw.info['meas_date'] is None:
-        daysback = None
-    else:
-        if 'daysback' not in anonymize or anonymize['daysback'] is None:
-            raise ValueError('`daysback` argument required to anonymize.')
-            daysback = anonymize['daysback']
-            daysback_min, daysback_max = _get_anonymization_daysback(raw)
-            if daysback < daysback_min:
-                warn('`daysback` is too small; the measurement date '
-                     'is after 1925, which is not recommended by BIDS.'
-                     'The minimum `daysback` value for changing the '
-                     'measurement date of this data to before this date '
-                     'is ' % daysback_min)
-        if ext == '.fif' and daysback > daysback_max:
-            raise ValueError('`daysback` exceeds maximum value MNE '
-                             'is able to store in FIF format, must '
-                             'be less than %i' % daysback_max)
-    keep_his = anonymize['keep_his'] if 'keep_his' in anonymize else False
-    return daysback, keep_his
-
-
 def _is_numeric(n):
     return isinstance(n, (np.integer, np.floating, int, float))
-
-
-def _stamp_to_dt(utc_stamp):
-    """Convert POSIX timestamp to datetime object in Windows-friendly way."""
-    # This is a windows datetime bug for timestamp < 0. A negative value
-    # is needed for anonymization which requires the date to be moved back
-    # to before 1925. This then requires a negative value of daysback
-    # compared the 1970 reference date.
-    if isinstance(utc_stamp, datetime):
-        return utc_stamp
-    stamp = [int(s) for s in utc_stamp]
-    if len(stamp) == 1:  # In case there is no microseconds information
-        stamp.append(0)
-    return (datetime.fromtimestamp(0, tz=timezone.utc) +
-            timedelta(0, stamp[0], stamp[1]))  # day, sec, μs
 
 
 def _channels_tsv(raw, fname, overwrite=False, verbose=True):
@@ -728,89 +689,6 @@ def _write_raw_brainvision(raw, bids_fname, events):
                       events=events,
                       resolution=1e-9,
                       meas_date=meas_date)
-
-
-def _get_anonymization_daysback(raw):
-    """Get the min and max number of daysback necessary to satisfy BIDS specs.
-
-    .. warning:: It is important that you remember the anonymization
-                 number if you would ever like to de-anonymize but
-                 that it is not included in the code publication
-                 as that would break the anonymization.
-
-    BIDS requires that anonymized dates be before 1925. In order to
-    preserve the longitudinal structure and ensure anonymization, the
-    user is asked to provide the same `daysback` argument to each call
-    of `write_raw_bids`. To determine the miniumum number of daysback
-    necessary, this function will calculate the minimum number based on
-    the most recent measurement date of raw objects.
-
-    Parameters
-    ----------
-    raw : instance of mne.io.Raw
-        The raw data. It must be an instance or list of instances of mne.Raw.
-
-    Returns
-    -------
-    daysback_min : int
-        The minimum number of daysback necessary to be compatible with BIDS.
-    daysback_max : int
-        The maximum number of daysback that MNE can store.
-    """
-    this_date = _stamp_to_dt(raw.info['meas_date']).date()
-    daysback_min = (this_date - date(year=1924, month=12, day=31)).days
-    daysback_max = (this_date - datetime.fromtimestamp(0).date() +
-                    timedelta(seconds=np.iinfo('>i4').max)).days
-    return daysback_min, daysback_max
-
-
-def get_anonymization_daysback(raws):
-    """Get the group min and max number of daysback necessary for BIDS specs.
-
-    .. warning:: It is important that you remember the anonymization
-                 number if you would ever like to de-anonymize but
-                 that it is not included in the code publication
-                 as that would break the anonymization.
-
-    BIDS requires that anonymized dates be before 1925. In order to
-    preserve the longitudinal structure and ensure anonymization, the
-    user is asked to provide the same `daysback` argument to each call
-    of `write_raw_bids`. To determine the miniumum number of daysback
-    necessary, this function will calculate the minimum number based on
-    the most recent measurement date of raw objects.
-
-    Parameters
-    ----------
-    raw : mne.io.Raw | list of Raw
-        The group raw data. It must be a list of instances of mne.Raw.
-
-    Returns
-    -------
-    daysback_min : int
-        The minimum number of daysback necessary to be compatible with BIDS.
-    daysback_max : int
-        The maximum number of daysback that MNE can store.
-    """
-    if not isinstance(raws, list):
-        raws = list([raws])
-    daysback_min_list = list()
-    daysback_max_list = list()
-    for raw in raws:
-        if raw.info['meas_date'] is not None:
-            daysback_min, daysback_max = _get_anonymization_daysback(raw)
-            daysback_min_list.append(daysback_min)
-            daysback_max_list.append(daysback_max)
-    if not daysback_min_list or not daysback_max_list:
-        raise ValueError('All measurement dates are None, ' +
-                         'pass any `daysback` value to anonymize.')
-    daysback_min = max(daysback_min_list)
-    daysback_max = min(daysback_max_list)
-    if daysback_min > daysback_max:
-        raise ValueError('The dataset spans more time than can be ' +
-                         'accomodated by MNE, you may have to ' +
-                         'not follow BIDS recommendations and use' +
-                         'anonymized dates after 1925')
-    return daysback_min, daysback_max
 
 
 def make_dataset_description(path, name, data_license=None,

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1194,14 +1194,11 @@ def write_raw_bids(raw, bids_basename, bids_root, events_data=None,
         print('Copying data files to %s' % op.splitext(bids_fname)[0])
 
     # File saving branching logic
-    if convert or (anonymize is not None):
+    if (convert or (anonymize is not None)) and ext != '.vhdr':
         if kind == 'meg':
             if ext == '.pdf':
                 bids_fname = op.join(data_path, op.basename(bids_fname))
             _write_raw_fif(raw, bids_fname)
-        elif kind is in ['eeg', 'ieeg'] and ext == '.vhdr':
-            copyfile_brainvision(raw_fname, bids_fname,
-                                 anonymize=raw.info['meas_date'])
         else:
             if verbose:
                 warn('Converting data files to BrainVision format')
@@ -1214,7 +1211,8 @@ def write_raw_bids(raw, bids_basename, bids_root, events_data=None,
         copyfile_ctf(raw_fname, bids_fname)
     # BrainVision is multifile, copy over all of them and fix pointers
     elif ext == '.vhdr':
-        copyfile_brainvision(raw_fname, bids_fname)
+        copyfile_brainvision(raw_fname, bids_fname, anonymize=anonymize,
+                             date=raw.info['meas_date'])
     # EEGLAB .set might be accompanied by a .fdt - find out and copy it too
     elif ext == '.set':
         copyfile_eeglab(raw_fname, bids_fname)

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -839,7 +839,7 @@ def write_raw_bids(raw, bids_basename, bids_root, events_data=None,
             Number of days by which to move back the recording date in time.
             In studies with multiple subjects the relative recording date
             differences between subjects can be kept by using the same number
-            of `daysback` for all subject anonymizations. `daysback` must be
+            of `daysback` for all subject anonymizations. `daysback` should be
             great enough to shift the date prior to 1925 to conform with BIDS
             anonymization rules.
 
@@ -877,7 +877,7 @@ def write_raw_bids(raw, bids_basename, bids_root, events_data=None,
     updated and raw.info['meas_date'] should not be None to compute the age
     of the participant correctly.
 
-    See also
+    See Also
     --------
     mne.io.anonymize_info
 

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1101,6 +1101,7 @@ def write_raw_bids(raw, bids_basename, bids_root, events_data=None,
         bids_fname.prefix = bids_raw_folder
 
     # Anonymize
+    convert = False
     if anonymize is not None:
         # if info['meas_date'] None, then the dates are not stored
         if raw.info['meas_date'] is None:
@@ -1123,7 +1124,7 @@ def write_raw_bids(raw, bids_basename, bids_root, events_data=None,
         keep_his = anonymize['keep_his'] if 'keep_his' in anonymize else False
         raw.info = anonymize_info(raw.info, daysback=daysback,
                                   keep_his=keep_his)
-        convert = False
+
         if kind == 'meg' and ext != '.fif':
             if verbose:
                 warn('Converting to FIF for anonymization')

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1127,7 +1127,7 @@ def write_raw_bids(raw, bids_basename, bids_root, events_data=None,
             if verbose:
                 warn('Converting to FIF for anonymization')
             bids_fname.suffix = bids_fname.suffix.replace(ext, '.fif')
-        elif kind in ['eeg', 'ieeg']:
+        elif kind in ['eeg', 'ieeg'] and ext != '.vhdr':
             if verbose:
                 warn('Converting to BV for anonymization')
             bids_fname.suffix = bids_fname.suffix.replace(ext, '.vhdr')
@@ -1199,6 +1199,9 @@ def write_raw_bids(raw, bids_basename, bids_root, events_data=None,
             if ext == '.pdf':
                 bids_fname = op.join(data_path, op.basename(bids_fname))
             _write_raw_fif(raw, bids_fname)
+        elif kind is in ['eeg', 'ieeg'] and ext == '.vhdr':
+            copyfile_brainvision(raw_fname, bids_fname,
+                                 anonymize=raw.info['meas_date'])
         else:
             if verbose:
                 warn('Converting data files to BrainVision format')

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -877,6 +877,10 @@ def write_raw_bids(raw, bids_basename, bids_root, events_data=None,
     updated and raw.info['meas_date'] should not be None to compute the age
     of the participant correctly.
 
+    See also
+    --------
+    mne.io.anonymize_info
+
     """
     if not check_version('mne', '0.17'):
         raise ValueError('Your version of MNE is too old. '

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -831,21 +831,22 @@ def write_raw_bids(raw, bids_basename, bids_root, events_data=None,
     event_id : dict | None
         The event id dict used to create a 'trial_type' column in events.tsv
     anonymize : dict | None
-        If None is provided (default) no anonymization is performed.
-        If a dictionary is passed, data will be anonymized; identifying data
-        structures such as study date and time will be changed.
-        `daysback` is a required argument and `keep_his` is optional, these
-        arguments are passed to :func:`mne.io.anonymize_info`.
+        If None (default), no anonymization is performed.
+        If dict, data will be anonymized depending on the keys provided with
+        the dict: `daysback` is a required key, `keep_his` is an optional key.
 
         `daysback` : int
-            Number of days to move back the date. To keep relative dates for
-            a subject use the same `daysback`. According to BIDS
-            specifications, the number of days back must be great enough
-            that the date is before 1925.
+            Number of days by which to move back the recording date in time.
+            In studies with multiple subjects the relative recording date
+            differences between subjects can be kept by using the same number
+            of `daysback` for all subject anonymizations. `daysback` must be
+            great enough to shift the date prior to 1925 to conform with BIDS
+            anonymization rules.
 
         `keep_his` : bool
-            If True info['subject_info']['his_id'] of subject_info will NOT be
-            overwritten. Defaults to False.
+            By default (False), all subject information next to the recording
+            date will be overwritten as well. If True, keep subject information
+            apart from the recording date.
 
     overwrite : bool
         Whether to overwrite existing files or data in files.


### PR DESCRIPTION
closes #473 

~This is a preview of the changes I imagine to make to fix #473~

It just seems more robust/safer to me.

Given this concrete proposal, are you still all against it? :-) 

To do
-------
- [x] update example on [copyfile_brainvision](https://mne.tools/mne-bids/stable/auto_examples/rename_brainvision_files.html#sphx-glr-auto-examples-rename-brainvision-files-py)

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [x] All comments resolved
- [x] This is not your own PR
- [x] All CIs are happy
- [x] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [x] PR description includes phrase "closes <#issue-number>"
- [x] Commit history does not contain any merge commits
