### PR TITLE
[MRG] updated dataset description overwrite

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -59,6 +59,7 @@ API
 - The :code:`mne_bids.write.make_bids_basename` function has been moved to :code:`mne_bids.utils.make_bids_basename`. Like before, it can also be accessed via `mne_bids.make_bids_basename`, by `Richard Höchenberger`_ (`#424 <https://github.com/mne-tools/mne-bids/pull/424>`_)
 - The :func:`mne_bids.make_bids_basename` function has been updated to create a :code:`mne_bids.utils.BIDSPath` object, which operates like a path object and allows dynamic updating of BIDs entities, by `Adam Li`_ (`#446 <https://github.com/mne-tools/mne-bids/pull/446>`_)
 - The ``datasets.py`` module was removed from ``MNE-BIDS`` and its utility was replaced by ``mne.datasets``, by `Stefan Appelhoff`_ (`#471 <https://github.com/mne-tools/mne-bids/pull/471>`_)
+- :func:`mne_bids.make_dataset_description` now takes the argument `overwrite` which will reset all fields if `True`. If `False`, user-provided fields will no longer be overwritten by :func:`mne_bids.write_raw_bids` when its `overwrite` argument is `True` unless new values are supplied, by `Alex Rockhill`_ (`#478 <https://github.com/mne-tools/mne-bids/pull/478>`_)
 
 .. _changes_0_4:
 

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -777,14 +777,14 @@ def get_anonymization_daysback(raws):
             daysback_min_list.append(daysback_min)
             daysback_max_list.append(daysback_max)
     if not daysback_min_list or not daysback_max_list:
-        raise ValueError('All measurement dates are None, ' +
+        raise ValueError('All measurement dates are None, '
                          'pass any `daysback` value to anonymize.')
     daysback_min = max(daysback_min_list)
     daysback_max = min(daysback_max_list)
     if daysback_min > daysback_max:
-        raise ValueError('The dataset spans more time than can be ' +
-                         'accomodated by MNE, you may have to ' +
-                         'not follow BIDS recommendations and use' +
+        raise ValueError('The dataset spans more time than can be '
+                         'accomodated by MNE, you may have to '
+                         'not follow BIDS recommendations and use'
                          'anonymized dates after 1925')
     return daysback_min, daysback_max
 
@@ -794,7 +794,7 @@ def make_dataset_description(path, name, data_license=None,
                              how_to_acknowledge=None, funding=None,
                              references_and_links=None, doi=None,
                              dataset_type='raw',
-                             verbose=False):
+                             overwrite=False, verbose=False):
     """Create json for a dataset description.
 
     BIDS datasets may have one or more fields, this function allows you to
@@ -831,6 +831,12 @@ def make_dataset_description(path, name, data_license=None,
         The DOI for the dataset.
     dataset_type : str
         Must be either "raw" or "derivative". Defaults to "raw".
+    overwrite : bool
+        Whether to overwrite existing files or data in files.
+        Defaults to False.
+        If overwrite is True, provided fields will overwrite previous data.
+        If overwrite is False, no existing data will be overwritten or
+        replaced.
     verbose : bool
         Set verbose output to True or False.
 
@@ -839,11 +845,6 @@ def make_dataset_description(path, name, data_license=None,
     The required field BIDSVersion will be automatically filled by mne_bids.
 
     """
-    # default author to make dataset description BIDS compliant
-    if authors is None:
-        authors = ("Please cite MNE-BIDS in your publication before removing "
-                   "this (citations in README)")
-
     # Put potential string input into list of strings
     if isinstance(authors, str):
         authors = authors.split(', ')
@@ -866,6 +867,24 @@ def make_dataset_description(path, name, data_license=None,
                                ('Funding', funding),
                                ('ReferencesAndLinks', references_and_links),
                                ('DatasetDOI', doi)])
+    if op.isfile(fname):
+        with open(fname, 'r') as fin:
+            orig_cols = json.load(fin)
+        if 'BIDSVersion' in orig_cols and \
+                orig_cols['BIDSVersion'] != BIDS_VERSION:
+            raise ValueError('Previous BIDS version used, please redo the '
+                             'conversion to BIDS in a new directory '
+                             'after ensuring all software is updated')
+        for key, val in description.items():
+            if description[key] is None or not overwrite:
+                description[key] = orig_cols.get(key, None)
+    # default author to make dataset description BIDS compliant
+    # if the user passed an author don't overwrite,
+    # if there was an author there, only overwrite if `overwrite=True`
+    if authors is None and (description['Authors'] is None or overwrite):
+        description['Authors'] = ["Please cite MNE-BIDS in your publication "
+                                  "before removing this (citations in README)"]
+
     pop_keys = [key for key, val in description.items() if val is None]
     for key in pop_keys:
         description.pop(key)
@@ -1164,9 +1183,8 @@ def write_raw_bids(raw, bids_basename, bids_root, events_data=None,
     if events is not None and len(events) > 0 and not emptyroom:
         _events_tsv(events, raw, events_fname, event_id, overwrite, verbose)
 
-    dataset_description_fpath = op.join(bids_root, "dataset_description.json")
-    if not op.exists(dataset_description_fpath) or overwrite:
-        make_dataset_description(bids_root, name=" ", verbose=verbose)
+    make_dataset_description(bids_root, name=" ", overwrite=overwrite,
+                             verbose=verbose)
 
     _sidecar_json(raw, task, manufacturer, sidecar_fname, kind, overwrite,
                   verbose)
@@ -1186,7 +1204,7 @@ def write_raw_bids(raw, bids_basename, bids_root, events_data=None,
     convert = ext not in ALLOWED_EXTENSIONS[kind]
 
     if kind == 'meg' and convert and not anonymize:
-        raise ValueError('Got file extension %s for MEG data, ' +
+        raise ValueError('Got file extension %s for MEG data, '
                          'expected one of %s' %
                          ALLOWED_EXTENSIONS['meg'])
 


### PR DESCRIPTION
After looking at it, participants.tsv and participants.json were done well, I was just frustrated because of my user error/lack of understanding how they worked :) I think this was because I was changing `sex` to `gender` where I would like it not to write a sex json description and to just put 'n/a's in all the columns that exist without erroring out that there was no `sex` column. There could be an `overwrite_modality_agnostic` keyword argument or it could be documented that it is recommended to leave `age` `sex` and `hand` alone and just add columns but I think I was just being difficult by trying to modify participants.tsv between conversions whereas it's best just to just to leave it alone until the end and that might be a unique error to my use of mne-bids so maybe best just to leave as is.

I changed dataset description so that it doesn't overwrite fields unless it is appropriate because the user supplied new data for the fields. Again this caused issues when I went to modify the file and the kept converting new files to BIDS. I think this version is better because it doesn't overwrite fields like name to " " even if `overwrite` is True unless the user supplies a new name. I think this better disambiguates overwriting a modality data file with write_raw_bids compared to overwriting the modality agnostic files which aren't necessarily the same thing. 

Closes #476.


Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [x] All comments resolved
- [x] This is not your own PR
- [x] All CIs are happy
- [x] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [x] PR description includes phrase "closes <#issue-number>"
- [x] Commit history does not contain any merge commits
