### PR TITLE
Make ch_type reading more robust & support RESP

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -34,7 +34,6 @@ Changelog
 - :func:`make_dataset_description` now has an additional parameter ``dataset_type`` to set the recommended field ``DatasetType`` (defaults to ``"raw"``), by `Stefan Appelhoff`_ (`#472 <https://github.com/mne-tools/mne-bids/pull/472>`_)
 - :func:`mne_bids.copyfiles.copyfile_brainvision` now has an ``anonymize`` parameter to control anonymization, by `Stefan Appelhoff`_ (`#475 <https://github.com/mne-tools/mne-bids/pull/475>`_)
 - :func:`mne_bids.read_raw_bids` and :func:`mne_bids.write_raw_bids` now map respiratory (``RESP``) channel types, by `Richard Höchenberger` (`#482 <https://github.com/mne-tools/mne-bids/pull/482>`_)
-- :func:`mne_bids.read_raw_bids` now tries to correctly map channel types that are not in all-uppercase letters. Since this is in violation of BIDS, a warning is raised, by `Richard Höchenberger` (`#482 <https://github.com/mne-tools/mne-bids/pull/482>`_)
 
 Bug
 ~~~

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -33,6 +33,8 @@ Changelog
 - :func:`write_raw_bids` now adds citations to the README, by `Alex Rockhill`_ (`#463 <https://github.com/mne-tools/mne-bids/pull/463>`_)
 - :func:`make_dataset_description` now has an additional parameter ``dataset_type`` to set the recommended field ``DatasetType`` (defaults to ``"raw"``), by `Stefan Appelhoff`_ (`#472 <https://github.com/mne-tools/mne-bids/pull/472>`_)
 - :func:`mne_bids.copyfiles.copyfile_brainvision` now has an ``anonymize`` parameter to control anonymization, by `Stefan Appelhoff`_ (`#475 <https://github.com/mne-tools/mne-bids/pull/475>`_)
+- :func:`mne_bids.read_raw_bids` and :func:`mne_bids.write_raw_bids` now map respiratory (``RESP``) channel types, by `Richard Höchenberger` (`#482 <https://github.com/mne-tools/mne-bids/pull/482>`_)
+- :func:`mne_bids.read_raw_bids` now tries to correctly map channel types that are not in all-uppercase letters. Since this is in violation of BIDS, a warning is raised, by `Richard Höchenberger` (`#482 <https://github.com/mne-tools/mne-bids/pull/482>`_)
 
 Bug
 ~~~

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -235,7 +235,8 @@ def _handle_channels_reading(channels_fname, bids_fname, raw):
         if updated_ch_type is None:
             # XXX Try again with uppercase spelling – this should be removed
             # XXX once https://github.com/bids-standard/bids-validator/issues/1018  # noqa:E501
-            # has been resolved.
+            # XXX has been resolved.
+            # XXX x-ref https://github.com/mne-tools/mne-bids/issues/481
             updated_ch_type = bids_to_mne_ch_types.get(ch_type.upper(), None)
             if updated_ch_type is not None:
                 msg = ('The BIDS dataset contains channel types in lowercase '

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -231,6 +231,18 @@ def _handle_channels_reading(channels_fname, bids_fname, raw):
         # Try to map from BIDS nomenclature to MNE, leave channel type
         # untouched if we are uncertain
         updated_ch_type = bids_to_mne_ch_types.get(ch_type, None)
+
+        if updated_ch_type is None:
+            # XXX Try again with uppercase spelling – this should be removed
+            # XXX once https://github.com/bids-standard/bids-validator/issues/1018  # noqa:E501
+            # has been resolved.
+            updated_ch_type = bids_to_mne_ch_types.get(ch_type.upper(), None)
+            if updated_ch_type is not None:
+                msg = (f'The BIDS dataset contains channel types in lowercase '
+                       f'spelling. This violates the BIDS specification and '
+                       f'will raise an error in the future.')
+                warn(msg)
+
         if updated_ch_type is not None:
             channel_type_dict[ch_name] = updated_ch_type
 

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -238,9 +238,9 @@ def _handle_channels_reading(channels_fname, bids_fname, raw):
             # has been resolved.
             updated_ch_type = bids_to_mne_ch_types.get(ch_type.upper(), None)
             if updated_ch_type is not None:
-                msg = (f'The BIDS dataset contains channel types in lowercase '
-                       f'spelling. This violates the BIDS specification and '
-                       f'will raise an error in the future.')
+                msg = ('The BIDS dataset contains channel types in lowercase '
+                       'spelling. This violates the BIDS specification and '
+                       'will raise an error in the future.')
                 warn(msg)
 
         if updated_ch_type is not None:

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -762,6 +762,7 @@ def test_read_raw_kind():
 
 
 def test_handle_channel_type_casing():
+    """Test that non-uppercase entries in the `type` column are accepted."""
     bids_root = _TempDir()
     raw = mne.io.read_raw_fif(raw_fname, verbose=False)
     write_raw_bids(raw, bids_basename, bids_root, overwrite=True,

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -759,3 +759,24 @@ def test_read_raw_kind():
 
     assert raw_1 == raw_2
     assert raw_1 == raw_3
+
+
+def test_handle_channel_type_casing():
+    bids_root = _TempDir()
+    raw = mne.io.read_raw_fif(raw_fname, verbose=False)
+    write_raw_bids(raw, bids_basename, bids_root, overwrite=True,
+                   verbose=False)
+
+    subject_path = op.join(bids_root, f'sub-{subject_id}', f'ses-{session_id}',
+                           'meg')
+    bids_channels_fname = (bids_basename.copy()
+                           .update(prefix=subject_path,
+                                   suffix='channels.tsv'))
+
+    # Convert all channel type entries to lowercase.
+    channels_data = _from_tsv(bids_channels_fname)
+    channels_data['type'] = [t.lower() for t in channels_data['type']]
+    _to_tsv(channels_data, bids_channels_fname)
+
+    with pytest.warns(RuntimeWarning, match='lowercase spelling'):
+        read_raw_bids(bids_basename, bids_root=bids_root)

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -690,10 +690,8 @@ def test_bti(_bids_validate):
     assert op.exists(op.join(bids_root, 'participants.tsv'))
     _bids_validate(bids_root)
 
-    print('before read')
     raw = read_raw_bids(bids_basename=bids_basename, bids_root=bids_root,
                         kind='meg')
-    print('after read')
 
     with pytest.raises(TypeError, match="unexpected keyword argument 'foo'"):
         read_raw_bids(bids_basename=bids_basename, bids_root=bids_root,

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -690,8 +690,10 @@ def test_bti(_bids_validate):
     assert op.exists(op.join(bids_root, 'participants.tsv'))
     _bids_validate(bids_root)
 
+    print('before read')
     raw = read_raw_bids(bids_basename=bids_basename, bids_root=bids_root,
                         kind='meg')
+    print('after read')
 
     with pytest.raises(TypeError, match="unexpected keyword argument 'foo'"):
         read_raw_bids(bids_basename=bids_basename, bids_root=bids_root,

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -13,7 +13,7 @@ import json
 import shutil as sh
 import re
 from datetime import datetime, date, timedelta, timezone
-from collections import defaultdict, OrderedDict
+from collections import OrderedDict
 from os import path as op
 from pathlib import Path
 from copy import deepcopy
@@ -421,7 +421,7 @@ def _get_ch_type_mapping(fro='mne', to='bids'):
 
     Returns
     -------
-    ch_type_mapping : collections.defaultdict
+    mapping : dict
         Dictionary mapping from one nomenclature of channel types to another.
         If a key is not present, a default value will be returned that depends
         on the `fro` and `to` parameters.
@@ -434,34 +434,27 @@ def _get_ch_type_mapping(fro='mne', to='bids'):
 
     """
     if fro == 'mne' and to == 'bids':
-        map_chs = dict(eeg='EEG', misc='MISC', stim='TRIG', emg='EMG',
+        mapping = dict(eeg='EEG', misc='MISC', stim='TRIG', emg='EMG',
                        ecog='ECOG', seeg='SEEG', eog='EOG', ecg='ECG',
+                       resp='RESP',
                        # MEG channels
                        meggradaxial='MEGGRADAXIAL', megmag='MEGMAG',
                        megrefgradaxial='MEGREFGRADAXIAL',
-                       meggradplanar='MEGGRADPLANAR', megrefmag='MEGREFMAG',
-                       )
-        default_value = 'OTHER'
+                       meggradplanar='MEGGRADPLANAR', megrefmag='MEGREFMAG')
 
     elif fro == 'bids' and to == 'mne':
-        map_chs = dict(EEG='eeg', MISC='misc', TRIG='stim', EMG='emg',
+        mapping = dict(EEG='eeg', MISC='misc', TRIG='stim', EMG='emg',
                        ECOG='ecog', SEEG='seeg', EOG='eog', ECG='ecg',
+                       RESP='resp',
                        # No MEG channels for now
                        # Many to one mapping
-                       VEOG='eog', HEOG='eog',
-                       )
-        default_value = 'misc'
-
+                       VEOG='eog', HEOG='eog')
     else:
         raise ValueError('Only two types of mappings are currently supported: '
                          'from mne to bids, or from bids to mne. However, '
                          'you specified from "{}" to "{}"'.format(fro, to))
 
-    # Make it a defaultdict to prevent key errors
-    ch_type_mapping = defaultdict(lambda: default_value)
-    ch_type_mapping.update(map_chs)
-
-    return ch_type_mapping
+    return mapping
 
 
 def print_dir_tree(folder, max_depth=None):


### PR DESCRIPTION

PR Description
--------------

If mapping of channel types from BIDS to MNE fails, retry with all-uppercase channel types. Closes GH-481.
I anticipate this will only be a temporary thing and therefore didn't add a dedicated test for this. – However, it _does_ come with a breaking change: we're not using a `defaultdict` for the mapping anymore.

This commit also adds support for mapping respiratory channels between BIDS and MNE.

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
- [ ] Commit history does not contain any merge commits
