### PR TITLE
[MRG] ENH: Write impedances to electrodes.tsv when available

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -33,7 +33,8 @@ Changelog
 - :func:`write_raw_bids` now adds citations to the README, by `Alex Rockhill`_ (`#463 <https://github.com/mne-tools/mne-bids/pull/463>`_)
 - :func:`make_dataset_description` now has an additional parameter ``dataset_type`` to set the recommended field ``DatasetType`` (defaults to ``"raw"``), by `Stefan Appelhoff`_ (`#472 <https://github.com/mne-tools/mne-bids/pull/472>`_)
 - :func:`mne_bids.copyfiles.copyfile_brainvision` now has an ``anonymize`` parameter to control anonymization, by `Stefan Appelhoff`_ (`#475 <https://github.com/mne-tools/mne-bids/pull/475>`_)
-- :func:`mne_bids.read_raw_bids` and :func:`mne_bids.write_raw_bids` now map respiratory (``RESP``) channel types, by `Richard Höchenberger` (`#482 <https://github.com/mne-tools/mne-bids/pull/482>`_)
+- :func:`mne_bids.read_raw_bids` and :func:`mne_bids.write_raw_bids` now map respiratory (``RESP``) channel types, by `Richard Höchenberger`_ (`#482 <https://github.com/mne-tools/mne-bids/pull/482>`_)
+- When impedance values are available from a ``raw.impedances`` attribute, MNE-BIDS will now write an ``impedance`` column to ``*_electrodes.tsv`` files, by `Stefan Appelhoff`_ (`#484 <https://github.com/mne-tools/mne-bids/pull/484>`_)
 
 Bug
 ~~~

--- a/mne_bids/dig.py
+++ b/mne_bids/dig.py
@@ -135,7 +135,7 @@ def _handle_coordsystem_reading(coordsystem_fpath, kind, verbose=True):
 
 def _get_impedances(raw, names):
     """Get the impedance values in kOhm from raw.impedances."""
-    if not hasattr(raw, 'impedances'):
+    if not hasattr(raw, 'impedances'):  # pragma: no cover
         return ['n/a'] * len(names)
     no_info = {'imp': 'n/a', 'imp_unit': 'kOhm'}
     impedance_dicts = [raw.impedances.get(name, no_info) for name in names]

--- a/mne_bids/dig.py
+++ b/mne_bids/dig.py
@@ -202,7 +202,7 @@ def _electrodes_tsv(raw, fname, kind, overwrite=False, verbose=True):
     # Add impedance values if available, currently only BrainVision:
     # https://github.com/mne-tools/mne-python/pull/7974
     if hasattr(raw, 'impedances'):
-        data['impedances'] = _get_impedances(raw, names)
+        data['impedance'] = _get_impedances(raw, names)
 
     _write_tsv(fname, data, overwrite=overwrite, verbose=verbose)
 

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -793,9 +793,9 @@ def test_vhdr(_bids_validate):
     electrodes_fpath = _find_matching_sidecar(bids_basename, bids_root,
                                               suffix='electrodes.tsv')
     tsv = _from_tsv(electrodes_fpath)
-    assert len(tsv.get('impedances', {})) > 0
-    assert tsv['impedances'][-3:] == ['n/a', 'n/a', 'n/a']
-    assert tsv['impedances'][:3] == ['5.0', '2.0', '4.0']
+    assert len(tsv.get('impedance', {})) > 0
+    assert tsv['impedance'][-3:] == ['n/a', 'n/a', 'n/a']
+    assert tsv['impedance'][:3] == ['5.0', '2.0', '4.0']
 
 
 

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -708,9 +708,8 @@ def test_bti(_bids_validate):
 
 
 # XXX: vhdr test currently passes only on MNE master. Skip until next release.
-# see: https://github.com/mne-tools/mne-python/pull/6558
-@pytest.mark.skipif(LooseVersion(mne.__version__) < LooseVersion('0.19'),
-                    reason='requires mne 0.19.dev0 or higher')
+@pytest.mark.skipif(LooseVersion(mne.__version__) < LooseVersion('0.21'),
+                    reason='requires mne 0.21.dev0 or higher')
 @pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
 def test_vhdr(_bids_validate):
     """Test write_raw_bids conversion for BrainVision data."""

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -797,7 +797,6 @@ def test_vhdr(_bids_validate):
     assert tsv['impedance'][:3] == ['5.0', '2.0', '4.0']
 
 
-
 @pytest.mark.filterwarnings(warning_str['nasion_not_found'])
 def test_edf(_bids_validate):
     """Test write_raw_bids conversion for European Data Format data."""


### PR DESCRIPTION
closes #477 

This adds impedance writing to electrodes.tsv when available (currently only BrainVision)

Tests will pass only once the MNE-testing-data is updated, see: https://github.com/mne-tools/mne-testing-data/pull/69


### BIDS spec on electrodes.tsv

eeg: https://bids-specification.readthedocs.io/en/stable/04-modality-specific-files/03-electroencephalography.html#electrodes-description-_electrodestsv

ieeg: https://bids-specification.readthedocs.io/en/stable/04-modality-specific-files/04-intracranial-electroencephalography.html#electrode-description-_electrodestsv

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [x] All comments resolved
- [x] This is not your own PR
- [x] All CIs are happy
- [x] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [x] PR description includes phrase "closes <#issue-number>"
- [x] Commit history does not contain any merge commits
