### PR TITLE
[MRG] Remove support for non-uppercase channel types

### DIFF
--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -231,19 +231,6 @@ def _handle_channels_reading(channels_fname, bids_fname, raw):
         # Try to map from BIDS nomenclature to MNE, leave channel type
         # untouched if we are uncertain
         updated_ch_type = bids_to_mne_ch_types.get(ch_type, None)
-
-        if updated_ch_type is None:
-            # XXX Try again with uppercase spelling – this should be removed
-            # XXX once https://github.com/bids-standard/bids-validator/issues/1018  # noqa:E501
-            # XXX has been resolved.
-            # XXX x-ref https://github.com/mne-tools/mne-bids/issues/481
-            updated_ch_type = bids_to_mne_ch_types.get(ch_type.upper(), None)
-            if updated_ch_type is not None:
-                msg = ('The BIDS dataset contains channel types in lowercase '
-                       'spelling. This violates the BIDS specification and '
-                       'will raise an error in the future.')
-                warn(msg)
-
         if updated_ch_type is not None:
             channel_type_dict[ch_name] = updated_ch_type
 

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -760,25 +760,3 @@ def test_read_raw_kind():
 
     assert raw_1 == raw_2
     assert raw_1 == raw_3
-
-
-def test_handle_channel_type_casing():
-    """Test that non-uppercase entries in the `type` column are accepted."""
-    bids_root = _TempDir()
-    raw = mne.io.read_raw_fif(raw_fname, verbose=False)
-    write_raw_bids(raw, bids_basename, bids_root, overwrite=True,
-                   verbose=False)
-
-    subject_path = op.join(bids_root, f'sub-{subject_id}', f'ses-{session_id}',
-                           'meg')
-    bids_channels_fname = (bids_basename.copy()
-                           .update(prefix=subject_path,
-                                   suffix='channels.tsv'))
-
-    # Convert all channel type entries to lowercase.
-    channels_data = _from_tsv(bids_channels_fname)
-    channels_data['type'] = [t.lower() for t in channels_data['type']]
-    _to_tsv(channels_data, bids_channels_fname)
-
-    with pytest.warns(RuntimeWarning, match='lowercase spelling'):
-        read_raw_bids(bids_basename, bids_root=bids_root)


### PR DESCRIPTION

PR Description
--------------

Since GH-481 has been closed and the BIDS validator was updated, we drop support for non-uppercase channel types.

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [x] All comments resolved
- [x] This is not your own PR
- [ ] All CIs are happy
- [x] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
- [x] Commit history does not contain any merge commits
