### PR TITLE
[MRG] Make _parse_bids_filename() public, drop verbose arg

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -56,6 +56,7 @@ Path
    :toctree: generated/
 
    BIDSPath
+   parse_bids_filename
 
 Copyfiles
 =========

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -65,6 +65,7 @@ API
 - :func:`mne_bids.make_dataset_description` now takes the argument `overwrite` which will reset all fields if `True`. If `False`, user-provided fields will no longer be overwritten by :func:`mne_bids.write_raw_bids` when its `overwrite` argument is `True` unless new values are supplied, by `Alex Rockhill`_ (`#478 <https://github.com/mne-tools/mne-bids/pull/478>`_)
 - :func:`mne_bids.make_report` is now available from the `mne_bids` namespace that creates a string output of a summary of the BIDS dataset. In addition, the command line interface allows one to call `make_report`, by `Adam Li`_ (`#457 <https://github.com/mne-tools/mne-bids/pull/457>`_)
 - Added namespace :code:`mne_bids.path` which hosts path-like functionality for MNE-BIDS by `Adam Li`_ (`#483 <https://github.com/mne-tools/mne-bids/pull/483>`_)
+- :func:`mne_bids.path._parse_bids_filename` is now part of the public API and has consequently been renamed to `:func:`mne_bids.path._parse_bids_filename`, by `Richard Höchenberger`_ (`#487 <https://github.com/mne-tools/mne-bids/pull/487>`_)
 
 .. _changes_0_4:
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -65,7 +65,7 @@ API
 - :func:`mne_bids.make_dataset_description` now takes the argument `overwrite` which will reset all fields if `True`. If `False`, user-provided fields will no longer be overwritten by :func:`mne_bids.write_raw_bids` when its `overwrite` argument is `True` unless new values are supplied, by `Alex Rockhill`_ (`#478 <https://github.com/mne-tools/mne-bids/pull/478>`_)
 - :func:`mne_bids.make_report` is now available from the `mne_bids` namespace that creates a string output of a summary of the BIDS dataset. In addition, the command line interface allows one to call `make_report`, by `Adam Li`_ (`#457 <https://github.com/mne-tools/mne-bids/pull/457>`_)
 - Added namespace :code:`mne_bids.path` which hosts path-like functionality for MNE-BIDS by `Adam Li`_ (`#483 <https://github.com/mne-tools/mne-bids/pull/483>`_)
-- A function for retrieval of BIDS entity values from a filename, :func:`mne_bids.path.parse_bids_filename`, is now part of the public API (it used to be a private function called :func:`mne_bids.path._parse_bids_filename`), by `Richard Höchenberger`_ (`#487 <https://github.com/mne-tools/mne-bids/pull/487>`_)
+- A function for retrieval of BIDS entity values from a filename, :func:`mne_bids.path.parse_bids_filename`, is now part of the public API (it used to be a private function called ``mne_bids.path._parse_bids_filename``), by `Richard Höchenberger`_ (`#487 <https://github.com/mne-tools/mne-bids/pull/487>`_)
 
 .. _changes_0_4:
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -65,7 +65,7 @@ API
 - :func:`mne_bids.make_dataset_description` now takes the argument `overwrite` which will reset all fields if `True`. If `False`, user-provided fields will no longer be overwritten by :func:`mne_bids.write_raw_bids` when its `overwrite` argument is `True` unless new values are supplied, by `Alex Rockhill`_ (`#478 <https://github.com/mne-tools/mne-bids/pull/478>`_)
 - :func:`mne_bids.make_report` is now available from the `mne_bids` namespace that creates a string output of a summary of the BIDS dataset. In addition, the command line interface allows one to call `make_report`, by `Adam Li`_ (`#457 <https://github.com/mne-tools/mne-bids/pull/457>`_)
 - Added namespace :code:`mne_bids.path` which hosts path-like functionality for MNE-BIDS by `Adam Li`_ (`#483 <https://github.com/mne-tools/mne-bids/pull/483>`_)
-- :func:`mne_bids.path._parse_bids_filename` is now part of the public API and has consequently been renamed to `:func:`mne_bids.path._parse_bids_filename`, by `Richard Höchenberger`_ (`#487 <https://github.com/mne-tools/mne-bids/pull/487>`_)
+- A function for retrieval of BIDS entity values from a filename, :func:`mne_bids.path.parse_bids_filename`, is now part of the public API (it used to be a private function called :func:`mne_bids.path._parse_bids_filename`), by `Richard Höchenberger`_ (`#487 <https://github.com/mne-tools/mne-bids/pull/487>`_)
 
 .. _changes_0_4:
 

--- a/mne_bids/dig.py
+++ b/mne_bids/dig.py
@@ -21,7 +21,7 @@ from mne_bids.tsv_handler import _from_tsv
 from mne_bids.utils import (_extract_landmarks, _scale_coord_to_meters,
                             _write_json, _write_tsv)
 from mne_bids import make_bids_basename
-from mne_bids.path import _parse_bids_filename
+from mne_bids.path import parse_bids_filename
 
 
 def _handle_electrodes_reading(electrodes_fname, coord_frame,
@@ -316,7 +316,7 @@ def _write_dig_bids(electrodes_fname, coordsystem_fname, data_path,
     # write electrodes data for iEEG and EEG
     unit = "m"  # defaults to meters
 
-    params = _parse_bids_filename(electrodes_fname, verbose)
+    params = parse_bids_filename(electrodes_fname)
     subject_id = params['sub']
     session_id = params['ses']
     acquisition = params['acq']
@@ -412,7 +412,7 @@ def _read_dig_bids(electrodes_fpath, coordsystem_fpath,
         The data as MNE-Python Raw object.
     """
     # get the space entity
-    params = _parse_bids_filename(electrodes_fpath, verbose)
+    params = parse_bids_filename(electrodes_fpath)
     space = params['space']
     if space is None:
         space = ''

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -372,8 +372,37 @@ def _parse_ext(raw_fname, verbose=False):
     return fname, ext
 
 
-def _parse_bids_filename(fname, verbose):
-    """Get dict from BIDS fname."""
+def parse_bids_filename(fname):
+    """Retrieve a dictionary of BIDS entities from a filename.
+
+    Entities not present in ``fname`` will be assigned the value of ``None``.
+
+    Parameters
+    ----------
+    fname : BIDSPath | str
+        The path to parse.
+
+    Returns
+    -------
+    params : dict
+        A dictionary with the keys corresponding to the BIDS entity names, and
+        the values to the entity values encoded in the filename.
+
+    Examples
+    --------
+    >>> fname = 'sub-01_ses-exp_run-02_meg.fif'
+    >>> parse_bids_filename(fname)
+    {'sub': '01',
+    'ses': 'exp',
+    'task': None,
+    'acq': None,
+    'run': '02',
+    'proc': None,
+    'space': None,
+    'rec': None,
+    'split': None,
+    'kind': None}
+    """
     keys = ['sub', 'ses', 'task', 'acq', 'run', 'proc', 'run', 'space',
             'rec', 'split', 'kind']
     params = {key: None for key in keys}
@@ -680,7 +709,7 @@ def _find_best_candidates(params, candidate_list):
     for candidate in candidate_list:
         n_matches = 0
         candidate_disqualified = False
-        candidate_params = _parse_bids_filename(candidate, verbose=False)
+        candidate_params = parse_bids_filename(candidate)
         for entity, value in params.items():
             if entity in candidate_params:
                 if candidate_params[entity] is None:

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -26,7 +26,7 @@ from mne_bids.config import (ALLOWED_EXTENSIONS, _convert_hand_options,
 from mne_bids.utils import (_extract_landmarks,
                             _get_ch_type_mapping, _estimate_line_freq)
 from mne_bids import make_bids_folders
-from mne_bids.path import (BIDSPath, _parse_ext, _parse_bids_filename,
+from mne_bids.path import (BIDSPath, _parse_ext, parse_bids_filename,
                            _find_matching_sidecar, _infer_kind)
 
 
@@ -312,7 +312,7 @@ def read_raw_bids(bids_basename, bids_root, kind=None, extra_params=None,
     """
     # convert to BIDS Path
     if isinstance(bids_basename, str):
-        params = _parse_bids_filename(bids_basename, verbose)
+        params = parse_bids_filename(bids_basename)
         bids_basename = BIDSPath(subject=params.get('sub'),
                                  session=params.get('ses'),
                                  recording=params.get('rec'),
@@ -422,7 +422,7 @@ def get_matched_empty_room(bids_basename, bids_root):
     """
     # convert to BIDS Path
     if isinstance(bids_basename, str):
-        params = _parse_bids_filename(bids_basename, False)
+        params = parse_bids_filename(bids_basename)
         bids_basename = BIDSPath(subject=params.get('sub'),
                                  session=params.get('ses'),
                                  recording=params.get('rec'),
@@ -489,7 +489,7 @@ def get_matched_empty_room(bids_basename, bids_root):
 
     failed_to_get_er_date_count = 0
     for er_fname in candidate_er_fnames:
-        params = _parse_bids_filename(er_fname, verbose=False)
+        params = parse_bids_filename(er_fname)
         er_meas_date = None
 
         er_bids_path = BIDSPath(subject='emptyroom',
@@ -579,7 +579,7 @@ def get_head_mri_trans(bids_basename, bids_root):
 
     # convert to BIDS Path
     if isinstance(bids_basename, str):
-        params = _parse_bids_filename(bids_basename, False)
+        params = parse_bids_filename(bids_basename)
         bids_basename = BIDSPath(subject=params.get('sub'),
                                  session=params.get('ses'),
                                  recording=params.get('rec'),

--- a/mne_bids/report.py
+++ b/mne_bids/report.py
@@ -333,7 +333,7 @@ def _summarize_sidecar_json(bids_root, scans_fpaths, verbose=True):
             n_scans += 1
 
             # convert to BIDS Path
-            params = parse_bids_filename(bids_basename, verbose)
+            params = parse_bids_filename(bids_basename)
             bids_basename = BIDSPath(subject=params.get('sub'),
                                      session=params.get('ses'),
                                      recording=params.get('rec'),
@@ -427,7 +427,7 @@ def _summarize_channels_tsv(bids_root, scans_fpaths, verbose=True):
                 continue
 
             # convert to BIDS Path
-            params = parse_bids_filename(bids_basename, verbose)
+            params = parse_bids_filename(bids_basename)
             bids_basename = BIDSPath(subject=params.get('sub'),
                                      session=params.get('ses'),
                                      recording=params.get('rec'),

--- a/mne_bids/report.py
+++ b/mne_bids/report.py
@@ -15,7 +15,7 @@ from mne_bids.config import DOI, ALLOWED_KINDS
 from mne_bids.tsv_handler import _from_tsv
 from mne_bids.path import (make_bids_basename, get_kinds,
                            get_entity_vals, _parse_ext,
-                           _find_matching_sidecar, _parse_bids_filename,
+                           _find_matching_sidecar, parse_bids_filename,
                            BIDSPath)
 
 # functions to be used inside Template strings
@@ -333,7 +333,7 @@ def _summarize_sidecar_json(bids_root, scans_fpaths, verbose=True):
             n_scans += 1
 
             # convert to BIDS Path
-            params = _parse_bids_filename(bids_basename, verbose)
+            params = parse_bids_filename(bids_basename, verbose)
             bids_basename = BIDSPath(subject=params.get('sub'),
                                      session=params.get('ses'),
                                      recording=params.get('rec'),
@@ -427,7 +427,7 @@ def _summarize_channels_tsv(bids_root, scans_fpaths, verbose=True):
                 continue
 
             # convert to BIDS Path
-            params = _parse_bids_filename(bids_basename, verbose)
+            params = parse_bids_filename(bids_basename, verbose)
             bids_basename = BIDSPath(subject=params.get('sub'),
                                      session=params.get('ses'),
                                      recording=params.get('rec'),

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -22,7 +22,7 @@ from mne.utils import _TempDir
 from mne_bids import (get_kinds, get_entity_vals, print_dir_tree,
                       make_bids_folders, make_bids_basename,
                       write_raw_bids)
-from mne_bids.path import (_parse_ext, _parse_bids_filename,
+from mne_bids.path import (_parse_ext, parse_bids_filename,
                            _find_best_candidates, _find_matching_sidecar)
 
 subject_id = '01'
@@ -192,7 +192,7 @@ def test_parse_ext():
 ])
 def test_parse_bids_filename(fname):
     """Test parsing entities from a bids filename."""
-    params = _parse_bids_filename(fname, verbose=False)
+    params = parse_bids_filename(fname)
     assert params['sub'] == '01'
     assert params['ses'] == '02'
     assert params['run'] == '3'

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -39,7 +39,7 @@ from mne_bids.utils import (_write_json, _write_tsv, _write_text,
                             _estimate_line_freq, _check_anonymize,
                             _stamp_to_dt)
 from mne_bids import make_bids_folders, make_bids_basename
-from mne_bids.path import (BIDSPath, _parse_ext, _parse_bids_filename,
+from mne_bids.path import (BIDSPath, _parse_ext, parse_bids_filename,
                            _mkdir_p, _path_to_str)
 from mne_bids.copyfiles import (copyfile_brainvision, copyfile_eeglab,
                                 copyfile_ctf, copyfile_bti, copyfile_kit)
@@ -946,7 +946,7 @@ def write_raw_bids(raw, bids_basename, bids_root, events_data=None,
 
     # convert to BIDS Path
     if isinstance(bids_basename, str):
-        params = _parse_bids_filename(bids_basename, verbose)
+        params = parse_bids_filename(bids_basename)
         bids_basename = BIDSPath(subject=params.get('sub'),
                                  session=params.get('ses'),
                                  recording=params.get('rec'),


### PR DESCRIPTION

PR Description
--------------

We make use of `mne_bids.path._parse_bids_filename()` in the mne-study-template in a totally un-hacky manner, making us believe that this function should probably be made public.

This PR also drops the function's `verbose` argument, as it was unused.

Describe your PR here

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
- [ ] Commit history does not contain any merge commits
