### PR TITLE
BF: get_head_mri_trans() should infer extension from file name, not from BIDS basename

### DIFF
--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -628,7 +628,7 @@ def get_head_mri_trans(bids_basename, bids_root):
     mri_landmarks = mri_landmarks * 1e-3
 
     # Get MEG landmarks from the raw file
-    _, ext = _parse_ext(bids_basename)
+    _, ext = _parse_ext(bids_fname)
     extra_params = None
     if ext == '.fif':
         extra_params = dict(allow_maxshield=True)


### PR DESCRIPTION

PR Description
--------------

`get_head_mri_trans()` in `master` tries to infer the filename extension from a BIDS basename; however, the basename, as is created inside that function, doesn't have a suffix. Correctly, the extension has to be inferred from `bids_fname`. This is what we used to do before GH-446 got merged. This commit restores the old behavior.

(I realized something was going wrong when MNE-BIDS started looking  for some .pdf files, while I only have .fif. So beyond what I'm  fixing here, there seems to be another bug in `parse_ext()`, causing  it to report `.pdf` when really it shouldn't.)

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
- [ ] Commit history does not contain any merge commits
