### PR TITLE
[MRG] Adding `status_description` to channels.tsv files defaulting to n/a for now

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -35,6 +35,7 @@ Changelog
 - :func:`mne_bids.copyfiles.copyfile_brainvision` now has an ``anonymize`` parameter to control anonymization, by `Stefan Appelhoff`_ (`#475 <https://github.com/mne-tools/mne-bids/pull/475>`_)
 - :func:`mne_bids.read_raw_bids` and :func:`mne_bids.write_raw_bids` now map respiratory (``RESP``) channel types, by `Richard Höchenberger`_ (`#482 <https://github.com/mne-tools/mne-bids/pull/482>`_)
 - When impedance values are available from a ``raw.impedances`` attribute, MNE-BIDS will now write an ``impedance`` column to ``*_electrodes.tsv`` files, by `Stefan Appelhoff`_ (`#484 <https://github.com/mne-tools/mne-bids/pull/484>`_)
+- :func:`mne_bids.write_raw_bids` writes out status_description with 'n/a' values into the channels.tsv sidecar file, by `Adam Li`_ (`#489 <https://github.com/mne-tools/mne-bids/pull/489>`_)
 
 Bug
 ~~~

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -751,6 +751,8 @@ def test_vhdr(_bids_validate):
     assert data['units'][data['name'].index('FP1')] == 'µV'
     assert data['units'][data['name'].index('CP5')] == 'n/a'
     assert data['status'][data['name'].index(injected_bad[0])] == 'bad'
+    status_description = data['status_description']
+    assert status_description[data['name'].index(injected_bad[0])] == 'n/a'
 
     # check events.tsv is written
     events_tsv_fname = str(channels_tsv_name).replace('channels', 'events')

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -118,6 +118,10 @@ def _channels_tsv(raw, fname, overwrite=False, verbose=True):
     n_channels = raw.info['nchan']
     sfreq = raw.info['sfreq']
 
+    # default to 'n/a' for status description
+    # XXX: improve with API to modify the description
+    status_description = ['n/a'] * len(status)
+
     ch_data = OrderedDict([
         ('name', raw.info['ch_names']),
         ('type', ch_type),
@@ -126,7 +130,9 @@ def _channels_tsv(raw, fname, overwrite=False, verbose=True):
         ('high_cutoff', np.full((n_channels), high_cutoff)),
         ('description', description),
         ('sampling_frequency', np.full((n_channels), sfreq)),
-        ('status', status)])
+        ('status', status),
+        ('status_description', status_description)
+    ])
     ch_data = _drop(ch_data, ignored_channels, 'name')
 
     _write_tsv(fname, ch_data, overwrite, verbose)


### PR DESCRIPTION
PR Description
--------------

Closes: #348 

Defaults to `n/a` for now to allow for easy grepping as @jasmainak suggested. Future improvements can be made that allow the status to change, pending an addition to mne-python, or implementation of #458 

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [x] All comments resolved
- [x] This is not your own PR
- [x] All CIs are happy
- [x] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [x] PR description includes phrase "closes <#issue-number>"
- [x] Commit history does not contain any merge commits
