### PR TITLE
[MRG] Allow marking channels as bad in existing datasets

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -34,6 +34,7 @@ MNE BIDS
    make_dataset_description
    make_report
    write_anat
+   mark_bad_channels
    get_head_mri_trans
    get_matched_empty_room
    get_anonymization_daysback

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -36,6 +36,7 @@ Changelog
 - :func:`mne_bids.read_raw_bids` and :func:`mne_bids.write_raw_bids` now map respiratory (``RESP``) channel types, by `Richard Höchenberger`_ (`#482 <https://github.com/mne-tools/mne-bids/pull/482>`_)
 - When impedance values are available from a ``raw.impedances`` attribute, MNE-BIDS will now write an ``impedance`` column to ``*_electrodes.tsv`` files, by `Stefan Appelhoff`_ (`#484 <https://github.com/mne-tools/mne-bids/pull/484>`_)
 - :func:`mne_bids.write_raw_bids` writes out status_description with 'n/a' values into the channels.tsv sidecar file, by `Adam Li`_ (`#489 <https://github.com/mne-tools/mne-bids/pull/489>`_)
+- Added a new function :func:`mne_bids.mark_bad_channels` which allows updating of the channel status (bad, good) and description in an existing BIDS dataset, by `Richard Höchenberger`_ (`#491 <https://github.com/mne-tools/mne-bids/pull/491>`_)
 
 Bug
 ~~~

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -36,7 +36,7 @@ Changelog
 - :func:`mne_bids.read_raw_bids` and :func:`mne_bids.write_raw_bids` now map respiratory (``RESP``) channel types, by `Richard Höchenberger`_ (`#482 <https://github.com/mne-tools/mne-bids/pull/482>`_)
 - When impedance values are available from a ``raw.impedances`` attribute, MNE-BIDS will now write an ``impedance`` column to ``*_electrodes.tsv`` files, by `Stefan Appelhoff`_ (`#484 <https://github.com/mne-tools/mne-bids/pull/484>`_)
 - :func:`mne_bids.write_raw_bids` writes out status_description with 'n/a' values into the channels.tsv sidecar file, by `Adam Li`_ (`#489 <https://github.com/mne-tools/mne-bids/pull/489>`_)
-- Added a new function :func:`mne_bids.mark_bad_channels` which allows updating of the channel status (bad, good) and description in an existing BIDS dataset, by `Richard Höchenberger`_ (`#491 <https://github.com/mne-tools/mne-bids/pull/491>`_)
+- Added a new function :func:`mne_bids.mark_bad_channels` and command line interface ``mark_bad_channels`` which allows updating of the channel status (bad, good) and description of an existing BIDS dataset, by `Richard Höchenberger`_ (`#491 <https://github.com/mne-tools/mne-bids/pull/491>`_)
 
 Bug
 ~~~

--- a/examples/mark_bad_channels.py
+++ b/examples/mark_bad_channels.py
@@ -26,7 +26,7 @@ import mne
 from mne_bids import (make_bids_basename, write_raw_bids, read_raw_bids,
                       mark_bad_channels)
 
-mne.set_log_level('error')
+mne.set_log_level('error')  # Suppress distracting log messages.
 
 data_path = mne.datasets.sample.data_path()
 raw_fname = op.join(data_path, 'MEG', 'sample', 'sample_audvis_raw.fif')

--- a/examples/mark_bad_channels.py
+++ b/examples/mark_bad_channels.py
@@ -1,0 +1,102 @@
+"""
+===============================================
+10. Changing which channels are marked as "bad"
+===============================================
+
+You can use MNE-BIDS to mark MEG or (i)EEG recording channels as "bad", for
+example if the connected ensor continuously produced noise – or no signal at
+all.
+
+Similarly, you can declare channels as "good", should you discover they were
+incorrectly marked as bad.
+"""
+
+# Authors: Richard Höchenberger <richard.hoechenberger@gmail.com>
+# License: BSD (3-clause)
+
+###############################################################################
+# We will demonstrate how to mark individual channels as bad on the MNE
+# "sample" dataset. After that, we will mark channels as good again.
+#
+# Let's start by importing the required modules and functions, reading the
+# "sample" data, and writing it in the BIDS format.
+
+import os.path as op
+import mne
+from mne_bids import (make_bids_basename, write_raw_bids, read_raw_bids,
+                      mark_bad_channels)
+
+mne.set_log_level('error')
+
+data_path = mne.datasets.sample.data_path()
+raw_fname = op.join(data_path, 'MEG', 'sample', 'sample_audvis_raw.fif')
+bids_root = op.join(data_path, '..', 'MNE-sample-data-bids')
+bids_basename = make_bids_basename(subject='01', session='01',
+                                   task='audiovisual', run='01')
+
+raw = mne.io.read_raw_fif(raw_fname, verbose=False)
+write_raw_bids(raw, bids_basename=bids_basename, bids_root=bids_root,
+               overwrite=True, verbose=False)
+
+###############################################################################
+# Read the (now BIDS-formatted) data and print a list of channels currently
+# marked as bad.
+
+raw = read_raw_bids(bids_basename=bids_basename, bids_root=bids_root,
+                    verbose=False)
+print(f'The following channels are currently marked as bad:\n'
+      f'    {", ".join(raw.info["bads"])}\n')
+
+###############################################################################
+# So currently, two channels are maked as bad: ``EEG 053`` and ``MEG 2443``.
+# Let's assume that through visual data inspection, we found that two more
+# MEG channels are problematic, and we would like to mark them as bad as well.
+# To do that, we simply add them to a list, which we then pass to
+# :func:`mne_bids.mark_bad_channels`:
+
+bads = ['MEG 0112', 'MEG 0131']
+mark_bad_channels(ch_names=bads, bids_basename=bids_basename,
+                  bids_root=bids_root, verbose=False)
+
+###############################################################################
+# That's it! Let's verify the result.
+
+raw = read_raw_bids(bids_basename=bids_basename, bids_root=bids_root,
+                    verbose=False)
+print(f'After marking MEG 0112 and MEG 0131 as bad, the following channels '
+      f'are now marked as bad:\n    {", ".join(raw.info["bads"])}\n')
+
+###############################################################################
+# As you can see, now a total of **four** channels is marked as bad: the ones
+# that were already bad when we started – ``EEG 053`` and ``MEG 2443`` – and
+# the two channels we passed to :func:`mne_bids.mark_bad_channels` –
+# ``MEG 0112`` and ``MEG 0131``. This shows that marking bad channels via
+# :func:`mne_bids.mark_bad_channels`, by default, is an **additive** procedure,
+# which allows you to mark additional channels as bad while retaining the
+# information about all channels that had *previously* been marked as bad.
+#
+# If you instead would like to **replace** the collection of bad channels
+# entirely, pass the argument ``overwrite=True``:
+
+bads = ['MEG 0112', 'MEG 0131']
+mark_bad_channels(ch_names=bads, bids_basename=bids_basename,
+                  bids_root=bids_root, overwrite=True, verbose=False)
+
+raw = read_raw_bids(bids_basename=bids_basename, bids_root=bids_root,
+                    verbose=False)
+print(f'After marking MEG 0112 and MEG 0131 as bad and passing '
+      f'`overwrite=True`, the following channels '
+      f'are now marked as bad:\n    {", ".join(raw.info["bads"])}\n')
+
+###############################################################################
+# Lastly, if you're looking for a way to mark all channels as good, simply
+# pass an empty list as ``ch_names``, combined with ``overwrite=True``:
+
+bads = []
+mark_bad_channels(ch_names=bads, bids_basename=bids_basename,
+                  bids_root=bids_root, overwrite=True, verbose=False)
+
+raw = read_raw_bids(bids_basename=bids_basename, bids_root=bids_root,
+                    verbose=False)
+print(f'After passing `ch_names=[]` and `overwrite=True`, the following '
+      f'channels are now marked as bad:\n    {", ".join(raw.info["bads"])}\n')

--- a/examples/mark_bad_channels.py
+++ b/examples/mark_bad_channels.py
@@ -23,27 +23,25 @@ incorrectly marked as bad.
 
 import os.path as op
 import mne
-from mne_bids import (make_bids_basename, write_raw_bids, read_raw_bids,
-                      mark_bad_channels)
+from mne_bids import BIDSPath, write_raw_bids, read_raw_bids, mark_bad_channels
 
 mne.set_log_level('error')  # Suppress distracting log messages.
 
 data_path = mne.datasets.sample.data_path()
 raw_fname = op.join(data_path, 'MEG', 'sample', 'sample_audvis_raw.fif')
 bids_root = op.join(data_path, '..', 'MNE-sample-data-bids')
-bids_basename = make_bids_basename(subject='01', session='01',
-                                   task='audiovisual', run='01')
+bids_path = BIDSPath(subject='01', session='01', task='audiovisual', run='01',
+                     root=bids_root)
 
 raw = mne.io.read_raw_fif(raw_fname, verbose=False)
-write_raw_bids(raw, bids_basename=bids_basename, bids_root=bids_root,
-               overwrite=True, verbose=False)
+raw.info['line_freq'] = 60  # Specify power line frequency as required by BIDS.
+write_raw_bids(raw, bids_path=bids_path, overwrite=True, verbose=False)
 
 ###############################################################################
 # Read the (now BIDS-formatted) data and print a list of channels currently
 # marked as bad.
 
-raw = read_raw_bids(bids_basename=bids_basename, bids_root=bids_root,
-                    verbose=False)
+raw = read_raw_bids(bids_path=bids_path, verbose=False)
 print(f'The following channels are currently marked as bad:\n'
       f'    {", ".join(raw.info["bads"])}\n')
 
@@ -55,14 +53,12 @@ print(f'The following channels are currently marked as bad:\n'
 # :func:`mne_bids.mark_bad_channels`:
 
 bads = ['MEG 0112', 'MEG 0131']
-mark_bad_channels(ch_names=bads, bids_basename=bids_basename,
-                  bids_root=bids_root, verbose=False)
+mark_bad_channels(ch_names=bads, bids_path=bids_path, verbose=False)
 
 ###############################################################################
 # That's it! Let's verify the result.
 
-raw = read_raw_bids(bids_basename=bids_basename, bids_root=bids_root,
-                    verbose=False)
+raw = read_raw_bids(bids_path=bids_path, verbose=False)
 print(f'After marking MEG 0112 and MEG 0131 as bad, the following channels '
       f'are now marked as bad:\n    {", ".join(raw.info["bads"])}\n')
 
@@ -79,11 +75,10 @@ print(f'After marking MEG 0112 and MEG 0131 as bad, the following channels '
 # entirely, pass the argument ``overwrite=True``:
 
 bads = ['MEG 0112', 'MEG 0131']
-mark_bad_channels(ch_names=bads, bids_basename=bids_basename,
-                  bids_root=bids_root, overwrite=True, verbose=False)
+mark_bad_channels(ch_names=bads, bids_path=bids_path, overwrite=True,
+                  verbose=False)
 
-raw = read_raw_bids(bids_basename=bids_basename, bids_root=bids_root,
-                    verbose=False)
+raw = read_raw_bids(bids_path=bids_path, verbose=False)
 print(f'After marking MEG 0112 and MEG 0131 as bad and passing '
       f'`overwrite=True`, the following channels '
       f'are now marked as bad:\n    {", ".join(raw.info["bads"])}\n')
@@ -93,10 +88,9 @@ print(f'After marking MEG 0112 and MEG 0131 as bad and passing '
 # pass an empty list as ``ch_names``, combined with ``overwrite=True``:
 
 bads = []
-mark_bad_channels(ch_names=bads, bids_basename=bids_basename,
-                  bids_root=bids_root, overwrite=True, verbose=False)
+mark_bad_channels(ch_names=bads, bids_path=bids_path, overwrite=True,
+                  verbose=False)
 
-raw = read_raw_bids(bids_basename=bids_basename, bids_root=bids_root,
-                    verbose=False)
+raw = read_raw_bids(bids_path=bids_path, verbose=False)
 print(f'After passing `ch_names=[]` and `overwrite=True`, the following '
       f'channels are now marked as bad:\n    {", ".join(raw.info["bads"])}\n')

--- a/examples/mark_bad_channels.py
+++ b/examples/mark_bad_channels.py
@@ -4,7 +4,7 @@
 ===============================================
 
 You can use MNE-BIDS to mark MEG or (i)EEG recording channels as "bad", for
-example if the connected ensor continuously produced noise – or no signal at
+example if the connected sensor produced mostly noise – or no signal at
 all.
 
 Similarly, you can declare channels as "good", should you discover they were

--- a/mne_bids/__init__.py
+++ b/mne_bids/__init__.py
@@ -9,4 +9,4 @@ from mne_bids.read import (get_head_mri_trans, read_raw_bids,
                            get_matched_empty_room)
 from mne_bids.utils import (get_anonymization_daysback)
 from mne_bids.write import (make_dataset_description, write_anat,
-                            write_raw_bids)
+                            write_raw_bids, mark_bad_channels)

--- a/mne_bids/commands/mne_bids_mark_bad_channels.py
+++ b/mne_bids/commands/mne_bids_mark_bad_channels.py
@@ -73,7 +73,7 @@ def run():
                                        session=opt.session, task=opt.task,
                                        acquisition=opt.acquisition,
                                        run=opt.run, processing=opt.processing,
-                                       recordig=opt.recording)
+                                       recording=opt.recording)
     mark_bad_channels(ch_names=ch_names, descriptions=opt.descriptions,
                       bids_basename=bids_basename, bids_root=opt.bids_root,
                       kind=opt.kind, overwrite=opt.overwrite)

--- a/mne_bids/commands/mne_bids_mark_bad_channels.py
+++ b/mne_bids/commands/mne_bids_mark_bad_channels.py
@@ -33,8 +33,8 @@ def run():
                            'multiple times.')
     parser.add_option('--description', dest='descriptions', action='append',
                       default=[],
-                      help='Descriptions as to why the channels are bad.
-                           'Must match the number of bad channels provided.'
+                      help='Descriptions as to why the channels are bad. '
+                           'Must match the number of bad channels provided. '
                            'Pass multiple times to suplly more than one '
                            'value in that case.')
     parser.add_option('--bids_root', dest='bids_root',

--- a/mne_bids/commands/mne_bids_mark_bad_channels.py
+++ b/mne_bids/commands/mne_bids_mark_bad_channels.py
@@ -35,7 +35,7 @@ def run():
                       default=[],
                       help='Descriptions as to why the channels are bad. '
                            'Must match the number of bad channels provided. '
-                           'Pass multiple times to suplly more than one '
+                           'Pass multiple times to supply more than one '
                            'value in that case.')
     parser.add_option('--bids_root', dest='bids_root',
                       help='The path of the folder containing the BIDS '

--- a/mne_bids/commands/mne_bids_mark_bad_channels.py
+++ b/mne_bids/commands/mne_bids_mark_bad_channels.py
@@ -1,0 +1,82 @@
+"""Mark channels in an existing BIDS dataset as "bad".
+
+example usage:
+$ mne_bids mark_bad_channels --ch_name="MEG 0112" --description="noisy" \
+                             --ch_name="MEG 0131" --description="flat" \
+                             --subject_id=01 --task=experiment --session=test \
+                             --bids_root=bids_root
+
+"""
+# Authors: Richard Höchenberger <richard.hoechenberger@gmail.com>
+#
+# License: BSD (3-clause)
+
+import mne_bids
+from mne_bids import make_bids_basename, mark_bad_channels
+
+
+def run():
+    """Run the mark_bad_channels command."""
+    from mne.commands.utils import get_optparser
+
+    parser = get_optparser(__file__, usage="usage: %prog options args",
+                           prog_prefix='mne_bids',
+                           version=mne_bids.__version__)
+
+    parser.add_option('--ch_name', dest='ch_names', action='append',
+                      help='The names of the channels, separated by commas')
+    parser.add_option('--description', dest='descriptions', action='append',
+                      help='Descriptions as to why the channels are bad')
+    parser.add_option('--bids_root', dest='bids_root',
+                      help='The path of the folder containing the BIDS '
+                           'dataset')
+    parser.add_option('--subject_id', dest='subject',
+                      help=('Subject name'))
+    parser.add_option('--session_id', dest='session',
+                      help='Session name')
+    parser.add_option('--task', dest='task',
+                      help='Task name')
+    parser.add_option('--acq', dest='acquisition',
+                      help='Acquisition parameter')
+    parser.add_option('--run', dest='run',
+                      help='Run number')
+    parser.add_option('--proc', dest='processing',
+                      help='Processing label.')
+    parser.add_option('--rec', dest='recording',
+                      help='Recording name')
+    parser.add_option('--kind', dest='kind',
+                      help='Recording kind, e.g. meg or eeg')
+    parser.add_option('--overwrite', dest='overwrite',
+                      help='Retain existing channel status entries or not')
+
+    opt, args = parser.parse_args()
+    opt = opt.__dict__  # XXX Is there a cleaner way?
+    ch_names = opt.pop('ch_names')
+    descriptions = opt.pop('descriptions')
+    bids_root = opt.pop('bids_root')
+    kind = opt.pop('kind')
+    overwrite = opt.pop('overwrite')
+
+    if args:
+        parser.print_help()
+        parser.error(f'Please do not specify arguments without flags. '
+                     f'Got: {args}.\n')
+
+    if bids_root is None:
+        parser.print_help()
+        parser.error('You must specify bids_root')
+    if ch_names is None:
+        parser.print_help()
+        parser.error('You must specify ch_names')
+    if opt['subject'] is None:
+        parser.print_help()
+        parser.error('You must specify subject_id')
+
+    bids_basename = make_bids_basename(**opt)
+    mark_bad_channels(ch_names=ch_names, descriptions=descriptions,
+                      bids_basename=bids_basename, bids_root=bids_root,
+                      kind=kind, overwrite=overwrite)
+
+
+if __name__ == '__main__':  # pragma: no cover
+    run()

--- a/mne_bids/commands/mne_bids_mark_bad_channels.py
+++ b/mne_bids/commands/mne_bids_mark_bad_channels.py
@@ -4,7 +4,7 @@ example usage:
 $ mne_bids mark_bad_channels --ch_name="MEG 0112" --description="noisy" \
                              --ch_name="MEG 0131" --description="flat" \
                              --subject_id=01 --task=experiment --session=test \
-                             --bids_root=bids_root
+                             --bids_root=bids_root --overwrite
 
 """
 # Authors: Richard Höchenberger <richard.hoechenberger@gmail.com>
@@ -24,8 +24,10 @@ def run():
                            version=mne_bids.__version__)
 
     parser.add_option('--ch_name', dest='ch_names', action='append',
+                      default=[],
                       help='The names of the channels, separated by commas')
     parser.add_option('--description', dest='descriptions', action='append',
+                      default=[],
                       help='Descriptions as to why the channels are bad')
     parser.add_option('--bids_root', dest='bids_root',
                       help='The path of the folder containing the BIDS '
@@ -46,8 +48,8 @@ def run():
                       help='Recording name')
     parser.add_option('--kind', dest='kind',
                       help='Recording kind, e.g. meg or eeg')
-    parser.add_option('--overwrite', dest='overwrite',
-                      help='Retain existing channel status entries or not')
+    parser.add_option('--overwrite', dest='overwrite', action='store_true',
+                      help='Replace existing channel status entries')
 
     opt, args = parser.parse_args()
     opt = opt.__dict__  # XXX Is there a cleaner way?
@@ -71,6 +73,9 @@ def run():
     if opt['subject'] is None:
         parser.print_help()
         parser.error('You must specify subject_id')
+
+    if ch_names == ['']:
+        ch_names = []
 
     bids_basename = make_bids_basename(**opt)
     mark_bad_channels(ch_names=ch_names, descriptions=descriptions,

--- a/mne_bids/commands/mne_bids_mark_bad_channels.py
+++ b/mne_bids/commands/mne_bids_mark_bad_channels.py
@@ -28,10 +28,15 @@ def run():
 
     parser.add_option('--ch_name', dest='ch_names', action='append',
                       default=[],
-                      help='The names of the channels, separated by commas')
+                      help='The names of the bad channels. If multiple '
+                           'channels are bad, pass the --ch_name parameter '
+                           'multiple times.')
     parser.add_option('--description', dest='descriptions', action='append',
                       default=[],
-                      help='Descriptions as to why the channels are bad')
+                      help='Descriptions as to why the channels are bad.
+                           'Must match the number of bad channels provided.'
+                           'Pass multiple times to suplly more than one '
+                           'value in that case.')
     parser.add_option('--bids_root', dest='bids_root',
                       help='The path of the folder containing the BIDS '
                            'dataset')
@@ -50,7 +55,7 @@ def run():
     parser.add_option('--rec', dest='recording',
                       help='Recording name')
     parser.add_option('--type', dest='datatype',
-                      help='Recording type, e.g. meg or eeg')
+                      help='Recording data type, e.g. meg, ieeg or eeg')
     parser.add_option('--suffix', dest='suffix',
                       help='The filename suffix, i.e. the last part before '
                            'the extension')
@@ -73,7 +78,7 @@ def run():
         parser.error('You must specify bids_root')
     if opt.ch_names is None:
         parser.print_help()
-        parser.error('You must specify ch_names')
+        parser.error('You must specify some --ch_name parameters.')
 
     ch_names = [] if opt.ch_names == [''] else opt.ch_names
     bids_path = BIDSPath(subject=opt.subject, session=opt.session,

--- a/mne_bids/commands/mne_bids_mark_bad_channels.py
+++ b/mne_bids/commands/mne_bids_mark_bad_channels.py
@@ -52,35 +52,31 @@ def run():
                       help='Replace existing channel status entries')
 
     opt, args = parser.parse_args()
-    opt = opt.__dict__  # XXX Is there a cleaner way?
-    ch_names = opt.pop('ch_names')
-    descriptions = opt.pop('descriptions')
-    bids_root = opt.pop('bids_root')
-    kind = opt.pop('kind')
-    overwrite = opt.pop('overwrite')
-
     if args:
         parser.print_help()
         parser.error(f'Please do not specify arguments without flags. '
                      f'Got: {args}.\n')
 
-    if bids_root is None:
+    if opt.bids_root is None:
         parser.print_help()
         parser.error('You must specify bids_root')
-    if ch_names is None:
+    if opt.ch_names is None:
         parser.print_help()
         parser.error('You must specify ch_names')
-    if opt['subject'] is None:
+    if opt.subject is None:
         parser.print_help()
         parser.error('You must specify subject_id')
 
-    if ch_names == ['']:
-        ch_names = []
+    ch_names = [] if opt.ch_names == [''] else opt.ch_names
 
-    bids_basename = make_bids_basename(**opt)
-    mark_bad_channels(ch_names=ch_names, descriptions=descriptions,
-                      bids_basename=bids_basename, bids_root=bids_root,
-                      kind=kind, overwrite=overwrite)
+    bids_basename = make_bids_basename(subject=opt.subject,
+                                       session=opt.session, task=opt.task,
+                                       acquisition=opt.acquisition,
+                                       run=opt.run, processing=opt.processing,
+                                       recordig=opt.recording)
+    mark_bad_channels(ch_names=ch_names, descriptions=opt.descriptions,
+                      bids_basename=bids_basename, bids_root=opt.bids_root,
+                      kind=opt.kind, overwrite=opt.overwrite)
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/mne_bids/commands/mne_bids_mark_bad_channels.py
+++ b/mne_bids/commands/mne_bids_mark_bad_channels.py
@@ -12,7 +12,7 @@ $ mne_bids mark_bad_channels --ch_name="MEG 0112" --description="noisy" \
 # License: BSD (3-clause)
 
 import mne_bids
-from mne_bids import make_bids_basename, mark_bad_channels
+from mne_bids import BIDSPath, mark_bad_channels
 
 
 def run():
@@ -46,8 +46,14 @@ def run():
                       help='Processing label.')
     parser.add_option('--rec', dest='recording',
                       help='Recording name')
-    parser.add_option('--kind', dest='kind',
-                      help='Recording kind, e.g. meg or eeg')
+    parser.add_option('--type', dest='datatype',
+                      help='Recording type, e.g. meg or eeg')
+    parser.add_option('--suffix', dest='suffix',
+                      help='The filename suffix, i.e. the last part before '
+                           'the extension')
+    parser.add_option('--ext', dest='extension',
+                      help='The filename extension, including the leading '
+                           'period, e.g. .fif')
     parser.add_option('--overwrite', dest='overwrite', action='store_true',
                       help='Replace existing channel status entries')
 
@@ -69,14 +75,14 @@ def run():
 
     ch_names = [] if opt.ch_names == [''] else opt.ch_names
 
-    bids_basename = make_bids_basename(subject=opt.subject,
-                                       session=opt.session, task=opt.task,
-                                       acquisition=opt.acquisition,
-                                       run=opt.run, processing=opt.processing,
-                                       recording=opt.recording)
+    bids_path = BIDSPath(subject=opt.subject, session=opt.session,
+                         task=opt.task, acquisition=opt.acquisition,
+                         run=opt.run, processing=opt.processing,
+                         recording=opt.recording, datatype=opt.datatype,
+                         suffix=opt.suffix, extension=opt.extension,
+                         root=opt.bids_root)
     mark_bad_channels(ch_names=ch_names, descriptions=opt.descriptions,
-                      bids_basename=bids_basename, bids_root=opt.bids_root,
-                      kind=opt.kind, overwrite=opt.overwrite)
+                      bids_path=bids_path, overwrite=opt.overwrite)
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/mne_bids/commands/tests/test_cli.py
+++ b/mne_bids/commands/tests/test_cli.py
@@ -87,7 +87,7 @@ def test_cp(tmpdir):
 
 
 def test_mark_bad_chanels(tmpdir):
-    """Test mne_bids cp."""
+    """Test mne_bids mark_bad_channels."""
 
     # Check that help is printed
     check_usage(mne_bids_mark_bad_channels)

--- a/mne_bids/commands/tests/test_cli.py
+++ b/mne_bids/commands/tests/test_cli.py
@@ -25,7 +25,7 @@ from mne_bids.commands import (mne_bids_raw_to_bids, mne_bids_cp,
 base_path = op.join(op.dirname(mne.__file__), 'io')
 subject_id = '01'
 task = 'testing'
-kind = 'meg'
+datatype = 'meg'
 
 
 def check_usage(module, force_help=False):
@@ -51,7 +51,7 @@ def test_raw_to_bids(tmpdir):
     # Should work
     with ArgvSetter(('--subject_id', subject_id, '--task', task, '--raw',
                      raw_fname, '--bids_root', output_path,
-                     '--line_freq', '60')):
+                     '--line_freq', 60)):
         mne_bids_raw_to_bids.run()
 
     # Test EDF files as well
@@ -59,7 +59,7 @@ def test_raw_to_bids(tmpdir):
     edf_fname = op.join(edf_data_path, 'test.edf')
     with ArgvSetter(('--subject_id', subject_id, '--task', task, '--raw',
                      edf_fname, '--bids_root', output_path,
-                     '--line_freq', '60')):
+                     '--line_freq', 60)):
         mne_bids_raw_to_bids.run()
 
     # Too few input args
@@ -100,8 +100,9 @@ def test_mark_bad_chanels(tmpdir):
     raw_fname = op.join(data_path, 'MEG', 'sample',
                         'sample_audvis_trunc_raw.fif')
 
-    with ArgvSetter(('--subject_id', subject_id, '--task', task, '--raw',
-                     raw_fname, '--bids_root', output_path)):
+    with ArgvSetter(('--subject_id', subject_id, '--task', task,
+                     '--raw', raw_fname, '--bids_root', output_path,
+                     '--line_freq', 60)):
         mne_bids_raw_to_bids.run()
 
     # Update the dataset.
@@ -109,18 +110,19 @@ def test_mark_bad_chanels(tmpdir):
     descriptions = ['Really bad!', 'Even worse.']
 
     args = ['--subject_id', subject_id, '--task', task,
-            '--bids_root', output_path, '--kind', kind]
+            '--bids_root', output_path, '--type', datatype]
     for ch_name, description in zip(ch_names, descriptions):
         args.extend(['--ch_name', ch_name])
         args.extend(['--description', description])
 
     args = tuple(args)
     with ArgvSetter(args):
-        mne_bids_mark_bad_channels.run()
+        with pytest.warns(RuntimeWarning, match='The unit for chann*'):
+            mne_bids_mark_bad_channels.run()
 
     # Test resettig bad channels.
     args = ('--subject_id', subject_id, '--task', task,
-            '--bids_root', output_path, '--kind', kind,
+            '--bids_root', output_path, '--type', datatype,
             '--ch_name', '', '--overwrite')
     with ArgvSetter(args):
         mne_bids_mark_bad_channels.run()

--- a/mne_bids/commands/tests/test_cli.py
+++ b/mne_bids/commands/tests/test_cli.py
@@ -116,5 +116,12 @@ def test_mark_bad_chanels(tmpdir):
     with ArgvSetter(args):
         mne_bids_mark_bad_channels.run()
 
+    # Test resettig bad channels.
+    args = ('--subject_id', subject_id, '--task', task,
+            '--bids_root', output_path, '--kind', kind,
+            '--ch_name', '', '--overwrite')
+    with ArgvSetter(args):
+        mne_bids_mark_bad_channels.run()
+
 
 run_tests_if_main()

--- a/mne_bids/commands/tests/test_cli.py
+++ b/mne_bids/commands/tests/test_cli.py
@@ -20,6 +20,7 @@ from mne.utils import run_tests_if_main, ArgvSetter
 
 from mne_bids.commands import (mne_bids_raw_to_bids, mne_bids_cp,
                                mne_bids_mark_bad_channels)
+from mne_bids import BIDSPath, read_raw_bids
 
 
 base_path = op.join(op.dirname(mne.__file__), 'io')
@@ -88,7 +89,7 @@ def test_cp(tmpdir):
             mne_bids_cp.run()
 
 
-def test_mark_bad_chanels(tmpdir):
+def test_mark_bad_chanels_single_file(tmpdir):
     """Test mne_bids mark_bad_channels."""
 
     # Check that help is printed
@@ -99,6 +100,9 @@ def test_mark_bad_chanels(tmpdir):
     data_path = testing.data_path()
     raw_fname = op.join(data_path, 'MEG', 'sample',
                         'sample_audvis_trunc_raw.fif')
+    old_bads = mne.io.read_raw_fif(raw_fname).info['bads']
+    bids_path = BIDSPath(subject=subject_id, task=task, root=output_path,
+                         datatype=datatype)
 
     with ArgvSetter(('--subject_id', subject_id, '--task', task,
                      '--raw', raw_fname, '--bids_root', output_path,
@@ -120,12 +124,61 @@ def test_mark_bad_chanels(tmpdir):
         with pytest.warns(RuntimeWarning, match='The unit for chann*'):
             mne_bids_mark_bad_channels.run()
 
+    # Check the data was properly written
+    raw = read_raw_bids(bids_path=bids_path)
+    assert set(old_bads + ch_names) == set(raw.info['bads'])
+
     # Test resettig bad channels.
     args = ('--subject_id', subject_id, '--task', task,
             '--bids_root', output_path, '--type', datatype,
             '--ch_name', '', '--overwrite')
     with ArgvSetter(args):
         mne_bids_mark_bad_channels.run()
+
+    # Check the data was properly written
+    raw = read_raw_bids(bids_path=bids_path)
+    assert raw.info['bads'] == []
+
+
+def test_mark_bad_chanels_multiple_files(tmpdir):
+    """Test mne_bids mark_bad_channels."""
+
+    # Check that help is printed
+    check_usage(mne_bids_mark_bad_channels)
+
+    # Create test dataset.
+    output_path = str(tmpdir)
+    data_path = testing.data_path()
+    raw_fname = op.join(data_path, 'MEG', 'sample',
+                        'sample_audvis_trunc_raw.fif')
+    old_bads = mne.io.read_raw_fif(raw_fname).info['bads']
+    bids_path = BIDSPath(task=task, root=output_path, datatype=datatype)
+
+    subjects = ['01', '02', '03']
+    for subject in subjects:
+        with ArgvSetter(('--subject_id', subject, '--task', task,
+                         '--raw', raw_fname, '--bids_root', output_path,
+                         '--line_freq', 60)):
+            mne_bids_raw_to_bids.run()
+
+    # Update the dataset.
+    ch_names = ['MEG 0112', 'MEG 0131']
+    descriptions = ['Really bad!', 'Even worse.']
+
+    args = ['--task', task, '--bids_root', output_path, '--type', datatype]
+    for ch_name, description in zip(ch_names, descriptions):
+        args.extend(['--ch_name', ch_name])
+        args.extend(['--description', description])
+
+    args = tuple(args)
+    with ArgvSetter(args):
+        with pytest.warns(RuntimeWarning, match='The unit for chann*'):
+            mne_bids_mark_bad_channels.run()
+
+    # Check the data was properly written
+    for subject in subjects:
+        raw = read_raw_bids(bids_path=bids_path.copy().update(subject=subject))
+        assert set(old_bads + ch_names) == set(raw.info['bads'])
 
 
 run_tests_if_main()

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -1502,3 +1502,13 @@ def test_mark_bad_channels(_bids_validate):
     tsv_data = _from_tsv(channels_fname)
     assert 'status' in tsv_data
     assert 'status_description' in tsv_data
+
+    # Test that we raise if `bids_basename` / `bids_root` parameters are
+    # missing.
+    bads = 'MEG 0112'
+
+    with pytest.raises(ValueError, match='You must specify the bids_basename'):
+        mark_bad_channels(channels=bads, bids_root=bids_root)
+
+    with pytest.raises(ValueError, match='You must specify the bids_root'):
+        mark_bad_channels(channels=bads, bids_basename=bids_basename)

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -1427,6 +1427,7 @@ def test_mark_bad_channels(_bids_validate):
     bads = ['MEG 0112', 'MEG 0131', 'EEG 053']
     mark_bad_channels(channels=bads, bids_basename=bids_basename,
                       bids_root=bids_root, kind='meg')
+    _bids_validate(bids_root)
     raw = read_raw_bids(bids_basename=bids_basename, bids_root=bids_root,
                         kind='meg', verbose=False)
     assert len(bads) == len(raw.info['bads'])
@@ -1442,19 +1443,15 @@ def test_mark_bad_channels(_bids_validate):
     bads = 'MEG 0123'
     mark_bad_channels(channels=bads, bids_basename=bids_basename,
                       bids_root=bids_root, kind='meg')
-
-    # Test that we warn if channel is already "bad".
-    with pytest.warns(RuntimeWarning, match='already marked as bad'):
-        mark_bad_channels(channels=bads, bids_basename=bids_basename,
-                          bids_root=bids_root, kind='meg')
+    _bids_validate(bids_root)
 
     # Set descriptions: list.
     bads = ['MEG 0112', 'MEG 0131']
     descriptions = ['Really bad!', 'Even worse.']
-    with pytest.warns(RuntimeWarning, match='already marked as bad'):
-        mark_bad_channels(channels=bads, descriptions=descriptions,
-                          bids_basename=bids_basename, bids_root=bids_root,
-                          kind='meg')
+    mark_bad_channels(channels=bads, descriptions=descriptions,
+                      bids_basename=bids_basename, bids_root=bids_root,
+                      kind='meg')
+    _bids_validate(bids_root)
     tsv_data = _from_tsv(channels_fname)
     for description in descriptions:
         assert description in tsv_data['status_description']
@@ -1462,23 +1459,12 @@ def test_mark_bad_channels(_bids_validate):
     # Set descriptions: string.
     bads = 'MEG 0112'
     descriptions = 'Really bad!'
-    with pytest.warns(RuntimeWarning, match='already marked as bad'):
-        mark_bad_channels(channels=bads, descriptions=descriptions,
-                          bids_basename=bids_basename, bids_root=bids_root,
-                          kind='meg')
+    mark_bad_channels(channels=bads, descriptions=descriptions,
+                      bids_basename=bids_basename, bids_root=bids_root,
+                      kind='meg')
+    _bids_validate(bids_root)
     tsv_data = _from_tsv(channels_fname)
     assert 'Really bad!' in tsv_data['status_description']
-
-    # Test that we warn if description doesn't change.
-    with warnings.catch_warnings():
-        warnings.filterwarnings(action='ignore',
-                                message='.*already marked as bad.')
-
-        with pytest.warns(RuntimeWarning,
-                          match='Description.*has not changed'):
-            mark_bad_channels(channels=bads, descriptions=descriptions,
-                              bids_basename=bids_basename, bids_root=bids_root,
-                              kind='meg')
 
     # Test that we raise if number of channels doesn't match number of
     # descriptions.
@@ -1499,10 +1485,7 @@ def test_mark_bad_channels(_bids_validate):
     mark_bad_channels(channels=bads, descriptions=descriptions,
                       bids_basename=bids_basename, bids_root=bids_root,
                       kind='meg')
+    _bids_validate(bids_root)
     tsv_data = _from_tsv(channels_fname)
     assert 'status' in tsv_data
     assert 'status_description' in tsv_data
-
-    # Test that we raise if `bids_basename` / `bids_root` parameters are
-    # missing.
-    bads = 'MEG 0112'

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -1573,7 +1573,7 @@ def test_mark_bad_channels(_bids_validate,
                           bids_path=bids_path, overwrite=True)
         _bids_validate(bids_root)
         raw = read_raw_bids(bids_path=bids_path, verbose=False)
-        # XXX Order is not preserved
+        # Order is not preserved
         assert set(existing_ch_names) == set(raw.info['bads'])
         del raw
 

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -10,7 +10,6 @@ For each supported file format, implement a test.
 #          Matt Sanderson <matt.sanderson@mq.edu.au>
 #
 # License: BSD (3-clause)
-from mne_bids.write import mark_bad_channels
 import os
 import os.path as op
 import pytest
@@ -41,7 +40,8 @@ from mne.io.constants import FIFF
 from mne.io.kit.kit import get_kit_info
 
 from mne_bids import (write_raw_bids, read_raw_bids, make_bids_basename,
-                      make_bids_folders, write_anat, make_dataset_description)
+                      make_bids_folders, write_anat, make_dataset_description,
+                      mark_bad_channels)
 from mne_bids.utils import (_stamp_to_dt, _get_anonymization_daysback,
                             get_anonymization_daysback)
 from mne_bids.tsv_handler import _from_tsv, _to_tsv

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -1598,7 +1598,7 @@ def test_mark_bad_channels(_bids_validate,
         expected_descriptions = (_ensure_list(descriptions) +
                                  _ensure_list(existing_descriptions))
 
-    # XXX Order is not preserved
+    # Order is not preserved
     assert len(expected_bads) == len(raw.info['bads'])
     assert set(expected_bads) == set(raw.info['bads'])
 

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -1463,11 +1463,13 @@ def test_mark_bad_channels(_bids_validate,
                                             'channels.tsv')
 
     if drop_status_col:
+        # Remove `status` column from the sidecare TSV file.
         tsv_data = _from_tsv(channels_fname)
         del tsv_data['status']
         _to_tsv(tsv_data, channels_fname)
 
     if drop_description_col:
+        # Remove `status_description` column from the sidecare TSV file.
         tsv_data = _from_tsv(channels_fname)
         del tsv_data['status_description']
         _to_tsv(tsv_data, channels_fname)
@@ -1492,7 +1494,9 @@ def test_mark_bad_channels(_bids_validate,
         return
 
     if not overwrite:
-        # Mark `existing_ch_names` as bad before we begin our actual tests.
+        # Mark `existing_ch_names` as bad in raw and sidecar TSV before we
+        # begin our actual tests, which should then add additional channels
+        # to the list of bads, retaining the ones we're specifying here.
         mark_bad_channels(ch_names=existing_ch_names,
                           descriptions=existing_descriptions,
                           bids_basename=bids_basename, bids_root=bids_root,

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -1506,9 +1506,3 @@ def test_mark_bad_channels(_bids_validate):
     # Test that we raise if `bids_basename` / `bids_root` parameters are
     # missing.
     bads = 'MEG 0112'
-
-    with pytest.raises(ValueError, match='You must specify the bids_basename'):
-        mark_bad_channels(channels=bads, bids_root=bids_root)
-
-    with pytest.raises(ValueError, match='You must specify the bids_root'):
-        mark_bad_channels(channels=bads, bids_basename=bids_basename)

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -1425,7 +1425,7 @@ def test_mark_bad_channels(_bids_validate):
     # Mark some channels as bad, and verify the result when reading the
     # dataset again.
     bads = ['MEG 0112', 'MEG 0131', 'EEG 053']
-    mark_bad_channels(channels=bads, bids_basename=bids_basename,
+    mark_bad_channels(ch_names=bads, bids_basename=bids_basename,
                       bids_root=bids_root, kind='meg')
     _bids_validate(bids_root)
     raw = read_raw_bids(bids_basename=bids_basename, bids_root=bids_root,
@@ -1436,19 +1436,19 @@ def test_mark_bad_channels(_bids_validate):
     # Test that we raise if we encounter an unknown channel name.
     bads = ['nonsense']
     with pytest.raises(ValueError, match='not found in dataset'):
-        mark_bad_channels(channels=bads, bids_basename=bids_basename,
+        mark_bad_channels(ch_names=bads, bids_basename=bids_basename,
                           bids_root=bids_root, kind='meg')
 
     # Test with channel name as string (not list).
     bads = 'MEG 0123'
-    mark_bad_channels(channels=bads, bids_basename=bids_basename,
+    mark_bad_channels(ch_names=bads, bids_basename=bids_basename,
                       bids_root=bids_root, kind='meg')
     _bids_validate(bids_root)
 
     # Set descriptions: list.
     bads = ['MEG 0112', 'MEG 0131']
     descriptions = ['Really bad!', 'Even worse.']
-    mark_bad_channels(channels=bads, descriptions=descriptions,
+    mark_bad_channels(ch_names=bads, descriptions=descriptions,
                       bids_basename=bids_basename, bids_root=bids_root,
                       kind='meg')
     _bids_validate(bids_root)
@@ -1459,7 +1459,7 @@ def test_mark_bad_channels(_bids_validate):
     # Set descriptions: string.
     bads = 'MEG 0112'
     descriptions = 'Really bad!'
-    mark_bad_channels(channels=bads, descriptions=descriptions,
+    mark_bad_channels(ch_names=bads, descriptions=descriptions,
                       bids_basename=bids_basename, bids_root=bids_root,
                       kind='meg')
     _bids_validate(bids_root)
@@ -1471,7 +1471,7 @@ def test_mark_bad_channels(_bids_validate):
     bads = ['MEG 0112', 'MEG 0131']
     descriptions = ['Really bad!']
     with pytest.raises(ValueError, match='must match'):
-        mark_bad_channels(channels=bads, descriptions=descriptions,
+        mark_bad_channels(ch_names=bads, descriptions=descriptions,
                           bids_basename=bids_basename, bids_root=bids_root,
                           kind='meg')
 
@@ -1482,7 +1482,7 @@ def test_mark_bad_channels(_bids_validate):
 
     bads = 'MEG 0112'
     descriptions = 'Really bad!'
-    mark_bad_channels(channels=bads, descriptions=descriptions,
+    mark_bad_channels(ch_names=bads, descriptions=descriptions,
                       bids_basename=bids_basename, bids_root=bids_root,
                       kind='meg')
     _bids_validate(bids_root)
@@ -1496,10 +1496,10 @@ def test_mark_bad_channels(_bids_validate):
     new_bads = ['EEG 053']
     new_descriptions = ['Just testing']
 
-    mark_bad_channels(channels=old_bads, descriptions=old_descriptions,
+    mark_bad_channels(ch_names=old_bads, descriptions=old_descriptions,
                       bids_basename=bids_basename, bids_root=bids_root,
                       kind='meg')
-    mark_bad_channels(channels=new_bads, descriptions=new_descriptions,
+    mark_bad_channels(ch_names=new_bads, descriptions=new_descriptions,
                       bids_basename=bids_basename, bids_root=bids_root,
                       kind='meg')
     _bids_validate(bids_root)
@@ -1518,10 +1518,10 @@ def test_mark_bad_channels(_bids_validate):
     new_bads = ['EEG 053']
     new_descriptions = ['Just testing']
 
-    mark_bad_channels(channels=old_bads, descriptions=old_descriptions,
+    mark_bad_channels(ch_names=old_bads, descriptions=old_descriptions,
                       bids_basename=bids_basename, bids_root=bids_root,
                       kind='meg')
-    mark_bad_channels(channels=new_bads, descriptions=new_descriptions,
+    mark_bad_channels(ch_names=new_bads, descriptions=new_descriptions,
                       bids_basename=bids_basename, bids_root=bids_root,
                       kind='meg', overwrite=True)
     _bids_validate(bids_root)

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -1516,7 +1516,8 @@ def test_mark_bad_channels(_bids_validate,
         # ones should be present.
         expected_bads = _ensure_list(ch_names)
     else:
-        expected_bads = _ensure_list(ch_names) + list(existing_ch_names)
+        expected_bads = (_ensure_list(ch_names) +
+                         _ensure_list(existing_ch_names))
 
     if drop_description_col or overwrite:
         # Existing column values should have been discarded, so only the new
@@ -1524,10 +1525,7 @@ def test_mark_bad_channels(_bids_validate,
         expected_descriptions = _ensure_list(descriptions)
     else:
         expected_descriptions = (_ensure_list(descriptions) +
-                                 list(existing_descriptions))
-
-    if expected_descriptions == [None]:
-        expected_descriptions = []
+                                 _ensure_list(existing_descriptions))
 
     # XXX Order is not preserved
     assert len(expected_bads) == len(raw.info['bads'])

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -1444,6 +1444,9 @@ def test_mark_bad_channels(_bids_validate):
     mark_bad_channels(ch_names=bads, bids_basename=bids_basename,
                       bids_root=bids_root, kind='meg')
     _bids_validate(bids_root)
+    tsv_data = _from_tsv(channels_fname)
+    idx = tsv_data['name'].index(bads)
+    assert tsv_data['status'][idx] == 'bad'
 
     # Set descriptions: list.
     bads = ['MEG 0112', 'MEG 0131']
@@ -1534,3 +1537,12 @@ def test_mark_bad_channels(_bids_validate):
     assert new_descriptions[0] in tsv_data['status_description']
     assert all([d not in tsv_data['status_description']
                 for d in old_descriptions])
+
+    # Test with `kind=None`.
+    bads = 'MEG 0123'
+    mark_bad_channels(ch_names=bads, bids_basename=bids_basename,
+                      bids_root=bids_root, kind=None, overwrite=True)
+    _bids_validate(bids_root)
+    tsv_data = _from_tsv(channels_fname)
+    idx = tsv_data['name'].index(bads)
+    assert tsv_data['status'][idx] == 'bad'

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1374,9 +1374,10 @@ def mark_bad_channels(channels, descriptions=None, bids_basename=None,
         channel(s). If ``None``, no descriptions are added.
     bids_basename : BIDSPath | str
         The base filename of the BIDS compatible files. Typically, this can be
-        generated using :func:`mne_bids.make_bids_basename`.
+        generated using :func:`mne_bids.make_bids_basename`. This is a required
+        argument.
     bids_root : str | pathlib.Path
-        Path to root of the BIDS folder
+        Path to root of the BIDS folder. This is a required argument.
     kind : str | None
         The kind of recording to  update. If ``None`` and only one kind (e.g.,
         only EEG or only MEG data) is present in the dataset, it will be

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1380,7 +1380,7 @@ def mark_bad_channels(ch_names, descriptions=None, *, bids_basename,
     bids_root : str | pathlib.Path
         Path to root of the BIDS folder.
     kind : str | None
-        The kind of recording to  update. If ``None`` and only one kind (e.g.,
+        The kind of recording to update. If ``None`` and only one kind (e.g.,
         only EEG or only MEG data) is present in the dataset, it will be
         selected automatically.
     overwrite : bool

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1468,10 +1468,10 @@ def mark_bad_channels(ch_names, descriptions=None, *, bids_path,
 
     # Update the sidecar data.
     if overwrite:
-        # XXX In cases where the "status" and / or "status_description"
-        # XXX columns were just created by us, we overwrite them again
-        # XXX here. This is not optimal in terms of performance, but
-        # XXX probably doesn't hurt anyone.
+        # In cases where the "status" and / or "status_description"
+        # columns were just created by us, we overwrite them again
+        # here. This is not optimal in terms of performance, but
+        # probably doesn't hurt anyone.
         logger.info('Resetting status and description for all channels.')
         tsv_data['status'] = ['good'] * len(tsv_data['name'])
         tsv_data['status_description'] = ['n/a'] * len(tsv_data['name'])

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -38,8 +38,7 @@ from mne_bids.utils import (_write_json, _write_tsv, _write_text,
                             _handle_datatype, _get_ch_type_mapping,
                             _check_anonymize, _stamp_to_dt)
 from mne_bids import make_bids_folders, read_raw_bids
-from mne_bids.path import (BIDSPath, _parse_ext, _mkdir_p, _path_to_str,
-                           _infer_datatype, get_entities_from_fname)
+from mne_bids.path import BIDSPath, _parse_ext, _mkdir_p, _path_to_str
 from mne_bids.copyfiles import (copyfile_brainvision, copyfile_eeglab,
                                 copyfile_ctf, copyfile_bti, copyfile_kit)
 from mne_bids.tsv_handler import (_from_tsv, _drop, _contains_row,
@@ -1443,24 +1442,14 @@ def mark_bad_channels(ch_names, descriptions=None, *, bids_path,
                          'Please use `bids_path.update(root="<root>")` '
                          'to set the root of the BIDS folder to read.')
 
-    # sub = bids_path.subject
-    # ses = bids_path.session
-
-    # if bids_path.datatype is None:
-    #     datatype = _infer_datatype(bids_root=bids_path.root, sub=sub, ses=ses)
-    # else:
-    #     datatype = bids_path.datatype
-
-    # bids_fname = bids_path.fpath()
-    channels_fname = _find_matching_sidecar(bids_path, suffix='channels',
-                                            extension='.tsv')
-
     # Read raw and sidecar file.
     raw = read_raw_bids(bids_path=bids_path,
                         extra_params=dict(allow_maxshield=True, preload=True),
                         verbose=False)
     bads_raw = raw.info['bads']
 
+    channels_fname = _find_matching_sidecar(bids_path, suffix='channels',
+                                            extension='.tsv')
     tsv_data = _from_tsv(channels_fname)
     if 'status' in tsv_data:
         bads_tsv = _get_bads_from_tsv_data(tsv_data)

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1392,27 +1392,6 @@ def mark_bad_channels(ch_names, descriptions=None, *, bids_basename,
     verbose : bool
         The verbosity level.
 
-    Raises
-    ------
-    ValueError
-        If the numbers of channels and descriptions do not match.
-
-    ValueError
-        If the specified channels cannot be found in the dataset.
-
-    ValueError
-        If the specified ``kind`` cannot be found in the dataset.
-
-    ValueError
-        If ``overwite=False``, but no channel names were passed.
-
-    RuntimeError
-        If multiple recording kinds are present in the dataset, but
-        ``kind=None``.
-
-    RuntimeError
-        If more than one data files exist for the specified recording.
-
     Examples
     --------
     Mark a single channel as bad.
@@ -1433,16 +1412,16 @@ def mark_bad_channels(ch_names, descriptions=None, *, bids_basename,
     >>> mark_bad_channels(bads, descriptions, bids_basename=bids_basename,
                           bids_root=bids_root)
 
-    Mark channels as bad, and reset all others existing in the dataset to
-    "good".
+    Mark channels as bad, and mark all others as good.
 
     >>> bads = ['MEG 0112', 'MEG 0131']
-    >>> mark_bad_channels(bads, overwrite=True, bids_basename=bids_basename,
-                          bids_root=bids_root)
+    >>> mark_bad_channels(bads, bids_basename=bids_basename,
+                          bids_root=bids_root, overwrite=True)
 
     Mark all channels as good.
 
-    >>> mark_bad_channels([], bids_basename=bids_basename, bids_root=bids_root)
+    >>> mark_bad_channels([], bids_basename=bids_basename, bids_root=bids_root,
+                          overwrite=True)
 
     """
     if not ch_names and not overwrite:

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1419,6 +1419,9 @@ def mark_bad_channels(channels, bids_basename, bids_root, kind=None,
     channels_fname = _find_matching_sidecar(bids_fname, bids_root,
                                             'channels.tsv')
     data = _from_tsv(channels_fname)
+    if isinstance(channels, str):
+        channels = [channels]
+
     for channel in channels:
         idx = data['name'].index(channel)
         if data['status'][idx] == 'bad':

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1459,7 +1459,7 @@ def mark_bad_channels(ch_names, descriptions=None, *, bids_basename,
         ch_names = [ch_names]
     if isinstance(descriptions, str):
         descriptions = [descriptions]
-    elif descriptions is None:
+    elif not descriptions:
         descriptions = ['n/a'] * len(ch_names)
     if len(ch_names) != len(descriptions):
         raise ValueError('Number of channels and descriptions must match.')

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1403,11 +1403,6 @@ def mark_bad_channels(channels, descriptions=None, *, bids_basename,
         If more than one data files exist for the specified recording.
 
     """
-    if bids_basename is None:
-        raise ValueError('You must specify the bids_basename parameter.')
-    if bids_root is None:
-        raise ValueError('You must specify the bids_root parameter.')
-
     if isinstance(channels, str):
         channels = [channels]
     if isinstance(descriptions, str):

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1372,7 +1372,8 @@ def mark_bad_channels(ch_names, descriptions=None, *, bids_basename,
         combination with ``overwrite=True`` to mark all channels as good.
     descriptions : None | str | list of str
         Descriptions of the reasons that lead to the exclusion of the
-        channel(s). If ``None``, no descriptions are added.
+        channel(s). If a list, it must match the length of ``ch_names``.
+        If ``None``, no descriptions are added.
     bids_basename : BIDSPath | str
         The base filename of the BIDS compatible files. Typically, this can be
         generated using :func:`mne_bids.make_bids_basename`.

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1361,13 +1361,13 @@ def write_anat(bids_root, subject, t1w, session=None, acquisition=None,
     return anat_dir
 
 
-def mark_bad_channels(channels, descriptions=None, *, bids_basename,
+def mark_bad_channels(ch_names, descriptions=None, *, bids_basename,
                       bids_root, kind=None, overwrite=False, verbose=True):
     """Update which channels are marked as "bad" in an existing BIDS dataset.
 
     Parameters
     ----------
-    channels : str | list of str | empty list
+    ch_names : str | list of str
         The names of the channel(s) to mark as bad. Pass an empty list in
         combination with ``overwrite=True`` to mark all channels as good.
     descriptions : None | str | list of str
@@ -1384,9 +1384,9 @@ def mark_bad_channels(channels, descriptions=None, *, bids_basename,
         selected automatically.
     overwrite : bool
         If ``False``, only update the information of the channels passed via
-        ``channels``, and leave the rest untouched. If ``True``, update the
+        ``ch_names``, and leave the rest untouched. If ``True``, update the
         information of **all** channels: mark the channels passed via
-        ``channels`` as bad, and all remaining channels as good, also
+        ``ch_names`` as bad, and all remaining channels as good, also
         discarding their descriptions.
     verbose : bool
         The verbosity level.
@@ -1427,7 +1427,7 @@ def mark_bad_channels(channels, descriptions=None, *, bids_basename,
 
     Mark channels as bad, and add a description as to why.
 
-    >>> bads = ['MEG 0112', 'MEG 0131']
+    >>> ch_names = ['MEG 0112', 'MEG 0131']
     >>> descriptions = ['Only produced noise', 'Continuously flat']
     >>> mark_bad_channels(bads, descriptions, bids_basename=bids_basename,
                           bids_root=bids_root)
@@ -1444,23 +1444,23 @@ def mark_bad_channels(channels, descriptions=None, *, bids_basename,
     >>> mark_bad_channels([], bids_basename=bids_basename, bids_root=bids_root)
 
     """
-    if not channels and not overwrite:
+    if not ch_names and not overwrite:
         raise ValueError('You did not pass a channel name, but set '
                          'overwrite=False. If you wish to mark all channels '
                          'as good, please pass overwrite=True')
 
-    if descriptions and not channels:
+    if descriptions and not ch_names:
         raise ValueError('You passed descriptions, but no channels.')
 
-    if not channels:
+    if not ch_names:
         descriptions = []
-    if isinstance(channels, str):
-        channels = [channels]
+    if isinstance(ch_names, str):
+        ch_names = [ch_names]
     if isinstance(descriptions, str):
         descriptions = [descriptions]
     elif descriptions is None:
-        descriptions = ['n/a'] * len(channels)
-    if len(channels) != len(descriptions):
+        descriptions = ['n/a'] * len(ch_names)
+    if len(ch_names) != len(descriptions):
         raise ValueError('Number of channels and descriptions must match.')
 
     # convert to BIDSPath
@@ -1505,13 +1505,13 @@ def mark_bad_channels(channels, descriptions=None, *, bids_basename,
         data['status'] = ['good'] * len(data['name'])
         data['status_description'] = ['n/a'] * len(data['name'])
 
-    for channel, description in zip(channels, descriptions):
-        if channel not in data['name']:
-            raise ValueError(f'Channel {channel} not found in dataset!')
+    for ch_name, description in zip(ch_names, descriptions):
+        if ch_name not in data['name']:
+            raise ValueError(f'Channel {ch_name} not found in dataset!')
 
-        idx = data['name'].index(channel)
+        idx = data['name'].index(ch_name)
 
-        logger.info(f'Processing channel {channel}:\n'
+        logger.info(f'Processing channel {ch_name}:\n'
                     f'    status: bad\n'
                     f'    description: {description}')
         data['status'][idx] = 'bad'

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1436,7 +1436,7 @@ def mark_bad_channels(channels, descriptions=None, *, bids_basename,
     "good".
 
     >>> bads = ['MEG 0112', 'MEG 0131']
-    >>> mark_bad_channels(bads, overwrite=True, bids_basename=bids_basename, 
+    >>> mark_bad_channels(bads, overwrite=True, bids_basename=bids_basename,
                           bids_root=bids_root)
 
     Mark all channels as good.

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1363,7 +1363,7 @@ def write_anat(bids_root, subject, t1w, session=None, acquisition=None,
 
 def mark_bad_channels(channels, descriptions=None, *, bids_basename,
                       bids_root, kind=None, overwrite=False, verbose=True):
-    """Update sidecar (metadata) files of an existing BIDS dataset.
+    """Update which channels are marked as "bad" in an existing BIDS dataset.
 
     Parameters
     ----------
@@ -1411,6 +1411,37 @@ def mark_bad_channels(channels, descriptions=None, *, bids_basename,
 
     RuntimeError
         If more than one data files exist for the specified recording.
+
+    Examples
+    --------
+    Mark a single channel as bad.
+
+    >>> mark_bad_channels('MEG 0112', bids_basename=bids_basename,
+                          bids_root=bids_root)
+
+    Mark multiple channels as bad.
+
+    >>> bads = ['MEG 0112', 'MEG 0131']
+    >>> mark_bad_channels(bads, bids_basename=bids_basename,
+                          bids_root=bids_root)
+
+    Mark channels as bad, and add a description as to why.
+
+    >>> bads = ['MEG 0112', 'MEG 0131']
+    >>> descriptions = ['Only produced noise', 'Continuously flat']
+    >>> mark_bad_channels(bads, descriptions, bids_basename=bids_basename,
+                          bids_root=bids_root)
+
+    Mark channels as bad, and reset all others existing in the dataset to
+    "good".
+
+    >>> bads = ['MEG 0112', 'MEG 0131']
+    >>> mark_bad_channels(bads, overwrite=True, bids_basename=bids_basename, 
+                          bids_root=bids_root)
+
+    Mark all channels as good.
+
+    >>> mark_bad_channels([], bids_basename=bids_basename, bids_root=bids_root)
 
     """
     if not channels and not overwrite:

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1361,8 +1361,8 @@ def write_anat(bids_root, subject, t1w, session=None, acquisition=None,
     return anat_dir
 
 
-def mark_bad_channels(channels, descriptions=None, bids_basename=None,
-                      bids_root=None, kind=None, verbose=True):
+def mark_bad_channels(channels, descriptions=None, *, bids_basename,
+                      bids_root, kind=None, verbose=True):
     """Update sidecar (metadata) files of an existing BIDS dataset.
 
     Parameters
@@ -1374,10 +1374,9 @@ def mark_bad_channels(channels, descriptions=None, bids_basename=None,
         channel(s). If ``None``, no descriptions are added.
     bids_basename : BIDSPath | str
         The base filename of the BIDS compatible files. Typically, this can be
-        generated using :func:`mne_bids.make_bids_basename`. This is a required
-        argument.
+        generated using :func:`mne_bids.make_bids_basename`.
     bids_root : str | pathlib.Path
-        Path to root of the BIDS folder. This is a required argument.
+        Path to root of the BIDS folder.
     kind : str | None
         The kind of recording to  update. If ``None`` and only one kind (e.g.,
         only EEG or only MEG data) is present in the dataset, it will be
@@ -1387,9 +1386,6 @@ def mark_bad_channels(channels, descriptions=None, bids_basename=None,
 
     Raises
     ------
-    ValueError
-        If no ``bids_basename`` or ``bids_root`` are specified.
-
     ValueError
         If the number of channels and descriptions does not match.
 

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1395,7 +1395,7 @@ def mark_bad_channels(ch_names, descriptions=None, *, bids_basename,
     Raises
     ------
     ValueError
-        If the number of channels and descriptions does not match.
+        If the numbers of channels and descriptions do not match.
 
     ValueError
         If the specified channels cannot be found in the dataset.

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1423,6 +1423,9 @@ def mark_bad_channels(channels, bids_basename, bids_root, kind=None,
         channels = [channels]
 
     for channel in channels:
+        if channel not in data['name']:
+            raise ValueError(f'Channel {channel} not found in dataset!')
+
         idx = data['name'].index(channel)
         if data['status'][idx] == 'bad':
             warn(f'Channel {channel} was already marked as bad, not updating.')

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1413,7 +1413,7 @@ def mark_bad_channels(channels, descriptions=None, *, bids_basename,
     if isinstance(descriptions, str):
         descriptions = [descriptions]
     elif descriptions is None:
-        descriptions = [None] * len(channels)
+        descriptions = ['n/a'] * len(channels)
     if len(channels) != len(descriptions):
         raise ValueError('Number of channels and descriptions must match.')
 
@@ -1447,7 +1447,7 @@ def mark_bad_channels(channels, descriptions=None, *, bids_basename,
     if 'status_description' not in data:
         logger.info('No "status_description" column found in input file. '
                     'Creating.')
-        data['status_description'] = [''] * len(data['name'])
+        data['status_description'] = ['n/a'] * len(data['name'])
 
     # Update the sidecar data.
     for channel, description in zip(channels, descriptions):
@@ -1456,22 +1456,10 @@ def mark_bad_channels(channels, descriptions=None, *, bids_basename,
 
         idx = data['name'].index(channel)
 
-        # Update 'status' column.
-        if data['status'][idx] == 'bad':
-            warn(f'Channel {channel} was already marked as bad.')
-        else:
-            logger.info(f'Updating status of channel {channel}: '
-                        f'{data["status"][idx]} -> bad')
-            data['status'][idx] = 'bad'
-
-        # Update 'status_description' column.
-        if description is not None:
-            if data['status_description'][idx] == description:
-                warn(f'Description for channel {channel} has not changed.')
-            else:
-                logger.info(f'Updating description of channel {channel}: '
-                            f'{data["status_description"][idx]} -> '
-                            f'{description}')
-                data['status_description'][idx] = description
+        logger.info(f'Processing channel {channel}:\n'
+                    f'    status: bad\n'
+                    f'    description: {description}')
+        data['status'][idx] = 'bad'
+        data['status_description'][idx] = description
 
     _write_tsv(channels_fname, data, overwrite=True, verbose=verbose)

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1438,7 +1438,7 @@ def mark_bad_channels(channels, descriptions=None, bids_basename=None,
         kind = _infer_kind(bids_basename=bids_basename, bids_root=bids_root,
                            sub=sub, ses=ses)
 
-    # Read sidecare and create required columns if they do not exist.
+    # Read sidecar and create required columns if they do not exist.
     bids_fname = bids_basename.get_bids_fname(kind=kind, bids_root=bids_root)
     channels_fname = _find_matching_sidecar(bids_fname, bids_root,
                                             'channels.tsv')


### PR DESCRIPTION
PR Description
--------------

I've started working on something we've needed for a long time now: marking channels of an existing BIDS dataset as "bad". This is needed because we'd like to encourage colleagues to convert to BIDS ASAP after data acquisition. Now, during data inspection / processing, they might discover problematic channels, and currently the only way to mark them as bad in the BIDS data is by editing the `channels.tsv` file(s) – not good! Even worse, some may opt to read the BIDS data, and mark channels as bad only in the derivative data they produce. Therefore we've figured we'd need a way to make it convenient to alter / amend existing metadata.

This implementation is just a first draft, adding a `write.mark_bad_channels()` function. It will read the relevant `channels.tsv` file, mark the requested channels as bad, and write the altered metadata back to disk, replacing the existing file. I do realize that what I'm doing here can be further abstracted, e.g. to also allow users to mark bad channels as good; or to update other bits of the metadata as well. However I just wanted to move ahead for now with a concrete implementation that has actual real-world relevance for us and our colleagues. Totally open to rethink and refactor this later, and looking forward to your thoughts and suggestions!

WIP because I also want to add a command line interface, and I haven't run extensive tests so far.

cc @agramfort

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
- [ ] Commit history does not contain any merge commits
