### PR TITLE
[MRG] Ensure raw.info['bads'] is a list

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -52,6 +52,7 @@ Bug
 - Fix `raw_to_bids` CLI tool to work with non-FIF files, by `Austin Hurst`_ (`#456 <https://github.com/mne-tools/mne-bids/pull/456>`_)
 - Fix :func:`mne_bids.write_raw_bids` to output BTI and CTF data in the scans.tsv according to the BIDS specification by `Adam Li`_ (`#465 <https://github.com/mne-tools/mne-bids/pull/465>`_)
 - :func:`mne_bids.read_raw_bids` now populates the list of bad channels based on ``*_channels.tsv`` if (and only if) a ``status`` column is present, ignoring similar metadata stored in raw file (which will still be used if **no** ``status`` column is present in ``*_channels.tsv``), by `Richard Höchenberger`_ (`#499 <https://github.com/mne-tools/mne-bids/pull/499>`_)
+- Ensure that ``Raw.info['bads']`` returned by :func:`mne_bids.read_raw_bids` is always a list, by `Richard Höchenberger`_ (`#501 <https://github.com/mne-tools/mne-bids/pull/501>`_)
 
 
 API

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -186,6 +186,17 @@ def _handle_events_reading(events_fname, raw):
     return raw
 
 
+def _get_bads_from_tsv_data(tsv_data):
+    """Extract names of bads from data read from channels.tsv"""
+    idx = []
+    for ch_idx, status in enumerate(tsv_data['status']):
+        if status.lower() == 'bad':
+            idx.append(ch_idx)
+
+    bads = [tsv_data['name'][i] for i in idx]
+    return bads
+
+
 def _handle_channels_reading(channels_fname, bids_fname, raw):
     """Read associated channels.tsv and populate raw.
 
@@ -254,9 +265,7 @@ def _handle_channels_reading(channels_fname, bids_fname, raw):
     # good and bad channels
     if 'status' in channels_dict:
         # find bads from channels.tsv
-        bad_bool = [True if chn.lower() == 'bad' else False
-                    for chn in channels_dict['status']]
-        bads_from_tsv = np.asarray(channels_dict['name'])[bad_bool]
+        bads_from_tsv = _get_bads_from_tsv_data(channels_dict)
 
         if raw.info['bads'] and set(bads_from_tsv) != set(raw.info['bads']):
             warn(f'Encountered conflicting information on channel status '

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -187,7 +187,7 @@ def _handle_events_reading(events_fname, raw):
 
 
 def _get_bads_from_tsv_data(tsv_data):
-    """Extract names of bads from data read from channels.tsv"""
+    """Extract names of bads from data read from channels.tsv."""
     idx = []
     for ch_idx, status in enumerate(tsv_data['status']):
         if status.lower() == 'bad':

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -827,6 +827,7 @@ def test_bads_reading():
 
     raw = read_raw_bids(bids_basename=bids_basename, bids_root=bids_root,
                         verbose=False)
+    assert type(raw.info['bads']) is list
     assert set(raw.info['bads']) == set(bads)
 
     ###########################################################################
@@ -846,4 +847,5 @@ def test_bads_reading():
     with pytest.warns(RuntimeWarning, match='conflicting information'):
         raw = read_raw_bids(bids_basename=bids_basename, bids_root=bids_root,
                             verbose=False)
+    assert type(raw.info['bads']) is list
     assert set(raw.info['bads']) == set(bads_bids)


### PR DESCRIPTION
PR Description
--------------

In some cases we created `info['bads']` as an ndarray, leading to unexpected behavior. MNE-Python docs say that it's expected to be a list.


Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [x] All comments resolved
- [x] This is not your own PR
- [x] All CIs are happy
- [x] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
- [x] Commit history does not contain any merge commits
