### PR TITLE
[MRG] get_entity_vals now expects "long" entity names

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -69,6 +69,7 @@ API
 - :func:`mne_bids.make_report` is now available from the `mne_bids` namespace that creates a string output of a summary of the BIDS dataset. In addition, the command line interface allows one to call `make_report`, by `Adam Li`_ (`#457 <https://github.com/mne-tools/mne-bids/pull/457>`_)
 - Added namespace :code:`mne_bids.path` which hosts path-like functionality for MNE-BIDS by `Adam Li`_ (`#483 <https://github.com/mne-tools/mne-bids/pull/483>`_)
 - A function for retrieval of BIDS entity values from a filename, :func:`mne_bids.path.parse_bids_filename`, is now part of the public API (it used to be a private function called ``mne_bids.path._parse_bids_filename``), by `Richard Höchenberger`_ (`#487 <https://github.com/mne-tools/mne-bids/pull/487>`_)
+- Entity names passed to :func:`mne_bids.get_entity_vals` hmust now be in the "long" for, e.g. ``subject`` instead of ``sub`` etc., by `Richard Höchenberger`_ (`#501 <https://github.com/mne-tools/mne-bids/pull/501>`_)
 
 .. _changes_0_4:
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -69,7 +69,7 @@ API
 - :func:`mne_bids.make_report` is now available from the `mne_bids` namespace that creates a string output of a summary of the BIDS dataset. In addition, the command line interface allows one to call `make_report`, by `Adam Li`_ (`#457 <https://github.com/mne-tools/mne-bids/pull/457>`_)
 - Added namespace :code:`mne_bids.path` which hosts path-like functionality for MNE-BIDS by `Adam Li`_ (`#483 <https://github.com/mne-tools/mne-bids/pull/483>`_)
 - A function for retrieval of BIDS entity values from a filename, :func:`mne_bids.path.parse_bids_filename`, is now part of the public API (it used to be a private function called ``mne_bids.path._parse_bids_filename``), by `Richard Höchenberger`_ (`#487 <https://github.com/mne-tools/mne-bids/pull/487>`_)
-- Entity names passed to :func:`mne_bids. ` must now be in the "long" for, e.g. ``subject`` instead of ``sub`` etc., by `Richard Höchenberger`_ (`#501 <https://github.com/mne-tools/mne-bids/pull/501>`_)
+- Entity names passed to :func:`mne_bids.get_entity_vals` must now be in the "long" for, e.g. ``subject`` instead of ``sub`` etc., by `Richard Höchenberger`_ (`#501 <https://github.com/mne-tools/mne-bids/pull/501>`_)
 
 .. _changes_0_4:
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -69,7 +69,7 @@ API
 - :func:`mne_bids.make_report` is now available from the `mne_bids` namespace that creates a string output of a summary of the BIDS dataset. In addition, the command line interface allows one to call `make_report`, by `Adam Li`_ (`#457 <https://github.com/mne-tools/mne-bids/pull/457>`_)
 - Added namespace :code:`mne_bids.path` which hosts path-like functionality for MNE-BIDS by `Adam Li`_ (`#483 <https://github.com/mne-tools/mne-bids/pull/483>`_)
 - A function for retrieval of BIDS entity values from a filename, :func:`mne_bids.path.parse_bids_filename`, is now part of the public API (it used to be a private function called ``mne_bids.path._parse_bids_filename``), by `Richard Höchenberger`_ (`#487 <https://github.com/mne-tools/mne-bids/pull/487>`_)
-- Entity names passed to :func:`mne_bids.get_entity_vals` hmust now be in the "long" for, e.g. ``subject`` instead of ``sub`` etc., by `Richard Höchenberger`_ (`#501 <https://github.com/mne-tools/mne-bids/pull/501>`_)
+- Entity names passed to :func:`mne_bids. ` must now be in the "long" for, e.g. ``subject`` instead of ``sub`` etc., by `Richard Höchenberger`_ (`#501 <https://github.com/mne-tools/mne-bids/pull/501>`_)
 
 .. _changes_0_4:
 

--- a/mne_bids/report.py
+++ b/mne_bids/report.py
@@ -496,8 +496,8 @@ def make_report(bids_root, session=None, verbose=True):
         describing the summary of the subjects.
     """
     # high level summary
-    subjects = get_entity_vals(bids_root, entity_key='sub')
-    sessions = get_entity_vals(bids_root, entity_key='ses')
+    subjects = get_entity_vals(bids_root, entity_key='subject')
+    sessions = get_entity_vals(bids_root, entity_key='session')
     kinds = get_kinds(bids_root)
 
     # only summarize allowed kinds (MEEG data)

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -69,20 +69,20 @@ def test_get_keys(return_bids_test_dir):
 
 @pytest.mark.parametrize('entity, expected_vals, kwargs',
                          [('bogus', None, None),
-                          ('sub', [subject_id], None),
-                          ('ses', [session_id], None),
+                          ('subject', [subject_id], None),
+                          ('session', [session_id], None),
                           ('run', [run, '02'], None),
-                          ('acq', [], None),
+                          ('acquisition', [], None),
                           ('task', [task], None),
-                          ('sub', [], dict(ignore_sub=[subject_id])),
-                          ('sub', [], dict(ignore_sub=subject_id)),
-                          ('ses', [], dict(ignore_ses=[session_id])),
-                          ('ses', [], dict(ignore_ses=session_id)),
-                          ('run', [run], dict(ignore_run=['02'])),
-                          ('run', [run], dict(ignore_run='02')),
-                          ('task', [], dict(ignore_task=[task])),
-                          ('task', [], dict(ignore_task=task)),
-                          ('run', [run, '02'], dict(ignore_run=['bogus']))])
+                          ('subject', [], dict(ignore_subjects=[subject_id])),
+                          ('subject', [], dict(ignore_subjects=subject_id)),
+                          ('session', [], dict(ignore_sessions=[session_id])),
+                          ('session', [], dict(ignore_sessions=session_id)),
+                          ('run', [run], dict(ignore_runs=['02'])),
+                          ('run', [run], dict(ignore_runs='02')),
+                          ('task', [], dict(ignore_tasks=[task])),
+                          ('task', [], dict(ignore_tasks=task)),
+                          ('run', [run, '02'], dict(ignore_runs=['bogus']))])
 def test_get_entity_vals(entity, expected_vals, kwargs, return_bids_test_dir):
     """Test getting a list of entities."""
     bids_root = return_bids_test_dir


### PR DESCRIPTION
PR Description
--------------
`mne_bids.path.get_entity_vals` now expects "long" entity names (e.g. ``subject`` instead of ``sub``). This is kind of complementary to #496 and required for #491 

Also support more entity names -- all that I could fine :)

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
- [ ] Commit history does not contain any merge commits
