### PR TITLE
In write_raw_bids, use Raw.anonymize

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -53,7 +53,7 @@ Bug
 - Fix :func:`mne_bids.write_raw_bids` to output BTI and CTF data in the scans.tsv according to the BIDS specification by `Adam Li`_ (`#465 <https://github.com/mne-tools/mne-bids/pull/465>`_)
 - :func:`mne_bids.read_raw_bids` now populates the list of bad channels based on ``*_channels.tsv`` if (and only if) a ``status`` column is present, ignoring similar metadata stored in raw file (which will still be used if **no** ``status`` column is present in ``*_channels.tsv``), by `Richard Höchenberger`_ (`#499 <https://github.com/mne-tools/mne-bids/pull/499>`_)
 - Ensure that ``Raw.info['bads']`` returned by :func:`mne_bids.read_raw_bids` is always a list, by `Richard Höchenberger`_ (`#501 <https://github.com/mne-tools/mne-bids/pull/501>`_)
-- :func:`mne_bids.write_raw_bids` now ensures that **all** parts of the :class:`mne.io.Raw` instance stay in sync, e.g. ``raw.annotations``, by `Richard Höchenberger`_ (`#504 <https://github.com/mne-tools/mne-bids/pull/504>`_)
+- :func:`mne_bids.write_raw_bids` now ensures that **all** parts of the :class:`mne.io.Raw` instance stay in sync when using anonymization to shift dates, e.g. ``raw.annotations``, by `Richard Höchenberger`_ (`#504 <https://github.com/mne-tools/mne-bids/pull/504>`_)
 
 API
 ~~~

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -53,7 +53,7 @@ Bug
 - Fix :func:`mne_bids.write_raw_bids` to output BTI and CTF data in the scans.tsv according to the BIDS specification by `Adam Li`_ (`#465 <https://github.com/mne-tools/mne-bids/pull/465>`_)
 - :func:`mne_bids.read_raw_bids` now populates the list of bad channels based on ``*_channels.tsv`` if (and only if) a ``status`` column is present, ignoring similar metadata stored in raw file (which will still be used if **no** ``status`` column is present in ``*_channels.tsv``), by `Richard Höchenberger`_ (`#499 <https://github.com/mne-tools/mne-bids/pull/499>`_)
 - Ensure that ``Raw.info['bads']`` returned by :func:`mne_bids.read_raw_bids` is always a list, by `Richard Höchenberger`_ (`#501 <https://github.com/mne-tools/mne-bids/pull/501>`_)
-
+- :func:`mne_bids.write_raw_bids` now ensures that **all** parts of the :class:`mne.io.Raw` instance stay in sync, e.g. ``raw.annotations``, by `Richard Höchenberger`_ (`#504 <https://github.com/mne-tools/mne-bids/pull/504>`_)
 
 API
 ~~~

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -22,7 +22,7 @@ from mne.transforms import (_get_trans, apply_trans, get_ras_to_neuromag_trans,
 from mne import Epochs
 from mne.io.constants import FIFF
 from mne.io.pick import channel_type
-from mne.io import BaseRaw, anonymize_info, read_fiducials
+from mne.io import BaseRaw, read_fiducials
 try:
     from mne.io._digitization import _get_fid_coords
 except ImportError:
@@ -907,7 +907,7 @@ def write_raw_bids(raw, bids_basename, bids_root, events_data=None,
 
     See Also
     --------
-    mne.io.anonymize_info
+    mne.io.Raw.anonymize
 
     """
     if not check_version('mne', '0.17'):
@@ -1039,8 +1039,7 @@ def write_raw_bids(raw, bids_basename, bids_root, events_data=None,
     convert = False
     if anonymize is not None:
         daysback, keep_his = _check_anonymize(anonymize, raw, ext)
-        raw.info = anonymize_info(raw.info, daysback=daysback,
-                                  keep_his=keep_his)
+        raw.anonymize(daysback=daysback, keep_his=keep_his, verbose=verbose)
 
         if kind == 'meg' and ext != '.fif':
             if verbose:


### PR DESCRIPTION


PR Description
--------------

MNE-Python docs state:
" you should directly use the method raw.anonymize() to ensure that all parts of the data are anonymized and stay synchronized (e.g., raw.annotations)."

In contrast to this, `master` only uses `anonymize_info()`, which is insufficient and yields the error reported here:
https://github.com/mne-tools/mne-python/issues/7575

WIP because I still need to add tests.

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
- [ ] Commit history does not contain any merge commits
