### PR TITLE
New function: get_matched_basenames()

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -57,6 +57,7 @@ Path
 
    BIDSPath
    get_entities_from_fname
+   get_matched_basenames
 
 Copyfiles
 =========

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -36,6 +36,7 @@ Changelog
 - :func:`mne_bids.read_raw_bids` and :func:`mne_bids.write_raw_bids` now map respiratory (``RESP``) channel types, by `Richard Höchenberger`_ (`#482 <https://github.com/mne-tools/mne-bids/pull/482>`_)
 - When impedance values are available from a ``raw.impedances`` attribute, MNE-BIDS will now write an ``impedance`` column to ``*_electrodes.tsv`` files, by `Stefan Appelhoff`_ (`#484 <https://github.com/mne-tools/mne-bids/pull/484>`_)
 - :func:`mne_bids.write_raw_bids` writes out status_description with 'n/a' values into the channels.tsv sidecar file, by `Adam Li`_ (`#489 <https://github.com/mne-tools/mne-bids/pull/489>`_)
+- The new function :func:`mne_bids.path.get_matched_basenames()` allows uers to retrieve a list of :class:`mne_bids.path.BIDSPath` objects matching a specified set of entity values in the dataset, by `Richard Höchenberger`_ (`#507 <https://github.com/mne-tools/mne-bids/pull/507>`_)
 
 Bug
 ~~~
@@ -72,7 +73,7 @@ API
 - A function for retrieval of BIDS entity values from a filename, :func:`mne_bids.path.get_entities_from_fname`, is now part of the public API (it used to be a private function called ``mne_bids.path._parse_bids_filename``), by `Richard Höchenberger`_ (`#487 <https://github.com/mne-tools/mne-bids/pull/487>`_)
 - Entity names passed to :func:`mne_bids.get_entity_vals` must now be in the "long" for, e.g. ``subject`` instead of ``sub`` etc., by `Richard Höchenberger`_ (`#501 <https://github.com/mne-tools/mne-bids/pull/501>`_)
 - Change :func:`mne_bids.path.get_entities_from_fname` to use full entity kwargs (e.g. 'subject' instead of 'sub') in the return dictionary structure by `Adam Li`_ (`#496 <https://github.com/mne-tools/mne-bids/pull/496>`_)
-- Change :func:`mne_bids.path.BIDSPath` and :func:`mne_bids.make_bids_basename` to use explicitly ``kind`` and ``extension`` instead of ``suffix`` in kwargs by `Adam Li`_ (`#496 <https://github.com/mne-tools/mne-bids/pull/496>`_)
+- Change :class:`mne_bids.path.BIDSPath` and :func:`mne_bids.make_bids_basename` to use explicitly ``kind`` and ``extension`` instead of ``suffix`` in kwargs by `Adam Li`_ (`#496 <https://github.com/mne-tools/mne-bids/pull/496>`_)
 
 
 .. _changes_0_4:

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -36,7 +36,7 @@ Changelog
 - :func:`mne_bids.read_raw_bids` and :func:`mne_bids.write_raw_bids` now map respiratory (``RESP``) channel types, by `Richard Höchenberger`_ (`#482 <https://github.com/mne-tools/mne-bids/pull/482>`_)
 - When impedance values are available from a ``raw.impedances`` attribute, MNE-BIDS will now write an ``impedance`` column to ``*_electrodes.tsv`` files, by `Stefan Appelhoff`_ (`#484 <https://github.com/mne-tools/mne-bids/pull/484>`_)
 - :func:`mne_bids.write_raw_bids` writes out status_description with 'n/a' values into the channels.tsv sidecar file, by `Adam Li`_ (`#489 <https://github.com/mne-tools/mne-bids/pull/489>`_)
-- The new function :func:`mne_bids.path.get_matched_basenames()` allows uers to retrieve a list of :class:`mne_bids.path.BIDSPath` objects matching a specified set of entity values in the dataset, by `Richard Höchenberger`_ (`#507 <https://github.com/mne-tools/mne-bids/pull/507>`_)
+- The new function :func:`mne_bids.path.get_matched_basenames` allows uers to retrieve a list of :class:`mne_bids.path.BIDSPath` objects matching a specified set of entity values in the dataset, by `Richard Höchenberger`_ (`#507 <https://github.com/mne-tools/mne-bids/pull/507>`_)
 
 Bug
 ~~~

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -1018,7 +1018,6 @@ def get_matched_basenames(bids_root, *, subject=None, session=None, task=None,
         matches were found.
 
     """
-
     bids_root = Path(bids_root)
 
     fnames = bids_root.rglob('*.*')

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -956,7 +956,8 @@ def _filter_fnames(fnames, *, subject=None, session=None, task=None,
     rec_str = f'_rec-{recording}' if recording else r'(|_rec-([^_]+))'
     space_str = f'_space-{space}' if space else r'(|_space-([^_]+))'
     split_str = f'_split-{split}' if split else r'(|_split-([^_]+))'
-    kind_str = f'_{kind}' if kind else r'_(meg|eeg|ieeg|mri)'  # XXX do we want MRI here?
+    # XXX do we want MRI here?
+    kind_str = f'_{kind}' if kind else r'_(meg|eeg|ieeg|mri)'
     ext_str = extension if extension else r'.([^_]+)'
 
     regexp = (sub_str + ses_str + task_str + acq_str + run_str + proc_str +

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -1021,6 +1021,7 @@ def get_matched_basenames(bids_root, *, subject=None, session=None, task=None,
     bids_root = Path(bids_root)
 
     fnames = bids_root.rglob('*.*')
+    # Only keep files (not directories), and omit the JSON sidecars.
     fnames = [str(f.name) for f in fnames
               if f.is_file() and f.suffix != '.json']
     fnames = _filter_fnames(fnames, subject=subject, session=session,

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -956,8 +956,8 @@ def _filter_fnames(fnames, *, subject=None, session=None, task=None,
     rec_str = f'_rec-{recording}' if recording else r'(|_rec-([^_]+))'
     space_str = f'_space-{space}' if space else r'(|_space-([^_]+))'
     split_str = f'_split-{split}' if split else r'(|_split-([^_]+))'
-    # XXX do we want MRI here?
-    kind_str = f'_{kind}' if kind else r'_(meg|eeg|ieeg|mri)'
+    kind_str = (f'_{kind}' if kind else r'_(' +
+                '|'.join(ALLOWED_FILENAME_KINDS) + ')')
     ext_str = extension if extension else r'.([^_]+)'
 
     regexp = (sub_str + ses_str + task_str + acq_str + run_str + proc_str +

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -346,7 +346,7 @@ def test_bids_path(return_bids_test_dir):
         (dict(task='audio'), 2),
         (dict(processing='sss'), 1),
         (dict(kind='meg'), 4),
-        (dict(acquisition='t1w'), 1),
+        (dict(acquisition='lowres'), 1),
         (dict(task='test', processing='ica', kind='eeg'), 2),
         (dict(subject='5', task='test', processing='ica', kind='eeg'), 1)
     ])
@@ -359,7 +359,7 @@ def test_filter_fnames(entities, expected_n_matches):
               'sub-Foo_ses-bar_meg.fif',
               'sub-Bar_task-invasive_run-1_ieeg.fif',
               'sub-3_task-fun_proc-sss_meg.fif',
-              'sub-4_task-pain_acq-t1w_mri.nii.gz',
+              'sub-4_task-pain_acq-lowres_T1w.nii.gz',
               'sub-5_task-test_proc-ica_eeg.vhdr',
               'sub-6_task-test_proc-ica_eeg.vhdr')
 
@@ -372,14 +372,13 @@ def test_get_matched_basenames(return_bids_test_dir):
     bids_root = return_bids_test_dir
 
     paths = get_matched_basenames(bids_root=bids_root)
-    assert len(paths) == 2
-    assert paths[0].basename == 'sub-01_ses-01_task-testing_run-01_meg'
-    assert paths[1].basename == 'sub-01_ses-01_task-testing_run-02_meg'
+    assert len(paths) == 7
+    assert all('sub-01_ses-01' in p.basename for p in paths)
     assert all([p.prefix == bids_root for p in paths])
 
     paths = get_matched_basenames(bids_root=bids_root, run='01')
-    assert len(paths) == 1
-    assert paths[0].basename == 'sub-01_ses-01_task-testing_run-01_meg'
+    assert len(paths) == 3
+    assert paths[0].basename == 'sub-01_ses-01_task-testing_run-01_channels'
 
     paths = get_matched_basenames(bids_root=bids_root, subject='unknown')
     assert len(paths) == 0


### PR DESCRIPTION
PR Description
--------------

`path.get_matched_basenames()` allows users to retrieve a list of `BIDSPaths` matching specified entities. The entire dataset (BIDS root) will be globbed, and a list of matching `BIDSPaths` will be returned. In case of no match, returns an empty list.

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
- [ ] Commit history does not contain any merge commits
