### PR TITLE
only do a deep check of BIDSPath entities in make_bids_basename

### DIFF
--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -255,6 +255,7 @@ class BIDSPath(object):
             # Ensure that run is a string
             entities['split'] = '{:02}'.format(split)
 
+        # ensure extension starts with a '.'
         extension = entities.get('extension')
         if extension is not None:
             if not extension.startswith('.'):

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -255,25 +255,11 @@ class BIDSPath(object):
             # Ensure that run is a string
             entities['split'] = '{:02}'.format(split)
 
-        # ensure extension starts with a '.'
         extension = entities.get('extension')
         if extension is not None:
             if not extension.startswith('.'):
                 extension = f'.{extension}'
                 entities['extension'] = extension
-            # check validity of the extension
-            if extension not in ALLOWED_FILENAME_EXTENSIONS:
-                raise ValueError(f'Extension {extension} is not '
-                                 f'allowed. Use one of these extensions '
-                                 f'{ALLOWED_FILENAME_EXTENSIONS}.')
-
-        # error check kind
-        kind = entities.get('kind')
-        if kind is not None:
-            if kind not in ALLOWED_FILENAME_KINDS:
-                raise ValueError(f'Kind {kind} is not allowed. '
-                                 f'Use one of these kinds '
-                                 f'{ALLOWED_FILENAME_KINDS}.')
 
         # error check entities
         for key, val in entities.items():
@@ -294,14 +280,33 @@ class BIDSPath(object):
                 val = str(val)
             setattr(self, key, val)
 
-        self._check(with_emptyroom=False)
+        self._check(deep=False)
         return self
 
-    def _check(self, with_emptyroom=True):
-        # check the task/session of er basename
+    def _check(self, deep=True):
+        """Deep check or not of the instance."""
         self.basename  # run basename to check validity of arguments
-        if with_emptyroom and self.subject == 'emptyroom':
-            _check_empty_room_basename(self)
+
+        if deep:
+            if self.subject == 'emptyroom':
+                _check_empty_room_basename(self)
+
+            # ensure extension starts with a '.'
+            extension = self.extension
+            if extension is not None:
+                # check validity of the extension
+                if extension not in ALLOWED_FILENAME_EXTENSIONS:
+                    raise ValueError(f'Extension {extension} is not '
+                                     f'allowed. Use one of these extensions '
+                                     f'{ALLOWED_FILENAME_EXTENSIONS}.')
+
+            # error check kind
+            kind = self.kind
+            if kind is not None:
+                if kind not in ALLOWED_FILENAME_KINDS:
+                    raise ValueError(f'Kind {kind} is not allowed. '
+                                     f'Use one of these kinds '
+                                     f'{ALLOWED_FILENAME_KINDS}.')
 
 
 def print_dir_tree(folder, max_depth=None):
@@ -452,6 +457,8 @@ def get_entities_from_fname(fname):
     'split': None,
     'kind': 'meg'}
     """
+    fname = str(fname)  # to accept also BIDSPath or Path instances
+
     # filename keywords to the BIDS entity mapping
     entity_vals = list(ALLOWED_PATH_ENTITIES_SHORT.values())
     fname_vals = list(ALLOWED_PATH_ENTITIES_SHORT.keys())

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -321,7 +321,7 @@ def test_bids_path(return_bids_test_dir):
     # do not error check kind in update (not deep check)
     bids_basename.update(kind='foobar')
 
-    # do not error check error check on extension in update (not deep check)
+    # error check on extension in make_bids_basename (deep check)
     extension = '.mat'
     with pytest.raises(ValueError, match=f'Extension {extension} is not'):
         make_bids_basename(subject=subject_id, session=session_id,

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -312,15 +312,23 @@ def test_bids_path(return_bids_test_dir):
     with pytest.raises(ValueError, match='Unallowed*'):
         bids_basename.update(subject=subject_id + '-')
 
-    # error check on kind in update
+    # error check on kind in make_bids_basename (deep check)
     kind = 'meeg'
     with pytest.raises(ValueError, match=f'Kind {kind} is not'):
-        bids_basename.update(kind=kind)
+        make_bids_basename(subject=subject_id, session=session_id,
+                           kind=kind)
 
-    # error check on extension in update
-    ext = '.mat'
-    with pytest.raises(ValueError, match=f'Extension {ext} is not'):
-        bids_basename.update(extension=ext)
+    # do not error check kind in update (not deep check)
+    bids_basename.update(kind='foobar')
+
+    # do not error check error check on extension in update (not deep check)
+    extension = '.mat'
+    with pytest.raises(ValueError, match=f'Extension {extension} is not'):
+        make_bids_basename(subject=subject_id, session=session_id,
+                           extension=extension)
+
+    # do not error extension in update (not deep check)
+    bids_basename.update(extension='.foo')
 
     # test repr
     bids_path = make_bids_basename(subject='01', session='02',


### PR DESCRIPTION
required by study template that writes derivatives with original kinds etc.