### PR TITLE
Remove BIDSPath.check attribute

### DIFF
--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -67,15 +67,8 @@ class BIDSPath(object):
     extension : str | None
         The extension of the filename. E.g., ``'.json'``.
     check : bool
-        If True enforces the entities to be valid according to the
-        current BIDS standard. Defaults to True.
-
-    Attributes
-    ----------
-    check : bool
-        If True enforces the entities to be valid according to the
-        current BIDS standard. The check is performed on instantiation
-        and any ``update`` function calls.
+        If ``True``, enforces the entities to be valid according to the
+        BIDS standard. Defaults to ``True``.
 
     Examples
     --------
@@ -92,7 +85,7 @@ class BIDSPath(object):
     sub-test2_ses-one_task-mytask_ieeg.edf
     """
 
-    def __init__(self, subject=None, session=None,
+    def __init__(self, *, subject=None, session=None,
                  task=None, acquisition=None, run=None, processing=None,
                  recording=None, space=None, split=None, prefix=None,
                  kind=None, extension=None, check=True):
@@ -102,12 +95,10 @@ class BIDSPath(object):
                                      extension]):
             raise ValueError("At least one parameter must be given.")
 
-        self.check = check
-
         self.update(subject=subject, session=session, task=task,
                     acquisition=acquisition, run=run, processing=processing,
                     recording=recording, space=space, split=split,
-                    prefix=prefix, kind=kind, extension=extension)
+                    prefix=prefix, kind=kind, extension=extension, check=check)
 
     @property
     def entities(self):
@@ -230,16 +221,19 @@ class BIDSPath(object):
 
         return bids_fname
 
-    def update(self, **entities):
+    def update(self, check=True, **entities):
         """Update inplace BIDS entity key/value pairs in object.
 
         Parameters
         ----------
+        check : bool
+            If ``True``, enforces the entities to be valid according to the
+            BIDS standard. Defaults to ``True``.
         entities : dict | kwarg
             Allowed BIDS path entities:
-            'subject', 'session', 'task', 'acquisition',
-            'processing', 'run', 'recording', 'space',
-            'suffix', 'prefix'
+            ``'subject'``, ``'session'``, ``'task'``, ``'acquisition'``,
+            ``'processing'``, ``'run'``, ``'recording'``, ``'space'``,
+            ``'suffix'``, ``'prefix'``
 
         Returns
         -------
@@ -298,10 +292,10 @@ class BIDSPath(object):
             setattr(self, key, val)
 
         # perform a check of the entities
-        self._check()
+        self._check(deep=check)
         return self
 
-    def _check(self):
+    def _check(self, deep):
         """Deep check or not of the instance."""
         self.basename  # run basename to check validity of arguments
 
@@ -312,7 +306,7 @@ class BIDSPath(object):
                              'subject and session entities. BIDSPath '
                              f'currently contains {self.entities}.')
 
-        if self.check:
+        if deep:
             if self.subject == 'emptyroom':
                 _check_empty_room_basename(self)
 

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -62,7 +62,7 @@ def return_bids_test_dir(tmpdir_factory):
     return bids_root
 
 
-def test_get_keys(return_bids_test_dir):
+def test_get_kinds(return_bids_test_dir):
     """Test getting the datatypes (=kinds) of a dir."""
     kinds = get_kinds(return_bids_test_dir)
     assert kinds == ['meg']
@@ -319,26 +319,25 @@ def test_bids_path(return_bids_test_dir):
         BIDSPath(subject=subject_id, session=session_id,
                  kind=kind)
 
-    # do not error check kind in update (not deep check)
+    # error check kind in update (deep check)
     error_kind = 'foobar'
     with pytest.raises(ValueError, match=f'Kind {error_kind} is not'):
         bids_basename.update(kind=error_kind)
 
-    # does not error check on kind in BIDSPath (deep check)
-    kind = 'meeg'
-    bids_basename = BIDSPath(subject=subject_id, session=session_id,
-                             kind=kind, check=False)
-    # also inherits error check from instantiation
-    bids_basename.update(kind=error_kind)
-
-    # error check on extension in BIDSPath (deep check)
+    # error check extension in BIDSPath (deep check)
     extension = '.mat'
     with pytest.raises(ValueError, match=f'Extension {extension} is not'):
         BIDSPath(subject=subject_id, session=session_id,
                  extension=extension)
 
-    # do not error extension in update (not deep check)
-    bids_basename.update(extension='.foo')
+    # does not error check on kind in BIDSPath (no deep check)
+    kind = 'meeg'
+    bids_basename = BIDSPath(subject=subject_id, session=session_id,
+                             kind=kind, check=False)
+    # Update with an invalid key or extension requires explicitly passing
+    # `check=False` too.
+    bids_basename.update(kind=error_kind, check=False)
+    bids_basename.update(extension='.foo', check=False)
 
     # test repr
     bids_path = BIDSPath(subject='01', session='02',


### PR DESCRIPTION
PR Description
--------------
As pointed out by @sappelhoff in https://github.com/mne-tools/mne-bids/pull/511#discussion_r476601505,
the presence of the attribute could lead to unexpected behavior.

My solution is to just drop it and expect users to explicitly pass the `check` kwarg to `BIDSPath.update()` if they want to disable checking during an update.

Also requires the entities passed to `BIDSPatch.__init__()` to be keyword-only arguments. Thoughts?


Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
- [ ] Commit history does not contain any merge commits
