### PR TITLE
[MRG] Use modality, suffix and extension explicitly in BIDSPath

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -39,7 +39,7 @@ MNE BIDS
    get_anonymization_daysback
    print_dir_tree
    get_entity_vals
-   get_kinds
+   get_modalities
 
 Path
 ====

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -76,7 +76,7 @@ API
 - :code:`mne_bids.make_bids_basename` has been removed. Use :class:`mne_bids.BIDSPath` directly, by `Adam Li`_ (`#511 <https://github.com/mne-tools/mne-bids/pull/511>`_)
 - Add ``check`` parameter and attribute to :class:`mne_bids.BIDSPath` that allows users to turn off entity checks by `Adam Li`_ (`#511 <https://github.com/mne-tools/mne-bids/pull/511>`_)
 - Add ``modality`` parameter and attribute to :class:`mne_bids.BIDSPath` that allows users to specify EEG, MEG, or iEEG datasets by `Adam Li`_ (`#514 <https://github.com/mne-tools/mne-bids/pull/514>`_)
-- Add ``modality`` to replace ``kind`` parameter to :func:`mne_bids.make_bids_folder` and :func:`mne_bids.read_raw_bids` that allows users to specify EEG, MEG, or iEEG datasets by `Adam Li`_ (`#514 <https://github.com/mne-tools/mne-bids/pull/514>`_)
+- Add ``modality`` to replace ``kind`` parameter to :func:`mne_bids.make_bids_folders` and :func:`mne_bids.read_raw_bids` that allows users to specify EEG, MEG, or iEEG datasets by `Adam Li`_ (`#514 <https://github.com/mne-tools/mne-bids/pull/514>`_)
 
 
 .. _changes_0_4:

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -75,7 +75,7 @@ API
 - It is now required to specify the Power Line Frequency to use :func:`write_raw_bids`, while in 0.4 it could be estimated, by `Alexandre Gramfort`_ and `Alex Rockhill`_ (`#506 <https://github.com/mne-tools/mne-bids/pull/506>`_)
 - :code:`mne_bids.make_bids_basename` has been removed. Use :class:`mne_bids.BIDSPath` directly, by `Adam Li`_ (`#511 <https://github.com/mne-tools/mne-bids/pull/511>`_)
 - Add ``check`` parameter and attribute to :class:`mne_bids.BIDSPath` that allows users to turn off entity checks by `Adam Li`_ (`#511 <https://github.com/mne-tools/mne-bids/pull/511>`_)
-- Add ``modality`` parameter and attribute to :class:`mne_bids.BIDSPath` that allows users to specify EEG, MEG, or iEEG datasets by `Adam Li`_ (`#511 <https://github.com/mne-tools/mne-bids/pull/511>`_)
+- Add ``modality`` parameter and attribute to :class:`mne_bids.BIDSPath` that allows users to specify EEG, MEG, or iEEG datasets by `Adam Li`_ (`#514 <https://github.com/mne-tools/mne-bids/pull/514>`_)
 
 
 .. _changes_0_4:

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -76,6 +76,7 @@ API
 - :code:`mne_bids.make_bids_basename` has been removed. Use :class:`mne_bids.BIDSPath` directly, by `Adam Li`_ (`#511 <https://github.com/mne-tools/mne-bids/pull/511>`_)
 - Add ``check`` parameter and attribute to :class:`mne_bids.BIDSPath` that allows users to turn off entity checks by `Adam Li`_ (`#511 <https://github.com/mne-tools/mne-bids/pull/511>`_)
 - Add ``modality`` parameter and attribute to :class:`mne_bids.BIDSPath` that allows users to specify EEG, MEG, or iEEG datasets by `Adam Li`_ (`#514 <https://github.com/mne-tools/mne-bids/pull/514>`_)
+- Add ``modality`` to replace ``kind`` parameter to :func:`mne_bids.make_bids_folder` and :func:`mne_bids.read_raw_bids` that allows users to specify EEG, MEG, or iEEG datasets by `Adam Li`_ (`#514 <https://github.com/mne-tools/mne-bids/pull/514>`_)
 
 
 .. _changes_0_4:
@@ -200,7 +201,7 @@ Bug
 - Allow files with no stim channel, which could be the case for example in resting state data, by `Mainak Jas`_ (`#167 <https://github.com/mne-tools/mne-bids/pull/167/files>`_)
 - Better handling of unicode strings in TSV files, by `Mainak Jas`_ (`#172 <https://github.com/mne-tools/mne-bids/pull/172/files>`_)
 - Fix separator in scans.tsv to always be `/`, by `Matt Sanderson`_ (`#176 <https://github.com/mne-tools/mne-bids/pull/176>`_)
-- Add seeg to :code:`mne_bids.utils._handle_kind` when determining the kind of ieeg data, by `Ezequiel Mikulan`_ (`#180 <https://github.com/mne-tools/mne-bids/pull/180/files>`_)
+- Add seeg to :code:`mne_bids.utils._handle_modality` when determining the kind of ieeg data, by `Ezequiel Mikulan`_ (`#180 <https://github.com/mne-tools/mne-bids/pull/180/files>`_)
 - Fix problem in copying CTF files on Network File System due to a bug upstream in Python by `Mainak Jas`_ (`#174 <https://github.com/mne-tools/mne-bids/pull/174/files>`_)
 - Fix problem in copying BTi files. Now, a utility function ensures that all the related files
   such as config and headshape are copied correctly, by `Mainak Jas`_ (`#135 <https://github.com/mne-tools/mne-bids/pull/135>`_)

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -141,7 +141,7 @@ Version 0.3
 Changelog
 ~~~~~~~~~
 
-- New function :func:`mne_bids.get_kinds` for getting data types from a BIDS dataset, by `Stefan Appelhoff`_ (`#253 <https://github.com/mne-tools/mne-bids/pull/253>`_)
+- New function :func:`mne_bids.get_modalities` for getting data types from a BIDS dataset, by `Stefan Appelhoff`_ (`#253 <https://github.com/mne-tools/mne-bids/pull/253>`_)
 - New function :func:`mne_bids.get_entity_vals` allows to get a list of instances of a certain entity in a BIDS directory, by `Mainak Jas`_ and `Stefan Appelhoff`_ (`#252 <https://github.com/mne-tools/mne-bids/pull/252>`_)
 - :func:`mne_bids.print_dir_tree` now accepts an argument :code:`max_depth` which can limit the depth until which the directory tree is printed, by `Stefan Appelhoff`_ (`#245 <https://github.com/mne-tools/mne-bids/pull/245>`_)
 - New command line function exposed :code:`cp` for renaming/copying files including automatic doc generation "CLI", by `Stefan Appelhoff`_ (`#225 <https://github.com/mne-tools/mne-bids/pull/225>`_)

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -71,10 +71,12 @@ API
 - A function for retrieval of BIDS entity values from a filename, :func:`mne_bids.path.get_entities_from_fname`, is now part of the public API (it used to be a private function called ``mne_bids.path._parse_bids_filename``), by `Richard Höchenberger`_ (`#487 <https://github.com/mne-tools/mne-bids/pull/487>`_)
 - Entity names passed to :func:`mne_bids.get_entity_vals` must now be in the "long" format, e.g. ``subject`` instead of ``sub`` etc., by `Richard Höchenberger`_ (`#501 <https://github.com/mne-tools/mne-bids/pull/501>`_)
 - Change :func:`mne_bids.path.get_entities_from_fname` to use full entity kwargs (e.g. 'subject' instead of 'sub') in the return dictionary structure by `Adam Li`_ (`#496 <https://github.com/mne-tools/mne-bids/pull/496>`_)
-- Change :class:`mne_bids.BIDSPath` to explicitly use  ``kind`` and ``extension`` instead of ``suffix`` in kwargs, by `Adam Li`_ (`#496 <https://github.com/mne-tools/mne-bids/pull/496>`_)
+- Change :class:`mne_bids.BIDSPath` to explicitly use  ``suffix`` and ``extension`` instead of just ``suffix`` in kwargs, by `Adam Li`_ (`#496 <https://github.com/mne-tools/mne-bids/pull/496>`_)
 - It is now required to specify the Power Line Frequency to use :func:`write_raw_bids`, while in 0.4 it could be estimated, by `Alexandre Gramfort`_ and `Alex Rockhill`_ (`#506 <https://github.com/mne-tools/mne-bids/pull/506>`_)
 - :code:`mne_bids.make_bids_basename` has been removed. Use :class:`mne_bids.BIDSPath` directly, by `Adam Li`_ (`#511 <https://github.com/mne-tools/mne-bids/pull/511>`_)
 - Add ``check`` parameter and attribute to :class:`mne_bids.BIDSPath` that allows users to turn off entity checks by `Adam Li`_ (`#511 <https://github.com/mne-tools/mne-bids/pull/511>`_)
+- Add ``modality`` parameter and attribute to :class:`mne_bids.BIDSPath` that allows users to specify EEG, MEG, or iEEG datasets by `Adam Li`_ (`#511 <https://github.com/mne-tools/mne-bids/pull/511>`_)
+
 
 .. _changes_0_4:
 

--- a/examples/create_bids_folder.py
+++ b/examples/create_bids_folder.py
@@ -31,7 +31,7 @@ from mne_bids import make_bids_folders, BIDSPath
 # final file path. Omitted keys will not be included in the file path.
 
 bids_basename = BIDSPath(subject='test', session='two', task='mytask',
-                         kind='events', extension='.tsv')
+                         suffix='events', extension='.tsv')
 print(bids_basename)
 
 ###############################################################################

--- a/examples/create_bids_folder.py
+++ b/examples/create_bids_folder.py
@@ -48,7 +48,7 @@ print(bids_basename)
 # You can also use MNE-BIDS to create folder hierarchies.
 
 path_folder = make_bids_folders(subject='01', session='mysession',
-                                kind='meg', bids_root='path/to/project',
+                                modality='meg', bids_root='path/to/project',
                                 make_dir=False)
 print(path_folder)
 

--- a/examples/read_bids_datasets.py
+++ b/examples/read_bids_datasets.py
@@ -61,7 +61,7 @@ print_dir_tree(bids_root)
 # Let's read in the dataset and show off a few features of the
 # loading function `read_raw_bids`. Note, this is just one line of code.
 raw = read_raw_bids(bids_basename=bids_basename, bids_root=bids_root,
-                    kind=kind, verbose=True)
+                    modality=kind, verbose=True)
 
 ###############################################################################
 # `raw.info` has the basic subject metadata

--- a/examples/read_bids_datasets.py
+++ b/examples/read_bids_datasets.py
@@ -43,7 +43,7 @@ from mne_bids import (BIDSPath, read_raw_bids,
 bids_root = somato.data_path()
 subject_id = '01'
 task = 'somato'
-kind = 'meg'
+modality = 'meg'
 
 bids_basename = BIDSPath(subject=subject_id, task=task)
 
@@ -61,7 +61,7 @@ print_dir_tree(bids_root)
 # Let's read in the dataset and show off a few features of the
 # loading function `read_raw_bids`. Note, this is just one line of code.
 raw = read_raw_bids(bids_basename=bids_basename, bids_root=bids_root,
-                    modality=kind, verbose=True)
+                    modality=modality, verbose=True)
 
 ###############################################################################
 # `raw.info` has the basic subject metadata

--- a/mne_bids/__init__.py
+++ b/mne_bids/__init__.py
@@ -4,7 +4,7 @@ __version__ = '0.5.dev0'
 from mne_bids import commands
 from mne_bids.report import make_report
 from mne_bids.path import (make_bids_folders, BIDSPath,
-                           get_kinds, get_entity_vals, print_dir_tree)
+                           get_modalities, get_entity_vals, print_dir_tree)
 from mne_bids.read import (get_head_mri_trans, read_raw_bids,
                            get_matched_empty_room)
 from mne_bids.utils import (get_anonymization_daysback)

--- a/mne_bids/config.py
+++ b/mne_bids/config.py
@@ -7,7 +7,6 @@ BIDS_VERSION = "1.4.0"
 
 DOI = """https://doi.org/10.21105/joss.01896"""
 
-ALLOWED_ELECTROPHYSIO_MODALITY = ['meg', 'eeg', 'ieeg']
 ALLOWED_MODALITIES = ['meg', 'eeg', 'ieeg', 'anat']
 
 # Orientation of the coordinate system dependent on manufacturer

--- a/mne_bids/config.py
+++ b/mne_bids/config.py
@@ -87,13 +87,13 @@ ALLOWED_FILENAME_EXTENSIONS = (
 # allowed BIDS path entities
 ALLOWED_PATH_ENTITIES = ('subject', 'session', 'task', 'run',
                          'processing', 'recording', 'space',
-                         'acquisition', 'split', 'suffix',
+                         'acquisition', 'split', 'str_suffix',
                          'prefix', 'extension')
 ALLOWED_PATH_ENTITIES_SHORT = {'sub': 'subject', 'ses': 'session',
                                'task': 'task', 'acq': 'acquisition',
                                'run': 'run', 'proc': 'processing',
                                'space': 'space', 'rec': 'recording',
-                               'split': 'split', 'suffix': 'suffix'}
+                               'split': 'split', 'str_suffix': 'str_suffix'}
 
 # accepted BIDS formats, which may be subject to change
 # depending on the specification

--- a/mne_bids/config.py
+++ b/mne_bids/config.py
@@ -65,7 +65,8 @@ ALLOWED_MODALITY_EXTENSIONS = {'meg': allowed_extensions_meg,
                                'eeg': allowed_extensions_eeg,
                                'ieeg': allowed_extensions_ieeg}
 
-# allowed kinds (i.e. last "_" delimiter in the BIDS filenames)
+# allowed suffixes (i.e. last "_" delimiter in the BIDS filenames before
+# the extension)
 ALLOWED_FILENAME_SUFFIX = [
     'meg', 'markers', 'eeg', 'ieeg', 'T1w',  # modality
     'participants', 'scans',

--- a/mne_bids/config.py
+++ b/mne_bids/config.py
@@ -87,13 +87,14 @@ ALLOWED_FILENAME_EXTENSIONS = (
 # allowed BIDS path entities
 ALLOWED_PATH_ENTITIES = ('subject', 'session', 'task', 'run',
                          'processing', 'recording', 'space',
-                         'acquisition', 'split', 'str_suffix',
-                         'prefix', 'extension')
+                         'acquisition', 'split',
+                         'suffix', 'extension',
+                         'modality', 'prefix')
 ALLOWED_PATH_ENTITIES_SHORT = {'sub': 'subject', 'ses': 'session',
                                'task': 'task', 'acq': 'acquisition',
                                'run': 'run', 'proc': 'processing',
                                'space': 'space', 'rec': 'recording',
-                               'split': 'split', 'str_suffix': 'str_suffix'}
+                               'split': 'split', 'suffix': 'suffix'}
 
 # accepted BIDS formats, which may be subject to change
 # depending on the specification

--- a/mne_bids/config.py
+++ b/mne_bids/config.py
@@ -7,7 +7,8 @@ BIDS_VERSION = "1.4.0"
 
 DOI = """https://doi.org/10.21105/joss.01896"""
 
-ALLOWED_MODALITY_KINDS = ['meg', 'eeg', 'ieeg']
+ALLOWED_ELECTROPHYSIO_MODALITY = ['meg', 'eeg', 'ieeg']
+ALLOWED_MODALITIES = ['meg', 'eeg', 'ieeg', 'anat']
 
 # Orientation of the coordinate system dependent on manufacturer
 ORIENTATION = {'.sqd': 'ALS', '.con': 'ALS', '.fif': 'RAS', '.pdf': 'ALS',
@@ -66,7 +67,7 @@ ALLOWED_MODALITY_EXTENSIONS = {'meg': allowed_extensions_meg,
                                'ieeg': allowed_extensions_ieeg}
 
 # allowed kinds (i.e. last "_" delimiter in the BIDS filenames)
-ALLOWED_FILENAME_KINDS = [
+ALLOWED_FILENAME_SUFFIX = [
     'meg', 'markers', 'eeg', 'ieeg', 'T1w',  # modality
     'participants', 'scans',
     'electrodes', 'channels', 'coordsystem', 'events',  # sidecars
@@ -86,13 +87,13 @@ ALLOWED_FILENAME_EXTENSIONS = (
 # allowed BIDS path entities
 ALLOWED_PATH_ENTITIES = ('subject', 'session', 'task', 'run',
                          'processing', 'recording', 'space',
-                         'acquisition', 'split', 'kind',
+                         'acquisition', 'split', 'suffix',
                          'prefix', 'extension')
 ALLOWED_PATH_ENTITIES_SHORT = {'sub': 'subject', 'ses': 'session',
                                'task': 'task', 'acq': 'acquisition',
                                'run': 'run', 'proc': 'processing',
                                'space': 'space', 'rec': 'recording',
-                               'split': 'split', 'kind': 'kind'}
+                               'split': 'split', 'suffix': 'suffix'}
 
 # accepted BIDS formats, which may be subject to change
 # depending on the specification

--- a/mne_bids/copyfiles.py
+++ b/mne_bids/copyfiles.py
@@ -196,7 +196,7 @@ def copyfile_kit(src, dest, subject_id, session_id,
         for key, value in acq_map.items():
             marker_fname = BIDSPath(
                 subject=subject_id, session=session_id, task=task, run=run,
-                acquisition=key, kind='markers', extension=marker_ext,
+                acquisition=key, suffix='markers', extension=marker_ext,
                 prefix=data_path)
             sh.copyfile(value, marker_fname)
     for acq in ['elp', 'hsp']:
@@ -206,7 +206,7 @@ def copyfile_kit(src, dest, subject_id, session_id,
             position_ext = '.pos'
             position_fname = BIDSPath(
                 subject=subject_id, session=session_id, task=task, run=run,
-                acquisition=acq, kind='headshape', extension=position_ext,
+                acquisition=acq, suffix='headshape', extension=position_ext,
                 prefix=data_path)
             sh.copyfile(position_file, position_fname)
 

--- a/mne_bids/dig.py
+++ b/mne_bids/dig.py
@@ -197,7 +197,7 @@ def _electrodes_tsv(raw, fname, kind, overwrite=False, verbose=True):
                             ('z', z),
                             ])
     else:  # pragma: no cover
-        raise RuntimeError("suffix {} not supported.".format(kind))
+        raise RuntimeError("kind {} not supported.".format(kind))
 
     # Add impedance values if available, currently only BrainVision:
     # https://github.com/mne-tools/mne-python/pull/7974
@@ -237,7 +237,7 @@ def _coordsystem_json(raw, unit, orient, coordsystem_name, fname,
     if dig is None:
         dig = []
     coords = _extract_landmarks(dig)
-    hpi = {d['ident']: d for d in dig if d['suffix'] == FIFF.FIFFV_POINT_HPI}
+    hpi = {d['ident']: d for d in dig if d['kind'] == FIFF.FIFFV_POINT_HPI}
     if hpi:
         for ident in hpi.keys():
             coords['coil%d' % ident] = hpi[ident]['r'].tolist()
@@ -254,9 +254,9 @@ def _coordsystem_json(raw, unit, orient, coordsystem_name, fname,
         print('Using the `Other` keyword for the CoordinateSystem field. '
               'Please specify the CoordinateSystemDescription field manually.')
 
-    # create the coordinate json data structure based on 'suffix'
+    # create the coordinate json data structure based on 'kind'
     if kind == 'meg':
-        hpi = {d['ident']: d for d in dig if d['suffix'] == FIFF.FIFFV_POINT_HPI}
+        hpi = {d['ident']: d for d in dig if d['kind'] == FIFF.FIFFV_POINT_HPI}
         if hpi:
             for ident in hpi.keys():
                 coords['coil%d' % ident] = hpi[ident]['r'].tolist()

--- a/mne_bids/dig.py
+++ b/mne_bids/dig.py
@@ -100,7 +100,7 @@ def _handle_electrodes_reading(electrodes_fname, coord_frame,
     return raw
 
 
-def _handle_coordsystem_reading(coordsystem_fpath, kind, verbose=True):
+def _handle_coordsystem_reading(coordsystem_fpath, modality, verbose=True):
     """Read associated coordsystem.json.
 
     Handle reading the coordinate frame and coordinate unit
@@ -110,17 +110,17 @@ def _handle_coordsystem_reading(coordsystem_fpath, kind, verbose=True):
     with open(coordsystem_fpath, 'r') as fin:
         coordsystem_json = json.load(fin)
 
-    if kind == 'meg':
+    if modality == 'meg':
         coord_frame = coordsystem_json['MEGCoordinateSystem'].lower()
         coord_unit = coordsystem_json['MEGCoordinateUnits']
         coord_frame_desc = coordsystem_json.get('MEGCoordinateDescription',
                                                 None)
-    elif kind == 'eeg':
+    elif modality == 'eeg':
         coord_frame = coordsystem_json['EEGCoordinateSystem'].lower()
         coord_unit = coordsystem_json['EEGCoordinateUnits']
         coord_frame_desc = coordsystem_json.get('EEGCoordinateDescription',
                                                 None)
-    elif kind == 'ieeg':
+    elif modality == 'ieeg':
         coord_frame = coordsystem_json['iEEGCoordinateSystem'].lower()
         coord_unit = coordsystem_json['iEEGCoordinateUnits']
         coord_frame_desc = coordsystem_json.get('iEEGCoordinateDescription',
@@ -148,7 +148,7 @@ def _get_impedances(raw, names):
     return impedances
 
 
-def _electrodes_tsv(raw, fname, kind, overwrite=False, verbose=True):
+def _electrodes_tsv(raw, fname, modality, overwrite=False, verbose=True):
     """Create an electrodes.tsv file and save it.
 
     Parameters
@@ -157,8 +157,9 @@ def _electrodes_tsv(raw, fname, kind, overwrite=False, verbose=True):
         The data as MNE-Python Raw object.
     fname : str
         Filename to save the electrodes.tsv to.
-    kind : str
-        Type of the data as in ALLOWED_KINDS. For iEEG, requires size.
+    modality : str
+        Type of the data recording. Can be ``meg``, ``eeg``,
+        or ``ieeg``.
     overwrite : bool
         Defaults to False.
         Whether to overwrite the existing data in the file.
@@ -181,7 +182,7 @@ def _electrodes_tsv(raw, fname, kind, overwrite=False, verbose=True):
         names.append(ch['ch_name'])
 
     # create OrderedDict to write to tsv file
-    if kind == "ieeg":
+    if modality == "ieeg":
         # XXX: size should be included in the future
         sizes = ['n/a'] * len(names)
         data = OrderedDict([('name', names),
@@ -190,14 +191,14 @@ def _electrodes_tsv(raw, fname, kind, overwrite=False, verbose=True):
                             ('z', z),
                             ('size', sizes),
                             ])
-    elif kind == 'eeg':
+    elif modality == 'eeg':
         data = OrderedDict([('name', names),
                             ('x', x),
                             ('y', y),
                             ('z', z),
                             ])
     else:  # pragma: no cover
-        raise RuntimeError("kind {} not supported.".format(kind))
+        raise RuntimeError("modality {} not supported.".format(modality))
 
     # Add impedance values if available, currently only BrainVision:
     # https://github.com/mne-tools/mne-python/pull/7974
@@ -208,7 +209,7 @@ def _electrodes_tsv(raw, fname, kind, overwrite=False, verbose=True):
 
 
 def _coordsystem_json(raw, unit, orient, coordsystem_name, fname,
-                      kind, overwrite=False, verbose=True):
+                      modality, overwrite=False, verbose=True):
     """Create a coordsystem.json file and save it.
 
     Parameters
@@ -224,8 +225,9 @@ def _coordsystem_json(raw, unit, orient, coordsystem_name, fname,
         Name of the coordinate system for the sensor positions.
     fname : str
         Filename to save the coordsystem.json to.
-    kind : str
-        Type of the data as in ALLOWED_KINDS.
+    modality : str
+        Type of the data recording. Can be ``meg``, ``eeg``,
+        or ``ieeg``.
     overwrite : bool
         Whether to overwrite the existing file.
         Defaults to False.
@@ -254,8 +256,8 @@ def _coordsystem_json(raw, unit, orient, coordsystem_name, fname,
         print('Using the `Other` keyword for the CoordinateSystem field. '
               'Please specify the CoordinateSystemDescription field manually.')
 
-    # create the coordinate json data structure based on 'kind'
-    if kind == 'meg':
+    # create the coordinate json data structure based on 'modality'
+    if modality == 'meg':
         hpi = {d['ident']: d for d in dig if d['kind'] == FIFF.FIFFV_POINT_HPI}
         if hpi:
             for ident in hpi.keys():
@@ -269,7 +271,7 @@ def _coordsystem_json(raw, unit, orient, coordsystem_name, fname,
             'HeadCoilCoordinateSystem': orient,
             'HeadCoilCoordinateUnits': unit  # XXX validate this
         }
-    elif kind == 'eeg':
+    elif modality == 'eeg':
         fid_json = {
             'EEGCoordinateSystem': coordsystem_name,
             'EEGCoordinateUnits': unit,
@@ -278,7 +280,7 @@ def _coordsystem_json(raw, unit, orient, coordsystem_name, fname,
             'AnatomicalLandmarkCoordinateSystem': coordsystem_name,
             'AnatomicalLandmarkCoordinateUnits': unit,
         }
-    elif kind == "ieeg":
+    elif modality == "ieeg":
         fid_json = {
             'iEEGCoordinateSystem': coordsystem_name,  # (Other, Pixels, ACPC)
             'iEEGCoordinateSystemDescription': coordsystem_desc,
@@ -289,7 +291,7 @@ def _coordsystem_json(raw, unit, orient, coordsystem_name, fname,
 
 
 def _write_dig_bids(electrodes_fname, coordsystem_fname, data_path,
-                    raw, kind, overwrite=False, verbose=True):
+                    raw, modality, overwrite=False, verbose=True):
     """Write BIDS formatted DigMontage from Raw instance.
 
     Handles coordinatesystem.json and electrodes.tsv writing
@@ -305,8 +307,9 @@ def _write_dig_bids(electrodes_fname, coordsystem_fname, data_path,
         Path to the data directory
     raw : instance of Raw
         The data as MNE-Python Raw object.
-    kind : str
-        Type of the data as in ALLOWED_KINDS.
+    modality : str
+        Type of the data recording. Can be ``meg``, ``eeg``,
+        or ``ieeg``.
     overwrite : bool
         Whether to overwrite the existing file.
         Defaults to False.
@@ -338,7 +341,7 @@ def _write_dig_bids(electrodes_fname, coordsystem_fname, data_path,
         print("Writing electrodes file to... ", electrodes_fname)
         print("Writing coordsytem file to... ", coordsystem_fname)
 
-    if kind == "ieeg":
+    if modality == "ieeg":
         if coord_frame is not None:
             # XXX: To improve when mne-python allows coord_frame='unknown'
             if coord_frame not in BIDS_IEEG_COORDINATE_FRAMES:
@@ -354,16 +357,16 @@ def _write_dig_bids(electrodes_fname, coordsystem_fname, data_path,
 
             # Now write the data to the elec coords and the coordsystem
             _electrodes_tsv(raw, electrodes_fname,
-                            kind, overwrite, verbose)
+                            modality, overwrite, verbose)
             _coordsystem_json(raw, unit, 'n/a',
-                              coord_frame, coordsystem_fname, kind,
+                              coord_frame, coordsystem_fname, modality,
                               overwrite, verbose)
         else:
             # default coordinate frame to mri if not available
             warn("Coordinate frame of iEEG coords missing/unknown "
                  "for {}. Skipping reading "
                  "in of montage...".format(electrodes_fname))
-    elif kind == 'eeg':
+    elif modality == 'eeg':
         # We only write EEG electrodes.tsv and coordsystem.json
         # if we have LPA, RPA, and NAS available to rescale to a known
         # coordinate system frame
@@ -374,10 +377,10 @@ def _write_dig_bids(electrodes_fname, coordsystem_fname, data_path,
         # mne-python automatically converts unknown coord frame to head
         if coord_frame_int == FIFF.FIFFV_COORD_HEAD and landmarks:
             # Now write the data
-            _electrodes_tsv(raw, electrodes_fname, kind,
+            _electrodes_tsv(raw, electrodes_fname, modality,
                             overwrite, verbose)
             _coordsystem_json(raw, 'm', 'RAS', 'CapTrak',
-                              coordsystem_fname, kind,
+                              coordsystem_fname, modality,
                               overwrite, verbose)
         else:
             warn("Skipping EEG electrodes.tsv... "
@@ -387,7 +390,7 @@ def _write_dig_bids(electrodes_fname, coordsystem_fname, data_path,
 
 
 def _read_dig_bids(electrodes_fpath, coordsystem_fpath,
-                   raw, kind, verbose):
+                   raw, modality, verbose):
     """Read MNE-Python formatted DigMontage from BIDS files.
 
     Handles coordinatesystem.json and electrodes.tsv reading
@@ -401,8 +404,9 @@ def _read_dig_bids(electrodes_fpath, coordsystem_fpath,
         Filepath of the coordsystem.json to read.
     raw : instance of Raw
         The data as MNE-Python Raw object.
-    kind : str
-        Type of the data as in ALLOWED_KINDS.
+    modality : str
+        Type of the data recording. Can be ``meg``, ``eeg``,
+        or ``ieeg``.
     verbose : bool
         Set verbose output to true or false.
 
@@ -420,9 +424,9 @@ def _read_dig_bids(electrodes_fpath, coordsystem_fpath,
 
     # read in coordinate information
     coord_frame, coord_unit = _handle_coordsystem_reading(coordsystem_fpath,
-                                                          kind, verbose)
+                                                          modality, verbose)
 
-    if kind == 'meg':
+    if modality == 'meg':
         if coord_frame not in BIDS_MEG_COORDINATE_FRAMES:
             warn("MEG Coordinate frame is not accepted "
                  "BIDS keyword. The allowed keywords are: "
@@ -435,7 +439,7 @@ def _read_dig_bids(electrodes_fpath, coordsystem_fpath,
             coord_frame = None
         else:
             coord_frame = BIDS_TO_MNE_FRAMES.get(coord_frame, None)
-    elif kind == 'ieeg':
+    elif modality == 'ieeg':
         if coord_frame not in BIDS_IEEG_COORDINATE_FRAMES:
             warn("iEEG Coordinate frame is not accepted "
                  "BIDS keyword. The allowed keywords are: "
@@ -456,7 +460,7 @@ def _read_dig_bids(electrodes_fpath, coordsystem_fpath,
                 warn("Defaulting coordinate frame to unknown "
                      "from coordinate system input {}".format(coord_frame))
             coord_frame = BIDS_TO_MNE_FRAMES.get(space, None)
-    elif kind == 'eeg':
+    elif modality == 'eeg':
         # only accept captrak
         if coord_frame not in BIDS_EEG_COORDINATE_FRAMES:
             warn("EEG Coordinate frame is not accepted "

--- a/mne_bids/dig.py
+++ b/mne_bids/dig.py
@@ -197,7 +197,7 @@ def _electrodes_tsv(raw, fname, kind, overwrite=False, verbose=True):
                             ('z', z),
                             ])
     else:  # pragma: no cover
-        raise RuntimeError("kind {} not supported.".format(kind))
+        raise RuntimeError("suffix {} not supported.".format(kind))
 
     # Add impedance values if available, currently only BrainVision:
     # https://github.com/mne-tools/mne-python/pull/7974
@@ -237,7 +237,7 @@ def _coordsystem_json(raw, unit, orient, coordsystem_name, fname,
     if dig is None:
         dig = []
     coords = _extract_landmarks(dig)
-    hpi = {d['ident']: d for d in dig if d['kind'] == FIFF.FIFFV_POINT_HPI}
+    hpi = {d['ident']: d for d in dig if d['suffix'] == FIFF.FIFFV_POINT_HPI}
     if hpi:
         for ident in hpi.keys():
             coords['coil%d' % ident] = hpi[ident]['r'].tolist()
@@ -254,9 +254,9 @@ def _coordsystem_json(raw, unit, orient, coordsystem_name, fname,
         print('Using the `Other` keyword for the CoordinateSystem field. '
               'Please specify the CoordinateSystemDescription field manually.')
 
-    # create the coordinate json data structure based on 'kind'
+    # create the coordinate json data structure based on 'suffix'
     if kind == 'meg':
-        hpi = {d['ident']: d for d in dig if d['kind'] == FIFF.FIFFV_POINT_HPI}
+        hpi = {d['ident']: d for d in dig if d['suffix'] == FIFF.FIFFV_POINT_HPI}
         if hpi:
             for ident in hpi.keys():
                 coords['coil%d' % ident] = hpi[ident]['r'].tolist()
@@ -345,11 +345,11 @@ def _write_dig_bids(electrodes_fname, coordsystem_fname, data_path,
                 coordsystem_fname = BIDSPath(
                     subject=subject_id, session=session_id,
                     acquisition=acquisition, space=coord_frame,
-                    kind='coordsystem', extension='.json', prefix=data_path)
+                    suffix='coordsystem', extension='.json', prefix=data_path)
                 electrodes_fname = BIDSPath(
                     subject=subject_id, session=session_id,
                     acquisition=acquisition, space=coord_frame,
-                    kind='electrodes', extension='.tsv', prefix=data_path)
+                    suffix='electrodes', extension='.tsv', prefix=data_path)
                 coord_frame = 'Other'
 
             # Now write the data to the elec coords and the coordsystem

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -448,7 +448,9 @@ def make_bids_folders(subject, session=None, modality=None, bids_root=None,
 
     Examples
     --------
-    >>> make_bids_folders('sub_01', session='mysession', suffix='meg', bids_root='/path/to/project', make_dir=False)  # noqa
+    >>> make_bids_folders('sub_01', session='mysession',
+                          modality='meg', bids_root='/path/to/project',
+                          make_dir=False)
     '/path/to/project/sub-sub_01/ses-mysession/meg'
 
     """  # noqa

--- a/mne_bids/pick.py
+++ b/mne_bids/pick.py
@@ -12,7 +12,7 @@ def get_coil_types():
     -------
     coil_types : dict
         The keys contain the channel types, and the values contain the
-        corresponding values in the info['chs'][idx]['kind']
+        corresponding values in the info['chs'][idx]['suffix']
 
     """
     return dict(meggradaxial=(FIFF.FIFFV_COIL_KIT_GRAD,

--- a/mne_bids/pick.py
+++ b/mne_bids/pick.py
@@ -12,7 +12,7 @@ def get_coil_types():
     -------
     coil_types : dict
         The keys contain the channel types, and the values contain the
-        corresponding values in the info['chs'][idx]['suffix']
+        corresponding values in the info['chs'][idx]['str_suffix']
 
     """
     return dict(meggradaxial=(FIFF.FIFFV_COIL_KIT_GRAD,

--- a/mne_bids/pick.py
+++ b/mne_bids/pick.py
@@ -12,7 +12,7 @@ def get_coil_types():
     -------
     coil_types : dict
         The keys contain the channel types, and the values contain the
-        corresponding values in the info['chs'][idx]['str_suffix']
+        corresponding values in the info['chs'][idx]['kind']
 
     """
     return dict(meggradaxial=(FIFF.FIFFV_COIL_KIT_GRAD,

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -26,7 +26,7 @@ from mne_bids.config import (ALLOWED_MODALITY_EXTENSIONS, reader,
 from mne_bids.utils import _extract_landmarks, _get_ch_type_mapping
 from mne_bids import make_bids_folders
 from mne_bids.path import (BIDSPath, _parse_ext, get_entities_from_fname,
-                           _find_matching_sidecar, _infer_kind,
+                           _find_matching_sidecar, _infer_modality,
                            _convert_str_to_bids_path)
 
 
@@ -332,9 +332,8 @@ def read_raw_bids(bids_basename, bids_root, modality=None, extra_params=None,
     ses = bids_basename.session
 
     if modality is None:
-        modality = _infer_kind(bids_basename=bids_basename,
-                               bids_root=bids_root,
-                               sub=sub, ses=ses)
+        modality = _infer_modality(bids_root=bids_root,
+                                   sub=sub, ses=ses)
 
     data_dir = make_bids_folders(subject=sub, session=ses, modality=modality,
                                  make_dir=False)

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -338,7 +338,7 @@ def read_raw_bids(bids_basename, bids_root, modality=None, extra_params=None,
 
     data_dir = make_bids_folders(subject=sub, session=ses, modality=modality,
                                  make_dir=False)
-    bids_fname = bids_basename.get_bids_fname(kind=modality,
+    bids_fname = bids_basename.get_bids_fname(suffix=modality,
                                               bids_root=bids_root)
 
     if op.splitext(bids_fname)[1] == '.pdf':
@@ -436,7 +436,7 @@ def get_matched_empty_room(bids_basename, bids_root):
     bids_basename = bids_basename.copy()
 
     modality = 'meg'  # We're only concerned about MEG data here
-    bids_fname = bids_basename.get_bids_fname(kind=modality,
+    bids_fname = bids_basename.get_bids_fname(suffix=modality,
                                               bids_root=bids_root)
     _, ext = _parse_ext(bids_fname)
     if ext == '.fif':
@@ -579,7 +579,8 @@ def get_head_mri_trans(bids_basename, bids_root):
         bids_basename = _convert_str_to_bids_path(bids_basename)
 
     # Get the sidecar file for MRI landmarks
-    bids_fname = bids_basename.get_bids_fname(kind='meg', bids_root=bids_root)
+    bids_fname = bids_basename.get_bids_fname(suffix='meg',
+                                              bids_root=bids_root)
     t1w_json_path = _find_matching_sidecar(bids_fname, bids_root,
                                            suffix='T1w', extension='.json')
 

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -516,7 +516,7 @@ def get_matched_empty_room(bids_basename, bids_root):
 
             er_raw = read_raw_bids(bids_basename=er_bids_path,
                                    bids_root=bids_root,
-                                   kind=kind,
+                                   modality=modality,
                                    extra_params=extra_params)
 
             er_meas_date = er_raw.info['meas_date']

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -294,7 +294,7 @@ def read_raw_bids(bids_basename, bids_root, kind=None, extra_params=None,
     bids_root : str | pathlib.Path
         Path to root of the BIDS folder
     kind : str | None
-        The kind of recording to read. If ``None`` and only one kind (e.g.,
+        The suffix of recording to read. If ``None`` and only one suffix (e.g.,
         only EEG or only MEG data) is present in the dataset, it will be
         selected automatically.
     extra_params : None | dict
@@ -312,7 +312,7 @@ def read_raw_bids(bids_basename, bids_root, kind=None, extra_params=None,
     ------
     RuntimeError
         If multiple recording kinds are present in the dataset, but
-        ``kind=None``.
+        ``suffix=None``.
 
     RuntimeError
         If more than one data files exist for the specified recording.
@@ -321,7 +321,7 @@ def read_raw_bids(bids_basename, bids_root, kind=None, extra_params=None,
         If no data file in a supported format can be located.
 
     ValueError
-        If the specified ``kind`` cannot be found in the dataset.
+        If the specified ``suffix`` cannot be found in the dataset.
 
     """
     # convert to BIDS Path

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -279,7 +279,7 @@ def _handle_channels_reading(channels_fname, bids_fname, raw):
     return raw
 
 
-def read_raw_bids(bids_basename, bids_root, kind=None, extra_params=None,
+def read_raw_bids(bids_basename, bids_root, modality=None, extra_params=None,
                   verbose=True):
     """Read BIDS compatible data.
 
@@ -293,8 +293,8 @@ def read_raw_bids(bids_basename, bids_root, kind=None, extra_params=None,
         generated using :func:`mne_bids.BIDSPath`.
     bids_root : str | pathlib.Path
         Path to root of the BIDS folder
-    kind : str | None
-        The suffix of recording to read. If ``None`` and only one suffix (e.g.,
+    modality : str | None
+        The kind of recording to read. If ``None`` and only one modality (e.g.,
         only EEG or only MEG data) is present in the dataset, it will be
         selected automatically.
     extra_params : None | dict
@@ -311,8 +311,8 @@ def read_raw_bids(bids_basename, bids_root, kind=None, extra_params=None,
     Raises
     ------
     RuntimeError
-        If multiple recording kinds are present in the dataset, but
-        ``suffix=None``.
+        If multiple recording modalities are present in the dataset, but
+        ``modality=None``.
 
     RuntimeError
         If more than one data files exist for the specified recording.
@@ -321,7 +321,7 @@ def read_raw_bids(bids_basename, bids_root, kind=None, extra_params=None,
         If no data file in a supported format can be located.
 
     ValueError
-        If the specified ``suffix`` cannot be found in the dataset.
+        If the specified ``modality`` cannot be found in the dataset.
 
     """
     # convert to BIDS Path
@@ -331,17 +331,19 @@ def read_raw_bids(bids_basename, bids_root, kind=None, extra_params=None,
     sub = bids_basename.subject
     ses = bids_basename.session
 
-    if kind is None:
-        kind = _infer_kind(bids_basename=bids_basename, bids_root=bids_root,
-                           sub=sub, ses=ses)
+    if modality is None:
+        modality = _infer_kind(bids_basename=bids_basename,
+                               bids_root=bids_root,
+                               sub=sub, ses=ses)
 
-    data_dir = make_bids_folders(subject=sub, session=ses, kind=kind,
+    data_dir = make_bids_folders(subject=sub, session=ses, modality=modality,
                                  make_dir=False)
-    bids_fname = bids_basename.get_bids_fname(kind=kind, bids_root=bids_root)
+    bids_fname = bids_basename.get_bids_fname(kind=modality,
+                                              bids_root=bids_root)
 
     if op.splitext(bids_fname)[1] == '.pdf':
         bids_raw_folder = op.join(bids_root, data_dir,
-                                  f'{bids_basename}_{kind}')
+                                  f'{bids_basename}_{modality}')
         bids_fpath = glob.glob(op.join(bids_raw_folder, 'c,rf*'))[0]
         config = op.join(bids_raw_folder, 'config')
     else:
@@ -356,7 +358,7 @@ def read_raw_bids(bids_basename, bids_root, kind=None, extra_params=None,
     # Try to find an associated events.tsv to get information about the
     # events in the recorded data
     events_fname = _find_matching_sidecar(bids_fname, bids_root,
-                                          kind='events', extension='.tsv',
+                                          suffix='events', extension='.tsv',
                                           allow_fail=True)
     if events_fname is not None:
         raw = _handle_events_reading(events_fname, raw)
@@ -364,7 +366,8 @@ def read_raw_bids(bids_basename, bids_root, kind=None, extra_params=None,
     # Try to find an associated channels.tsv to get information about the
     # status and type of present channels
     channels_fname = _find_matching_sidecar(bids_fname, bids_root,
-                                            kind='channels', extension='.tsv',
+                                            suffix='channels',
+                                            extension='.tsv',
                                             allow_fail=True)
     if channels_fname is not None:
         raw = _handle_channels_reading(channels_fname, bids_fname, raw)
@@ -372,11 +375,11 @@ def read_raw_bids(bids_basename, bids_root, kind=None, extra_params=None,
     # Try to find an associated electrodes.tsv and coordsystem.json
     # to get information about the status and type of present channels
     electrodes_fname = _find_matching_sidecar(bids_fname, bids_root,
-                                              kind='electrodes',
+                                              suffix='electrodes',
                                               extension='.tsv',
                                               allow_fail=True)
     coordsystem_fname = _find_matching_sidecar(bids_fname, bids_root,
-                                               kind='coordsystem',
+                                               suffix='coordsystem',
                                                extension='.json',
                                                allow_fail=True)
     if electrodes_fname is not None:
@@ -385,14 +388,14 @@ def read_raw_bids(bids_basename, bids_root, kind=None, extra_params=None,
                                "should exist if electrodes.tsv does. "
                                "Please create coordsystem.json for"
                                "{}".format(bids_basename))
-        if kind in ['meg', 'eeg', 'ieeg']:
+        if modality in ['meg', 'eeg', 'ieeg']:
             raw = _read_dig_bids(electrodes_fname, coordsystem_fname,
-                                 raw, kind, verbose)
+                                 raw, modality, verbose)
 
     # Try to find an associated sidecar.json to get information about the
     # recording snapshot
     sidecar_fname = _find_matching_sidecar(bids_fname, bids_root,
-                                           kind=kind, extension='.json',
+                                           suffix=modality, extension='.json',
                                            allow_fail=True)
     if sidecar_fname is not None:
         raw = _handle_info_reading(sidecar_fname, raw, verbose=verbose)
@@ -432,8 +435,9 @@ def get_matched_empty_room(bids_basename, bids_root):
         bids_basename = _convert_str_to_bids_path(bids_basename)
     bids_basename = bids_basename.copy()
 
-    kind = 'meg'  # We're only concerned about MEG data here
-    bids_fname = bids_basename.get_bids_fname(kind=kind, bids_root=bids_root)
+    modality = 'meg'  # We're only concerned about MEG data here
+    bids_fname = bids_basename.get_bids_fname(kind=modality,
+                                              bids_root=bids_root)
     _, ext = _parse_ext(bids_fname)
     if ext == '.fif':
         extra_params = dict(allow_maxshield=True)
@@ -441,7 +445,7 @@ def get_matched_empty_room(bids_basename, bids_root):
         extra_params = None
 
     raw = read_raw_bids(bids_basename=bids_basename, bids_root=bids_root,
-                        kind=kind, extra_params=extra_params)
+                        modality=modality, extra_params=extra_params)
     if raw.info['meas_date'] is None:
         raise ValueError('The provided recording does not have a measurement '
                          'date set. Cannot get matching empty-room file.')
@@ -473,8 +477,8 @@ def get_matched_empty_room(bids_basename, bids_root):
 
     candidate_er_fnames = []
     for session_dir in emptyroom_session_dirs:
-        dir_contents = glob.glob(op.join(session_dir, kind,
-                                         f'sub-emptyroom_*_{kind}*'))
+        dir_contents = glob.glob(op.join(session_dir, modality,
+                                         f'sub-emptyroom_*_{modality}*'))
         for item in dir_contents:
             item = pathlib.Path(item)
             if ((item.suffix in allowed_extensions) or
@@ -577,7 +581,7 @@ def get_head_mri_trans(bids_basename, bids_root):
     # Get the sidecar file for MRI landmarks
     bids_fname = bids_basename.get_bids_fname(kind='meg', bids_root=bids_root)
     t1w_json_path = _find_matching_sidecar(bids_fname, bids_root,
-                                           kind='T1w', extension='.json')
+                                           suffix='T1w', extension='.json')
 
     # Get MRI landmarks from the JSON sidecar
     with open(t1w_json_path, 'r') as f:
@@ -620,7 +624,7 @@ def get_head_mri_trans(bids_basename, bids_root):
         extra_params = dict(allow_maxshield=True)
 
     raw = read_raw_bids(bids_basename=bids_basename, bids_root=bids_root,
-                        extra_params=extra_params, kind='meg')
+                        extra_params=extra_params, modality='meg')
     meg_coords_dict = _extract_landmarks(raw.info['dig'])
     meg_landmarks = np.asarray((meg_coords_dict['LPA'],
                                 meg_coords_dict['NAS'],

--- a/mne_bids/report.py
+++ b/mne_bids/report.py
@@ -11,7 +11,7 @@ import numpy as np
 from mne.externals.tempita import Template
 from mne.utils import warn
 
-from mne_bids.config import DOI, ALLOWED_MODALITY_KINDS
+from mne_bids.config import DOI, ALLOWED_ELECTROPHYSIO_MODALITY
 from mne_bids.tsv_handler import _from_tsv
 from mne_bids.path import (get_kinds, get_entity_vals, BIDSPath,
                            _parse_ext, _find_matching_sidecar,
@@ -325,7 +325,7 @@ def _summarize_sidecar_json(bids_root, scans_fpaths, verbose=True):
             # summarize metadata of recordings
             bids_basename, ext = _parse_ext(scan)
             kind = op.dirname(scan)
-            if kind not in ALLOWED_MODALITY_KINDS:
+            if kind not in ALLOWED_ELECTROPHYSIO_MODALITY:
                 continue
 
             n_scans += 1
@@ -492,7 +492,7 @@ def make_report(bids_root, session=None, verbose=True):
         'ieeg': 'iEEG',
     }
     kinds = [kind_map[kind] for kind in kinds
-             if kind in ALLOWED_MODALITY_KINDS]
+             if kind in ALLOWED_ELECTROPHYSIO_MODALITY]
 
     # REQUIRED: dataset_description.json summary
     dataset_summary = _summarize_dataset(bids_root)

--- a/mne_bids/report.py
+++ b/mne_bids/report.py
@@ -13,7 +13,7 @@ from mne.utils import warn
 
 from mne_bids.config import DOI, ALLOWED_MODALITIES
 from mne_bids.tsv_handler import _from_tsv
-from mne_bids.path import (get_kinds, get_entity_vals, BIDSPath,
+from mne_bids.path import (get_modalities, get_entity_vals, BIDSPath,
                            _parse_ext, _find_matching_sidecar,
                            get_entities_from_fname)
 
@@ -324,8 +324,8 @@ def _summarize_sidecar_json(bids_root, scans_fpaths, verbose=True):
         for scan in scans:
             # summarize metadata of recordings
             bids_basename, ext = _parse_ext(scan)
-            kind = op.dirname(scan)
-            if kind not in ALLOWED_MODALITIES:
+            modality = op.dirname(scan)
+            if modality not in ALLOWED_MODALITIES:
                 continue
 
             n_scans += 1
@@ -340,7 +340,7 @@ def _summarize_sidecar_json(bids_root, scans_fpaths, verbose=True):
 
             sidecar_fname = _find_matching_sidecar(bids_fname=bids_basename,
                                                    bids_root=bids_root,
-                                                   suffix=kind,
+                                                   suffix=modality,
                                                    extension='.json')
             with open(sidecar_fname, 'r') as fin:
                 sidecar_json = json.load(fin)
@@ -413,8 +413,8 @@ def _summarize_channels_tsv(bids_root, scans_fpaths, verbose=True):
         for scan in scans:
             # summarize metadata of recordings
             bids_basename, _ = _parse_ext(scan)
-            kind = op.dirname(scan)
-            if kind not in ['meg', 'eeg', 'ieeg']:
+            modality = op.dirname(scan)
+            if modality not in ['meg', 'eeg', 'ieeg']:
                 continue
 
             # convert to BIDS Path
@@ -482,17 +482,17 @@ def make_report(bids_root, session=None, verbose=True):
     # high level summary
     subjects = get_entity_vals(bids_root, entity_key='subject')
     sessions = get_entity_vals(bids_root, entity_key='session')
-    kinds = get_kinds(bids_root)
+    modalities = get_modalities(bids_root)
 
-    # only summarize allowed kinds (MEG/EEG/iEEG) data
+    # only summarize allowed modalities (MEG/EEG/iEEG) data
     # map them to a pretty looking string
-    kind_map = {
+    modality_map = {
         'meg': 'MEG',
         'eeg': 'EEG',
         'ieeg': 'iEEG',
     }
-    kinds = [kind_map[kind] for kind in kinds
-             if kind in kind_map.keys()]
+    modalities = [modality_map[modality] for modality in modalities
+                  if modality in modality_map.keys()]
 
     # REQUIRED: dataset_description.json summary
     dataset_summary = _summarize_dataset(bids_root)
@@ -524,13 +524,13 @@ def make_report(bids_root, session=None, verbose=True):
         modality_agnostic_template = MODALITY_AGNOSTIC_TEMPLATE
 
     dataset_summary.update({
-        'system': kinds,
+        'system': modalities,
         'n_subjects': len(subjects),
         'n_sessions': len(sessions),
         'sessions': sessions,
     })
 
-    # XXX: add channel summary for kinds (ieeg, meg, eeg)
+    # XXX: add channel summary for modalities (ieeg, meg, eeg)
     # create the content and mne Template
     # lower-case templates are "Recommended",
     # while upper-case templates are "Required".

--- a/mne_bids/report.py
+++ b/mne_bids/report.py
@@ -11,7 +11,7 @@ import numpy as np
 from mne.externals.tempita import Template
 from mne.utils import warn
 
-from mne_bids.config import DOI, ALLOWED_ELECTROPHYSIO_MODALITY
+from mne_bids.config import DOI, ALLOWED_MODALITIES
 from mne_bids.tsv_handler import _from_tsv
 from mne_bids.path import (get_kinds, get_entity_vals, BIDSPath,
                            _parse_ext, _find_matching_sidecar,
@@ -325,7 +325,7 @@ def _summarize_sidecar_json(bids_root, scans_fpaths, verbose=True):
             # summarize metadata of recordings
             bids_basename, ext = _parse_ext(scan)
             kind = op.dirname(scan)
-            if kind not in ALLOWED_ELECTROPHYSIO_MODALITY:
+            if kind not in ALLOWED_MODALITIES:
                 continue
 
             n_scans += 1
@@ -492,7 +492,7 @@ def make_report(bids_root, session=None, verbose=True):
         'ieeg': 'iEEG',
     }
     kinds = [kind_map[kind] for kind in kinds
-             if kind in ALLOWED_ELECTROPHYSIO_MODALITY]
+             if kind in kind_map.keys()]
 
     # REQUIRED: dataset_description.json summary
     dataset_summary = _summarize_dataset(bids_root)

--- a/mne_bids/report.py
+++ b/mne_bids/report.py
@@ -340,7 +340,7 @@ def _summarize_sidecar_json(bids_root, scans_fpaths, verbose=True):
 
             sidecar_fname = _find_matching_sidecar(bids_fname=bids_basename,
                                                    bids_root=bids_root,
-                                                   kind=kind,
+                                                   suffix=kind,
                                                    extension='.json')
             with open(sidecar_fname, 'r') as fin:
                 sidecar_json = json.load(fin)
@@ -427,7 +427,7 @@ def _summarize_channels_tsv(bids_root, scans_fpaths, verbose=True):
 
             channels_fname = _find_matching_sidecar(bids_fname=bids_basename,
                                                     bids_root=bids_root,
-                                                    kind='channels',
+                                                    suffix='channels',
                                                     extension='.tsv')
 
             # summarize channels.tsv

--- a/mne_bids/tests/test_copyfiles.py
+++ b/mne_bids/tests/test_copyfiles.py
@@ -21,7 +21,7 @@ with warnings.catch_warnings():
 from mne.datasets import testing
 from mne.utils import _TempDir
 from mne_bids import BIDSPath
-from mne_bids.utils import _handle_kind
+from mne_bids.utils import _handle_modality
 from mne_bids.path import _parse_ext
 
 from mne_bids.copyfiles import (_get_brainvision_encoding,
@@ -161,8 +161,9 @@ def test_copyfile_kit():
         raw_fname, mrk=hpi_fname, elp=electrode_fname,
         hsp=headshape_fname)
     _, ext = _parse_ext(raw_fname, verbose=True)
-    kind = _handle_kind(raw)
-    bids_fname = str(bids_basename.copy().update(kind=kind,
+    modality = _handle_modality(raw)
+    bids_fname = str(bids_basename.copy().update(modality=modality,
+                                                 suffix=modality,
                                                  extension=ext,
                                                  prefix=output_path))
 
@@ -171,10 +172,10 @@ def test_copyfile_kit():
     assert op.exists(bids_fname)
     _, ext = _parse_ext(hpi_fname, verbose=True)
     if ext == '.sqd':
-        kit_bids_basename.update(kind='markers', extension='.sqd')
+        kit_bids_basename.update(suffix='markers', extension='.sqd')
         assert op.exists(kit_bids_basename)
     elif ext == '.mrk':
-        kit_bids_basename.update(kind='markers', extension='.mrk')
+        kit_bids_basename.update(suffix='markers', extension='.mrk')
         assert op.exists(kit_bids_basename)
 
     if op.exists(electrode_fname):

--- a/mne_bids/tests/test_copyfiles.py
+++ b/mne_bids/tests/test_copyfiles.py
@@ -182,7 +182,7 @@ def test_copyfile_kit():
         elp_ext = '.pos'
         elp_fname = BIDSPath(
             subject=subject_id, session=session_id, task=task, run=run,
-            acquisition=key, kind='headshape', extension=elp_ext,
+            acquisition=key, suffix='headshape', extension=elp_ext,
             prefix=output_path)
         assert op.exists(elp_fname)
 
@@ -191,6 +191,6 @@ def test_copyfile_kit():
         hsp_ext = '.pos'
         hsp_fname = BIDSPath(
             subject=subject_id, session=session_id, task=task, run=run,
-            acquisition=key, kind='headshape', extension=hsp_ext,
+            acquisition=key, suffix='headshape', extension=hsp_ext,
             prefix=output_path)
         assert op.exists(hsp_fname)

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -19,7 +19,7 @@ with warnings.catch_warnings():
 from mne.datasets import testing
 from mne.utils import _TempDir
 
-from mne_bids import (get_kinds, get_entity_vals, print_dir_tree,
+from mne_bids import (get_modalities, get_entity_vals, print_dir_tree,
                       make_bids_folders, BIDSPath,
                       write_raw_bids)
 from mne_bids.path import (_parse_ext, get_entities_from_fname,
@@ -63,9 +63,9 @@ def return_bids_test_dir(tmpdir_factory):
 
 
 def test_get_keys(return_bids_test_dir):
-    """Test getting the datatypes (=kinds) of a dir."""
-    kinds = get_kinds(return_bids_test_dir)
-    assert kinds == ['meg']
+    """Test getting the datatypes (=modalities) of a dir."""
+    modalities = get_modalities(return_bids_test_dir)
+    assert modalities == ['meg']
 
 
 @pytest.mark.parametrize('entity, expected_vals, kwargs',
@@ -315,10 +315,10 @@ def test_bids_path(return_bids_test_dir):
         bids_basename.update(subject=subject_id + '-')
 
     # error check on suffix in BIDSPath (deep check)
-    kind = 'meeg'
-    with pytest.raises(ValueError, match=f'Suffix {kind} is not'):
+    suffix = 'meeg'
+    with pytest.raises(ValueError, match=f'Suffix {suffix} is not'):
         BIDSPath(subject=subject_id, session=session_id,
-                 suffix=kind)
+                 suffix=suffix)
 
     # do error check suffix in update
     error_kind = 'foobar'
@@ -326,10 +326,9 @@ def test_bids_path(return_bids_test_dir):
         bids_basename.update(suffix=error_kind)
 
     # does not error check on suffix in BIDSPath (deep check)
-    kind = 'meeg'
+    suffix = 'meeg'
     bids_basename = BIDSPath(subject=subject_id, session=session_id,
-                             suffix=kind, check=False)
-
+                             suffix=suffix, check=False)
     # also inherits error check from instantiation
     # always error check modality
     with pytest.raises(ValueError, match='"modality" can only be '
@@ -337,7 +336,7 @@ def test_bids_path(return_bids_test_dir):
         bids_basename.copy().update(modality=error_kind)
 
     # suffix won't be error checks if initial check was false
-    bids_basename.update(suffix=kind)
+    bids_basename.update(suffix=suffix)
 
     # error check on extension in BIDSPath (deep check)
     extension = '.mat'

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -201,10 +201,10 @@ def test_parse_bids_filename(fname):
     assert params['task'] == 'test'
     assert params['split'] == '01'
     if 'meg' in fname:
-        assert params['kind'] == 'meg'
+        assert params['suffix'] == 'meg'
     assert list(params.keys()) == ['subject', 'session', 'task',
                                    'acquisition', 'run', 'processing',
-                                   'space', 'recording', 'split', 'kind']
+                                   'space', 'recording', 'split', 'suffix']
 
 
 @pytest.mark.parametrize('candidate_list, best_candidates', [
@@ -284,7 +284,7 @@ def test_bids_path(return_bids_test_dir):
     assert all(bids_basename.entities.get(entity) is None
                for entity in ['task', 'run', 'recording', 'acquisition',
                               'space', 'processing',
-                              'prefix', 'kind', 'extension'])
+                              'prefix', 'suffix', 'extension'])
 
     # test updating functionality
     bids_basename.update(acquisition='03', run='2', session='02',
@@ -313,29 +313,25 @@ def test_bids_path(return_bids_test_dir):
     with pytest.raises(ValueError, match='Unallowed*'):
         bids_basename.update(subject=subject_id + '-')
 
-    # error check on kind in BIDSPath (deep check)
+    # error check on suffix in BIDSPath (deep check)
     kind = 'meeg'
     with pytest.raises(ValueError, match=f'Kind {kind} is not'):
         BIDSPath(subject=subject_id, session=session_id,
-                 kind=kind)
+                 suffix=kind)
 
-    # error check kind in update (deep check)
-    error_kind = 'foobar'
-    with pytest.raises(ValueError, match=f'Kind {error_kind} is not'):
-        bids_basename.update(kind=error_kind)
-
+    # do not error check suffix in update (not deep check)
     # disable check in update by setting check=False
     error_kind = 'foobar'
     bids_basename = BIDSPath(subject=subject_id, session=session_id, run=run,
                              acquisition=acq, task=task)
     bids_basename.update(kind=error_kind, check=False)
 
-    # does not error check on kind in BIDSPath (deep check)
+    # does not error check on suffix in BIDSPath (deep check)
     kind = 'meeg'
     bids_basename = BIDSPath(subject=subject_id, session=session_id,
-                             kind=kind, check=False)
+                             suffix=kind, check=False)
     # also inherits error check from instantiation
-    bids_basename.update(kind=error_kind)
+    bids_basename.update(suffix=error_kind)
 
     # error check on extension in BIDSPath (deep check)
     extension = '.mat'
@@ -348,7 +344,7 @@ def test_bids_path(return_bids_test_dir):
 
     # test repr
     bids_path = BIDSPath(subject='01', session='02',
-                         task='03', kind='ieeg',
+                         task='03', suffix='ieeg',
                          extension='.edf')
     assert repr(bids_path) == 'BIDSPath(sub-01_ses-02_task-03_ieeg.edf)'
 
@@ -366,11 +362,11 @@ def test_make_filenames():
     assert (BIDSPath(subject='one', task='three', run=4) ==
             'sub-one_task-three_run-04')
     assert (BIDSPath(subject='one', task='three',
-                     kind='meg', extension='.json') ==
+                     suffix='meg', extension='.json') ==
             'sub-one_task-three_meg.json')
 
     with pytest.raises(ValueError):
-        BIDSPath(subject='one-two', kind='ieeg', extension='.edf')
+        BIDSPath(subject='one-two', suffix='ieeg', extension='.edf')
 
     with pytest.raises(ValueError, match='At least one'):
         BIDSPath()
@@ -378,7 +374,7 @@ def test_make_filenames():
     # emptyroom check: invalid task
     with pytest.raises(ValueError, match='task must be'):
         BIDSPath(subject='emptyroom', session='20131201',
-                 task='blah', kind='meg')
+                 task='blah', suffix='meg')
 
     # when the suffix is not 'meg', then it does not result in
     # an error
@@ -397,7 +393,7 @@ def test_make_filenames():
                                          'can only contain'):
         BIDSPath(
             subject=subject_id, session=session_id, task=task,
-            kind='scans', extension='.tsv'
+            suffix='scans', extension='.tsv'
         )
 
 

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -135,22 +135,22 @@ def test_make_folders():
     """Test that folders are created and named properly."""
     # Make sure folders are created properly
     bids_root = _TempDir()
-    make_bids_folders(subject='hi', session='foo', kind='ba',
+    make_bids_folders(subject='hi', session='foo', modality='ba',
                       bids_root=bids_root)
     assert op.isdir(op.join(bids_root, 'sub-hi', 'ses-foo', 'ba'))
 
     # If we remove a kwarg the folder shouldn't be created
     bids_root = _TempDir()
-    make_bids_folders(subject='hi', kind='ba', bids_root=bids_root)
+    make_bids_folders(subject='hi', modality='ba', bids_root=bids_root)
     assert op.isdir(op.join(bids_root, 'sub-hi', 'ba'))
 
     # check overwriting of folders
-    make_bids_folders(subject='hi', kind='ba', bids_root=bids_root,
+    make_bids_folders(subject='hi', modality='ba', bids_root=bids_root,
                       overwrite=True, verbose=True)
 
     # Check if a pathlib.Path bids_root works.
     bids_root = Path(_TempDir())
-    make_bids_folders(subject='hi', session='foo', kind='ba',
+    make_bids_folders(subject='hi', session='foo', modality='ba',
                       bids_root=bids_root)
     assert op.isdir(op.join(bids_root, 'sub-hi', 'ses-foo', 'ba'))
 
@@ -158,7 +158,7 @@ def test_make_folders():
     bids_root = _TempDir()
     curr_dir = os.getcwd()
     os.chdir(bids_root)
-    make_bids_folders(subject='hi', session='foo', kind='ba',
+    make_bids_folders(subject='hi', session='foo', modality='ba',
                       bids_root=None)
     assert op.isdir(op.join(os.getcwd(), 'sub-hi', 'ses-foo', 'ba'))
     os.chdir(curr_dir)
@@ -201,10 +201,10 @@ def test_parse_bids_filename(fname):
     assert params['task'] == 'test'
     assert params['split'] == '01'
     if 'meg' in fname:
-        assert params['suffix'] == 'meg'
+        assert params['str_suffix'] == 'meg'
     assert list(params.keys()) == ['subject', 'session', 'task',
                                    'acquisition', 'run', 'processing',
-                                   'space', 'recording', 'split', 'suffix']
+                                   'space', 'recording', 'split', 'str_suffix']
 
 
 @pytest.mark.parametrize('candidate_list, best_candidates', [
@@ -235,7 +235,7 @@ def test_find_matching_sidecar(return_bids_test_dir):
 
     # Now find a sidecar
     sidecar_fname = _find_matching_sidecar(bids_basename, bids_root,
-                                           kind='coordsystem',
+                                           suffix='coordsystem',
                                            extension='.json')
     expected_file = op.join('sub-01', 'ses-01', 'meg',
                             'sub-01_ses-01_coordsystem.json')
@@ -247,12 +247,12 @@ def test_find_matching_sidecar(return_bids_test_dir):
                                    '2coordsystem.json'), 'w').close()
         print_dir_tree(bids_root)
         _find_matching_sidecar(bids_basename, bids_root,
-                               kind='coordsystem', extension='.json')
+                               suffix='coordsystem', extension='.json')
 
     # Find nothing but receive None, because we set `allow_fail` to True
     with pytest.warns(RuntimeWarning, match='Did not find any'):
         _find_matching_sidecar(bids_basename, bids_root,
-                               kind='foo', extension='.bogus',
+                               suffix='foo', extension='.bogus',
                                allow_fail=True)
 
 
@@ -284,7 +284,7 @@ def test_bids_path(return_bids_test_dir):
     assert all(bids_basename.entities.get(entity) is None
                for entity in ['task', 'run', 'recording', 'acquisition',
                               'space', 'processing',
-                              'prefix', 'suffix', 'extension'])
+                              'prefix', 'str_suffix', 'extension'])
 
     # test updating functionality
     bids_basename.update(acquisition='03', run='2', session='02',
@@ -313,7 +313,7 @@ def test_bids_path(return_bids_test_dir):
     with pytest.raises(ValueError, match='Unallowed*'):
         bids_basename.update(subject=subject_id + '-')
 
-    # error check on suffix in BIDSPath (deep check)
+    # error check on str_suffix in BIDSPath (deep check)
     kind = 'meeg'
     with pytest.raises(ValueError, match=f'Kind {kind} is not'):
         BIDSPath(subject=subject_id, session=session_id,
@@ -326,7 +326,7 @@ def test_bids_path(return_bids_test_dir):
                              acquisition=acq, task=task)
     bids_basename.update(kind=error_kind, check=False)
 
-    # does not error check on suffix in BIDSPath (deep check)
+    # does not error check on str_suffix in BIDSPath (deep check)
     kind = 'meeg'
     bids_basename = BIDSPath(subject=subject_id, session=session_id,
                              suffix=kind, check=False)
@@ -376,7 +376,7 @@ def test_make_filenames():
         BIDSPath(subject='emptyroom', session='20131201',
                  task='blah', suffix='meg')
 
-    # when the suffix is not 'meg', then it does not result in
+    # when the str_suffix is not 'meg', then it does not result in
     # an error
     BIDSPath(subject='emptyroom', session='20131201',
              task='blah')

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -119,7 +119,7 @@ def test_read_participants_data():
     write_raw_bids(raw, bids_basename, bids_root, overwrite=True,
                    verbose=False)
     raw = read_raw_bids(bids_basename=bids_basename, bids_root=bids_root,
-                        kind='meg')
+                        modality='meg')
     print(raw.info['subject_info'])
     assert raw.info['subject_info']['hand'] == 1
     assert raw.info['subject_info']['sex'] == 2
@@ -131,7 +131,7 @@ def test_read_participants_data():
     participants_tsv['hand'][0] = 'n/a'
     _to_tsv(participants_tsv, participants_tsv_fpath)
     raw = read_raw_bids(bids_basename=bids_basename, bids_root=Path(bids_root),
-                        kind='meg')
+                        modality='meg')
     assert raw.info['subject_info']['hand'] == 0
     assert raw.info['subject_info']['sex'] == 2
     assert raw.info['subject_info'].get('birthday', None) is None
@@ -143,7 +143,7 @@ def test_read_participants_data():
     _to_tsv(participants_tsv, participants_tsv_fpath)
     with pytest.warns(RuntimeWarning, match='Unable to map'):
         raw = read_raw_bids(bids_basename=bids_basename,
-                            bids_root=Path(bids_root), kind='meg')
+                            bids_root=Path(bids_root), modality='meg')
         assert raw.info['subject_info']['hand'] is None
         assert raw.info['subject_info']['sex'] is None
 
@@ -154,7 +154,7 @@ def test_read_participants_data():
     os.remove(participants_tsv_fpath)
     with pytest.warns(RuntimeWarning, match='Participants file not found'):
         raw = read_raw_bids(bids_basename=bids_basename,
-                            bids_root=Path(bids_root), kind='meg')
+                            bids_root=Path(bids_root), modality='meg')
         assert raw.info['subject_info'] is None
 
 
@@ -250,12 +250,12 @@ def test_handle_info_reading():
 
     # find sidecar JSON fname
     sidecar_fname = _find_matching_sidecar(bids_fname, bids_root,
-                                           kind=kind, extension='.json',
+                                           suffix=kind, extension='.json',
                                            allow_fail=True)
 
     # assert that we get the same line frequency set
     raw = read_raw_bids(bids_basename=bids_basename, bids_root=bids_root,
-                        kind=kind)
+                        modality=kind)
     assert raw.info['line_freq'] == 60
 
     # 2. if line frequency is not set in raw file, then ValueError
@@ -275,14 +275,14 @@ def test_handle_info_reading():
         sidecar_json["PowerLineFrequency"] = 45
     _write_json(sidecar_copy, sidecar_json)
     raw = read_raw_bids(bids_basename=bids_basename, bids_root=bids_root,
-                        kind=kind)
+                        modality=kind)
     assert raw.info['line_freq'] == 60
 
     # 3. assert that we get an error when sidecar json doesn't match
     _update_sidecar(sidecar_fname, "PowerLineFrequency", 55)
     with pytest.raises(ValueError, match="Line frequency in sidecar json"):
         raw = read_raw_bids(bids_basename=bids_basename, bids_root=bids_root,
-                            kind=kind)
+                            modality=kind)
         assert raw.info['line_freq'] == 55
 
 
@@ -313,11 +313,11 @@ def test_handle_eeg_coords_reading():
     with pytest.warns(RuntimeWarning, match="Skipping EEG electrodes.tsv"):
         write_raw_bids(raw, bids_basename, bids_root, overwrite=True)
         coordsystem_fname = _find_matching_sidecar(bids_basename, bids_root,
-                                                   kind='coordsystem',
+                                                   suffix='coordsystem',
                                                    extension='.json',
                                                    allow_fail=True)
         electrodes_fname = _find_matching_sidecar(bids_basename, bids_root,
-                                                  kind='electrodes',
+                                                  suffix='electrodes',
                                                   extension='.tsv',
                                                   allow_fail=True)
         assert coordsystem_fname is None
@@ -346,7 +346,7 @@ def test_handle_eeg_coords_reading():
 
     # modify coordinate frame to not-captrak
     coordsystem_fname = _find_matching_sidecar(bids_basename, bids_root,
-                                               kind='coordsystem',
+                                               suffix='coordsystem',
                                                extension='.json',
                                                allow_fail=True)
     _update_sidecar(coordsystem_fname, 'EEGCoordinateSystem', 'besa')
@@ -414,11 +414,11 @@ def test_handle_ieeg_coords_reading(bids_basename):
     # regardless of 'm', 'cm', 'mm', or 'pixel'
     scalings = {'m': 1, 'cm': 100, 'mm': 1000}
     coordsystem_fname = _find_matching_sidecar(bids_fname, bids_root,
-                                               kind='coordsystem',
+                                               suffix='coordsystem',
                                                extension='.json',
                                                allow_fail=True)
     electrodes_fname = _find_matching_sidecar(bids_fname, bids_root,
-                                              kind='electrodes',
+                                              suffix='electrodes',
                                               extension='.tsv',
                                               allow_fail=True)
     orig_electrodes_dict = _from_tsv(electrodes_fname,
@@ -611,7 +611,7 @@ def test_get_matched_empty_room():
 
     # assert that we get error if meas_date is not available.
     raw = read_raw_bids(bids_basename=bids_basename, bids_root=bids_root,
-                        kind='meg')
+                        modality='meg')
     if check_version('mne', '0.20'):
         raw.set_meas_date(None)
     else:
@@ -631,7 +631,7 @@ def test_get_matched_emptyroom_ties():
     bids_root = _TempDir()
     session = '20010101'
     er_dir = make_bids_folders(subject='emptyroom', session=session,
-                               kind='meg', bids_root=bids_root)
+                               modality='meg', bids_root=bids_root)
 
     meas_date = (datetime
                  .strptime(session, '%Y%m%d')
@@ -705,21 +705,21 @@ def test_read_raw_bids_pathlike():
     write_raw_bids(raw, bids_basename, bids_root, overwrite=True,
                    verbose=False)
     raw = read_raw_bids(bids_basename=bids_basename, bids_root=Path(bids_root),
-                        kind='meg')
+                        modality='meg')
 
 
 @pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
 def test_read_raw_kind():
-    """Test that read_raw_bids() can infer the suffix if need be."""
+    """Test that read_raw_bids() can infer the str_suffix if need be."""
     bids_root = _TempDir()
     raw = _read_raw_fif(raw_fname, verbose=False)
     write_raw_bids(raw, bids_basename, bids_root, overwrite=True,
                    verbose=False)
 
     raw_1 = read_raw_bids(bids_basename=bids_basename, bids_root=bids_root,
-                          kind='meg')
+                          modality='meg')
     raw_2 = read_raw_bids(bids_basename=bids_basename, bids_root=bids_root,
-                          kind=None)
+                          modality=None)
     raw_3 = read_raw_bids(bids_basename=bids_basename, bids_root=bids_root)
 
     raw_1.crop(0, 2).load_data()

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -584,7 +584,7 @@ def test_get_matched_empty_room():
         er_date = datetime.fromtimestamp(er_raw.info['meas_date'][0])
     er_date = er_date.strftime('%Y%m%d')
     er_bids_basename = BIDSPath(subject='emptyroom', task='noise',
-                                session=er_date, kind='meg')
+                                session=er_date, suffix='meg')
     write_raw_bids(er_raw, er_bids_basename, bids_root, overwrite=True)
 
     recovered_er_basename = get_matched_empty_room(bids_basename=bids_basename,
@@ -710,7 +710,7 @@ def test_read_raw_bids_pathlike():
 
 @pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
 def test_read_raw_kind():
-    """Test that read_raw_bids() can infer the kind if need be."""
+    """Test that read_raw_bids() can infer the suffix if need be."""
     bids_root = _TempDir()
     raw = _read_raw_fif(raw_fname, verbose=False)
     write_raw_bids(raw, bids_basename, bids_root, overwrite=True,

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -673,7 +673,7 @@ def test_get_matched_emptyroom_no_meas_date():
     er_meas_date = None
 
     er_dir = make_bids_folders(subject='emptyroom', session=er_session,
-                               kind='meg', bids_root=bids_root)
+                               modality='meg', bids_root=bids_root)
     er_bids_path = BIDSPath(subject='emptyroom', session=er_session,
                             task='noise', check=False)
     er_basename = str(er_bids_path)

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -243,19 +243,19 @@ def test_handle_info_reading():
     # bids basename and fname
     bids_basename = BIDSPath(subject='01', session='01',
                              task='audiovisual', run='01')
-    kind = "meg"
-    bids_fname = bids_basename.copy().update(suffix=kind,
+    suffix = "meg"
+    bids_fname = bids_basename.copy().update(suffix=suffix,
                                              extension='.fif')
     write_raw_bids(raw, bids_basename, bids_root, overwrite=True)
 
     # find sidecar JSON fname
     sidecar_fname = _find_matching_sidecar(bids_fname, bids_root,
-                                           suffix=kind, extension='.json',
+                                           suffix=suffix, extension='.json',
                                            allow_fail=True)
 
     # assert that we get the same line frequency set
     raw = read_raw_bids(bids_basename=bids_basename, bids_root=bids_root,
-                        modality=kind)
+                        modality=suffix)
     assert raw.info['line_freq'] == 60
 
     # 2. if line frequency is not set in raw file, then ValueError
@@ -275,14 +275,14 @@ def test_handle_info_reading():
         sidecar_json["PowerLineFrequency"] = 45
     _write_json(sidecar_copy, sidecar_json)
     raw = read_raw_bids(bids_basename=bids_basename, bids_root=bids_root,
-                        modality=kind)
+                        modality=suffix)
     assert raw.info['line_freq'] == 60
 
     # 3. assert that we get an error when sidecar json doesn't match
     _update_sidecar(sidecar_fname, "PowerLineFrequency", 55)
     with pytest.raises(ValueError, match="Line frequency in sidecar json"):
         raw = read_raw_bids(bids_basename=bids_basename, bids_root=bids_root,
-                            modality=kind)
+                            modality=suffix)
         assert raw.info['line_freq'] == 55
 
 
@@ -709,7 +709,7 @@ def test_read_raw_bids_pathlike():
 
 
 @pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
-def test_read_raw_kind():
+def test_read_raw_modality():
     """Test that read_raw_bids() can infer the str_suffix if need be."""
     bids_root = _TempDir()
     raw = _read_raw_fif(raw_fname, verbose=False)

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -244,7 +244,7 @@ def test_handle_info_reading():
     bids_basename = BIDSPath(subject='01', session='01',
                              task='audiovisual', run='01')
     kind = "meg"
-    bids_fname = bids_basename.copy().update(kind=kind,
+    bids_fname = bids_basename.copy().update(suffix=kind,
                                              extension='.fif')
     write_raw_bids(raw, bids_basename, bids_root, overwrite=True)
 
@@ -366,7 +366,7 @@ def test_handle_ieeg_coords_reading(bids_basename):
 
     data_path = op.join(testing.data_path(), 'EDF')
     raw_fname = op.join(data_path, 'test_reduced.edf')
-    bids_fname = bids_basename.copy().update(kind='ieeg',
+    bids_fname = bids_basename.copy().update(suffix='ieeg',
                                              extension='.edf')
 
     raw = _read_raw_edf(raw_fname)
@@ -742,7 +742,7 @@ def test_handle_channel_type_casing():
                            'meg')
     bids_channels_fname = (bids_basename.copy()
                            .update(prefix=subject_path,
-                                   kind='channels', extension='.tsv'))
+                                   suffix='channels', extension='.tsv'))
 
     # Convert all channel type entries to lowercase.
     channels_data = _from_tsv(bids_channels_fname)
@@ -759,11 +759,11 @@ def test_bads_reading():
     channels_fname = (bids_basename.copy()
                       .update(prefix=op.join(bids_root, 'sub-01', 'ses-01',
                                              'meg'),
-                              kind='channels', extension='.tsv'))
+                              suffix='channels', extension='.tsv'))
     raw_bids_fname = (bids_basename.copy()
                       .update(prefix=op.join(bids_root, 'sub-01', 'ses-01',
                                              'meg'),
-                              kind='meg', extension='.fif'))
+                              suffix='meg', extension='.fif'))
     raw = _read_raw_fif(raw_fname, verbose=False)
 
     ###########################################################################

--- a/mne_bids/tests/test_report.py
+++ b/mne_bids/tests/test_report.py
@@ -35,7 +35,7 @@ warning_str = dict(
 
 @pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
 def test_read_raw_kind():
-    """Test that read_raw_bids() can infer the kind if need be."""
+    """Test that read_raw_bids() can infer the suffix if need be."""
     bids_root = _TempDir()
     raw = mne.io.read_raw_fif(raw_fname, verbose=False)
     raw.info['line_freq'] = 60

--- a/mne_bids/tests/test_report.py
+++ b/mne_bids/tests/test_report.py
@@ -34,8 +34,8 @@ warning_str = dict(
 
 
 @pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
-def test_read_raw_kind():
-    """Test that read_raw_bids() can infer the str_suffix if need be."""
+def test_report():
+    """Test that report generated works as intended."""
     bids_root = _TempDir()
     raw = mne.io.read_raw_fif(raw_fname, verbose=False)
     raw.info['line_freq'] = 60

--- a/mne_bids/tests/test_report.py
+++ b/mne_bids/tests/test_report.py
@@ -35,7 +35,7 @@ warning_str = dict(
 
 @pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
 def test_read_raw_kind():
-    """Test that read_raw_bids() can infer the suffix if need be."""
+    """Test that read_raw_bids() can infer the str_suffix if need be."""
     bids_root = _TempDir()
     raw = mne.io.read_raw_fif(raw_fname, verbose=False)
     raw.info['line_freq'] = 60

--- a/mne_bids/tests/test_utils.py
+++ b/mne_bids/tests/test_utils.py
@@ -44,7 +44,7 @@ def test_get_ch_type_mapping():
 
 
 def test_handle_modality():
-    """Test the automatic extraction of str_suffix from the data."""
+    """Test the automatic extraction of modality from the data."""
     # Create a dummy raw
     n_channels = 1
     sampling_rate = 100

--- a/mne_bids/tests/test_utils.py
+++ b/mne_bids/tests/test_utils.py
@@ -44,7 +44,7 @@ def test_get_ch_type_mapping():
 
 
 def test_handle_kind():
-    """Test the automatic extraction of kind from the data."""
+    """Test the automatic extraction of suffix from the data."""
     # Create a dummy raw
     n_channels = 1
     sampling_rate = 100

--- a/mne_bids/tests/test_utils.py
+++ b/mne_bids/tests/test_utils.py
@@ -43,19 +43,19 @@ def test_get_ch_type_mapping():
         _get_ch_type_mapping(fro='bogus', to='mne')
 
 
-def test_handle_kind():
+def test_handle_modality():
     """Test the automatic extraction of str_suffix from the data."""
     # Create a dummy raw
     n_channels = 1
     sampling_rate = 100
     data = random((n_channels, sampling_rate))
     channel_types = ['grad', 'eeg', 'ecog']
-    expected_kinds = ['meg', 'eeg', 'ieeg']
+    expected_modalities = ['meg', 'eeg', 'ieeg']
     # do it once for each type ... and once for "no type"
-    for chtype, kind in zip(channel_types, expected_kinds):
+    for chtype, modality in zip(channel_types, expected_modalities):
         info = mne.create_info(n_channels, sampling_rate, ch_types=[chtype])
         raw = mne.io.RawArray(data, info)
-        assert _handle_modality(raw) == kind
+        assert _handle_modality(raw) == modality
 
     # if the situation is ambiguous (EEG and iEEG channels both), raise error
     with pytest.raises(ValueError, match='Both EEG and iEEG channels found'):

--- a/mne_bids/tests/test_utils.py
+++ b/mne_bids/tests/test_utils.py
@@ -21,7 +21,7 @@ with warnings.catch_warnings():
 
 from mne_bids import BIDSPath
 from mne_bids.utils import (_check_types, _age_on_date,
-                            _infer_eeg_placement_scheme, _handle_kind,
+                            _infer_eeg_placement_scheme, _handle_modality,
                             _get_ch_type_mapping)
 from mne_bids.path import _path_to_str
 
@@ -55,20 +55,20 @@ def test_handle_kind():
     for chtype, kind in zip(channel_types, expected_kinds):
         info = mne.create_info(n_channels, sampling_rate, ch_types=[chtype])
         raw = mne.io.RawArray(data, info)
-        assert _handle_kind(raw) == kind
+        assert _handle_modality(raw) == kind
 
     # if the situation is ambiguous (EEG and iEEG channels both), raise error
     with pytest.raises(ValueError, match='Both EEG and iEEG channels found'):
         info = mne.create_info(2, sampling_rate,
                                ch_types=['eeg', 'ecog'])
         raw = mne.io.RawArray(random((2, sampling_rate)), info)
-        _handle_kind(raw)
+        _handle_modality(raw)
 
     # if we cannot find a proper channel type, we raise an error
     with pytest.raises(ValueError, match='Neither MEG/EEG/iEEG channels'):
         info = mne.create_info(n_channels, sampling_rate, ch_types=['misc'])
         raw = mne.io.RawArray(data, info)
-        _handle_kind(raw)
+        _handle_modality(raw)
 
 
 def test_check_types():

--- a/mne_bids/tests/test_utils.py
+++ b/mne_bids/tests/test_utils.py
@@ -44,7 +44,7 @@ def test_get_ch_type_mapping():
 
 
 def test_handle_kind():
-    """Test the automatic extraction of suffix from the data."""
+    """Test the automatic extraction of str_suffix from the data."""
     # Create a dummy raw
     n_channels = 1
     sampling_rate = 100

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -126,7 +126,7 @@ def _test_anonymize(raw, bids_basename, events_fname=None, event_id=None):
                    overwrite=False)
     scans_tsv = BIDSPath(
         subject=subject_id, session=session_id,
-        kind='scans', extension='.tsv',
+        suffix='scans', extension='.tsv',
         prefix=op.join(bids_root, 'sub-01', 'ses-01'))
     data = _from_tsv(scans_tsv)
     if data['acq_time'] is not None and data['acq_time'][0] != 'n/a':
@@ -349,7 +349,7 @@ def test_fif(_bids_validate):
     # test that the acquisition time was written properly
     scans_tsv = BIDSPath(
         subject=subject_id, session=session_id,
-        kind='scans', extension='.tsv',
+        suffix='scans', extension='.tsv',
         prefix=op.join(bids_root, 'sub-01', 'ses-01'))
     data = _from_tsv(scans_tsv)
     assert data['acq_time'][0] == meas_date.strftime('%Y-%m-%dT%H:%M:%S')
@@ -565,7 +565,7 @@ def test_fif_anonymize(_bids_validate):
                    overwrite=False)
     scans_tsv = BIDSPath(
         subject=subject_id, session=session_id,
-        kind='scans', extension='.tsv',
+        suffix='scans', extension='.tsv',
         prefix=op.join(bids_root, 'sub-01', 'ses-01'))
     data = _from_tsv(scans_tsv)
 
@@ -608,7 +608,7 @@ def test_kit(_bids_validate):
     # ensure the marker file is produced in the right place
     marker_fname = BIDSPath(
         subject=subject_id, session=session_id, task=task, run=run,
-        kind='markers', extension='.sqd',
+        suffix='markers', extension='.sqd',
         prefix=op.join(bids_root, 'sub-01', 'ses-01', 'meg'))
     assert op.exists(marker_fname)
 
@@ -924,7 +924,7 @@ def test_edf(_bids_validate):
     # ensure there is an EMG channel in the channels.tsv:
     channels_tsv = BIDSPath(
         subject=subject_id, session=session_id, task=task, run=run,
-        kind='channels', extension='.tsv', acquisition=acq,
+        suffix='channels', extension='.tsv', acquisition=acq,
         prefix=op.join(bids_root, 'sub-01', 'ses-01', 'eeg'))
     data = _from_tsv(channels_tsv)
     assert 'ElectroMyoGram' in data['description']
@@ -932,7 +932,7 @@ def test_edf(_bids_validate):
     # check that the scans list contains two scans
     scans_tsv = BIDSPath(
         subject=subject_id, session=session_id,
-        kind='scans', extension='.tsv',
+        suffix='scans', extension='.tsv',
         prefix=op.join(bids_root, 'sub-01', 'ses-01'))
     data = _from_tsv(scans_tsv)
     assert len(list(data.values())[0]) == 2
@@ -1161,7 +1161,7 @@ def test_write_anat(_bids_validate):
                                   point_list)
     sidecar_basename = BIDSPath(subject='01', session='01',
                                 acquisition='01',
-                                kind='T1w', extension='.nii.gz')
+                                suffix='T1w', extension='.nii.gz')
     # test the actual values of the voxels (no floating points)
     for i, point in enumerate([(66, 51, 46), (41, 32, 74), (17, 53, 47)]):
         coords = anat_dict[point_list[i]]

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -270,10 +270,11 @@ def test_fif(_bids_validate):
     # Events and bad channel information was read through JSON sidecar files.
     with pytest.raises(TypeError, match="unexpected keyword argument 'foo'"):
         read_raw_bids(bids_basename=bids_basename, bids_root=bids_root,
-                      kind='meg', extra_params=dict(foo='bar'))
+                      modality='meg', extra_params=dict(foo='bar'))
 
     raw2 = read_raw_bids(bids_basename=bids_basename, bids_root=bids_root,
-                         kind='meg', extra_params=dict(allow_maxshield=True))
+                         modality='meg',
+                         extra_params=dict(allow_maxshield=True))
     assert set(raw.info['bads']) == set(raw2.info['bads'])
     events, _ = mne.events_from_annotations(raw2)
     events2 = mne.read_events(events_fname)
@@ -317,7 +318,7 @@ def test_fif(_bids_validate):
         assert op.isfile(op.join(bids_dir, sidecar_basename))
 
     raw2 = read_raw_bids(bids_basename=bids_basename, bids_root=bids_root,
-                         kind='eeg')
+                         modality='eeg')
     os.remove(op.join(bids_root, 'test-raw.fif'))
 
     events2 = mne.find_events(raw2)
@@ -603,7 +604,7 @@ def test_kit(_bids_validate):
     assert op.exists(op.join(bids_root, 'participants.tsv'))
 
     read_raw_bids(bids_basename=kit_bids_basename, bids_root=bids_root,
-                  kind='meg')
+                  modality='meg')
 
     # ensure the marker file is produced in the right place
     marker_fname = BIDSPath(
@@ -691,7 +692,8 @@ def test_ctf(_bids_validate):
     _bids_validate(bids_root)
     with pytest.warns(RuntimeWarning, match='Did not find any events'):
         raw = read_raw_bids(bids_basename=bids_basename, bids_root=bids_root,
-                            kind='meg', extra_params=dict(clean_names=False))
+                            modality='meg',
+                            extra_params=dict(clean_names=False))
 
     # test to check that running again with overwrite == False raises an error
     with pytest.raises(FileExistsError, match="already exists"):  # noqa: F821
@@ -733,11 +735,11 @@ def test_bti(_bids_validate):
     _bids_validate(bids_root)
 
     raw = read_raw_bids(bids_basename=bids_basename, bids_root=bids_root,
-                        kind='meg')
+                        modality='meg')
 
     with pytest.raises(TypeError, match="unexpected keyword argument 'foo'"):
         read_raw_bids(bids_basename=bids_basename, bids_root=bids_root,
-                      kind='meg', extra_params=dict(foo='bar'))
+                      modality='meg', extra_params=dict(foo='bar'))
 
     if check_version('mne', '0.20'):
         # test anonymize
@@ -772,11 +774,11 @@ def test_vhdr(_bids_validate):
 
     # read and also get the bad channels
     raw = read_raw_bids(bids_basename=bids_basename_minimal,
-                        bids_root=bids_root, kind='eeg')
+                        bids_root=bids_root, modality='eeg')
 
     with pytest.raises(TypeError, match="unexpected keyword argument 'foo'"):
         read_raw_bids(bids_basename=bids_basename_minimal, bids_root=bids_root,
-                      kind='eeg', extra_params=dict(foo='bar'))
+                      modality='eeg', extra_params=dict(foo='bar'))
 
     # Check that injected bad channel shows up in raw after reading
     np.testing.assert_array_equal(np.asarray(raw.info['bads']),
@@ -801,7 +803,7 @@ def test_vhdr(_bids_validate):
 
     # create another bids folder with the overwrite command and check
     # no files are in the folder
-    data_path = make_bids_folders(subject=subject_id, kind='eeg',
+    data_path = make_bids_folders(subject=subject_id, modality='eeg',
                                   bids_root=bids_root, overwrite=True)
     assert len([f for f in os.listdir(data_path) if op.isfile(f)]) == 0
 
@@ -834,7 +836,7 @@ def test_vhdr(_bids_validate):
     bids_root = _TempDir()
     write_raw_bids(raw, bids_basename, bids_root)
     electrodes_fpath = _find_matching_sidecar(bids_basename, bids_root,
-                                              kind='electrodes',
+                                              suffix='electrodes',
                                               extension='.tsv')
     tsv = _from_tsv(electrodes_fpath)
     assert len(tsv.get('impedance', {})) > 0
@@ -880,11 +882,11 @@ def test_edf(_bids_validate):
     # in raw clash
     with pytest.raises(RuntimeError, match='Channels do not correspond'):
         read_raw_bids(bids_basename=bids_basename, bids_root=bids_root,
-                      kind='eeg')
+                      modality='eeg')
 
     with pytest.raises(TypeError, match="unexpected keyword argument 'foo'"):
         read_raw_bids(bids_basename=bids_basename, bids_root=bids_root,
-                      kind='eeg', extra_params=dict(foo='bar'))
+                      modality='eeg', extra_params=dict(foo='bar'))
 
     bids_fname = bids_basename.copy().update(run=run2)
     # add data in as a montage
@@ -902,7 +904,7 @@ def test_edf(_bids_validate):
                                             'Setting montage not possible'):
         write_raw_bids(raw, bids_fname, bids_root, overwrite=True)
         electrodes_fpath = _find_matching_sidecar(bids_fname, bids_root,
-                                                  kind='electrodes',
+                                                  suffix='electrodes',
                                                   extension='.tsv',
                                                   allow_fail=True)
         assert electrodes_fpath is None
@@ -916,7 +918,7 @@ def test_edf(_bids_validate):
     raw.set_montage(eeg_montage)
     write_raw_bids(raw, bids_fname, bids_root, overwrite=True)
     electrodes_fpath = _find_matching_sidecar(bids_fname, bids_root,
-                                              kind='electrodes',
+                                              suffix='electrodes',
                                               extension='.tsv')
     assert op.exists(electrodes_fpath)
     _bids_validate(bids_root)
@@ -985,10 +987,10 @@ def test_edf(_bids_validate):
     # XXX: Should be improved with additional coordinate system descriptions
     # iEEG montages written from mne-python end up as "Other"
     electrodes_fname = _find_matching_sidecar(bids_fname, bids_root,
-                                              kind='electrodes',
+                                              suffix='electrodes',
                                               extension='.tsv')
     coordsystem_fname = _find_matching_sidecar(bids_fname, bids_root,
-                                               kind='coordsystem',
+                                               suffix='coordsystem',
                                                extension='.json')
     assert 'space-mri' in electrodes_fname
     assert 'space-mri' in coordsystem_fname
@@ -1028,9 +1030,11 @@ def test_bdf(_bids_validate):
     assert coil_type(raw.info, test_ch_idx) != 'misc'
 
     # we will change the channel type to MISC and overwrite the channels file
-    bids_fname = bids_basename.copy().update(kind='eeg', extension='.bdf')
+    bids_fname = bids_basename.copy().update(kind='eeg',
+                                             extension='.bdf')
     channels_fname = _find_matching_sidecar(bids_fname, bids_root,
-                                            kind='channels', extension='.tsv')
+                                            suffix='channels',
+                                            extension='.tsv')
     channels_dict = _from_tsv(channels_fname)
     channels_dict['type'][test_ch_idx] = 'MISC'
     _to_tsv(channels_dict, channels_fname)
@@ -1039,12 +1043,12 @@ def test_bdf(_bids_validate):
     # that the channels.tsv truly influences how read_raw_bids sets ch_types
     # in the raw data object
     raw = read_raw_bids(bids_basename=bids_basename, bids_root=bids_root,
-                        kind='eeg')
+                        modality='eeg')
     assert coil_type(raw.info, test_ch_idx) == 'misc'
 
     with pytest.raises(TypeError, match="unexpected keyword argument 'foo'"):
         read_raw_bids(bids_basename=bids_basename, bids_root=bids_root,
-                      kind='eeg', extra_params=dict(foo='bar'))
+                      modality='eeg', extra_params=dict(foo='bar'))
 
     # Test cropped assertion error
     raw = _read_raw_bdf(raw_fname)
@@ -1078,11 +1082,12 @@ def test_set(_bids_validate):
 
     # proceed with the actual test for EEGLAB data
     write_raw_bids(raw, bids_basename, bids_root, overwrite=False)
-    read_raw_bids(bids_basename=bids_basename, bids_root=bids_root, kind='eeg')
+    read_raw_bids(bids_basename=bids_basename, bids_root=bids_root,
+                  modality='eeg')
 
     with pytest.raises(TypeError, match="unexpected keyword argument 'foo'"):
         read_raw_bids(bids_basename=bids_basename, bids_root=bids_root,
-                      kind='eeg', extra_params=dict(foo='bar'))
+                      modality='eeg', extra_params=dict(foo='bar'))
 
     with pytest.raises(FileExistsError, match="already exists"):  # noqa: F821
         write_raw_bids(raw, bids_basename, bids_root=bids_root,
@@ -1170,7 +1175,7 @@ def test_write_anat(_bids_validate):
 
         # BONUS: test also that we can find the matching sidecar
         side_fname = _find_matching_sidecar(sidecar_basename,
-                                            bids_root, kind='T1w',
+                                            bids_root, suffix='T1w',
                                             extension='.json')
         assert op.split(side_fname)[-1] == 'sub-01_ses-01_acq-01_T1w.json'
 
@@ -1192,7 +1197,7 @@ def test_write_anat(_bids_validate):
     # Assert that we truly cannot find a sidecar
     with pytest.raises(RuntimeError, match='Did not find any'):
         _find_matching_sidecar(sidecar_basename,
-                               bids_root, kind='T1w', extension='.json')
+                               bids_root, suffix='T1w', extension='.json')
 
     # trans has a wrong type
     wrong_type = 1

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -313,8 +313,8 @@ def test_fif(_bids_validate):
     sidecar_basename = bids_basename.copy()
     for sidecar in ['channels.tsv', 'eeg.eeg', 'eeg.json', 'eeg.vhdr',
                     'eeg.vmrk', 'events.tsv']:
-        kind, extension = sidecar.split('.')
-        sidecar_basename.update(kind=kind, extension=extension)
+        suffix, extension = sidecar.split('.')
+        sidecar_basename.update(suffix=suffix, extension=extension)
         assert op.isfile(op.join(bids_dir, sidecar_basename))
 
     raw2 = read_raw_bids(bids_basename=bids_basename, bids_root=bids_root,
@@ -624,7 +624,7 @@ def test_kit(_bids_validate):
                                           events_fname, event_id)
 
     # ensure the channels file has no STI 014 channel:
-    channels_tsv = marker_fname.copy().update(kind='channels',
+    channels_tsv = marker_fname.copy().update(suffix='channels',
                                               extension='.tsv')
     data = _from_tsv(channels_tsv)
     assert 'STI 014' not in data['name']
@@ -788,7 +788,7 @@ def test_vhdr(_bids_validate):
     # is in channels.tsv
     prefix = op.join(bids_root, f'sub-{subject_id}', 'eeg')
     channels_tsv_name = bids_basename_minimal.copy().update(prefix=prefix,
-                                                            kind='channels',
+                                                            suffix='channels',
                                                             extension='.tsv')
     data = _from_tsv(channels_tsv_name)
     assert data['units'][data['name'].index('FP1')] == 'µV'
@@ -945,7 +945,7 @@ def test_edf(_bids_validate):
                        anonymize=dict(daysback=33000),
                        overwrite=True)
         data = _from_tsv(scans_tsv)
-        bids_fname = bids_basename.copy().update(kind='eeg',
+        bids_fname = bids_basename.copy().update(suffix='eeg',
                                                  extension='.vhdr')
         assert any([str(bids_fname) in fname for fname in data['filename']])
 
@@ -1030,7 +1030,7 @@ def test_bdf(_bids_validate):
     assert coil_type(raw.info, test_ch_idx) != 'misc'
 
     # we will change the channel type to MISC and overwrite the channels file
-    bids_fname = bids_basename.copy().update(kind='eeg',
+    bids_fname = bids_basename.copy().update(suffix='eeg',
                                              extension='.bdf')
     channels_fname = _find_matching_sidecar(bids_fname, bids_root,
                                             suffix='channels',

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -87,7 +87,7 @@ def _get_ch_type_mapping(fro='mne', to='bids'):
     return mapping
 
 
-def _handle_kind(raw):
+def _handle_modality(raw):
     """Get kind."""
     if 'eeg' in raw and ('ecog' in raw or 'seeg' in raw):
         raise ValueError('Both EEG and iEEG channels found in data.'
@@ -333,7 +333,7 @@ def _scale_coord_to_meters(coord, unit):
 
 def _check_empty_room_basename(bids_path, on_invalid_er_task='raise'):
     # only check task entity for emptyroom when it is the sidecar/MEG file
-    if bids_path.kind == 'meg':
+    if bids_path.suffix == 'meg':
         if bids_path.task != 'noise':
             msg = (f'task must be "noise" if subject is "emptyroom", but '
                    f'received: {bids_path.task}')

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -88,22 +88,22 @@ def _get_ch_type_mapping(fro='mne', to='bids'):
 
 
 def _handle_modality(raw):
-    """Get kind."""
+    """Get modality."""
     if 'eeg' in raw and ('ecog' in raw or 'seeg' in raw):
         raise ValueError('Both EEG and iEEG channels found in data.'
                          'There is currently no specification on how'
                          'to handle this data. Please proceed manually.')
     elif 'meg' in raw:
-        kind = 'meg'
+        modality = 'meg'
     elif 'ecog' in raw or 'seeg' in raw:
-        kind = 'ieeg'
+        modality = 'ieeg'
     elif 'eeg' in raw:
-        kind = 'eeg'
+        modality = 'eeg'
     else:
         raise ValueError('Neither MEG/EEG/iEEG channels found in data.'
                          'Please use raw.set_channel_types to set the '
                          'channel types in the data.')
-    return kind
+    return modality
 
 
 def _age_on_date(bday, exp_date):

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -88,7 +88,7 @@ def _get_ch_type_mapping(fro='mne', to='bids'):
 
 
 def _handle_kind(raw):
-    """Get kind."""
+    """Get suffix."""
     if 'eeg' in raw and ('ecog' in raw or 'seeg' in raw):
         raise ValueError('Both EEG and iEEG channels found in data.'
                          'There is currently no specification on how'
@@ -291,7 +291,7 @@ def _extract_landmarks(dig):
     """Extract NAS, LPA, and RPA from raw.info['dig']."""
     coords = dict()
     landmarks = {d['ident']: d for d in dig
-                 if d['kind'] == FIFF.FIFFV_POINT_CARDINAL}
+                 if d['suffix'] == FIFF.FIFFV_POINT_CARDINAL}
     if landmarks:
         if FIFF.FIFFV_POINT_NASION in landmarks:
             coords['NAS'] = landmarks[FIFF.FIFFV_POINT_NASION]['r'].tolist()

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -88,7 +88,7 @@ def _get_ch_type_mapping(fro='mne', to='bids'):
 
 
 def _handle_kind(raw):
-    """Get suffix."""
+    """Get kind."""
     if 'eeg' in raw and ('ecog' in raw or 'seeg' in raw):
         raise ValueError('Both EEG and iEEG channels found in data.'
                          'There is currently no specification on how'
@@ -291,7 +291,7 @@ def _extract_landmarks(dig):
     """Extract NAS, LPA, and RPA from raw.info['dig']."""
     coords = dict()
     landmarks = {d['ident']: d for d in dig
-                 if d['suffix'] == FIFF.FIFFV_POINT_CARDINAL}
+                 if d['kind'] == FIFF.FIFFV_POINT_CARDINAL}
     if landmarks:
         if FIFF.FIFFV_POINT_NASION in landmarks:
             coords['NAS'] = landmarks[FIFF.FIFFV_POINT_NASION]['r'].tolist()

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -193,7 +193,7 @@ def _events_tsv(events, raw, fname, trial_type, overwrite=False,
     _write_tsv(fname, data, overwrite, verbose)
 
 
-def _readme(kind, fname, overwrite=False, verbose=True):
+def _readme(modality, fname, overwrite=False, verbose=True):
     """Create a README file and save it.
 
     This will write a README file containing an MNE-BIDS citation.
@@ -202,7 +202,7 @@ def _readme(kind, fname, overwrite=False, verbose=True):
 
     Parameters
     ----------
-    kind : string
+    modality : string
         The type of data contained in the raw file ('meg', 'eeg', 'ieeg')
     fname : str | BIDSPath
         Filename to save the README to.
@@ -219,16 +219,16 @@ def _readme(kind, fname, overwrite=False, verbose=True):
         with open(fname, 'r') as fid:
             orig_data = fid.read()
         mne_bids_ref = REFERENCES['mne-bids'] in orig_data
-        kind_ref = REFERENCES[kind] in orig_data
-        if mne_bids_ref and kind_ref:
+        modality_ref = REFERENCES[modality] in orig_data
+        if mne_bids_ref and modality_ref:
             return
         text = '{}References\n----------\n{}{}'.format(
             orig_data + '\n\n',
             '' if mne_bids_ref else REFERENCES['mne-bids'] + '\n\n',
-            '' if kind_ref else REFERENCES[kind] + '\n')
+            '' if modality_ref else REFERENCES[modality] + '\n')
     else:
         text = 'References\n----------\n{}{}'.format(
-            REFERENCES['mne-bids'] + '\n\n', REFERENCES[kind] + '\n')
+            REFERENCES['mne-bids'] + '\n\n', REFERENCES[modality] + '\n')
 
     _write_text(fname, text, overwrite=True, verbose=verbose)
 
@@ -565,13 +565,13 @@ def _sidecar_json(raw, task, manufacturer, fname, modality, overwrite=False,
     # Stitch together the complete JSON dictionary
     ch_info_json = ch_info_json_common
     if modality == 'meg':
-        append_kind_json = ch_info_json_meg
+        append_modality_json = ch_info_json_meg
     elif modality == 'eeg':
-        append_kind_json = ch_info_json_eeg
+        append_modality_json = ch_info_json_eeg
     elif modality == 'ieeg':
-        append_kind_json = ch_info_json_ieeg
+        append_modality_json = ch_info_json_ieeg
 
-    ch_info_json += append_kind_json
+    ch_info_json += append_modality_json
     ch_info_json += ch_info_ch_counts
     ch_info_json = OrderedDict(ch_info_json)
 
@@ -1076,9 +1076,9 @@ def write_raw_bids(raw, bids_basename, bids_root, events_data=None,
             _write_dig_bids(electrodes_fname, coordsystem_fname, data_path,
                             raw, modality, overwrite, verbose)
     else:
-        logger.warning('Writing of electrodes.tsv '
-                       'is not supported for suffix "{}". '
-                       'Skipping ...'.format(modality))
+        logger.warning(f'Writing of electrodes.tsv '
+                       f'is not supported for modality "{modality}". '
+                       f'Skipping ...')
 
     events, event_id = _read_events(events_data, event_id, raw, ext,
                                     verbose=verbose)

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -462,11 +462,12 @@ def _mri_landmarks_to_mri_voxels(mri_landmarks, t1_mgh):
     return mri_landmarks
 
 
-def _sidecar_json(raw, task, manufacturer, fname, kind, overwrite=False,
+def _sidecar_json(raw, task, manufacturer, fname, modality, overwrite=False,
                   verbose=True):
     """Create a sidecar json file depending on the suffix and save it.
 
-    The sidecar json file provides meta data about the data of a certain suffix.
+    The sidecar json file provides meta data about the data
+    of a certain modality.
 
     Parameters
     ----------
@@ -479,7 +480,7 @@ def _sidecar_json(raw, task, manufacturer, fname, kind, overwrite=False,
         coordinate system for the MEG sensors.
     fname : str | BIDSPath
         Filename to save the sidecar json to.
-    kind : str
+    modality : str
         Type of the data as in ALLOWED_ELECTROPHYSIO_MODALITY.
     overwrite : bool
         Whether to overwrite the existing file.
@@ -511,25 +512,25 @@ def _sidecar_json(raw, task, manufacturer, fname, kind, overwrite=False,
     # all ignored channels are trigger channels at the moment...
 
     n_megchan = len([ch for ch in raw.info['chs']
-                     if ch['suffix'] == FIFF.FIFFV_MEG_CH])
+                     if ch['kind'] == FIFF.FIFFV_MEG_CH])
     n_megrefchan = len([ch for ch in raw.info['chs']
-                        if ch['suffix'] == FIFF.FIFFV_REF_MEG_CH])
+                        if ch['kind'] == FIFF.FIFFV_REF_MEG_CH])
     n_eegchan = len([ch for ch in raw.info['chs']
-                     if ch['suffix'] == FIFF.FIFFV_EEG_CH])
+                     if ch['kind'] == FIFF.FIFFV_EEG_CH])
     n_ecogchan = len([ch for ch in raw.info['chs']
-                      if ch['suffix'] == FIFF.FIFFV_ECOG_CH])
+                      if ch['kind'] == FIFF.FIFFV_ECOG_CH])
     n_seegchan = len([ch for ch in raw.info['chs']
-                      if ch['suffix'] == FIFF.FIFFV_SEEG_CH])
+                      if ch['kind'] == FIFF.FIFFV_SEEG_CH])
     n_eogchan = len([ch for ch in raw.info['chs']
-                     if ch['suffix'] == FIFF.FIFFV_EOG_CH])
+                     if ch['kind'] == FIFF.FIFFV_EOG_CH])
     n_ecgchan = len([ch for ch in raw.info['chs']
-                     if ch['suffix'] == FIFF.FIFFV_ECG_CH])
+                     if ch['kind'] == FIFF.FIFFV_ECG_CH])
     n_emgchan = len([ch for ch in raw.info['chs']
-                     if ch['suffix'] == FIFF.FIFFV_EMG_CH])
+                     if ch['kind'] == FIFF.FIFFV_EMG_CH])
     n_miscchan = len([ch for ch in raw.info['chs']
-                      if ch['suffix'] == FIFF.FIFFV_MISC_CH])
+                      if ch['kind'] == FIFF.FIFFV_MISC_CH])
     n_stimchan = len([ch for ch in raw.info['chs']
-                      if ch['suffix'] == FIFF.FIFFV_STIM_CH]) - n_ignored
+                      if ch['kind'] == FIFF.FIFFV_STIM_CH]) - n_ignored
 
     # Define modality-specific JSON dictionaries
     ch_info_json_common = [
@@ -565,11 +566,11 @@ def _sidecar_json(raw, task, manufacturer, fname, kind, overwrite=False,
 
     # Stitch together the complete JSON dictionary
     ch_info_json = ch_info_json_common
-    if kind == 'meg':
+    if modality == 'meg':
         append_kind_json = ch_info_json_meg
-    elif kind == 'eeg':
+    elif modality == 'eeg':
         append_kind_json = ch_info_json_eeg
-    elif kind == 'ieeg':
+    elif modality == 'ieeg':
         append_kind_json = ch_info_json_ieeg
 
     ch_info_json += append_kind_json
@@ -980,7 +981,7 @@ def write_raw_bids(raw, bids_basename, bids_root, events_data=None,
                                  "session date.")
 
     data_path = make_bids_folders(subject=subject_id, session=session_id,
-                                  kind=kind, bids_root=bids_root,
+                                  modality=kind, bids_root=bids_root,
                                   overwrite=False, verbose=verbose)
     if session_id is None:
         ses_path = os.sep.join(data_path.split(os.sep)[:-1])

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -35,7 +35,7 @@ from mne_bids.dig import _write_dig_bids, _coordsystem_json
 from mne_bids.utils import (_write_json, _write_tsv, _write_text,
                             _read_events, _age_on_date,
                             _infer_eeg_placement_scheme,
-                            _handle_kind, _get_ch_type_mapping,
+                            _handle_modality, _get_ch_type_mapping,
                             _check_anonymize, _stamp_to_dt)
 from mne_bids import make_bids_folders
 from mne_bids.path import (BIDSPath, _parse_ext, _mkdir_p, _path_to_str,
@@ -92,8 +92,6 @@ def _channels_tsv(raw, fname, overwrite=False, verbose=True):
     get_specific = ('mag', 'ref_meg', 'grad')
 
     # get the manufacturer from the file in the Raw object
-    manufacturer = None
-
     _, ext = _parse_ext(raw.filenames[0], verbose=verbose)
     manufacturer = MANUFACTURERS[ext]
 
@@ -960,9 +958,11 @@ def write_raw_bids(raw, bids_basename, bids_root, events_data=None,
     subject_id, session_id = bids_basename.subject, bids_basename.session
     task, run = bids_basename.task, bids_basename.run
     acquisition, space = bids_basename.acquisition, bids_basename.space
-    kind = _handle_kind(raw)
+    modality = _handle_modality(raw)
 
-    bids_fname = bids_basename.copy().update(kind=kind, extension=ext)
+    bids_fname = bids_basename.copy().update(modality=modality,
+                                             suffix=modality,
+                                             extension=ext)
 
     # check whether the info provided indicates that the data is emptyroom
     # data
@@ -981,7 +981,7 @@ def write_raw_bids(raw, bids_basename, bids_root, events_data=None,
                                  "session date.")
 
     data_path = make_bids_folders(subject=subject_id, session=session_id,
-                                  modality=kind, bids_root=bids_root,
+                                  modality=modality, bids_root=bids_root,
                                   overwrite=False, verbose=verbose)
     if session_id is None:
         ses_path = os.sep.join(data_path.split(os.sep)[:-1])
@@ -1005,12 +1005,12 @@ def write_raw_bids(raw, bids_basename, bids_root, events_data=None,
 
     # create *_coordsystem.json
     bids_path.update(acquisition=acquisition, space=space,
-                     prefix=data_path, kind='coordsystem',
-                     extension='.json')
+                     prefix=data_path, modality=modality,
+                     suffix='coordsystem', extension='.json')
     coordsystem_fname = str(bids_path)
 
     # create *_electrodes.tsv
-    bids_path = bids_path.update(kind='electrodes',
+    bids_path = bids_path.update(suffix='electrodes',
                                  extension='.tsv')
     electrodes_fname = str(bids_path)
 
@@ -1021,12 +1021,12 @@ def write_raw_bids(raw, bids_basename, bids_root, events_data=None,
                                                              'json')
 
     sidecar_fname = bids_fname.copy().update(prefix=data_path,
-                                             kind=kind,
+                                             suffix=modality,
                                              extension='.json')
 
-    events_fname = sidecar_fname.copy().update(kind='events',
+    events_fname = sidecar_fname.copy().update(suffix='events',
                                                extension='.tsv')
-    channels_fname = sidecar_fname.copy().update(kind='channels',
+    channels_fname = sidecar_fname.copy().update(suffix='channels',
                                                  extension='.tsv')
 
     if ext not in ['.fif', '.ds', '.vhdr', '.edf', '.bdf', '.set', '.con',
@@ -1040,12 +1040,12 @@ def write_raw_bids(raw, bids_basename, bids_root, events_data=None,
         daysback, keep_his = _check_anonymize(anonymize, raw, ext)
         raw.anonymize(daysback=daysback, keep_his=keep_his, verbose=verbose)
 
-        if kind == 'meg' and ext != '.fif':
+        if modality == 'meg' and ext != '.fif':
             if verbose:
                 warn('Converting to FIF for anonymization')
             convert = True
             bids_fname.update(extension='.fif')
-        elif kind in ['eeg', 'ieeg'] and ext != '.vhdr':
+        elif modality in ['eeg', 'ieeg'] and ext != '.vhdr':
             if verbose:
                 warn('Converting to BV for anonymization')
             convert = True
@@ -1057,7 +1057,7 @@ def write_raw_bids(raw, bids_basename, bids_root, events_data=None,
     manufacturer = MANUFACTURERS.get(ext, 'n/a')
 
     # save all participants meta data and readme file
-    _readme(kind, readme_fname, overwrite, verbose)
+    _readme(modality, readme_fname, overwrite, verbose)
 
     # save all participants meta data
     _participants_tsv(raw, subject_id, participants_tsv_fname, overwrite,
@@ -1065,20 +1065,20 @@ def write_raw_bids(raw, bids_basename, bids_root, events_data=None,
     _participants_json(participants_json_fname, True, verbose)
 
     # for MEG, we only write coordinate system
-    if kind == 'meg' and not emptyroom:
+    if modality == 'meg' and not emptyroom:
         _coordsystem_json(raw, unit, orient,
-                          manufacturer, coordsystem_fname, kind,
+                          manufacturer, coordsystem_fname, modality,
                           overwrite, verbose)
-    elif kind in ['eeg', 'ieeg']:
+    elif modality in ['eeg', 'ieeg']:
         # We only write electrodes.tsv and accompanying coordsystem.json
         # if we have an available DigMontage
         if raw.info['dig'] is not None and raw.info['dig']:
             _write_dig_bids(electrodes_fname, coordsystem_fname, data_path,
-                            raw, kind, overwrite, verbose)
+                            raw, modality, overwrite, verbose)
     else:
         logger.warning('Writing of electrodes.tsv '
                        'is not supported for suffix "{}". '
-                       'Skipping ...'.format(kind))
+                       'Skipping ...'.format(modality))
 
     events, event_id = _read_events(events_data, event_id, raw, ext,
                                     verbose=verbose)
@@ -1088,7 +1088,7 @@ def write_raw_bids(raw, bids_basename, bids_root, events_data=None,
     make_dataset_description(bids_root, name=" ", overwrite=overwrite,
                              verbose=verbose)
 
-    _sidecar_json(raw, task, manufacturer, sidecar_fname, kind, overwrite,
+    _sidecar_json(raw, task, manufacturer, sidecar_fname, modality, overwrite,
                   verbose)
     _channels_tsv(raw, channels_fname, overwrite, verbose)
 
@@ -1105,9 +1105,9 @@ def write_raw_bids(raw, bids_basename, bids_root, events_data=None,
     # If not already converting for anonymization, we may still need to do it
     # if current format not BIDS compliant
     if not convert:
-        convert = ext not in ALLOWED_MODALITY_EXTENSIONS[kind]
+        convert = ext not in ALLOWED_MODALITY_EXTENSIONS[modality]
 
-    if kind == 'meg' and convert and not anonymize:
+    if modality == 'meg' and convert and not anonymize:
         raise ValueError(f"Got file extension {convert} for MEG data, "
                          f"expected one of "
                          f"{ALLOWED_MODALITY_EXTENSIONS['meg']}")
@@ -1117,14 +1117,14 @@ def write_raw_bids(raw, bids_basename, bids_root, events_data=None,
 
     # File saving branching logic
     if convert:
-        if kind == 'meg':
+        if modality == 'meg':
             if ext == '.pdf':
                 bids_fname = op.join(data_path, op.basename(bids_fname))
             _write_raw_fif(raw, bids_fname)
         else:
             if verbose:
                 warn('Converting data files to BrainVision format')
-            bids_fname.update(kind=kind, extension='.vhdr')
+            bids_fname.update(suffix=modality, extension='.vhdr')
             _write_raw_brainvision(raw, bids_fname, events)
     elif ext == '.fif':
         _write_raw_fif(raw, bids_fname)
@@ -1147,7 +1147,7 @@ def write_raw_bids(raw, bids_basename, bids_root, events_data=None,
         sh.copyfile(raw_fname, bids_fname)
 
     # write to the scans.tsv file the output file written
-    scan_relative_fpath = op.join(kind, op.basename(bids_fname))
+    scan_relative_fpath = op.join(modality, op.basename(bids_fname))
     _scans_tsv(raw, scan_relative_fpath, scans_fname, overwrite, verbose)
     if verbose:
         print(f'Wrote {scans_fname} entry with {scan_relative_fpath}.')

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -464,9 +464,9 @@ def _mri_landmarks_to_mri_voxels(mri_landmarks, t1_mgh):
 
 def _sidecar_json(raw, task, manufacturer, fname, kind, overwrite=False,
                   verbose=True):
-    """Create a sidecar json file depending on the kind and save it.
+    """Create a sidecar json file depending on the suffix and save it.
 
-    The sidecar json file provides meta data about the data of a certain kind.
+    The sidecar json file provides meta data about the data of a certain suffix.
 
     Parameters
     ----------
@@ -480,7 +480,7 @@ def _sidecar_json(raw, task, manufacturer, fname, kind, overwrite=False,
     fname : str | BIDSPath
         Filename to save the sidecar json to.
     kind : str
-        Type of the data as in ALLOWED_MODALITY_KINDS.
+        Type of the data as in ALLOWED_ELECTROPHYSIO_MODALITY.
     overwrite : bool
         Whether to overwrite the existing file.
         Defaults to False.
@@ -511,25 +511,25 @@ def _sidecar_json(raw, task, manufacturer, fname, kind, overwrite=False,
     # all ignored channels are trigger channels at the moment...
 
     n_megchan = len([ch for ch in raw.info['chs']
-                     if ch['kind'] == FIFF.FIFFV_MEG_CH])
+                     if ch['suffix'] == FIFF.FIFFV_MEG_CH])
     n_megrefchan = len([ch for ch in raw.info['chs']
-                        if ch['kind'] == FIFF.FIFFV_REF_MEG_CH])
+                        if ch['suffix'] == FIFF.FIFFV_REF_MEG_CH])
     n_eegchan = len([ch for ch in raw.info['chs']
-                     if ch['kind'] == FIFF.FIFFV_EEG_CH])
+                     if ch['suffix'] == FIFF.FIFFV_EEG_CH])
     n_ecogchan = len([ch for ch in raw.info['chs']
-                      if ch['kind'] == FIFF.FIFFV_ECOG_CH])
+                      if ch['suffix'] == FIFF.FIFFV_ECOG_CH])
     n_seegchan = len([ch for ch in raw.info['chs']
-                      if ch['kind'] == FIFF.FIFFV_SEEG_CH])
+                      if ch['suffix'] == FIFF.FIFFV_SEEG_CH])
     n_eogchan = len([ch for ch in raw.info['chs']
-                     if ch['kind'] == FIFF.FIFFV_EOG_CH])
+                     if ch['suffix'] == FIFF.FIFFV_EOG_CH])
     n_ecgchan = len([ch for ch in raw.info['chs']
-                     if ch['kind'] == FIFF.FIFFV_ECG_CH])
+                     if ch['suffix'] == FIFF.FIFFV_ECG_CH])
     n_emgchan = len([ch for ch in raw.info['chs']
-                     if ch['kind'] == FIFF.FIFFV_EMG_CH])
+                     if ch['suffix'] == FIFF.FIFFV_EMG_CH])
     n_miscchan = len([ch for ch in raw.info['chs']
-                      if ch['kind'] == FIFF.FIFFV_MISC_CH])
+                      if ch['suffix'] == FIFF.FIFFV_MISC_CH])
     n_stimchan = len([ch for ch in raw.info['chs']
-                      if ch['kind'] == FIFF.FIFFV_STIM_CH]) - n_ignored
+                      if ch['suffix'] == FIFF.FIFFV_STIM_CH]) - n_ignored
 
     # Define modality-specific JSON dictionaries
     ch_info_json_common = [
@@ -998,7 +998,7 @@ def write_raw_bids(raw, bids_basename, bids_root, events_data=None,
 
     # create *_scans.tsv
     bids_path = BIDSPath(subject=subject_id, session=session_id,
-                         prefix=ses_path, kind='scans', extension='.tsv',
+                         prefix=ses_path, suffix='scans', extension='.tsv',
                          task=None)
     scans_fname = str(bids_path)
 
@@ -1076,7 +1076,7 @@ def write_raw_bids(raw, bids_basename, bids_root, events_data=None,
                             raw, kind, overwrite, verbose)
     else:
         logger.warning('Writing of electrodes.tsv '
-                       'is not supported for kind "{}". '
+                       'is not supported for suffix "{}". '
                        'Skipping ...'.format(kind))
 
     events, event_id = _read_events(events_data, event_id, raw, ext,
@@ -1268,7 +1268,7 @@ def write_anat(bids_root, subject, t1w, session=None, acquisition=None,
     t1w_basename = BIDSPath(subject=subject, session=session,
                             acquisition=acquisition,
                             prefix=anat_dir,
-                            kind='T1w', extension='.nii.gz')
+                            suffix='T1w', extension='.nii.gz')
 
     # Check if we have necessary conditions for writing a sidecar JSON
     if trans is not None or landmarks is not None:

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ filterwarnings =
     ignore:Converting to FIF for anonymization:RuntimeWarning
     ignore:Converting to BV for anonymization:RuntimeWarning
     ignore:Converting data files to BrainVision format:RuntimeWarning
-    ignore:Writing of electrodes.tsv is not supported for kind.*:RuntimeWarning
+    ignore:Writing of electrodes.tsv is not supported for modality.*:RuntimeWarning
     ignore:numpy.ufunc size changed.*:RuntimeWarning
     ignore:tostring\(\) is deprecated.*:DeprecationWarning
 


### PR DESCRIPTION
PR Description
--------------

Closes: #509 

Addresses part 2 of PR for #511 as described here: https://github.com/mne-tools/mne-bids/pull/492#issuecomment-678891024

Most changes are kwarg changes:

1. Changes `kind` -> `suffix` and add `modality`. I think there can be some auto-assumptions like:
- if `suffix = 'meg' (or eeg or ieeg)`, then `modality` is the same
2. Changed the private functions and naming of some private functions to reflect that change.

**Should I just change `prefix` to `bids_root` right now, to lessen the diff in the next PR?**

**Next PR**
- Sub out `get_bids_fname` for the `fpath` functionality.

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
- [ ] Commit history does not contain any merge commits
