### PR TITLE
Add check kwarg to BIDSPath.update()

### DIFF
--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -73,9 +73,10 @@ class BIDSPath(object):
     Attributes
     ----------
     check : bool
-        If True enforces the entities to be valid according to the
-        current BIDS standard. The check is performed on instantiation
-        and any ``update`` function calls.
+        If ``True``, enforces the entities to be valid according to the
+        BIDS specification. The check is performed on instantiation
+        and any ``update`` function calls (and may be overridden in the
+        latter).
 
     Examples
     --------
@@ -230,11 +231,18 @@ class BIDSPath(object):
 
         return bids_fname
 
-    def update(self, **entities):
+    def update(self, check=None, **entities):
         """Update inplace BIDS entity key/value pairs in object.
 
         Parameters
         ----------
+        check : None | bool
+            If a boolean, controls whether to enforce the entities to be valid
+            according to the BIDS specification. This will set the
+            ``.check`` attribute accordingly. If ``None``, rely on the existing
+            ``.check`` attribute instead, which is set upon ``BIDSPath``
+            instantiation. Defaults to ``None``.
+
         entities : dict | kwarg
             Allowed BIDS path entities:
             'subject', 'session', 'task', 'acquisition',
@@ -297,7 +305,9 @@ class BIDSPath(object):
                 val = str(val)
             setattr(self, key, val)
 
-        # perform a check of the entities
+        # Update .check attribute and perform a check of the entities.
+        if check is not None:
+            self.check = check
         self._check()
         return self
 

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -214,8 +214,7 @@ class BIDSPath(object):
                    'automatically inferred because no bids_root was passed.')
             raise ValueError(msg)
 
-        bids_basename = self.copy()
-        bids_basename.check = False
+        bids_basename = self.copy().update(check=False)
 
         if extension is None:
             # since kind is passed in, use that
@@ -571,9 +570,7 @@ def _find_matching_sidecar(bids_fname, bids_root, kind=None,
         suffix = suffix + kind
 
         # do not search for kind if kind is explicitly passed
-        bids_fname = bids_fname.copy()
-        bids_fname.check = False
-        bids_fname.update(kind=None)
+        bids_fname = bids_fname.copy().update(kind=None, check=False)
 
     if extension is not None:
         suffix = suffix + extension

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -319,10 +319,16 @@ def test_bids_path(return_bids_test_dir):
         BIDSPath(subject=subject_id, session=session_id,
                  kind=kind)
 
-    # do not error check kind in update (not deep check)
+    # error check kind in update (deep check)
     error_kind = 'foobar'
     with pytest.raises(ValueError, match=f'Kind {error_kind} is not'):
         bids_basename.update(kind=error_kind)
+
+    # disable check in update by setting check=False
+    error_kind = 'foobar'
+    bids_basename = BIDSPath(subject=subject_id, session=session_id, run=run,
+                             acquisition=acq, task=task)
+    bids_basename.update(kind=error_kind, check=False)
 
     # does not error check on kind in BIDSPath (deep check)
     kind = 'meeg'
@@ -337,7 +343,7 @@ def test_bids_path(return_bids_test_dir):
         BIDSPath(subject=subject_id, session=session_id,
                  extension=extension)
 
-    # do not error extension in update (not deep check)
+    # do not error check extension in update (not deep check)
     bids_basename.update(extension='.foo')
 
     # test repr


### PR DESCRIPTION
PR Description
--------------

This allows to disable the deep check upon an update, even if the `BIDSPath` instance we want to update was created with `check=True`.

This can simplify code from:

```python
    updated_path = path.copy()
    updated_path.check = False
    updated_path.update(kind='invalid')

```
to

```python
    updated_path = path.copy().update(kind='invalid', check=False)
```


Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
- [ ] Commit history does not contain any merge commits
