### PR TITLE
[MRG] Fix empty-room handling

### DIFF
--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -481,12 +481,13 @@ def get_matched_empty_room(bids_basename, bids_root):
                     (not item.suffix and item.is_dir())):  # Hopefully BTi?
                 candidate_er_fnames.append(item.name)
 
-    # Walk through recordings, trying to extract the recording date from the
-    # filename.
+    # Walk through recordings, trying to extract the recording date:
+    # First, from the filename; and if that fails, from `info['meas_date']`.
     best_er_basename = None
     min_delta_t = np.inf
     date_tie = False
 
+    failed_to_get_er_date_count = 0
     for er_fname in candidate_er_fnames:
         params = get_entities_from_fname(er_fname)
         er_meas_date = None
@@ -501,10 +502,24 @@ def get_matched_empty_room(bids_basename, bids_root):
             except (ValueError, TypeError):
                 # There is a session in the filename, but it doesn't encode a
                 # valid date.
-                msg = (f'Encountered an invalid empty-room session: '
-                       f'{params["session"]}. Empty-room sessions must be in '
-                       f'the form of: YYYYMMDD. Please fix your BIDS dataset.')
-                raise RuntimeError(msg)
+                pass
+
+        if er_meas_date is None:  # No luck so far! Check info['meas_date']
+            _, ext = _parse_ext(er_fname)
+            if ext == '.fif':
+                extra_params = dict(allow_maxshield=True)
+            else:
+                extra_params = None
+
+            er_raw = read_raw_bids(bids_basename=er_bids_path,
+                                   bids_root=bids_root,
+                                   kind=kind,
+                                   extra_params=extra_params)
+
+            er_meas_date = er_raw.info['meas_date']
+            if er_meas_date is None:  # There's nothing we can do.
+                failed_to_get_er_date_count += 1
+                continue
 
         er_meas_date = er_meas_date.replace(tzinfo=ref_date.tzinfo)
         delta_t = er_meas_date - ref_date
@@ -515,6 +530,11 @@ def get_matched_empty_room(bids_basename, bids_root):
             min_delta_t = abs(delta_t.total_seconds())
             best_er_basename = er_bids_path.basename
             date_tie = False
+
+    if failed_to_get_er_date_count > 0:
+        msg = (f'Could not retrieve the empty-room measurement date from '
+               f'a total of {failed_to_get_er_date_count} recording(s).')
+        warn(msg)
 
     if date_tie:
         msg = ('Found more than one matching empty-room measurement with the '

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -375,10 +375,7 @@ def test_make_filenames():
     with pytest.raises(ValueError, match='At least one'):
         BIDSPath()
 
-    # emptyroom checks
-    with pytest.raises(ValueError, match='empty-room session should be a '
-                                         'string of format YYYYMMDD'):
-        BIDSPath(subject='emptyroom', session='12345', task='noise')
+    # emptyroom check: invalid task
     with pytest.raises(ValueError, match='task must be'):
         BIDSPath(subject='emptyroom', session='20131201',
                  task='blah', kind='meg')

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -6,6 +6,7 @@ import json
 import os
 import os.path as op
 from datetime import datetime, timezone
+from distutils.version import LooseVersion
 from pathlib import Path
 
 import pytest
@@ -623,39 +624,6 @@ def test_get_matched_empty_room():
         get_matched_empty_room(bids_basename=bids_basename,
                                bids_root=bids_root)
 
-    # Raise upon invalid session.
-    er_session = 'invalid'
-    with pytest.raises(ValueError, match='.*should be a string of format'):
-        BIDSPath(subject='emptyroom', session=er_session, task='noise',
-                 kind='meg')
-
-    # Create an ER-file with a naming scheme violating BIDS, and check that
-    # we raise upon invoking get_matched_empty_room().
-
-    # First write the empty-room file.
-    er_raw = _read_raw_fif(er_raw_fname)
-    er_meas_date = (datetime.strptime('20200825', '%Y%m%d')
-                    .replace(tzinfo=timezone.utc))
-    er_raw.set_meas_date(er_meas_date)
-    kws = dict(subject='emptyroom', session='invalid', kind='meg')
-    er_basename = BIDSPath(**kws, task='noise', extension='.fif',
-                           prefix=bids_root, check=False)
-    er_ses_dir = make_bids_folders(**kws, bids_root=bids_root, make_dir=True)
-    er_raw.save(op.join(er_ses_dir, er_basename.basename))
-
-    # Now add a matching raw file.
-    raw = _read_raw_fif(raw_fname)
-    raw.set_meas_date(er_meas_date)
-    raw_basename = BIDSPath(subject='01', session='01', task='audiovisual',
-                            run='01', kind='meg')
-    write_raw_bids(raw, raw_basename, bids_root, overwrite=True)
-
-    # When searching for the empty-room file matching the raw, we should
-    # encounter the invalid ER naming and raise.
-    with pytest.raises(RuntimeError, match='invalid empty-room session'):
-        get_matched_empty_room(bids_basename=raw_basename,
-                               bids_root=bids_root)
-
 
 @pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
 def test_get_matched_emptyroom_ties():
@@ -691,6 +659,40 @@ def test_get_matched_emptyroom_ties():
     er_raw.save(op.join(er_dir, f'{er_basename_2}_meg.fif'))
 
     with pytest.warns(RuntimeWarning, match='Found more than one'):
+        get_matched_empty_room(bids_basename=bids_basename,
+                               bids_root=bids_root)
+
+
+@pytest.mark.skipif(LooseVersion(mne.__version__) < LooseVersion('0.21'),
+                    reason="requires mne 0.21.dev0 or higher")
+@pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
+def test_get_matched_emptyroom_no_meas_date():
+    """Test that we warn if measurement date can be read or inferred."""
+    bids_root = _TempDir()
+    er_session = 'mysession'
+    er_meas_date = None
+
+    er_dir = make_bids_folders(subject='emptyroom', session=er_session,
+                               kind='meg', bids_root=bids_root)
+    er_bids_path = BIDSPath(subject='emptyroom', session=er_session,
+                            task='noise', check=False)
+    er_basename = str(er_bids_path)
+    raw = _read_raw_fif(raw_fname)
+
+    er_raw_fname = op.join(data_path, 'MEG', 'sample', 'ernoise_raw.fif')
+    raw.copy().crop(0, 10).save(er_raw_fname, overwrite=True)
+    er_raw = _read_raw_fif(er_raw_fname)
+    er_raw.set_meas_date(er_meas_date)
+    er_raw.save(op.join(er_dir, f'{er_basename}_meg.fif'), overwrite=True)
+
+    # Write raw file data using mne-bids, and remove participants.tsv
+    # as it's incomplete (doesn't contain the emptyroom subject we wrote
+    # manually using MNE's Raw.save() above)
+    raw = _read_raw_fif(raw_fname)
+    write_raw_bids(raw, bids_basename, bids_root, overwrite=True)
+    os.remove(op.join(bids_root, 'participants.tsv'))
+
+    with pytest.warns(RuntimeWarning, match='Could not retrieve .* date'):
         get_matched_empty_room(bids_basename=bids_basename,
                                bids_root=bids_root)
 

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -331,8 +331,7 @@ def _scale_coord_to_meters(coord, unit):
         return coord
 
 
-def _check_empty_room_basename(bids_path, on_invalid_er_session='raise',
-                               on_invalid_er_task='raise'):
+def _check_empty_room_basename(bids_path, on_invalid_er_task='raise'):
     # only check task entity for emptyroom when it is the sidecar/MEG file
     if bids_path.kind == 'meg':
         if bids_path.task != 'noise':
@@ -344,19 +343,6 @@ def _check_empty_room_basename(bids_path, on_invalid_er_session='raise',
                 logger.critical(msg)
             else:
                 pass
-    try:
-        datetime.strptime(bids_path.session, '%Y%m%d')
-    except (ValueError, TypeError):
-        msg = (f'empty-room session should be a string of format '
-               f'YYYYMMDD, but received: {bids_path.session}')
-        if on_invalid_er_session == 'raise':
-            raise ValueError(msg)
-        elif on_invalid_er_session == 'warn':
-            msg = (f'{msg}. Will proceed anyway, but you should consider '
-                   f'fixing your dataset.')
-            logger.critical(msg)
-        else:
-            pass
 
 
 def _check_anonymize(anonymize, raw, ext):

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -977,7 +977,7 @@ def write_raw_bids(raw, bids_basename, bids_root, events_data=None,
             er_date = meas_date.strftime('%Y%m%d')
             if er_date != session_id:
                 raise ValueError("Date provided for session doesn't match "
-                                 "measurement date.")
+                                 "session date.")
 
     data_path = make_bids_folders(subject=subject_id, session=session_id,
                                   kind=kind, bids_root=bids_root,


### PR DESCRIPTION
PR Description
--------------

Turns out, empty-room recording sessions SHOULD be the recording date, but not MUST.

This reverts e7e25c87ea36bfd58647385e0f85f21e91496f97 of GH-511

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
- [ ] Commit history does not contain any merge commits
