### PR TITLE
[MRG] Replace get_bids_fname func for fpath in BIDSPath and root for prefix

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -77,7 +77,6 @@ API
 - Add ``check`` parameter and attribute to :class:`mne_bids.BIDSPath` that allows users to turn off entity checks by `Adam Li`_ (`#511 <https://github.com/mne-tools/mne-bids/pull/511>`_)
 - Add ``modality`` parameter and attribute to :class:`mne_bids.BIDSPath` that allows users to specify EEG, MEG, or iEEG datasets by `Adam Li`_ (`#514 <https://github.com/mne-tools/mne-bids/pull/514>`_)
 - Add ``modality`` to replace ``kind`` parameter to :func:`mne_bids.make_bids_folders` and :func:`mne_bids.read_raw_bids` that allows users to specify EEG, MEG, or iEEG datasets by `Adam Li`_ (`#514 <https://github.com/mne-tools/mne-bids/pull/514>`_)
-- The :class:`mne_bids.path.BIDSPath` object now stores the `basename` and `root` of the path, and replaces ``root`` for ``prefix`` kwarg, and can get the full file path of a dataset using the ``fpath`` property by `Adam Li`_ (`#515 <https://github.com/mne-tools/mne-bids/pull/446>`_, `#492 <https://github.com/mne-tools/mne-bids/pull/515>`_)
 
 .. _changes_0_4:
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -36,7 +36,7 @@ Changelog
 - :func:`mne_bids.read_raw_bids` and :func:`mne_bids.write_raw_bids` now map respiratory (``RESP``) channel types, by `Richard Höchenberger`_ (`#482 <https://github.com/mne-tools/mne-bids/pull/482>`_)
 - When impedance values are available from a ``raw.impedances`` attribute, MNE-BIDS will now write an ``impedance`` column to ``*_electrodes.tsv`` files, by `Stefan Appelhoff`_ (`#484 <https://github.com/mne-tools/mne-bids/pull/484>`_)
 - :func:`mne_bids.write_raw_bids` writes out status_description with 'n/a' values into the channels.tsv sidecar file, by `Adam Li`_ (`#489 <https://github.com/mne-tools/mne-bids/pull/489>`_)
-- The new function :func:`mne_bids.path.get_matched_basenames` allows uers to retrieve a list of :class:`mne_bids.path.BIDSPath` objects matching a specified set of entity values in the dataset, by `Richard Höchenberger`_ (`#507 <https://github.com/mne-tools/mne-bids/pull/507>`_)
+- The new function :func:`mne_bids.path.get_matched_basenames` allows uers to retrieve a list of :class:`mne_bids.BIDSPath` objects matching a specified set of entity values in the dataset, by `Richard Höchenberger`_ (`#507 <https://github.com/mne-tools/mne-bids/pull/507>`_)
 
 Bug
 ~~~

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -77,7 +77,7 @@ API
 - Add ``check`` parameter and attribute to :class:`mne_bids.BIDSPath` that allows users to turn off entity checks by `Adam Li`_ (`#511 <https://github.com/mne-tools/mne-bids/pull/511>`_)
 - Add ``modality`` parameter and attribute to :class:`mne_bids.BIDSPath` that allows users to specify EEG, MEG, or iEEG datasets by `Adam Li`_ (`#514 <https://github.com/mne-tools/mne-bids/pull/514>`_)
 - Add ``modality`` to replace ``kind`` parameter to :func:`mne_bids.make_bids_folders` and :func:`mne_bids.read_raw_bids` that allows users to specify EEG, MEG, or iEEG datasets by `Adam Li`_ (`#514 <https://github.com/mne-tools/mne-bids/pull/514>`_)
-- The :class:`mne_bids.path.BIDSPath` object now stores the `basename` and `bids_root` of the path, and replaces ``bids_root`` for ``prefix`` kwarg, and can get the full file path of a dataset using the ``fpath`` property by `Adam Li`_ (`#515 <https://github.com/mne-tools/mne-bids/pull/446>`_, `#492 <https://github.com/mne-tools/mne-bids/pull/515>`_)
+- The :class:`mne_bids.path.BIDSPath` object now stores the `basename` and `root` of the path, and replaces ``root`` for ``prefix`` kwarg, and can get the full file path of a dataset using the ``fpath`` property by `Adam Li`_ (`#515 <https://github.com/mne-tools/mne-bids/pull/446>`_, `#492 <https://github.com/mne-tools/mne-bids/pull/515>`_)
 
 .. _changes_0_4:
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -77,7 +77,7 @@ API
 - Add ``check`` parameter and attribute to :class:`mne_bids.BIDSPath` that allows users to turn off entity checks by `Adam Li`_ (`#511 <https://github.com/mne-tools/mne-bids/pull/511>`_)
 - Add ``modality`` parameter and attribute to :class:`mne_bids.BIDSPath` that allows users to specify EEG, MEG, or iEEG datasets by `Adam Li`_ (`#514 <https://github.com/mne-tools/mne-bids/pull/514>`_)
 - Add ``modality`` to replace ``kind`` parameter to :func:`mne_bids.make_bids_folders` and :func:`mne_bids.read_raw_bids` that allows users to specify EEG, MEG, or iEEG datasets by `Adam Li`_ (`#514 <https://github.com/mne-tools/mne-bids/pull/514>`_)
-
+- The :class:`mne_bids.path.BIDSPath` object now stores the `basename` and `bids_root` of the path, and replaces ``bids_root`` for ``prefix`` kwarg, and can get the full file path of a dataset using the ``fpath`` property by `Adam Li`_ (`#515 <https://github.com/mne-tools/mne-bids/pull/446>`_, `#492 <https://github.com/mne-tools/mne-bids/pull/515>`_)
 
 .. _changes_0_4:
 

--- a/mne_bids/config.py
+++ b/mne_bids/config.py
@@ -75,6 +75,11 @@ ALLOWED_FILENAME_SUFFIX = [
     'behav', 'phsyio', 'stim'  # behavioral
 ]
 
+# converts suffix to known path modalities
+SUFFIX_TO_MODALITY = {
+    'meg': 'meg', 'eeg': 'eeg', 'ieeg': 'ieeg', 'T1w': 'anat'
+}
+
 # allowed BIDS extensions (extension in the BIDS filename)
 ALLOWED_FILENAME_EXTENSIONS = (
     allowed_extensions_meg +
@@ -89,7 +94,7 @@ ALLOWED_PATH_ENTITIES = ('subject', 'session', 'task', 'run',
                          'processing', 'recording', 'space',
                          'acquisition', 'split',
                          'suffix', 'extension',
-                         'modality', 'prefix')
+                         'modality', 'bids_root')
 ALLOWED_PATH_ENTITIES_SHORT = {'sub': 'subject', 'ses': 'session',
                                'task': 'task', 'acq': 'acquisition',
                                'run': 'run', 'proc': 'processing',

--- a/mne_bids/config.py
+++ b/mne_bids/config.py
@@ -77,7 +77,8 @@ ALLOWED_FILENAME_SUFFIX = [
 
 # converts suffix to known path modalities
 SUFFIX_TO_MODALITY = {
-    'meg': 'meg', 'eeg': 'eeg', 'ieeg': 'ieeg', 'T1w': 'anat'
+    'meg': 'meg', 'eeg': 'eeg', 'ieeg': 'ieeg', 'T1w': 'anat',
+    'headshape': 'meg', 'digitizer': 'meg', 'markers': 'meg'
 }
 
 # allowed BIDS extensions (extension in the BIDS filename)
@@ -94,7 +95,7 @@ ALLOWED_PATH_ENTITIES = ('subject', 'session', 'task', 'run',
                          'processing', 'recording', 'space',
                          'acquisition', 'split',
                          'suffix', 'extension',
-                         'modality', 'bids_root')
+                         'modality', 'root')
 ALLOWED_PATH_ENTITIES_SHORT = {'sub': 'subject', 'ses': 'session',
                                'task': 'task', 'acq': 'acquisition',
                                'run': 'run', 'proc': 'processing',

--- a/mne_bids/copyfiles.py
+++ b/mne_bids/copyfiles.py
@@ -23,7 +23,7 @@ import shutil as sh
 from mne.io import read_raw_brainvision, anonymize_info
 from scipy.io import loadmat, savemat
 
-from mne_bids.path import _parse_ext
+from mne_bids.path import BIDSPath, _parse_ext, _mkdir_p
 from mne_bids.utils import _get_mrk_meas_date, _check_anonymize
 
 
@@ -178,10 +178,13 @@ def copyfile_kit(src, dest, subject_id, session_id,
         Extract information of marker and headpoints
 
     """
-    from mne_bids import BIDSPath
+    # create parent directories in case it does not exist yet
+    _mkdir_p(op.dirname(dest))
+
     # KIT data requires the marker file to be copied over too
     sh.copyfile(src, dest)
     data_path = op.split(dest)[0]
+    modality = 'meg'
     if 'mrk' in _init_kwargs:
         hpi = _init_kwargs['mrk']
         acq_map = dict()
@@ -197,8 +200,8 @@ def copyfile_kit(src, dest, subject_id, session_id,
             marker_fname = BIDSPath(
                 subject=subject_id, session=session_id, task=task, run=run,
                 acquisition=key, suffix='markers', extension=marker_ext,
-                bids_root=data_path)
-            sh.copyfile(value, marker_fname)
+                modality=modality)
+            sh.copyfile(value, op.join(data_path, marker_fname.basename))
     for acq in ['elp', 'hsp']:
         if acq in _init_kwargs:
             position_file = _init_kwargs[acq]
@@ -207,8 +210,9 @@ def copyfile_kit(src, dest, subject_id, session_id,
             position_fname = BIDSPath(
                 subject=subject_id, session=session_id, task=task, run=run,
                 acquisition=acq, suffix='headshape', extension=position_ext,
-                bids_root=data_path)
-            sh.copyfile(position_file, position_fname)
+                modality=modality)
+            sh.copyfile(position_file,
+                        op.join(data_path, position_fname.basename))
 
 
 def _replace_file(fname, pattern, replace):

--- a/mne_bids/copyfiles.py
+++ b/mne_bids/copyfiles.py
@@ -197,7 +197,7 @@ def copyfile_kit(src, dest, subject_id, session_id,
             marker_fname = BIDSPath(
                 subject=subject_id, session=session_id, task=task, run=run,
                 acquisition=key, suffix='markers', extension=marker_ext,
-                prefix=data_path)
+                bids_root=data_path)
             sh.copyfile(value, marker_fname)
     for acq in ['elp', 'hsp']:
         if acq in _init_kwargs:
@@ -207,7 +207,7 @@ def copyfile_kit(src, dest, subject_id, session_id,
             position_fname = BIDSPath(
                 subject=subject_id, session=session_id, task=task, run=run,
                 acquisition=acq, suffix='headshape', extension=position_ext,
-                prefix=data_path)
+                bids_root=data_path)
             sh.copyfile(position_file, position_fname)
 
 

--- a/mne_bids/dig.py
+++ b/mne_bids/dig.py
@@ -290,7 +290,7 @@ def _coordsystem_json(raw, unit, orient, coordsystem_name, fname,
     _write_json(fname, fid_json, overwrite, verbose)
 
 
-def _write_dig_bids(electrodes_fname, coordsystem_fname, bids_root,
+def _write_dig_bids(electrodes_fname, coordsystem_fname, root,
                     raw, modality, overwrite=False, verbose=True):
     """Write BIDS formatted DigMontage from Raw instance.
 
@@ -303,7 +303,7 @@ def _write_dig_bids(electrodes_fname, coordsystem_fname, bids_root,
         Filename to save the electrodes.tsv to.
     coordsystem_fname : str
         Filename to save the coordsystem.json to.
-    bids_root : str | pathlib.Path
+    root : str | pathlib.Path
         Path to the data directory
     raw : instance of Raw
         The data as MNE-Python Raw object.
@@ -349,12 +349,12 @@ def _write_dig_bids(electrodes_fname, coordsystem_fname, bids_root,
                     subject=subject_id, session=session_id,
                     acquisition=acquisition, space=coord_frame,
                     suffix='coordsystem', extension='.json',
-                    bids_root=bids_root)
+                    root=root)
                 electrodes_fname = BIDSPath(
                     subject=subject_id, session=session_id,
                     acquisition=acquisition, space=coord_frame,
                     suffix='electrodes', extension='.tsv',
-                    bids_root=bids_root)
+                    root=root)
                 coord_frame = 'Other'
 
             # Now write the data to the elec coords and the coordsystem

--- a/mne_bids/dig.py
+++ b/mne_bids/dig.py
@@ -348,11 +348,13 @@ def _write_dig_bids(electrodes_fname, coordsystem_fname, data_path,
                 coordsystem_fname = BIDSPath(
                     subject=subject_id, session=session_id,
                     acquisition=acquisition, space=coord_frame,
-                    suffix='coordsystem', extension='.json', prefix=data_path)
+                    suffix='coordsystem', extension='.json',
+                    bids_root=data_path)
                 electrodes_fname = BIDSPath(
                     subject=subject_id, session=session_id,
                     acquisition=acquisition, space=coord_frame,
-                    suffix='electrodes', extension='.tsv', prefix=data_path)
+                    suffix='electrodes', extension='.tsv',
+                    bids_root=data_path)
                 coord_frame = 'Other'
 
             # Now write the data to the elec coords and the coordsystem

--- a/mne_bids/dig.py
+++ b/mne_bids/dig.py
@@ -290,7 +290,7 @@ def _coordsystem_json(raw, unit, orient, coordsystem_name, fname,
     _write_json(fname, fid_json, overwrite, verbose)
 
 
-def _write_dig_bids(electrodes_fname, coordsystem_fname, data_path,
+def _write_dig_bids(electrodes_fname, coordsystem_fname, bids_root,
                     raw, modality, overwrite=False, verbose=True):
     """Write BIDS formatted DigMontage from Raw instance.
 
@@ -303,7 +303,7 @@ def _write_dig_bids(electrodes_fname, coordsystem_fname, data_path,
         Filename to save the electrodes.tsv to.
     coordsystem_fname : str
         Filename to save the coordsystem.json to.
-    data_path : str | pathlib.Path
+    bids_root : str | pathlib.Path
         Path to the data directory
     raw : instance of Raw
         The data as MNE-Python Raw object.
@@ -349,12 +349,12 @@ def _write_dig_bids(electrodes_fname, coordsystem_fname, data_path,
                     subject=subject_id, session=session_id,
                     acquisition=acquisition, space=coord_frame,
                     suffix='coordsystem', extension='.json',
-                    bids_root=data_path)
+                    bids_root=bids_root)
                 electrodes_fname = BIDSPath(
                     subject=subject_id, session=session_id,
                     acquisition=acquisition, space=coord_frame,
                     suffix='electrodes', extension='.tsv',
-                    bids_root=data_path)
+                    bids_root=bids_root)
                 coord_frame = 'Other'
 
             # Now write the data to the elec coords and the coordsystem

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -188,7 +188,7 @@ class BIDSPath(object):
 
     def __str__(self):
         """Return the string representation of the path."""
-        return self.fpath
+        return str(self.fpath)
 
     def __repr__(self):
         """Representation in the style of `pathlib.Path`."""
@@ -198,7 +198,7 @@ class BIDSPath(object):
 
     def __fspath__(self):
         """Return the string representation for any fs functions."""
-        return self.fpath
+        return str(self.fpath)
 
     def __eq__(self, other):
         """Compare str representations."""
@@ -228,7 +228,7 @@ class BIDSPath(object):
 
         Returns
         -------
-        bids_fpath : str
+        bids_fpath : pathlib.Path
             Either the relative, or full path to the dataset.
         """
         # create the data path based on entities available
@@ -299,6 +299,7 @@ class BIDSPath(object):
             else:
                 bids_fpath = op.join(data_path, self.basename)
 
+        bids_fpath = Path(bids_fpath)
         return bids_fpath
 
     def update(self, check=None, **entities):

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -264,9 +264,9 @@ class BIDSPath(object):
                 matching_paths = \
                     _get_matching_bidspaths_from_filesystem(self)
 
-                # FIXME This will break e.g. with FIFF data split across multiple
-                # FIXME files.
-                # if extension is not specified and there is no unique file path
+                # FIXME This will break
+                # FIXME e.g. with FIFF data split across multiple FIXME files.
+                # if extension is not specified and no unique file path
                 # return filepath of the actual dataset for MEG/EEG/iEEG data
                 if self.suffix in ALLOWED_MODALITIES:
                     # now only use valid modality extension
@@ -441,7 +441,7 @@ class BIDSPath(object):
                 raise ValueError(f'Suffix {suffix} is not allowed. '
                                  f'Use one of these suffixes '
                                  f'{ALLOWED_FILENAME_SUFFIX}.')
-            
+
 
 def _get_matching_bidspaths_from_filesystem(bids_path):
     """Get matching file paths for a BIDS path.

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -463,7 +463,7 @@ class BIDSPath(object):
 
 def _get_matching_bidspaths_from_filesystem(bids_path):
     """Get matching file paths for a BIDS path.
-    
+
     Assumes suffix and/or extension is not provided.
     """
     # extract relevant entities to find filepath

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -86,6 +86,8 @@ class BIDSPath(object):
         ``run``, ``processing``, ``space``, ``recording`` and ``suffix``.
     basename : str
         The basename of the file path. Similar to `os.path.basename(fpath)`.
+    root : str
+        The root of the BIDS path.
     fpath : str
         The full file path.
     check : bool
@@ -96,34 +98,34 @@ class BIDSPath(object):
 
     Examples
     --------
-    >>> bids_basename = BIDSPath(subject='test', session='two', task='mytask',
+    >>> bids_path = BIDSPath(subject='test', session='two', task='mytask',
                                  suffix='ieeg', extension='.edf')
-    >>> print(bids_basename.basename)
+    >>> print(bids_path.basename)
     sub-test_ses-two_task-mytask_ieeg.edf
-    >>> bids_basename
+    >>> bids_path
     BIDSPath(root: None,
     basename: sub-test_ses-two_task-mytask_ieeg.edf)
     >>> # copy and update multiple entities at once
-    >>> new_basename = bids_basename.copy().update(subject='test2',
+    >>> new_bids_path = bids_path.copy().update(subject='test2',
                                                    session='one')
-    >>> print(new_basename.basename)
+    >>> print(new_bids_path.basename)
     sub-test2_ses-one_task-mytask_ieeg.edf
     >>> # printing the BIDSPath will show relative path when
     >>> # root is not set
-    >>> print(new_basename)
+    >>> print(new_bids_path)
     sub-test2/ses-one/ieeg/sub-test2_ses-one_task-mytask_ieeg.edf
-    >>> new_basename.update(suffix='channels', extension='.tsv')
+    >>> new_bids_path.update(suffix='channels', extension='.tsv')
     >>> # setting suffix without an identifiable modality will
     >>> # result in a wildcard at the modality directory level
-    >>> print(new_basename)
+    >>> print(new_bids_path)
     sub-test2/ses-one/*/sub-test2_ses-one_task-mytask_channels.tsv
     >>> # set a bids_root
-    >>> new_basename.update(root='/bids_dataset')
-    >>> print(new_basename.root)
+    >>> new_bids_path.update(root='/bids_dataset')
+    >>> print(new_bids_path.root)
     /bids_dataset
-    >>> print(new_basename.basename)
+    >>> print(new_bids_path.basename)
     sub-test2_ses-one_task-mytask_ieeg.edf
-    >>> print(new_basename)
+    >>> print(new_bids_path)
     /bids_dataset/sub-test2/ses-one/ieeg/sub-test2_ses-one_task-mytask_ieeg.edf
     """
 
@@ -706,7 +708,7 @@ def _find_matching_sidecar(bids_path, suffix=None,
         and no sidecar_fname was found
 
     """
-    bids_root = bids_path.bids_root
+    bids_root = bids_path.root
 
     # search suffix is BIDS-suffix and extension
     search_suffix = ''

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -302,16 +302,14 @@ class BIDSPath(object):
         - ``suffix`` should be one of:
             (``anat``, ``eeg``, ``ieeg``, ``meg``)
         - ``extension`` should be one of the accepted file
-        extensions in the file path:
-             (``.con``, ``.sqd``, ``.fif``, ``.pdf``, ``.ds``,
-              ``.vhdr``, ``.edf``, ``.bdf``, ``.set``, ``.edf``,
-              ``.set``, ``.mef``, ``.nwb``)
+        extensions in the file path: (``.con``, ``.sqd``, ``.fif``,
+        ``.pdf``, ``.ds``, ``.vhdr``, ``.edf``, ``.bdf``, ``.set``,
+        ``.edf``, ``.set``, ``.mef``, ``.nwb``)
         - ``suffix`` should be one acceptable file suffixes in:
-            (``meg``, ``markers``, ``eeg``, ``ieeg``, ``T1w``,
-            ``participants``, ``scans``,
-            ``electrodes``, ``channels``, ``coordsystem``,
-            ``events``, ``headshape``, ``digitizer``,
-            ``behav``, ``phsyio``, ``stim``)
+        (``meg``, ``markers``, ``eeg``, ``ieeg``, ``T1w``,
+        ``participants``, ``scans``, ``electrodes``, ``channels``,
+        ``coordsystem``, ``events``, ``headshape``, ``digitizer``,
+        ``behav``, ``phsyio``, ``stim``)
 
         Parameters
         ----------

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -159,7 +159,8 @@ class BIDSPath(object):
             ('processing', self.processing),
             ('space', self.space),
             ('recording', self.recording),
-            ('suffix', self.suffix),
+            ('split', self.split),
+            ('modality', self.modality)
         ])
 
     @property
@@ -167,7 +168,7 @@ class BIDSPath(object):
         """Path basename."""
         basename = []
         for key, val in self.entities.items():
-            if key != 'suffix' and val is not None:
+            if val is not None and key != 'modality':
                 # convert certain keys to shorthand
                 long_to_short_entity = {
                     val: key for key, val

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -299,17 +299,16 @@ class BIDSPath(object):
 
         Also performs error checks on various entities to
         adhere to the BIDS specification. Specifically:
-        - ``suffix`` should be one of:
-            (``anat``, ``eeg``, ``ieeg``, ``meg``)
+        - ``suffix`` should be one of: ``anat``, ``eeg``, ``ieeg``, ``meg``
         - ``extension`` should be one of the accepted file
-        extensions in the file path: (``.con``, ``.sqd``, ``.fif``,
+        extensions in the file path: ``.con``, ``.sqd``, ``.fif``,
         ``.pdf``, ``.ds``, ``.vhdr``, ``.edf``, ``.bdf``, ``.set``,
-        ``.edf``, ``.set``, ``.mef``, ``.nwb``)
-        - ``suffix`` should be one acceptable file suffixes in:
-        (``meg``, ``markers``, ``eeg``, ``ieeg``, ``T1w``,
+        ``.edf``, ``.set``, ``.mef``, ``.nwb``
+        - ``suffix`` should be one acceptable file suffixes in: ``meg``,
+        ``markers``, ``eeg``, ``ieeg``, ``T1w``,
         ``participants``, ``scans``, ``electrodes``, ``channels``,
         ``coordsystem``, ``events``, ``headshape``, ``digitizer``,
-        ``behav``, ``phsyio``, ``stim``)
+        ``behav``, ``phsyio``, ``stim``
 
         Parameters
         ----------

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -440,7 +440,7 @@ def get_matched_empty_room(bids_basename, bids_root):
 
     modality = 'meg'  # We're only concerned about MEG data here
     bids_fname = bids_basename.update(suffix=modality,
-                                      bids_root=bids_root).fpath
+                                      root=bids_root).fpath
     _, ext = _parse_ext(bids_fname)
     if ext == '.fif':
         extra_params = dict(allow_maxshield=True)
@@ -582,7 +582,7 @@ def get_head_mri_trans(bids_basename, bids_root):
         bids_basename = _convert_str_to_bids_path(bids_basename)
 
     # Get the sidecar file for MRI landmarks
-    bids_fname = bids_basename.update(suffix='meg', bids_root=bids_root)
+    bids_fname = bids_basename.update(suffix='meg', root=bids_root)
     t1w_json_path = _find_matching_sidecar(bids_fname, suffix='T1w',
                                            extension='.json')
 

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -330,11 +330,14 @@ def read_raw_bids(bids_basename, bids_root, modality=None, extra_params=None,
     bids_basename = bids_basename.copy()
     sub = bids_basename.subject
     ses = bids_basename.session
-    bids_basename.update(bids_root=bids_root)
 
+    # set root, infer the modality and
+    # then set it to the modality and suffix of the BIDSPath
+    bids_basename.update(root=bids_root)
     if modality is None:
         modality = _infer_modality(bids_root=bids_root,
                                    sub=sub, ses=ses)
+    bids_basename.update(modality=modality, suffix=modality)
 
     data_dir = make_bids_folders(subject=sub, session=ses, modality=modality,
                                  make_dir=False)

--- a/mne_bids/report.py
+++ b/mne_bids/report.py
@@ -332,7 +332,7 @@ def _summarize_sidecar_json(bids_root, scans_fpaths, verbose=True):
 
             # convert to BIDS Path
             params = get_entities_from_fname(bids_basename)
-            bids_basename = BIDSPath(bids_root=bids_root, **params)
+            bids_basename = BIDSPath(root=bids_root, **params)
 
             # XXX: improve to allow emptyroom
             if bids_basename.subject == 'emptyroom':
@@ -418,7 +418,7 @@ def _summarize_channels_tsv(bids_root, scans_fpaths, verbose=True):
 
             # convert to BIDS Path
             params = get_entities_from_fname(bids_basename)
-            bids_basename = BIDSPath(bids_root=bids_root, **params)
+            bids_basename = BIDSPath(root=bids_root, **params)
 
             # XXX: improve to allow emptyroom
             if bids_basename.subject == 'emptyroom':

--- a/mne_bids/report.py
+++ b/mne_bids/report.py
@@ -332,7 +332,7 @@ def _summarize_sidecar_json(bids_root, scans_fpaths, verbose=True):
 
             # convert to BIDS Path
             params = get_entities_from_fname(bids_basename)
-            bids_basename = BIDSPath(**params)
+            bids_basename = BIDSPath(bids_root=bids_root, **params)
 
             # XXX: improve to allow emptyroom
             if bids_basename.subject == 'emptyroom':
@@ -419,7 +419,7 @@ def _summarize_channels_tsv(bids_root, scans_fpaths, verbose=True):
 
             # convert to BIDS Path
             params = get_entities_from_fname(bids_basename)
-            bids_basename = BIDSPath(**params)
+            bids_basename = BIDSPath(bids_root=bids_root, **params)
 
             # XXX: improve to allow emptyroom
             if bids_basename.subject == 'emptyroom':

--- a/mne_bids/report.py
+++ b/mne_bids/report.py
@@ -338,8 +338,7 @@ def _summarize_sidecar_json(bids_root, scans_fpaths, verbose=True):
             if bids_basename.subject == 'emptyroom':
                 continue
 
-            sidecar_fname = _find_matching_sidecar(bids_fname=bids_basename,
-                                                   bids_root=bids_root,
+            sidecar_fname = _find_matching_sidecar(bids_path=bids_basename,
                                                    suffix=modality,
                                                    extension='.json')
             with open(sidecar_fname, 'r') as fin:
@@ -425,8 +424,7 @@ def _summarize_channels_tsv(bids_root, scans_fpaths, verbose=True):
             if bids_basename.subject == 'emptyroom':
                 continue
 
-            channels_fname = _find_matching_sidecar(bids_fname=bids_basename,
-                                                    bids_root=bids_root,
+            channels_fname = _find_matching_sidecar(bids_path=bids_basename,
                                                     suffix='channels',
                                                     extension='.tsv')
 

--- a/mne_bids/tests/test_copyfiles.py
+++ b/mne_bids/tests/test_copyfiles.py
@@ -184,7 +184,7 @@ def test_copyfile_kit():
         elp_fname = BIDSPath(
             subject=subject_id, session=session_id, task=task, run=run,
             acquisition=key, suffix='headshape', extension=elp_ext,
-            prefix=output_path)
+            bids_root=output_path)
         assert op.exists(elp_fname)
 
     if op.exists(headshape_fname):
@@ -193,5 +193,5 @@ def test_copyfile_kit():
         hsp_fname = BIDSPath(
             subject=subject_id, session=session_id, task=task, run=run,
             acquisition=key, suffix='headshape', extension=hsp_ext,
-            prefix=output_path)
+            bids_root=output_path)
         assert op.exists(hsp_fname)

--- a/mne_bids/tests/test_copyfiles.py
+++ b/mne_bids/tests/test_copyfiles.py
@@ -150,22 +150,22 @@ def test_copyfile_kit():
     acq = '01'
     task = 'testing'
 
-    bids_basename = BIDSPath(
-        subject=subject_id, session=session_id, run=run, acquisition=acq,
-        task=task)
-
-    kit_bids_basename = bids_basename.copy().update(acquisition=None,
-                                                    prefix=output_path)
-
     raw = mne.io.read_raw_kit(
         raw_fname, mrk=hpi_fname, elp=electrode_fname,
         hsp=headshape_fname)
     _, ext = _parse_ext(raw_fname, verbose=True)
     modality = _handle_modality(raw)
+
+    bids_basename = BIDSPath(
+        subject=subject_id, session=session_id, run=run, acquisition=acq,
+        task=task)
+    kit_bids_basename = bids_basename.copy().update(acquisition=None,
+                                                    modality=modality,
+                                                    bids_root=output_path)
     bids_fname = str(bids_basename.copy().update(modality=modality,
                                                  suffix=modality,
                                                  extension=ext,
-                                                 prefix=output_path))
+                                                 bids_root=output_path))
 
     copyfile_kit(raw_fname, bids_fname, subject_id, session_id,
                  task, run, raw._init_kwargs)
@@ -184,7 +184,7 @@ def test_copyfile_kit():
         elp_fname = BIDSPath(
             subject=subject_id, session=session_id, task=task, run=run,
             acquisition=key, suffix='headshape', extension=elp_ext,
-            bids_root=output_path)
+            modality='meg', bids_root=output_path)
         assert op.exists(elp_fname)
 
     if op.exists(headshape_fname):
@@ -193,5 +193,5 @@ def test_copyfile_kit():
         hsp_fname = BIDSPath(
             subject=subject_id, session=session_id, task=task, run=run,
             acquisition=key, suffix='headshape', extension=hsp_ext,
-            bids_root=output_path)
+            modality='meg', bids_root=output_path)
         assert op.exists(hsp_fname)

--- a/mne_bids/tests/test_copyfiles.py
+++ b/mne_bids/tests/test_copyfiles.py
@@ -161,11 +161,11 @@ def test_copyfile_kit():
         task=task)
     kit_bids_basename = bids_basename.copy().update(acquisition=None,
                                                     modality=modality,
-                                                    bids_root=output_path)
+                                                    root=output_path)
     bids_fname = str(bids_basename.copy().update(modality=modality,
                                                  suffix=modality,
                                                  extension=ext,
-                                                 bids_root=output_path))
+                                                 root=output_path))
 
     copyfile_kit(raw_fname, bids_fname, subject_id, session_id,
                  task, run, raw._init_kwargs)
@@ -184,7 +184,7 @@ def test_copyfile_kit():
         elp_fname = BIDSPath(
             subject=subject_id, session=session_id, task=task, run=run,
             acquisition=key, suffix='headshape', extension=elp_ext,
-            modality='meg', bids_root=output_path)
+            modality='meg', root=output_path)
         assert op.exists(elp_fname)
 
     if op.exists(headshape_fname):
@@ -193,5 +193,5 @@ def test_copyfile_kit():
         hsp_fname = BIDSPath(
             subject=subject_id, session=session_id, task=task, run=run,
             acquisition=key, suffix='headshape', extension=hsp_ext,
-            modality='meg', bids_root=output_path)
+            modality='meg', root=output_path)
         assert op.exists(hsp_fname)

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -380,7 +380,7 @@ def test_bids_path(return_bids_test_dir):
                          task='03', suffix='ieeg',
                          extension='.edf')
     assert repr(bids_path) == ('BIDSPath(\n'
-                               'bids_root: None\n'
+                               'root: None\n'
                                'basename: sub-01_ses-02_task-03_ieeg.edf)')
 
 
@@ -470,7 +470,7 @@ def test_get_matched_basenames(return_bids_test_dir):
     paths = get_matched_basenames(bids_root=bids_root)
     assert len(paths) == 7
     assert all('sub-01_ses-01' in p.basename for p in paths)
-    assert all([p.bids_root == bids_root for p in paths])
+    assert all([p.root == bids_root for p in paths])
 
     paths = get_matched_basenames(bids_root=bids_root, run='01')
     assert len(paths) == 3

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -284,20 +284,19 @@ def test_bids_path_inference(return_bids_test_dir):
     channels_fname = BIDSPath(subject=subject_id, session=session_id,
                               run=run, acquisition=acq, task=task,
                               root=bids_root, suffix='channels')
-    channels_fpath = channels_fname.fpath
+    channels_fname.fpath
 
     # create an extra file under 'eeg'
-    extra_file = Path(bids_root) / \
-                 f'sub-{subject_id}' / \
-                 f'ses-{session_id}' / \
-                 'eeg' / \
-                 (channels_fname.basename + '.tsv')
-    extra_file.parent.mkdir(exist_ok=True, parents=True)
-    # Creates a new file
-    with open(extra_file, 'w') as fp:
+    extra_file = op.join(bids_root, f'sub-{subject_id}',
+                         f'ses-{session_id}', 'eeg',
+                         channels_fname.basename + '.tsv')
+    Path(extra_file).parent.mkdir(exist_ok=True, parents=True)
+    # Creates a new file and because of this new file, there is now
+    # ambiguity
+    with open(extra_file, 'w'):
         pass
     with pytest.raises(RuntimeError, match='Found data of more than one'):
-        channels_fpath = channels_fname.fpath
+        channels_fname.fpath
 
     # if you set modality, now there is no ambiguity
     channels_fname.update(modality='eeg')

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -300,9 +300,9 @@ def test_bids_path_inference(return_bids_test_dir):
 
     # if you set modality, now there is no ambiguity
     channels_fname.update(modality='eeg')
-    assert channels_fname.fpath == extra_file.as_posix()
+    assert channels_fname.fpath == extra_file
     # set state back to original
-    shutil.rmtree(extra_file.parent)
+    shutil.rmtree(Path(extra_file).parent)
 
 
 def test_bids_path(return_bids_test_dir):

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -277,8 +277,9 @@ def test_bids_path_inference(return_bids_test_dir):
         task=task, run='10', root=bids_root)
     with pytest.warns(RuntimeWarning, match='Could not locate'):
         fpath = bids_path.fpath
-        assert fpath == op.join(bids_root, f'sub-{subject_id}',
-                                f'ses-{session_id}', bids_path.basename)
+        assert str(fpath) == op.join(bids_root, f'sub-{subject_id}',
+                                     f'ses-{session_id}',
+                                     bids_path.basename)
 
     # shouldn't error out when there is no uncertainty
     channels_fname = BIDSPath(subject=subject_id, session=session_id,
@@ -300,7 +301,7 @@ def test_bids_path_inference(return_bids_test_dir):
 
     # if you set modality, now there is no ambiguity
     channels_fname.update(modality='eeg')
-    assert channels_fname.fpath == extra_file
+    assert str(channels_fname.fpath) == extra_file
     # set state back to original
     shutil.rmtree(Path(extra_file).parent)
 
@@ -312,6 +313,10 @@ def test_bids_path(return_bids_test_dir):
     bids_path = BIDSPath(
         subject=subject_id, session=session_id, run=run, acquisition=acq,
         task=task, root=bids_root, suffix='meg')
+
+    expected_parent_dir = op.join(bids_root, f'sub-{subject_id}',
+                                  f'ses-{session_id}', 'meg')
+    assert str(bids_path.fpath.parent) == expected_parent_dir
 
     # test bids path without bids_root, suffix, extension
     # basename and fpath should be the same
@@ -325,7 +330,7 @@ def test_bids_path(return_bids_test_dir):
     expected_relpath = op.join(
         f'sub-{subject_id}', f'ses-{session_id}', 'meg',
         expected_basename + '_meg')
-    assert bids_path2.fpath == expected_relpath
+    assert str(bids_path2.fpath) == expected_relpath
 
     # without bids_root and with suffix/extension
     # basename and fpath should be the same
@@ -345,6 +350,8 @@ def test_bids_path(return_bids_test_dir):
     bids_fpath = bids_path.fpath
     assert op.basename(bids_fpath) == \
            bids_path.basename
+    # Same test, but exploiting the fact that bids_fpath is a pathlib.Path
+    assert bids_fpath.name == bids_path.basename
 
     # confirm BIDSPath assigns properties correctly
     bids_basename = BIDSPath(subject=subject_id,

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -249,7 +249,7 @@ def test_handle_info_reading():
     write_raw_bids(raw, bids_basename, bids_root, overwrite=True)
 
     # find sidecar JSON fname
-    bids_fname.update(bids_root=bids_root)
+    bids_fname.update(root=bids_root)
     sidecar_fname = _find_matching_sidecar(bids_fname,
                                            suffix=suffix, extension='.json',
                                            allow_fail=True)
@@ -293,6 +293,10 @@ def test_handle_eeg_coords_reading():
     """Test reading iEEG coordinates from BIDS files."""
     bids_root = _TempDir()
 
+    bids_basename = BIDSPath(
+        subject=subject_id, session=session_id, run=run, acquisition=acq,
+        task=task)
+
     data_path = op.join(testing.data_path(), 'EDF')
     raw_fname = op.join(data_path, 'test_reduced.edf')
     raw = _read_raw_edf(raw_fname)
@@ -313,7 +317,7 @@ def test_handle_eeg_coords_reading():
     raw.set_montage(montage)
     with pytest.warns(RuntimeWarning, match="Skipping EEG electrodes.tsv"):
         write_raw_bids(raw, bids_basename, bids_root, overwrite=True)
-        bids_basename.update(bids_root=bids_root)
+        bids_basename.update(root=bids_root)
         coordsystem_fname = _find_matching_sidecar(bids_basename,
                                                    suffix='coordsystem',
                                                    extension='.json',
@@ -371,7 +375,6 @@ def test_handle_ieeg_coords_reading(bids_basename):
     bids_fname = bids_basename.copy().update(modality='ieeg',
                                              suffix='ieeg',
                                              extension='.edf')
-
     raw = _read_raw_edf(raw_fname)
 
     # ensure we are writing 'ecog'/'ieeg' data
@@ -390,11 +393,11 @@ def test_handle_ieeg_coords_reading(bids_basename):
         montage = mne.channels.make_dig_montage(ch_pos=ch_pos,
                                                 coord_frame=coord_frame)
         raw.set_montage(montage)
-        write_raw_bids(raw, bids_basename, bids_root,
+        write_raw_bids(raw, bids_fname, bids_root,
                        overwrite=True, verbose=False)
         # read in raw file w/ updated coordinate frame
         # and make sure all digpoints are correct coordinate frames
-        raw_test = read_raw_bids(bids_basename=bids_basename,
+        raw_test = read_raw_bids(bids_basename=bids_fname,
                                  bids_root=bids_root, verbose=False)
         coord_frame_int = MNE_STR_TO_FRAME[coord_frame]
         for digpoint in raw_test.info['dig']:
@@ -402,11 +405,11 @@ def test_handle_ieeg_coords_reading(bids_basename):
 
     # start w/ new bids root
     sh.rmtree(bids_root)
-    write_raw_bids(raw, bids_basename, bids_root,
+    write_raw_bids(raw, bids_fname, bids_root,
                    overwrite=True, verbose=False)
 
     # obtain the sensor positions and assert ch_coords are same
-    raw_test = read_raw_bids(bids_basename=bids_basename, bids_root=bids_root,
+    raw_test = read_raw_bids(bids_basename=bids_fname, bids_root=bids_root,
                              verbose=False)
     orig_locs = raw.info['dig'][1]
     test_locs = raw_test.info['dig'][1]
@@ -416,7 +419,7 @@ def test_handle_ieeg_coords_reading(bids_basename):
     # read in the data and assert montage is the same
     # regardless of 'm', 'cm', 'mm', or 'pixel'
     scalings = {'m': 1, 'cm': 100, 'mm': 1000}
-    bids_fname.update(bids_root=bids_root)
+    bids_fname.update(root=bids_root)
     coordsystem_fname = _find_matching_sidecar(bids_fname,
                                                suffix='coordsystem',
                                                extension='.json',
@@ -440,7 +443,7 @@ def test_handle_ieeg_coords_reading(bids_basename):
     _to_tsv(electrodes_dict, electrodes_fname)
     with pytest.warns(RuntimeWarning, match='Coordinate unit is not '
                                             'an accepted BIDS unit'):
-        raw_test = read_raw_bids(bids_basename=bids_basename,
+        raw_test = read_raw_bids(bids_basename=bids_fname,
                                  bids_root=bids_root, verbose=False)
 
     # correct BIDS units should scale to meters properly
@@ -455,7 +458,7 @@ def test_handle_ieeg_coords_reading(bids_basename):
         _to_tsv(electrodes_dict, electrodes_fname)
 
         # read in raw file w/ updated montage
-        raw_test = read_raw_bids(bids_basename=bids_basename,
+        raw_test = read_raw_bids(bids_basename=bids_fname,
                                  bids_root=bids_root, verbose=False)
 
         # obtain the sensor positions and make sure they're the same
@@ -472,13 +475,13 @@ def test_handle_ieeg_coords_reading(bids_basename):
         # and make sure all digpoints are MRI coordinate frame
         with pytest.warns(RuntimeWarning, match="iEEG Coordinate frame is "
                                                 "not accepted BIDS keyword"):
-            raw_test = read_raw_bids(bids_basename=bids_basename,
+            raw_test = read_raw_bids(bids_basename=bids_fname,
                                      bids_root=bids_root, verbose=False)
             assert raw_test.info['dig'] is None
 
     # ACPC should be read in as RAS for iEEG
     _update_sidecar(coordsystem_fname, 'iEEGCoordinateSystem', 'acpc')
-    raw_test = read_raw_bids(bids_basename=bids_basename, bids_root=bids_root,
+    raw_test = read_raw_bids(bids_basename=bids_fname, bids_root=bids_root,
                              verbose=False)
     coord_frame_int = MNE_STR_TO_FRAME['ras']
     for digpoint in raw_test.info['dig']:
@@ -488,7 +491,7 @@ def test_handle_ieeg_coords_reading(bids_basename):
     os.remove(coordsystem_fname)
     with pytest.raises(RuntimeError, match='BIDS mandates that '
                                            'the coordsystem.json'):
-        raw = read_raw_bids(bids_basename=bids_basename,
+        raw = read_raw_bids(bids_basename=bids_fname,
                             bids_root=bids_root, verbose=False)
 
     # test error message if electrodes don't match
@@ -500,7 +503,7 @@ def test_handle_ieeg_coords_reading(bids_basename):
             electrodes_dict[key].pop()
     _to_tsv(electrodes_dict, electrodes_fname)
     with pytest.raises(RuntimeError, match='Channels do not correspond'):
-        raw_test = read_raw_bids(bids_basename=bids_basename,
+        raw_test = read_raw_bids(bids_basename=bids_fname,
                                  bids_root=bids_root, verbose=False)
 
     # make sure montage is set if there are coordinates w/ 'n/a'
@@ -519,7 +522,7 @@ def test_handle_ieeg_coords_reading(bids_basename):
     nan_chs = [electrodes_dict['name'][i] for i in [0, 3]]
     with pytest.warns(RuntimeWarning, match='There are channels '
                                             'without locations'):
-        raw = read_raw_bids(bids_basename=bids_basename, bids_root=bids_root,
+        raw = read_raw_bids(bids_basename=bids_fname, bids_root=bids_root,
                             verbose=False)
         for idx, ch in enumerate(raw.info['chs']):
             if ch['ch_name'] in nan_chs:
@@ -656,9 +659,9 @@ def test_get_matched_emptyroom_ties():
 
     write_raw_bids(raw, bids_basename, bids_root, overwrite=True)
     er_bids_path = BIDSPath(subject='emptyroom', session=session)
-    er_basename_1 = str(er_bids_path)
+    er_basename_1 = er_bids_path.basename
     er_basename_2 = BIDSPath(subject='emptyroom', session=session,
-                             task='noise')
+                             task='noise').basename
     er_raw.save(op.join(er_dir, f'{er_basename_1}_meg.fif'))
     er_raw.save(op.join(er_dir, f'{er_basename_2}_meg.fif'))
 
@@ -680,7 +683,7 @@ def test_get_matched_emptyroom_no_meas_date():
                                modality='meg', bids_root=bids_root)
     er_bids_path = BIDSPath(subject='emptyroom', session=er_session,
                             task='noise', check=False)
-    er_basename = str(er_bids_path)
+    er_basename = er_bids_path.basename
     raw = _read_raw_fif(raw_fname)
 
     er_raw_fname = op.join(data_path, 'MEG', 'sample', 'ernoise_raw.fif')
@@ -742,7 +745,7 @@ def test_handle_channel_type_casing():
     write_raw_bids(raw, bids_basename, bids_root, overwrite=True,
                    verbose=False)
 
-    ch_path = bids_basename.copy().update(bids_root=bids_root,
+    ch_path = bids_basename.copy().update(root=bids_root,
                                           modality='meg',
                                           suffix='channels',
                                           extension='.tsv')
@@ -768,7 +771,7 @@ def test_bads_reading():
     channels_fname = op.join(data_path, ch_path.basename)
 
     raw_bids_fname = (bids_basename.copy()
-                      .update(bids_root=bids_root, modality='meg',
+                      .update(root=bids_root, modality='meg',
                               suffix='meg', extension='.fif'))
     raw = _read_raw_fif(raw_fname, verbose=False)
 

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -126,7 +126,7 @@ def _test_anonymize(raw, bids_basename, events_fname=None, event_id=None):
                    overwrite=False)
     scans_tsv = BIDSPath(
         subject=subject_id, session=session_id,
-        suffix='scans', extension='.tsv', bids_root=bids_root)
+        suffix='scans', extension='.tsv', root=bids_root)
     data = _from_tsv(scans_tsv)
     if data['acq_time'] is not None and data['acq_time'][0] != 'n/a':
         assert datetime.strptime(data['acq_time'][0],
@@ -349,7 +349,7 @@ def test_fif(_bids_validate):
     # test that the acquisition time was written properly
     scans_tsv = BIDSPath(
         subject=subject_id, session=session_id,
-        suffix='scans', extension='.tsv', bids_root=bids_root)
+        suffix='scans', extension='.tsv', root=bids_root)
     data = _from_tsv(scans_tsv)
     assert data['acq_time'][0] == meas_date.strftime('%Y-%m-%dT%H:%M:%S')
 
@@ -565,7 +565,7 @@ def test_fif_anonymize(_bids_validate):
     scans_tsv = BIDSPath(
         subject=subject_id, session=session_id,
         suffix='scans', extension='.tsv',
-        bids_root=bids_root)
+        root=bids_root)
     data = _from_tsv(scans_tsv)
 
     # anonymize using MNE manually
@@ -589,7 +589,8 @@ def test_kit(_bids_validate):
     headshape_fname = op.join(data_path, 'test.hsp')
     event_id = dict(cond=1)
 
-    kit_bids_basename = bids_basename.copy().update(acquisition=None)
+    kit_bids_basename = bids_basename.copy().update(acquisition=None,
+                                                    suffix='meg')
 
     raw = _read_raw_kit(
         raw_fname, mrk=hpi_fname, elp=electrode_fname,
@@ -608,7 +609,7 @@ def test_kit(_bids_validate):
     marker_fname = BIDSPath(
         subject=subject_id, session=session_id, task=task, run=run,
         suffix='markers', extension='.sqd',
-        bids_root=bids_root)
+        root=bids_root)
     assert op.exists(marker_fname)
 
     # test anonymize
@@ -622,7 +623,8 @@ def test_kit(_bids_validate):
                                           events_fname, event_id)
 
     # ensure the channels file has no STI 014 channel:
-    channels_tsv = marker_fname.copy().update(suffix='channels',
+    channels_tsv = marker_fname.copy().update(modality='meg',
+                                              suffix='channels',
                                               extension='.tsv')
     data = _from_tsv(channels_tsv)
     assert 'STI 014' not in data['name']
@@ -833,7 +835,7 @@ def test_vhdr(_bids_validate):
     bids_root = _TempDir()
     write_raw_bids(raw, bids_basename, bids_root)
     electrodes_fpath = _find_matching_sidecar(
-        bids_basename.copy().update(bids_root=bids_root),
+        bids_basename.copy().update(root=bids_root),
         suffix='electrodes', extension='.tsv')
     tsv = _from_tsv(electrodes_fpath)
     assert len(tsv.get('impedance', {})) > 0
@@ -900,7 +902,7 @@ def test_edf(_bids_validate):
     with pytest.warns(RuntimeWarning, match='Skipping EEG electrodes.tsv... '
                                             'Setting montage not possible'):
         write_raw_bids(raw, bids_fname, bids_root, overwrite=True)
-        bids_fname.update(bids_root=bids_root)
+        bids_fname.update(root=bids_root)
         electrodes_fpath = _find_matching_sidecar(bids_fname,
                                                   suffix='electrodes',
                                                   extension='.tsv',
@@ -925,7 +927,7 @@ def test_edf(_bids_validate):
     channels_tsv = BIDSPath(
         subject=subject_id, session=session_id, task=task, run=run,
         suffix='channels', extension='.tsv', acquisition=acq,
-        bids_root=bids_root, modality='eeg')
+        root=bids_root, modality='eeg')
     data = _from_tsv(channels_tsv)
     assert 'ElectroMyoGram' in data['description']
 
@@ -933,7 +935,7 @@ def test_edf(_bids_validate):
     scans_tsv = BIDSPath(
         subject=subject_id, session=session_id,
         suffix='scans', extension='.tsv',
-        bids_root=bids_root)
+        root=bids_root)
     data = _from_tsv(scans_tsv)
     assert len(list(data.values())[0]) == 2
 
@@ -985,7 +987,7 @@ def test_edf(_bids_validate):
 
     # XXX: Should be improved with additional coordinate system descriptions
     # iEEG montages written from mne-python end up as "Other"
-    bids_fname.update(bids_root=bids_root)
+    bids_fname.update(root=bids_root)
     electrodes_fname = _find_matching_sidecar(bids_fname,
                                               suffix='electrodes',
                                               extension='.tsv')
@@ -1166,7 +1168,7 @@ def test_write_anat(_bids_validate):
     np.testing.assert_array_equal(list(anat_dict.keys()),
                                   point_list)
     sidecar_basename = BIDSPath(subject='01', session='01',
-                                acquisition='01', bids_root=bids_root,
+                                acquisition='01', root=bids_root,
                                 suffix='T1w', extension='.nii.gz')
     # test the actual values of the voxels (no floating points)
     for i, point in enumerate([(66, 51, 46), (41, 32, 74), (17, 53, 47)]):

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -127,7 +127,7 @@ def _test_anonymize(raw, bids_basename, events_fname=None, event_id=None):
     scans_tsv = BIDSPath(
         subject=subject_id, session=session_id,
         suffix='scans', extension='.tsv',
-        prefix=op.join(bids_root, 'sub-01', 'ses-01'))
+        bids_root=op.join(bids_root, 'sub-01', 'ses-01'))
     data = _from_tsv(scans_tsv)
     if data['acq_time'] is not None and data['acq_time'][0] != 'n/a':
         assert datetime.strptime(data['acq_time'][0],
@@ -351,7 +351,7 @@ def test_fif(_bids_validate):
     scans_tsv = BIDSPath(
         subject=subject_id, session=session_id,
         suffix='scans', extension='.tsv',
-        prefix=op.join(bids_root, 'sub-01', 'ses-01'))
+        bids_root=op.join(bids_root, 'sub-01', 'ses-01'))
     data = _from_tsv(scans_tsv)
     assert data['acq_time'][0] == meas_date.strftime('%Y-%m-%dT%H:%M:%S')
 
@@ -567,7 +567,7 @@ def test_fif_anonymize(_bids_validate):
     scans_tsv = BIDSPath(
         subject=subject_id, session=session_id,
         suffix='scans', extension='.tsv',
-        prefix=op.join(bids_root, 'sub-01', 'ses-01'))
+        bids_root=op.join(bids_root, 'sub-01', 'ses-01'))
     data = _from_tsv(scans_tsv)
 
     # anonymize using MNE manually
@@ -610,7 +610,7 @@ def test_kit(_bids_validate):
     marker_fname = BIDSPath(
         subject=subject_id, session=session_id, task=task, run=run,
         suffix='markers', extension='.sqd',
-        prefix=op.join(bids_root, 'sub-01', 'ses-01', 'meg'))
+        bids_root=op.join(bids_root, 'sub-01', 'ses-01', 'meg'))
     assert op.exists(marker_fname)
 
     # test anonymize
@@ -927,7 +927,7 @@ def test_edf(_bids_validate):
     channels_tsv = BIDSPath(
         subject=subject_id, session=session_id, task=task, run=run,
         suffix='channels', extension='.tsv', acquisition=acq,
-        prefix=op.join(bids_root, 'sub-01', 'ses-01', 'eeg'))
+        bids_root=op.join(bids_root, 'sub-01', 'ses-01', 'eeg'))
     data = _from_tsv(channels_tsv)
     assert 'ElectroMyoGram' in data['description']
 
@@ -935,7 +935,7 @@ def test_edf(_bids_validate):
     scans_tsv = BIDSPath(
         subject=subject_id, session=session_id,
         suffix='scans', extension='.tsv',
-        prefix=op.join(bids_root, 'sub-01', 'ses-01'))
+        bids_root=op.join(bids_root, 'sub-01', 'ses-01'))
     data = _from_tsv(scans_tsv)
     assert len(list(data.values())[0]) == 2
 

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -787,7 +787,7 @@ def test_vhdr(_bids_validate):
     # is in channels.tsv
     suffix, ext = 'channels', '.tsv'
     channels_tsv_name = bids_basename_minimal.copy().update(
-        modality='eeg', bids_root=bids_root, suffix=suffix, extension=ext)
+        modality='eeg', root=bids_root, suffix=suffix, extension=ext)
 
     data = _from_tsv(channels_tsv_name)
     assert data['units'][data['name'].index('FP1')] == 'µV'
@@ -1034,7 +1034,7 @@ def test_bdf(_bids_validate):
     # we will change the channel type to MISC and overwrite the channels file
     bids_fname = bids_basename.copy().update(suffix='eeg',
                                              extension='.bdf',
-                                             bids_root=bids_root)
+                                             root=bids_root)
     channels_fname = _find_matching_sidecar(bids_fname,
                                             suffix='channels',
                                             extension='.tsv')

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -962,7 +962,7 @@ def write_raw_bids(raw, bids_basename, bids_root, events_data=None,
 
     bids_fname = bids_basename.copy().update(
         modality=modality, suffix=modality, extension=ext,
-        bids_root=bids_root)
+        root=bids_root)
 
     # check whether the info provided indicates that the data is emptyroom
     # data

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -993,7 +993,7 @@ def write_raw_bids(raw, bids_basename, bids_root, events_data=None,
 
     # create *_scans.tsv
     bids_path = BIDSPath(subject=subject_id, session=session_id,
-                         bids_root=bids_root,
+                         root=bids_root,
                          suffix='scans', extension='.tsv')
     scans_fname = bids_path.fpath
 
@@ -1024,7 +1024,7 @@ def write_raw_bids(raw, bids_basename, bids_root, events_data=None,
     if ext not in ['.fif', '.ds', '.vhdr', '.edf', '.bdf', '.set', '.con',
                    '.sqd']:
         bids_raw_folder = str(bids_fname).split(".")[0]
-        bids_fname.update(bids_root=bids_raw_folder)
+        bids_fname.update(root=bids_raw_folder)
 
     # Anonymize
     convert = False
@@ -1258,7 +1258,7 @@ def write_anat(bids_root, subject, t1w, session=None, acquisition=None,
     # this needs to be a string, since nibabel assumes a string input
     t1w_basename = BIDSPath(subject=subject, session=session,
                             acquisition=acquisition,
-                            bids_root=bids_root,
+                            root=bids_root,
                             suffix='T1w', extension='.nii.gz')
 
     # Check if we have necessary conditions for writing a sidecar JSON

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -999,7 +999,7 @@ def write_raw_bids(raw, bids_basename, bids_root, events_data=None,
 
     # create *_scans.tsv
     bids_path = BIDSPath(subject=subject_id, session=session_id,
-                         prefix=ses_path, suffix='scans', extension='.tsv',
+                         bids_root=ses_path, suffix='scans', extension='.tsv',
                          task=None)
     scans_fname = str(bids_path)
 
@@ -1032,7 +1032,7 @@ def write_raw_bids(raw, bids_basename, bids_root, events_data=None,
     if ext not in ['.fif', '.ds', '.vhdr', '.edf', '.bdf', '.set', '.con',
                    '.sqd']:
         bids_raw_folder = str(bids_fname).split(".")[0]
-        bids_fname.prefix = bids_raw_folder
+        bids_fname.bids_root = bids_raw_folder
 
     # Anonymize
     convert = False
@@ -1096,7 +1096,7 @@ def write_raw_bids(raw, bids_basename, bids_root, events_data=None,
 
     # set the raw file name to now be the absolute path to ensure the files
     # are placed in the right location
-    bids_fname.prefix = data_path
+    bids_fname.bids_root = data_path
 
     if os.path.exists(bids_fname) and not overwrite:
         raise FileExistsError(f'"{bids_fname}" already exists. '  # noqa: F821
@@ -1268,7 +1268,7 @@ def write_anat(bids_root, subject, t1w, session=None, acquisition=None,
     # this needs to be a string, since nibabel assumes a string input
     t1w_basename = BIDSPath(subject=subject, session=session,
                             acquisition=acquisition,
-                            prefix=anat_dir,
+                            bids_root=anat_dir,
                             suffix='T1w', extension='.nii.gz')
 
     # Check if we have necessary conditions for writing a sidecar JSON


### PR DESCRIPTION
PR Description
--------------

Closes: #492 
Closes: #454 

- Replaces `prefix` for `root`
- Replace `get_bids_fname` for `fpath`

BIDSPath will allow "inference" of the full file path in the following situations:

1. `modality is None` and `suffix` is one of 'meg', 'eeg', 'ieeg', 'T1w' -> set `modality` automatically
2. `extension is None`, and `modality` is set -> then try to find the correct file path

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
- [ ] Commit history does not contain any merge commits
