### PR TITLE
[MRG] get_matched_empty_room() now returns a BIDSPath

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -61,7 +61,7 @@ API
 ~~~
 
 - :func:`read_raw_bids` now expects `bids_basename` as the first argument and gains a `kind` parameter. The name of the file to read will be inferred automatically, and can no longer be passed to the function directly. This ensures better API consistency with :func:`write_raw_bids`, by `Richard Höchenberger`_ (`#410 <https://github.com/mne-tools/mne-bids/pull/410>`_)
-- :func:`get_matched_empty_room` now expects `bids_basename` as the first argument and returns the `bids_basename` of the best-matching empty-room recording (instead of its filename before). The `bids_fname` argument has been dropped, by `Richard Höchenberger`_ (`#410 <https://github.com/mne-tools/mne-bids/pull/410>`_)
+- :func:`get_matched_empty_room` now expects `bids_basename` as the first argument and returns the :class:`mne_bids.BIDSPath` of the best-matching empty-room recording (instead of its filename before). The `bids_fname` argument has been dropped, by `Richard Höchenberger`_ (`#410 <https://github.com/mne-tools/mne-bids/pull/410>`_, `#521 <https://github.com/mne-tools/mne-bids/pull/521>`_)
 - :func:`get_head_mri_trans` now expects `bids_basename` as the first argument. The `bids_fname` argument has been dropped, by `Richard Höchenberger`_ (`#410 <https://github.com/mne-tools/mne-bids/pull/410>`_)
 - BIDS conformity: The ``_part-%d`` entity is now called ``_split-`` throughout BIDS, MNE, and MNE-BIDS, by `Stefan Appelhoff`_ (`#417 <https://github.com/mne-tools/mne-bids/pull/417>`_)
 - The ``datasets.py`` module was removed from ``MNE-BIDS`` and its utility was replaced by ``mne.datasets``, by `Stefan Appelhoff`_ (`#471 <https://github.com/mne-tools/mne-bids/pull/471>`_)

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -429,7 +429,7 @@ def get_matched_empty_room(bids_basename, bids_root):
 
     Returns
     -------
-    er_basename : str | None.
+    er_path : BIDSPath | None
         The basename corresponding to the best-matching empty-room measurement.
         Returns None if none was found.
     """
@@ -490,7 +490,7 @@ def get_matched_empty_room(bids_basename, bids_root):
 
     # Walk through recordings, trying to extract the recording date:
     # First, from the filename; and if that fails, from `info['meas_date']`.
-    best_er_basename = None
+    best_er_bids_path = None
     min_delta_t = np.inf
     date_tie = False
 
@@ -499,8 +499,8 @@ def get_matched_empty_room(bids_basename, bids_root):
         params = get_entities_from_fname(er_fname)
         er_meas_date = None
         params.pop('subject')  # er subject entity is different
-        er_bids_path = BIDSPath(subject='emptyroom', **params,
-                                check=False)
+        er_bids_path = BIDSPath(subject='emptyroom', **params, modality='meg',
+                                root=bids_root, check=False)
 
         # Try to extract date from filename.
         if params['session'] is not None:
@@ -535,7 +535,7 @@ def get_matched_empty_room(bids_basename, bids_root):
             date_tie = True
         elif abs(delta_t.total_seconds()) < min_delta_t:
             min_delta_t = abs(delta_t.total_seconds())
-            best_er_basename = er_bids_path.basename
+            best_er_bids_path = er_bids_path
             date_tie = False
 
     if failed_to_get_er_date_count > 0:
@@ -548,7 +548,7 @@ def get_matched_empty_room(bids_basename, bids_root):
                'same recording date. Selecting the first match.')
         warn(msg)
 
-    return best_er_basename
+    return best_er_bids_path
 
 
 def get_head_mri_trans(bids_basename, bids_root):

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -429,9 +429,10 @@ def get_matched_empty_room(bids_basename, bids_root):
 
     Returns
     -------
-    er_path : BIDSPath | None
-        The basename corresponding to the best-matching empty-room measurement.
+    BIDSPath | None
+        The path corresponding to the best-matching empty-room measurement.
         Returns None if none was found.
+
     """
     # convert to BIDS Path
     if isinstance(bids_basename, str):

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -570,7 +570,6 @@ def test_get_matched_empty_room():
     bids_root = _TempDir()
 
     raw = _read_raw_fif(raw_fname)
-
     bids_basename = BIDSPath(subject='01', session='01',
                              task='audiovisual', run='01')
     write_raw_bids(raw, bids_basename, bids_root, overwrite=True)
@@ -591,12 +590,13 @@ def test_get_matched_empty_room():
         er_date = datetime.fromtimestamp(er_raw.info['meas_date'][0])
     er_date = er_date.strftime('%Y%m%d')
     er_bids_basename = BIDSPath(subject='emptyroom', task='noise',
-                                session=er_date, suffix='meg')
+                                session=er_date, suffix='meg',
+                                root=bids_root)
     write_raw_bids(er_raw, er_bids_basename, bids_root, overwrite=True)
 
     recovered_er_basename = get_matched_empty_room(bids_basename=bids_basename,
                                                    bids_root=bids_root)
-    assert er_bids_basename.basename == recovered_er_basename
+    assert er_bids_basename == recovered_er_basename
 
     # assert that we get best emptyroom if there are multiple available
     sh.rmtree(op.join(bids_root, 'sub-emptyroom'))
@@ -614,7 +614,7 @@ def test_get_matched_empty_room():
 
     best_er_basename = get_matched_empty_room(bids_basename=bids_basename,
                                               bids_root=bids_root)
-    assert '20021204' in best_er_basename
+    assert '20021204' in best_er_basename.basename
 
     # assert that we get error if meas_date is not available.
     raw = read_raw_bids(bids_basename=bids_basename, bids_root=bids_root,

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -614,7 +614,7 @@ def test_get_matched_empty_room():
 
     best_er_basename = get_matched_empty_room(bids_basename=bids_basename,
                                               bids_root=bids_root)
-    assert '20021204' in best_er_basename.basename
+    assert best_er_basename.session == '20021204'
 
     # assert that we get error if meas_date is not available.
     raw = read_raw_bids(bids_basename=bids_basename, bids_root=bids_root,


### PR DESCRIPTION
PR Description
--------------

`get_matched_empty_room()` in `master` returns a string; precisely, it first finds the `BIDSPath` of the empty-room file, and then only returns the `BIDSPath.basename`. 

With how we're using `BIDSPath` in other places now, this feels inconsistent to me, and I'd prefer to get back a `BIDSPath` – also considering that the input to this function is a `BIDSPath` too; and if one only desires to retrieve the basename, one can do `get_matched_empty_room(...).basename`. 

Returning a `BIDSPath` also makes it easier to pass this object around without having to call `get_entities_from_fname` again if one wishes to get the entities; thanks to `BIDSPath`, we can just use the attributes, e.g. `get_matched_empty_room(...).session`, which is super convenient.

So – this PR changes `get_matched_empty_room()` such that it returns a `BIDSPath`.

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
- [ ] Commit history does not contain any merge commits
