### PR TITLE
[MRG] Remove "no merge commits" from checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,4 +17,3 @@ Maintainer, please confirm the following before merging:
 - [ ] PR title starts with [MRG]
 - [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
 - [ ] PR description includes phrase "closes <#issue-number>"
-- [ ] Commit history does not contain any merge commits


### PR DESCRIPTION
PR Description
--------------
Closes #530


I've already changed the settings to:

<img width="400" alt="Screenshot 2020-08-28 at 12 46 40" src="https://user-images.githubusercontent.com/2046265/91553042-13033980-e92d-11ea-9bfd-f95feea443b7.png">



Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [x] All comments resolved
- [x] This is not your own PR
- [x] All CIs are happy
- [x] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [x] PR description includes phrase "closes <#issue-number>"
- [ ] Commit history does not contain any merge commits
