### PR TITLE
[MRG] BF: Handle extension corrently in BIDSPath.match()

### DIFF
--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -546,7 +546,7 @@ class BIDSPath(object):
 
         Returns
         -------
-        paths : list of BIDSPath
+        bids_paths : list of BIDSPath
             The matching paths.
         """
         if self.root is None:
@@ -569,15 +569,15 @@ class BIDSPath(object):
         fnames = _filter_fnames(fnames, extension=self.extension,
                                 **self.entities)
 
-        paths = []
+        bids_paths = []
         for fname in fnames:
             entities = get_entities_from_fname(fname)
             extension = fname.suffix if fname.suffix else None
-            path = BIDSPath(root=self.root, datatype=self.datatype,
-                            extension=extension, **entities)
-            paths.append(path)
+            bids_path = BIDSPath(root=self.root, datatype=self.datatype,
+                                 extension=extension, **entities)
+            bids_paths.append(bids_path)
 
-        return paths
+        return bids_paths
 
     def _check(self):
         """Deep check or not of the instance."""

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -1250,7 +1250,7 @@ def _filter_fnames(fnames, *, subject=None, session=None, task=None,
     regexp = (sub_str + ses_str + task_str + acq_str + run_str + proc_str +
               rec_str + space_str + split_str + suffix_str + ext_str)
 
-    # Convert to str for we can apply the regexp ...
+    # Convert to str so we can apply the regexp ...
     fnames = [str(f) for f in fnames]
 
     # https://stackoverflow.com/a/51246151/1944216

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -1250,7 +1250,7 @@ def _filter_fnames(fnames, *, subject=None, session=None, task=None,
     regexp = (sub_str + ses_str + task_str + acq_str + run_str + proc_str +
               rec_str + space_str + split_str + suffix_str + ext_str)
 
-    # Convert to str ...
+    # Convert to str for we can apply the regexp ...
     fnames = [str(f) for f in fnames]
 
     # https://stackoverflow.com/a/51246151/1944216

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -564,15 +564,17 @@ class BIDSPath(object):
 
         fnames = Path(self.root).rglob(search_str)
         # Only keep files (not directories), and omit the JSON sidecars.
-        fnames = [str(f.name) for f in fnames
+        fnames = [f.name for f in fnames
                   if f.is_file() and f.suffix != '.json']
-        fnames = _filter_fnames(fnames, **self.entities)
+        fnames = _filter_fnames(fnames, extension=self.extension,
+                                **self.entities)
 
         paths = []
         for fname in fnames:
             entities = get_entities_from_fname(fname)
+            extension = fname.suffix if fname.suffix else None
             path = BIDSPath(root=self.root, datatype=self.datatype,
-                            **entities)
+                            extension=extension, **entities)
             paths.append(path)
 
         return paths
@@ -1221,7 +1223,17 @@ def _path_to_str(var):
 def _filter_fnames(fnames, *, subject=None, session=None, task=None,
                    acquisition=None, run=None, processing=None, recording=None,
                    space=None, split=None, suffix=None, extension=None):
-    """Filter a list of BIDS filenames based on BIDS entity values."""
+    """Filter a list of BIDS filenames based on BIDS entity values.
+
+    Parameters
+    ----------
+    fnames : iterable of pathlib.Path | iterable of str
+
+    Returns
+    -------
+    list of pathlib.Path
+
+    """
     sub_str = f'sub-{subject}' if subject else r'sub-([^_]+)'
     ses_str = f'_ses-{session}' if session else r'(|_ses-([^_]+))'
     task_str = f'_task-{task}' if task else r'(|_task-([^_]+))'
@@ -1238,6 +1250,12 @@ def _filter_fnames(fnames, *, subject=None, session=None, task=None,
     regexp = (sub_str + ses_str + task_str + acq_str + run_str + proc_str +
               rec_str + space_str + split_str + suffix_str + ext_str)
 
+    # Convert to str ...
+    fnames = [str(f) for f in fnames]
+
     # https://stackoverflow.com/a/51246151/1944216
     fnames_filtered = sorted(filter(re.compile(regexp).match, fnames))
+
+    # ... and return Paths.
+    fnames_filtered = [Path(f) for f in fnames_filtered]
     return fnames_filtered

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -530,7 +530,7 @@ def test_filter_fnames(entities, expected_n_matches):
     assert len(output) == expected_n_matches
 
 
-def test_get_matched_basenames(return_bids_test_dir):
+def test_match(return_bids_test_dir):
     """Test retrieval of matching basenames."""
     bids_root = return_bids_test_dir
 
@@ -543,7 +543,8 @@ def test_get_matched_basenames(return_bids_test_dir):
     bids_path_01 = BIDSPath(root=bids_root, run='01')
     paths = bids_path_01.match()
     assert len(paths) == 3
-    assert paths[0].basename == 'sub-01_ses-01_task-testing_run-01_channels'
+    assert paths[0].basename == ('sub-01_ses-01_task-testing_run-01_'
+                                 'channels.tsv')
 
     bids_path_01 = BIDSPath(root=bids_root, subject='unknown')
     paths = bids_path_01.match()
@@ -556,6 +557,19 @@ def test_get_matched_basenames(return_bids_test_dir):
     bids_path_01.update(datatype='meg', root=bids_root)
     same_paths = bids_path_01.match()
     assert len(same_paths) == 3
+
+    # Check handling of `extension`, part 1: no extension specified.
+    bids_path_01 = BIDSPath(root=bids_root, run='01')
+    paths = bids_path_01.match()
+    assert [p.extension for p in paths] == ['.tsv', '.tsv', '.fif']
+
+    # Check handling of `extension`, part 2: extension specified.
+    bids_path_01 = BIDSPath(root=bids_root, run='01', extension='.fif',
+                            datatype='meg')
+    paths = bids_path_01.match()
+    assert len(paths) == 1
+    assert paths[0].extension == '.fif'
+
 
 
 @pytest.mark.filterwarnings(warning_str['meas_date_set_to_none'])

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -571,7 +571,6 @@ def test_match(return_bids_test_dir):
     assert paths[0].extension == '.fif'
 
 
-
 @pytest.mark.filterwarnings(warning_str['meas_date_set_to_none'])
 @pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
 def test_find_empty_room(return_bids_test_dir):


### PR DESCRIPTION
PR Description
--------------

We didn't handle filename extensions properly in `BIDSPath.match()`; probably this bug was introduced when we moved `extension` out of `BIDSPath.entities` (cannot find the respective PR / commit now)

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
