### PR TITLE
[WIP] Deleting Files from BIDs dataset

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -82,7 +82,7 @@ API
 - ``mne_bids.get_matched_empty_room`` has been removed. Use :meth:`mne_bids.BIDSPath.find_empty_room` instead, by `Richard Höchenberger`_ (`#535 <https://github.com/mne-tools/mne-bids/pull/535>`_)
 - ``mne_bids.make_bids_folders`` has been removed. Use :meth:`mne_bids.BIDSPath.mkdir` instead, by `Adam Li`_ (`#543 <https://github.com/mne-tools/mne-bids/pull/543>`_)
 - Rename ``mne_bids.get_modalities`` to :func:`mne_bids.get_datatypes` for getting data types from a BIDS dataset, by `Alexandre Gramfort`_ (`#253 <https://github.com/mne-tools/mne-bids/pull/253>`_)
-
+- The :func:`mne_bids.delete_participant` function will safely delete a participant from the BIDS dataset, by `Adam Li`_ (`#443 <https://github.com/mne-tools/mne-bids/pull/443>`_)
 
 .. _changes_0_4:
 

--- a/mne_bids/tests/test_utils.py
+++ b/mne_bids/tests/test_utils.py
@@ -37,6 +37,7 @@ bids_path = BIDSPath(
     subject=subject_id, session=session_id, run=run, acquisition=acq,
     task=task)
 
+
 @pytest.fixture(scope='function')
 def return_bids_test_dir(tmpdir_factory):
     """Return path to a written test BIDS dir."""
@@ -60,6 +61,7 @@ def return_bids_test_dir(tmpdir_factory):
                        event_id=event_id, overwrite=True)
 
     return bids_root
+
 
 def test_get_ch_type_mapping():
     """Test getting a correct channel mapping."""


### PR DESCRIPTION
PR Description
--------------

Closes: #443 
Closes: #439 

Only grab files based on all entities from `BIDSPath` object except for suffix and extension (i.e. if you fully specify the BIDs entities, it should delete all the files, not just say the `*_channels.tsv` file because then that would make the dataset non-compliant).

Need to add:
1. unit tests for safely doing scans
2. unit tests for safely doing subjects

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
