### PR TITLE
[MRG] Fix raw reading

### DIFF
--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -192,7 +192,7 @@ class BIDSPath(object):
         The "data type" of folder being created at the end of the folder
         hierarchy. E.g., ``'anat'``, ``'func'``, ``'eeg'``, ``'meg'``,
         ``'ieeg'``, etc.
-    root : str | None
+    root : str | pathlib.Path | None
         The root for the filename to be created. E.g., a path to the folder
         in which you wish to create a file with this name.
     check : bool
@@ -210,11 +210,11 @@ class BIDSPath(object):
         ``'anat'``.
     basename : str
         The basename of the file path. Similar to `os.path.basename(fpath)`.
-    root : str
+    root : pathlib.Path
         The root of the BIDS path.
     directory : pathlib.Path
         The directory path.
-    fpath : str
+    fpath : pathlib.Path
         The full file path.
     check : bool
         If ``True``, enforces the entities to be valid according to the
@@ -557,9 +557,9 @@ class BIDSPath(object):
             if val is not None and key != 'root':
                 _check_key_val(key, val)
 
-            # set entity value, ensuring `root` is a string
+            # set entity value, ensuring `root` is a Path
             if key == 'root' and val is not None:
-                val = str(val)
+                val = Path(val)
             setattr(self, key, val)
 
         # infer datatype if suffix is uniquely the datatype
@@ -597,7 +597,7 @@ class BIDSPath(object):
         else:
             search_str = '*.*'
 
-        fnames = Path(self.root).rglob(search_str)
+        fnames = self.root.rglob(search_str)
         # Only keep files (not directories), and omit the JSON sidecars.
         fnames = [f.name for f in fnames
                   if f.is_file() and f.suffix != '.json']

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -340,7 +340,7 @@ def read_raw_bids(bids_path, extra_params=None, verbose=True):
     if suffix is None:
         bids_path.update(suffix=datatype)
 
-    data_dir = bids_path.mkdir().directory
+    data_dir = bids_path.directory
     bids_fname = bids_path.fpath.name
 
     if op.splitext(bids_fname)[1] == '.pdf':

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -325,6 +325,7 @@ def read_raw_bids(bids_path, extra_params=None, verbose=True):
     ses = bids_path.session
     bids_root = bids_path.root
     datatype = bids_path.datatype
+    suffix = bids_path.suffix
 
     # check root available
     if bids_root is None:
@@ -332,24 +333,22 @@ def read_raw_bids(bids_path, extra_params=None, verbose=True):
                          'Please use `bids_path.update(root="<root>")` '
                          'to set the root of the BIDS folder to read.')
 
-    # set root, infer the datatype and
-    # then set it to the datatype and suffix of the BIDSPath
-    bids_path.update(root=bids_root)
+    # infer the datatype and suffix if they are not present in the BIDSPath
     if datatype is None:
-        datatype = _infer_datatype(bids_root=bids_root,
-                                   sub=sub, ses=ses)
-    bids_path.update(datatype=datatype, suffix=datatype)
+        datatype = _infer_datatype(bids_root=bids_root, sub=sub, ses=ses)
+        bids_path.update(datatype=datatype)
+    if suffix is None:
+        bids_path.update(suffix=datatype)
 
     data_dir = bids_path.mkdir().directory
     bids_fname = bids_path.fpath.name
 
     if op.splitext(bids_fname)[1] == '.pdf':
-        bids_raw_folder = op.join(bids_root, data_dir,
-                                  f'{bids_path.basename}')
+        bids_raw_folder = op.join(data_dir, f'{bids_path.basename}')
         bids_fpath = glob.glob(op.join(bids_raw_folder, 'c,rf*'))[0]
         config = op.join(bids_raw_folder, 'config')
     else:
-        bids_fpath = op.join(bids_root, data_dir, bids_fname)
+        bids_fpath = op.join(data_dir, bids_fname)
         config = None
 
     if extra_params is None:

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -532,7 +532,7 @@ def test_filter_fnames(entities, expected_n_matches):
 
 def test_match(return_bids_test_dir):
     """Test retrieval of matching basenames."""
-    bids_root = return_bids_test_dir
+    bids_root = Path(return_bids_test_dir)
 
     bids_path_01 = BIDSPath(root=bids_root)
     paths = bids_path_01.match()

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -1409,7 +1409,7 @@ def test_write_raw_pathlike():
 
     # write_raw_bids() should return a string.
     assert isinstance(bids_path_, BIDSPath)
-    assert bids_path_.root == str(bids_root)
+    assert bids_path_.root == bids_root
 
 
 def test_write_raw_no_dig():
@@ -1421,13 +1421,13 @@ def test_write_raw_no_dig():
     bids_path = _bids_path.copy().update(root=bids_root)
     bids_path_ = write_raw_bids(raw=raw, bids_path=bids_path,
                                 overwrite=True)
-    assert bids_path_.root == str(bids_root)
+    assert bids_path_.root == bids_root
     raw.info['dig'] = None
     raw.save(str(bids_root / 'tmp_raw.fif'))
     raw = _read_raw_fif(bids_root / 'tmp_raw.fif')
     bids_path_ = write_raw_bids(raw=raw, bids_path=bids_path,
                                 overwrite=True)
-    assert bids_path_.root == str(bids_root)
+    assert bids_path_.root == bids_root
     assert bids_path_.suffix == 'meg'
     assert bids_path_.extension == '.fif'
 


### PR DESCRIPTION
PR Description
--------------

I couldn't read files anymore using `read_raw_bids`. 

Reason was that we now construct the directory location via `bids_path.directory`, which includes the
BIDS root; yet we were still joining that path with the root, yielding invalid paths (i.e., the root would essentially appear twice at the beginning of the path).

Now, our CI didn't catch it for the simple reason that in our tests were essentially joining a string (root) and a `Path` (`BIDSPath.directory`) via `os.path.join`, exposing an interesting behavior of that function:

```python
import os
import pathlib

path_str = '/foo/bar'
path = pathlib.Path(path_str)

print(os.path.join(path_str, path))
```
What do you think would it produce?

**WRONG**, it would produce:
```
/foo/bar
```

So in this PR:

- We construct the path of the file to be read in `read_raw_bids` correctly by calling `bids_fpath = op.join(data_dir, bids_fname)` instead of `bids_fpath = op.join(bids_root, data_dir, bids_fname)`
- We remove a small bug (or at least an unnecessary call) in `read_raw_bids`, which was that we would try to create the folder structure when trying to retrieve the directory path (i.e., `bids_path.mkdir().directory` where `bids_path.directory` should suffice)
- We turn `BIDSPath.root` into a `pathlib.Path` which will avoid these kinds of silent bugs in the future; this also leads to a more consistent API


Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
