### PR TITLE
add support for CTF gradient compensated data

### DIFF
--- a/mne_bids/pick.py
+++ b/mne_bids/pick.py
@@ -17,6 +17,8 @@ def get_coil_types():
     """
     return dict(meggradaxial=(FIFF.FIFFV_COIL_KIT_GRAD,
                               FIFF.FIFFV_COIL_CTF_GRAD,
+                              # Support for gradient-compensated data:
+                              int(FIFF.FIFFV_COIL_CTF_GRAD | (3 << 16)),
                               FIFF.FIFFV_COIL_AXIAL_GRAD_5CM,
                               FIFF.FIFFV_COIL_BABY_GRAD),
                 megrefgradaxial=(FIFF.FIFFV_COIL_CTF_REF_GRAD,


### PR DESCRIPTION
see https://github.com/mne-tools/mne-python/blob/master/mne/io/ctf/info.py#L235

cc @hoechenberger 

it fixes it but I don't understand why it's done this way in mne-python.

maybe @larsoner can help