### PR TITLE
MRG: ENH: Support full range of  hand & sex options

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -37,6 +37,7 @@ Changelog
 - When impedance values are available from a ``raw.impedances`` attribute, MNE-BIDS will now write an ``impedance`` column to ``*_electrodes.tsv`` files, by `Stefan Appelhoff`_ (`#484 <https://github.com/mne-tools/mne-bids/pull/484>`_)
 - :func:`mne_bids.write_raw_bids` writes out status_description with 'n/a' values into the channels.tsv sidecar file, by `Adam Li`_ (`#489 <https://github.com/mne-tools/mne-bids/pull/489>`_)
 - Added a new function :func:`mne_bids.mark_bad_channels` and command line interface ``mark_bad_channels`` which allows updating of the channel status (bad, good) and description of an existing BIDS dataset, by `Richard Höchenberger`_ (`#491 <https://github.com/mne-tools/mne-bids/pull/491>`_)
+- :func:`mne_bids.read_raw_bids` correctly maps all specified ``handedness`` and ``sex`` options to MNE-Python, instead of only an incomplete subset, by `Richard Höchenberger`_ (`#550 <https://github.com/mne-tools/mne-bids/pull/550>`_)
 
 Bug
 ~~~

--- a/mne_bids/config.py
+++ b/mne_bids/config.py
@@ -215,29 +215,32 @@ REFERENCES = {'mne-bids':
               '6, 102. https://doi.org/10.1038/s41597-019-0105-7'}
 
 
-# mapping subject information back to mne-python
+# Mapping subject information between MNE-BIDS and MNE-Python.
+HAND_BIDS_TO_MNE = {
+    ('n/a',): 0,
+    ('right', 'r', 'R', 'RIGHT', 'Right'): 1,
+    ('left', 'l', 'L', 'LEFT', 'Left'): 2,
+    ('ambidextrous', 'a', 'A', 'AMBIDEXTROUS', 'Ambidextrous'): 3
+}
+
+HAND_MNE_TO_BIDS = {0: 'n/a', 1: 'R', 2: 'L', 3: 'A'}
+
+SEX_BIDS_TO_MNE = {
+    ('n/a', 'other', 'o', 'O', 'OTHER', 'Other'): 0,
+    ('male', 'm', 'M', 'MALE', 'Male'): 1,
+    ('female', 'f', 'F', 'FEMALE', 'Female'): 2
+}
+
+SEX_MNE_TO_BIDS = {0: 'n/a', 1: 'M', 2: 'F'}
+
+
 def _map_options(what, key, fro, to):
-    hand_options_bids_to_mne = {
-        ('n/a',): 0,
-        ('right', 'r', 'R', 'RIGHT', 'Right'): 1,
-        ('left', 'l', 'L', 'LEFT', 'Left'): 2,
-        ('ambidextrous', 'a', 'A', 'AMBIDEXTROUS', 'Ambidextrous'): 3
-    }
-    hand_options_mne_to_bids = {0: 'n/a', 1: 'R', 2: 'L', 3: 'A'}
-
-    sex_options_bids_to_mne = {
-        ('n/a', 'other', 'o', 'O', 'OTHER', 'Other'): 0,
-        ('male', 'm', 'M', 'MALE', 'Male'): 1,
-        ('female', 'f', 'F', 'FEMALE', 'Female'): 2
-    }
-    sex_options_mne_to_bids = {0: 'n/a', 1: 'M', 2: 'F'}
-
     if what == 'sex':
-        mapping_bids_mne = sex_options_bids_to_mne
-        mapping_mne_bids = sex_options_mne_to_bids
+        mapping_bids_mne = SEX_BIDS_TO_MNE
+        mapping_mne_bids = SEX_MNE_TO_BIDS
     elif what == 'hand':
-        mapping_bids_mne = hand_options_bids_to_mne
-        mapping_mne_bids = hand_options_mne_to_bids
+        mapping_bids_mne = HAND_BIDS_TO_MNE
+        mapping_mne_bids = HAND_MNE_TO_BIDS
     else:
         raise ValueError('Can only map `sex` and `hand`.')
 

--- a/mne_bids/config.py
+++ b/mne_bids/config.py
@@ -216,25 +216,54 @@ REFERENCES = {'mne-bids':
 
 
 # mapping subject information back to mne-python
-# XXX: MNE currently only handles R/L,
-# follow https://github.com/mne-tools/mne-python/issues/7347
 def _convert_hand_options(key, fro, to):
+    hand_options_bids_to_mne = {
+        ('n/a',): 0,
+        ('right', 'r', 'R', 'RIGHT', 'Right'): 1,
+        ('left', 'l', 'L', 'LEFT', 'Left'): 2,
+        ('ambidextrous', 'a', 'A', 'AMBIDEXTROUS', 'Ambidextrous'): 3
+    }
+
+    hand_options_mne_to_bids = {0: 'n/a', 1: 'R', 2: 'L', 3: 'A'}
+
     if fro == 'bids' and to == 'mne':
-        hand_options = {'n/a': 0, 'R': 1, 'L': 2, 'A': 3}
+        # Many-to-one mapping
+        mapped_option = None
+        for bids_keys, mne_option in hand_options_bids_to_mne.items():
+            if key in bids_keys:
+                mapped_option = mne_option
+                break
     elif fro == 'mne' and to == 'bids':
-        hand_options = {0: 'n/a', 1: 'R', 2: 'L', 3: 'A'}
+        # One-to-one mapping
+        mapped_option = hand_options_mne_to_bids.get(key, None)
     else:
         raise RuntimeError("fro value {} and to value {} are not "
                            "accepted. Use 'mne', or 'bids'.".format(fro, to))
-    return hand_options.get(key, None)
+
+    return mapped_option
 
 
 def _convert_sex_options(key, fro, to):
+    sex_options_bids_to_mne = {
+        ('n/a', 'other', 'o', 'O', 'OTHER', 'Other'): 0,
+        ('male', 'm', 'M', 'MALE', 'Male'): 1,
+        ('female', 'f', 'F', 'FEMALE', 'Female'): 2
+    }
+
+    sex_options_mne_to_bids = {0: 'n/a', 1: 'M', 2: 'F'}
+
     if fro == 'bids' and to == 'mne':
-        sex_options = {'n/a': 0, 'M': 1, 'F': 2}
+        # Many-to-one mapping
+        mapped_option = None
+        for bids_keys, mne_option in sex_options_bids_to_mne.items():
+            if key in bids_keys:
+                mapped_option = mne_option
+                break
     elif fro == 'mne' and to == 'bids':
-        sex_options = {0: 'n/a', 1: 'M', 2: 'F'}
+        # One-to-one mapping
+        mapped_option = sex_options_mne_to_bids.get(key, None)
     else:
         raise RuntimeError("fro value {} and to value {} are not "
                            "accepted. Use 'mne', or 'bids'.".format(fro, to))
-    return sex_options.get(key, None)
+
+    return mapped_option

--- a/mne_bids/config.py
+++ b/mne_bids/config.py
@@ -216,52 +216,41 @@ REFERENCES = {'mne-bids':
 
 
 # mapping subject information back to mne-python
-def _convert_hand_options(key, fro, to):
+def _map_options(what, key, fro, to):
     hand_options_bids_to_mne = {
         ('n/a',): 0,
         ('right', 'r', 'R', 'RIGHT', 'Right'): 1,
         ('left', 'l', 'L', 'LEFT', 'Left'): 2,
         ('ambidextrous', 'a', 'A', 'AMBIDEXTROUS', 'Ambidextrous'): 3
     }
-
     hand_options_mne_to_bids = {0: 'n/a', 1: 'R', 2: 'L', 3: 'A'}
 
-    if fro == 'bids' and to == 'mne':
-        # Many-to-one mapping
-        mapped_option = None
-        for bids_keys, mne_option in hand_options_bids_to_mne.items():
-            if key in bids_keys:
-                mapped_option = mne_option
-                break
-    elif fro == 'mne' and to == 'bids':
-        # One-to-one mapping
-        mapped_option = hand_options_mne_to_bids.get(key, None)
-    else:
-        raise RuntimeError("fro value {} and to value {} are not "
-                           "accepted. Use 'mne', or 'bids'.".format(fro, to))
-
-    return mapped_option
-
-
-def _convert_sex_options(key, fro, to):
     sex_options_bids_to_mne = {
         ('n/a', 'other', 'o', 'O', 'OTHER', 'Other'): 0,
         ('male', 'm', 'M', 'MALE', 'Male'): 1,
         ('female', 'f', 'F', 'FEMALE', 'Female'): 2
     }
-
     sex_options_mne_to_bids = {0: 'n/a', 1: 'M', 2: 'F'}
+
+    if what == 'sex':
+        mapping_bids_mne = sex_options_bids_to_mne
+        mapping_mne_bids = sex_options_mne_to_bids
+    elif what == 'hand':
+        mapping_bids_mne = hand_options_bids_to_mne
+        mapping_mne_bids = hand_options_mne_to_bids
+    else:
+        raise ValueError('Can only map `sex` and `hand`.')
 
     if fro == 'bids' and to == 'mne':
         # Many-to-one mapping
         mapped_option = None
-        for bids_keys, mne_option in sex_options_bids_to_mne.items():
+        for bids_keys, mne_option in mapping_bids_mne.items():
             if key in bids_keys:
                 mapped_option = mne_option
                 break
     elif fro == 'mne' and to == 'bids':
         # One-to-one mapping
-        mapped_option = sex_options_mne_to_bids.get(key, None)
+        mapped_option = mapping_mne_bids.get(key, None)
     else:
         raise RuntimeError("fro value {} and to value {} are not "
                            "accepted. Use 'mne', or 'bids'.".format(fro, to))

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -19,7 +19,7 @@ from mne.transforms import apply_trans
 
 from mne_bids.dig import _read_dig_bids
 from mne_bids.tsv_handler import _from_tsv, _drop
-from mne_bids.config import (ALLOWED_DATATYPE_EXTENSIONS, reader, _map_options)
+from mne_bids.config import ALLOWED_DATATYPE_EXTENSIONS, reader, _map_options
 from mne_bids.utils import _extract_landmarks, _get_ch_type_mapping
 from mne_bids.path import (BIDSPath, _parse_ext, _find_matching_sidecar,
                            _infer_datatype)

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -177,11 +177,8 @@ def test_read_participants_handedness_and_sex_mapping(hand_bids, hand_mne,
     participants_tsv_fpath = op.join(bids_root, 'participants.tsv')
     raw = _read_raw_fif(raw_fname, verbose=False)
 
-    subject_info = {
-        'hand': 1,
-        'sex': 2,
-    }
-    raw.info['subject_info'] = subject_info
+    # Avoid that we end up with subject information stored in the raw data.
+    raw.info['subject_info'] = {}
     write_raw_bids(raw, bids_path, overwrite=True, verbose=False)
 
     participants_tsv = _from_tsv(participants_tsv_fpath)

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -41,11 +41,11 @@ run = '01'
 acq = '01'
 task = 'testing'
 
-bids_path = BIDSPath(
+_bids_path = BIDSPath(
     subject=subject_id, session=session_id, run=run, acquisition=acq,
     task=task)
 
-bids_path_minimal = BIDSPath(subject=subject_id, task=task)
+_bids_path_minimal = BIDSPath(subject=subject_id, task=task)
 
 # Get the MNE testing sample data - USA
 data_path = testing.data_path()
@@ -114,6 +114,7 @@ def test_read_correct_inputs():
 def test_read_participants_data():
     """Test reading information from a BIDS sidecar.json file."""
     bids_root = _TempDir()
+    bids_path = _bids_path.copy().update(root=bids_root, datatype='meg')
     raw = _read_raw_fif(raw_fname, verbose=False)
 
     # if subject info was set, we don't roundtrip birthday
@@ -123,7 +124,6 @@ def test_read_participants_data():
         'sex': 2,
     }
     raw.info['subject_info'] = subject_info
-    bids_path.update(root=bids_root, datatype='meg')
     write_raw_bids(raw, bids_path, overwrite=True, verbose=False)
     raw = read_raw_bids(bids_path=bids_path)
     print(raw.info['subject_info'])
@@ -173,6 +173,7 @@ def test_read_participants_handedness_and_sex_mapping(hand_bids, hand_mne,
                                                       sex_bids, sex_mne):
     """Test we're correctly mapping handedness and sex between BIDS and MNE."""
     bids_root = _TempDir()
+    bids_path = _bids_path.copy().update(root=bids_root, datatype='meg')
     participants_tsv_fpath = op.join(bids_root, 'participants.tsv')
     raw = _read_raw_fif(raw_fname, verbose=False)
 
@@ -181,7 +182,6 @@ def test_read_participants_handedness_and_sex_mapping(hand_bids, hand_mne,
         'sex': 2,
     }
     raw.info['subject_info'] = subject_info
-    bids_path.update(root=bids_root, datatype='meg')
     write_raw_bids(raw, bids_path, overwrite=True, verbose=False)
 
     participants_tsv = _from_tsv(participants_tsv_fpath)
@@ -208,7 +208,7 @@ def test_get_head_mri_trans():
     # Write it to BIDS
     raw = _read_raw_fif(raw_fname)
     bids_root = _TempDir()
-    bids_path.update(root=bids_root)
+    bids_path = _bids_path.copy().update(root=bids_root)
     write_raw_bids(raw, bids_path, events_data=events_fname,
                    event_id=event_id, overwrite=False)
 
@@ -394,7 +394,7 @@ def test_handle_eeg_coords_reading():
 
 
 @pytest.mark.parametrize('bids_path',
-                         [bids_path, bids_path_minimal])
+                         [_bids_path, _bids_path_minimal])
 @pytest.mark.filterwarnings(warning_str['nasion_not_found'])
 @pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
 def test_handle_ieeg_coords_reading(bids_path):
@@ -565,7 +565,7 @@ def test_get_head_mri_trans_ctf():
     raw_ctf_fname = op.join(ctf_data_path, 'testdata_ctf.ds')
     raw_ctf = _read_raw_ctf(raw_ctf_fname)
     bids_root = _TempDir()
-    bids_path.update(root=bids_root)
+    bids_path = _bids_path.copy().update(root=bids_root)
     write_raw_bids(raw_ctf, bids_path, overwrite=False)
 
     # Take a fake trans
@@ -589,7 +589,7 @@ def test_get_head_mri_trans_ctf():
 def test_read_raw_bids_pathlike():
     """Test that read_raw_bids() can handle a Path-like bids_root."""
     bids_root = _TempDir()
-    bids_path.update(root=bids_root, datatype='meg')
+    bids_path = _bids_path.copy().update(root=bids_root, datatype='meg')
     raw = _read_raw_fif(raw_fname, verbose=False)
     write_raw_bids(raw, bids_path, overwrite=True, verbose=False)
     raw = read_raw_bids(bids_path=bids_path)
@@ -599,7 +599,7 @@ def test_read_raw_bids_pathlike():
 def test_read_raw_datatype():
     """Test that read_raw_bids() can infer the str_suffix if need be."""
     bids_root = _TempDir()
-    bids_path.update(root=bids_root, datatype='meg')
+    bids_path = _bids_path.copy().update(root=bids_root, datatype='meg')
     raw = _read_raw_fif(raw_fname, verbose=False)
     write_raw_bids(raw, bids_path, overwrite=True, verbose=False)
 
@@ -619,7 +619,7 @@ def test_read_raw_datatype():
 def test_handle_channel_type_casing():
     """Test that non-uppercase entries in the `type` column are accepted."""
     bids_root = _TempDir()
-    bids_path.update(root=bids_root)
+    bids_path = _bids_path.copy().update(root=bids_root)
     raw = _read_raw_fif(raw_fname, verbose=False)
 
     write_raw_bids(raw, bids_path, overwrite=True,
@@ -643,7 +643,7 @@ def test_handle_channel_type_casing():
 @pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
 def test_bads_reading():
     bids_root = _TempDir()
-    bids_path.update(root=bids_root)
+    bids_path = _bids_path.copy().update(root=bids_root)
     data_path = BIDSPath(
         subject=subject_id, session=session_id, datatype='meg',
         root=bids_root).mkdir().directory

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -269,7 +269,7 @@ def _participants_tsv(raw, subject_id, fname, overwrite=False,
                            fro='mne', to='bids')
 
         # add handedness
-        hand = _map_options(what='hand', subject_info.get('hand', 0),
+        hand = _map_options(what='hand', key=subject_info.get('hand', 0),
                             fro='mne', to='bids')
 
         # determine the age of the participant

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -265,12 +265,12 @@ def _participants_tsv(raw, subject_id, fname, overwrite=False,
     subject_info = raw.info.get('subject_info', None)
     if subject_info is not None:
         # add sex
-        sex = _convert_sex_options(subject_info.get('sex', 0),
-                                   fro='mne', to='bids')
+        sex = _map_options(what='sex', key=subject_info.get('sex', 0),
+                           fro='mne', to='bids')
 
         # add handedness
-        hand = _convert_hand_options(subject_info.get('hand', 0),
-                                     fro='mne', to='bids')
+        hand = _map_options(what='hand', subject_info.get('hand', 0),
+                            fro='mne', to='bids')
 
         # determine the age of the participant
         age = subject_info.get('birthday', None)

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -47,8 +47,7 @@ from mne_bids.read import _get_bads_from_tsv_data, _find_matching_sidecar
 
 from mne_bids.config import (ORIENTATION, UNITS, MANUFACTURERS,
                              IGNORED_CHANNELS, ALLOWED_DATATYPE_EXTENSIONS,
-                             BIDS_VERSION, REFERENCES, _convert_hand_options,
-                             _convert_sex_options, reader)
+                             BIDS_VERSION, REFERENCES, _map_options, reader)
 
 
 def _is_numeric(n):


### PR DESCRIPTION
PR Description
--------------
The standard demands a much more extensive list of valid values than we are currently supporting in `master`:
https://bids-specification.readthedocs.io/en/latest/03-modality-agnostic-files.html#participants-file

I realized this when reading a dataset with IMHO properly specified sex & handedness, yet ended up without these values
in `raw.info['subject_info']`.

<strike>WIP: need to add tests and potentially changelog entry.</strike>

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
