### PR TITLE
[MRG] Allow print_dir_tree to accept a pathlib.Path object

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -41,6 +41,7 @@ Changelog
 - :func:`mne_bids.write_raw_bids` only writes a README if it does not already exist, by `Adam Li`_ (`#489 <https://github.com/mne-tools/mne-bids/pull/489>`_)
 - Allow :func:`mne_bids.write_raw_bids` to write EEG/iEEG files from Persyst using ``mne.io.read_raw_persyst`` function, by `Adam Li`_ (`#546 <https://github.com/mne-tools/mne-bids/pull/546>`_)
 
+
 Bug
 ~~~
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -40,7 +40,7 @@ Changelog
 - :func:`mne_bids.read_raw_bids` correctly maps all specified ``handedness`` and ``sex`` options to MNE-Python, instead of only an incomplete subset, by `Richard Höchenberger`_ (`#550 <https://github.com/mne-tools/mne-bids/pull/550>`_)
 - :func:`mne_bids.write_raw_bids` only writes a README if it does not already exist, by `Adam Li`_ (`#489 <https://github.com/mne-tools/mne-bids/pull/489>`_)
 - Allow :func:`mne_bids.write_raw_bids` to write EEG/iEEG files from Persyst using ``mne.io.read_raw_persyst`` function, by `Adam Li`_ (`#546 <https://github.com/mne-tools/mne-bids/pull/546>`_)
-- :func:`mne_bids.print_dir_tree` now works if a :func:`pathlib.Path` object is passed in, by `Adam Li`_ (`#555 <https://github.com/mne-tools/mne-bids/pull/555>`_)
+- :func:`mne_bids.print_dir_tree` now works if a ``pathlib.Path`` object is passed in, by `Adam Li`_ (`#555 <https://github.com/mne-tools/mne-bids/pull/555>`_)
 
 
 Bug

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -40,6 +40,7 @@ Changelog
 - :func:`mne_bids.read_raw_bids` correctly maps all specified ``handedness`` and ``sex`` options to MNE-Python, instead of only an incomplete subset, by `Richard Höchenberger`_ (`#550 <https://github.com/mne-tools/mne-bids/pull/550>`_)
 - :func:`mne_bids.write_raw_bids` only writes a README if it does not already exist, by `Adam Li`_ (`#489 <https://github.com/mne-tools/mne-bids/pull/489>`_)
 - Allow :func:`mne_bids.write_raw_bids` to write EEG/iEEG files from Persyst using ``mne.io.read_raw_persyst`` function, by `Adam Li`_ (`#546 <https://github.com/mne-tools/mne-bids/pull/546>`_)
+- :func:`mne_bids.print_dir_tree` now works if a :func:`pathlib.Path` object is passed in, by `Adam Li`_ (`#489 <https://github.com/mne-tools/mne-bids/pull/555>`_)
 
 
 Bug

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -40,7 +40,7 @@ Changelog
 - :func:`mne_bids.read_raw_bids` correctly maps all specified ``handedness`` and ``sex`` options to MNE-Python, instead of only an incomplete subset, by `Richard Höchenberger`_ (`#550 <https://github.com/mne-tools/mne-bids/pull/550>`_)
 - :func:`mne_bids.write_raw_bids` only writes a README if it does not already exist, by `Adam Li`_ (`#489 <https://github.com/mne-tools/mne-bids/pull/489>`_)
 - Allow :func:`mne_bids.write_raw_bids` to write EEG/iEEG files from Persyst using ``mne.io.read_raw_persyst`` function, by `Adam Li`_ (`#546 <https://github.com/mne-tools/mne-bids/pull/546>`_)
-- :func:`mne_bids.print_dir_tree` now works if a :func:`pathlib.Path` object is passed in, by `Adam Li`_ (`#489 <https://github.com/mne-tools/mne-bids/pull/555>`_)
+- :func:`mne_bids.print_dir_tree` now works if a :func:`pathlib.Path` object is passed in, by `Adam Li`_ (`#555 <https://github.com/mne-tools/mne-bids/pull/555>`_)
 
 
 Bug

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -734,7 +734,7 @@ def print_dir_tree(folder, max_depth=None):
     max_depth += 1
 
     # Base length of a tree branch, to normalize each tree's start to 0
-    baselen = len(folder.split(os.sep)) - 1
+    baselen = len(str(folder).split(os.sep)) - 1
 
     # Recursively walk through all directories
     for root, dirs, files in os.walk(folder):

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -138,6 +138,9 @@ def test_print_dir_tree(capsys):
     captured = capsys.readouterr()
     assert captured.out == '|tests{}\n'.format(os.sep)
 
+    # test if pathlib.Path object
+    print_dir_tree(Path(test_dir))
+
 
 def test_make_folders():
     """Test that folders are created and named properly."""


### PR DESCRIPTION
PR Description
--------------

A one-line fix to allow `print_dir_tree` to accept a `Path` object.

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
