### PR TITLE
[MRG] Consolidates all bids_root kwarg to root

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -39,6 +39,7 @@ Changelog
 - Added a new function :func:`mne_bids.mark_bad_channels` and command line interface ``mark_bad_channels`` which allows updating of the channel status (bad, good) and description of an existing BIDS dataset, by `Richard Höchenberger`_ (`#491 <https://github.com/mne-tools/mne-bids/pull/491>`_)
 - :func:`mne_bids.read_raw_bids` correctly maps all specified ``handedness`` and ``sex`` options to MNE-Python, instead of only an incomplete subset, by `Richard Höchenberger`_ (`#550 <https://github.com/mne-tools/mne-bids/pull/550>`_)
 - :func:`mne_bids.write_raw_bids` only writes a README if it does not already exist, by `Adam Li`_ (`#489 <https://github.com/mne-tools/mne-bids/pull/489>`_)
+- All functions :func:`mne_bids.write_anat`, :func:`mne_bids.make_report`, :func:`mne_bids.get_entity_vals` and :func:`mne_bids.get_datatypes` use now kwarg ``root`` instead of ``bids_root``, `Adam Li`_ (`#489 <https://github.com/mne-tools/mne-bids/pull/489>`_)
 
 
 Bug

--- a/examples/convert_group_studies.py
+++ b/examples/convert_group_studies.py
@@ -104,5 +104,5 @@ print_dir_tree(bids_root)
 
 ###############################################################################
 # Now let's generate a report on the dataset.
-dataset_report = make_report(bids_root=bids_root)
+dataset_report = make_report(root=bids_root)
 print(dataset_report)

--- a/examples/convert_mri_and_trans.py
+++ b/examples/convert_mri_and_trans.py
@@ -99,7 +99,7 @@ print(trans)
 # retrieve our transformation matrix :code:`trans`.
 
 # We use the write_anat function
-anat_dir = write_anat(bids_root=output_path,  # the BIDS dir we wrote earlier
+anat_dir = write_anat(root=output_path,  # the BIDS dir we wrote earlier
                       subject=sub,
                       t1w=t1_mgh_fname,  # path to the MRI scan
                       session=ses,
@@ -154,7 +154,7 @@ plt.show()
 
 ###############################################################################
 # We can deface the MRI for anonymization
-anat_dir = write_anat(bids_root=output_path,  # the BIDS dir we wrote earlier
+anat_dir = write_anat(root=output_path,  # the BIDS dir we wrote earlier
                       subject=sub,
                       t1w=t1_mgh_fname,  # path to the MRI scan
                       session=ses,

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -331,7 +331,7 @@ def read_raw_bids(bids_path, extra_params=None, verbose=True):
 
     # infer the datatype and suffix if they are not present in the BIDSPath
     if datatype is None:
-        datatype = _infer_datatype(bids_root=bids_root, sub=sub, ses=ses)
+        datatype = _infer_datatype(root=bids_root, sub=sub, ses=ses)
         bids_path.update(datatype=datatype)
     if suffix is None:
         bids_path.update(suffix=datatype)

--- a/mne_bids/report.py
+++ b/mne_bids/report.py
@@ -130,7 +130,7 @@ def _pretty_dict(template_dict):
             template_dict[key] = 'n/a'
 
 
-def _summarize_dataset(bids_root):
+def _summarize_dataset(root):
     """Summarize the dataset_desecription.json file.
 
     Required dataset descriptors include:
@@ -143,7 +143,7 @@ def _summarize_dataset(bids_root):
 
     Parameters
     ----------
-    bids_root : str | pathlib.Path
+    root : str | pathlib.Path
         The path of the root of the BIDS compatible folder.
 
     Returns
@@ -151,7 +151,7 @@ def _summarize_dataset(bids_root):
     template_dict : dict
         A dictionary of values for various template strings.
     """
-    dataset_descrip_fpath = op.join(bids_root,
+    dataset_descrip_fpath = op.join(root,
                                     'dataset_description.json')
     if not op.exists(dataset_descrip_fpath):
         return dict()
@@ -174,12 +174,12 @@ def _summarize_dataset(bids_root):
     return template_dict
 
 
-def _summarize_participants_tsv(bids_root, verbose=True):
+def _summarize_participants_tsv(root, verbose=True):
     """Summarize `participants.tsv` file in BIDS root directory.
 
     Parameters
     ----------
-    bids_root : str | pathlib.Path
+    root : str | pathlib.Path
         The path of the root of the BIDS compatible folder.
     verbose: bool
         Set verbose output to true or false.
@@ -189,7 +189,7 @@ def _summarize_participants_tsv(bids_root, verbose=True):
     template_dict : dict
         A dictionary of values for various template strings.
     """
-    participants_tsv_fpath = op.join(bids_root, 'participants.tsv')
+    participants_tsv_fpath = op.join(root, 'participants.tsv')
     if not op.exists(participants_tsv_fpath):
         return dict()
 
@@ -246,14 +246,14 @@ def _summarize_participants_tsv(bids_root, verbose=True):
     return template_dict
 
 
-def _summarize_scans(bids_root, session=None, verbose=True):
+def _summarize_scans(root, session=None, verbose=True):
     """Summarize scans in BIDS root directory.
 
     Summarizes scans only if there is a *_scans.tsv file.
 
     Parameters
     ----------
-    bids_root : str | pathlib.Path
+    root : str | pathlib.Path
         The path of the root of the BIDS compatible folder.
     session : str, optional
         The session for a item. Corresponds to "ses".
@@ -265,13 +265,13 @@ def _summarize_scans(bids_root, session=None, verbose=True):
     template_dict : dict
         A dictionary of values for various template strings.
     """
-    bids_root = Path(bids_root)
+    root = Path(root)
     if session is None:
         search_str = '*_scans.tsv'
     else:
         search_str = f'*ses-{session}' \
                      f'*_scans.tsv'
-    scans_fpaths = list(bids_root.rglob(search_str))
+    scans_fpaths = list(root.rglob(search_str))
     if len(scans_fpaths) == 0:
         warn('No *scans.tsv files found. Currently, '
              'we do not generate a report without the scans.tsv files.')
@@ -281,9 +281,9 @@ def _summarize_scans(bids_root, session=None, verbose=True):
         print(f'Summarizing scans.tsv files {scans_fpaths}...')
 
     # summarize sidecar.json, channels.tsv template
-    sidecar_dict = _summarize_sidecar_json(bids_root, scans_fpaths,
+    sidecar_dict = _summarize_sidecar_json(root, scans_fpaths,
                                            verbose=verbose)
-    channels_dict = _summarize_channels_tsv(bids_root, scans_fpaths,
+    channels_dict = _summarize_channels_tsv(root, scans_fpaths,
                                             verbose=verbose)
     template_dict = dict()
     template_dict.update(**sidecar_dict)
@@ -292,15 +292,15 @@ def _summarize_scans(bids_root, session=None, verbose=True):
     return template_dict
 
 
-def _summarize_sidecar_json(bids_root, scans_fpaths, verbose=True):
+def _summarize_sidecar_json(root, scans_fpaths, verbose=True):
     """Summarize scans in BIDS root directory.
 
     Parameters
     ----------
-    bids_root : str | pathlib.Path
+    root : str | pathlib.Path
         The path of the root of the BIDS compatible folder.
     scans_fpaths : list
-        A list of all *_scans.tsv files in bids_root. The summary
+        A list of all *_scans.tsv files in ``root``. The summary
         will occur for all scans listed in the *_scans.tsv files.
     verbose : bool
         Set verbose output to true or false.
@@ -332,7 +332,7 @@ def _summarize_sidecar_json(bids_root, scans_fpaths, verbose=True):
 
             # convert to BIDS Path
             params = get_entities_from_fname(bids_path)
-            bids_path = BIDSPath(root=bids_root, **params)
+            bids_path = BIDSPath(root=root, **params)
 
             # XXX: improve to allow emptyroom
             if bids_path.subject == 'emptyroom':
@@ -377,7 +377,7 @@ def _summarize_sidecar_json(bids_root, scans_fpaths, verbose=True):
     return template_dict
 
 
-def _summarize_channels_tsv(bids_root, scans_fpaths, verbose=True):
+def _summarize_channels_tsv(root, scans_fpaths, verbose=True):
     """Summarize channels.tsv data in BIDS root directory.
 
     Currently, summarizes all REQUIRED components of channels
@@ -385,10 +385,10 @@ def _summarize_channels_tsv(bids_root, scans_fpaths, verbose=True):
 
     Parameters
     ----------
-    bids_root : str | pathlib.Path
+    root : str | pathlib.Path
         The path of the root of the BIDS compatible folder.
     scans_fpaths : list
-        A list of all *_scans.tsv files in bids_root. The summary
+        A list of all *_scans.tsv files in ``root``. The summary
         will occur for all scans listed in the *_scans.tsv files.
     verbose : bool
 
@@ -397,7 +397,7 @@ def _summarize_channels_tsv(bids_root, scans_fpaths, verbose=True):
     template_dict : dict
         A dictionary of values for various template strings.
     """
-    bids_root = Path(bids_root)
+    root = Path(root)
 
     # keep track of channel type, status
     ch_status_count = {'bad': [], 'good': []}
@@ -418,7 +418,7 @@ def _summarize_channels_tsv(bids_root, scans_fpaths, verbose=True):
 
             # convert to BIDS Path
             params = get_entities_from_fname(bids_path)
-            bids_path = BIDSPath(root=bids_root, **params)
+            bids_path = BIDSPath(root=root, **params)
 
             # XXX: improve to allow emptyroom
             if bids_path.subject == 'emptyroom':
@@ -450,7 +450,7 @@ def _summarize_channels_tsv(bids_root, scans_fpaths, verbose=True):
     return template_dict
 
 
-def make_report(bids_root, session=None, verbose=True):
+def make_report(root, session=None, verbose=True):
     """Create a methods paragraph string from BIDS dataset.
 
     Summarizes the REQUIRED components in the BIDS specification
@@ -464,7 +464,7 @@ def make_report(bids_root, session=None, verbose=True):
 
     Parameters
     ----------
-    bids_root : str | pathlib.Path
+    root : str | pathlib.Path
         The path of the root of the BIDS compatible folder.
     session : str , optional
             The session for a item. Corresponds to "ses".
@@ -478,9 +478,9 @@ def make_report(bids_root, session=None, verbose=True):
         describing the summary of the subjects.
     """
     # high level summary
-    subjects = get_entity_vals(bids_root, entity_key='subject')
-    sessions = get_entity_vals(bids_root, entity_key='session')
-    modalities = get_datatypes(bids_root)
+    subjects = get_entity_vals(root, entity_key='subject')
+    sessions = get_entity_vals(root, entity_key='session')
+    modalities = get_datatypes(root)
 
     # only summarize allowed modalities (MEG/EEG/iEEG) data
     # map them to a pretty looking string
@@ -493,13 +493,13 @@ def make_report(bids_root, session=None, verbose=True):
                   if datatype in datatype_map.keys()]
 
     # REQUIRED: dataset_description.json summary
-    dataset_summary = _summarize_dataset(bids_root)
+    dataset_summary = _summarize_dataset(root)
 
     # RECOMMENDED: participants summary
-    participant_summary = _summarize_participants_tsv(bids_root)
+    participant_summary = _summarize_participants_tsv(root)
 
     # RECOMMENDED: scans summary
-    scans_summary = _summarize_scans(bids_root, session=session,
+    scans_summary = _summarize_scans(root, session=session,
                                      verbose=verbose)
 
     # turn off 'recommended' report summary

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -100,9 +100,9 @@ def test_get_entity_vals(entity, expected_vals, kwargs, return_bids_test_dir):
 
     if entity == 'bogus':
         with pytest.raises(ValueError, match='`key` must be one of'):
-            get_entity_vals(bids_root=bids_root, entity_key=entity, **kwargs)
+            get_entity_vals(root=bids_root, entity_key=entity, **kwargs)
     else:
-        vals = get_entity_vals(bids_root=bids_root, entity_key=entity,
+        vals = get_entity_vals(root=bids_root, entity_key=entity,
                                **kwargs)
         assert vals == expected_vals
 

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -1444,7 +1444,7 @@ def test_write_anat_pathlike():
 
     bids_root = Path(_TempDir())
     t1w_mgh_fname = Path(data_path) / 'subjects' / 'sample' / 'mri' / 'T1.mgz'
-    anat_dir = write_anat(bids_root=bids_root, subject=subject_id,
+    anat_dir = write_anat(root=bids_root, subject=subject_id,
                           t1w=t1w_mgh_fname,
                           session=session_id, acquisition=acq,
                           raw=raw, trans=trans, deface=True, verbose=True,

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1144,7 +1144,7 @@ def write_raw_bids(raw, bids_path, events_data=None,
     return bids_path
 
 
-def write_anat(bids_root, subject, t1w, session=None, acquisition=None,
+def write_anat(root, subject, t1w, session=None, acquisition=None,
                raw=None, trans=None, landmarks=None, deface=False,
                overwrite=False, verbose=False):
     """Put anatomical MRI data into a BIDS format.
@@ -1156,7 +1156,7 @@ def write_anat(bids_root, subject, t1w, session=None, acquisition=None,
 
     Parameters
     ----------
-    bids_root : str | pathlib.Path
+    root : str | pathlib.Path
         Path to root of the BIDS folder
     subject : str
         Subject label as in 'sub-<label>', for example: '01'
@@ -1222,7 +1222,7 @@ def write_anat(bids_root, subject, t1w, session=None, acquisition=None,
                          'must be provided to deface the T1')
 
     # Make directory for anatomical data
-    anat_dir = op.join(bids_root, 'sub-{}'.format(subject))
+    anat_dir = op.join(root, 'sub-{}'.format(subject))
     # Session is optional
     if session is not None:
         anat_dir = op.join(anat_dir, 'ses-{}'.format(session))
@@ -1257,7 +1257,7 @@ def write_anat(bids_root, subject, t1w, session=None, acquisition=None,
     # this needs to be a string, since nibabel assumes a string input
     t1w_basename = BIDSPath(subject=subject, session=session,
                             acquisition=acquisition,
-                            root=bids_root,
+                            root=root,
                             suffix='T1w', extension='.nii.gz')
 
     # Check if we have necessary conditions for writing a sidecar JSON


### PR DESCRIPTION
PR Description
--------------

Addresses #454 where we rename things to `root` instead of `bids_root`. This follows the pattern in `BIDSPath` and the other functions that accept `root` as a kwarg.

This only changes all kwarg inputs to consolidate it to `root`. Anything in tests, or examples, I left untouched.

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
