### PR TITLE
MRG: BF: Use persyst reader func and not return value

### DIFF
--- a/mne_bids/config.py
+++ b/mne_bids/config.py
@@ -48,7 +48,7 @@ reader = {'.con': io.read_raw_kit, '.sqd': io.read_raw_kit,
           '.fif': io.read_raw_fif, '.pdf': io.read_raw_bti,
           '.ds': io.read_raw_ctf, '.vhdr': io.read_raw_brainvision,
           '.edf': io.read_raw_edf, '.bdf': io.read_raw_bdf,
-          '.set': io.read_raw_eeglab, '.lay': _read_raw_persyst_func()}
+          '.set': io.read_raw_eeglab, '.lay': _read_raw_persyst_func}
 
 
 # Merge the manufacturer dictionaries in a python2 / python3 compatible way


### PR DESCRIPTION
PR Description
--------------

Use persyst reader function instead of the return value of that function to read persyst data.

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
