### PR TITLE
Silence some warnings during sidecar search

### DIFF
--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -356,7 +356,7 @@ def read_raw_bids(bids_path, extra_params=None, verbose=True):
     # events in the recorded data
     events_fname = _find_matching_sidecar(bids_path, suffix='events',
                                           extension='.tsv',
-                                          allow_fail=True)
+                                          on_fail='warn')
     if events_fname is not None:
         raw = _handle_events_reading(events_fname, raw)
 
@@ -365,20 +365,21 @@ def read_raw_bids(bids_path, extra_params=None, verbose=True):
     channels_fname = _find_matching_sidecar(bids_path,
                                             suffix='channels',
                                             extension='.tsv',
-                                            allow_fail=True)
+                                            on_fail='warn')
     if channels_fname is not None:
         raw = _handle_channels_reading(channels_fname, bids_fname, raw)
 
     # Try to find an associated electrodes.tsv and coordsystem.json
     # to get information about the status and type of present channels
+    on_fail = 'warn' if suffix == 'ieeg' else 'ignore'
     electrodes_fname = _find_matching_sidecar(bids_path,
                                               suffix='electrodes',
                                               extension='.tsv',
-                                              allow_fail=True)
+                                              on_fail=on_fail)
     coordsystem_fname = _find_matching_sidecar(bids_path,
                                                suffix='coordsystem',
                                                extension='.json',
-                                               allow_fail=True)
+                                               on_fail='warn')
     if electrodes_fname is not None:
         if coordsystem_fname is None:
             raise RuntimeError(f"BIDS mandates that the coordsystem.json "
@@ -389,12 +390,12 @@ def read_raw_bids(bids_path, extra_params=None, verbose=True):
             raw = _read_dig_bids(electrodes_fname, coordsystem_fname,
                                  raw, datatype, verbose)
 
-    # Try to find an associated sidecar.json to get information about the
+    # Try to find an associated sidecar .json to get information about the
     # recording snapshot
     sidecar_fname = _find_matching_sidecar(bids_path,
                                            suffix=datatype,
                                            extension='.json',
-                                           allow_fail=True)
+                                           on_fail='warn')
     if sidecar_fname is not None:
         raw = _handle_info_reading(sidecar_fname, raw, verbose=verbose)
 

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -263,11 +263,23 @@ def test_find_matching_sidecar(return_bids_test_dir):
         _find_matching_sidecar(bids_fpath,
                                suffix='coordsystem', extension='.json')
 
-    # Find nothing but receive None, because we set `allow_fail` to True
+    # Find nothing and raise.
+    with pytest.raises(RuntimeError, match='Did not find any'):
+        fname = _find_matching_sidecar(bids_fpath, suffix='foo',
+                                       extension='.bogus')
+
+    # Find nothing and receive None and a warning.
+    on_fail = 'warn'
     with pytest.warns(RuntimeWarning, match='Did not find any'):
-        _find_matching_sidecar(bids_fpath,
-                               suffix='foo', extension='.bogus',
-                               allow_fail=True)
+        fname = _find_matching_sidecar(bids_fpath, suffix='foo',
+                                       extension='.bogus', on_fail=on_fail)
+    assert fname is None
+
+    # Find nothing and receive None.
+    on_fail = 'ignore'
+    fname = _find_matching_sidecar(bids_fpath, suffix='foo',
+                                   extension='.bogus', on_fail=on_fail)
+    assert fname is None
 
 
 def test_bids_path_inference(return_bids_test_dir):

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -281,6 +281,12 @@ def test_find_matching_sidecar(return_bids_test_dir):
                                    extension='.bogus', on_fail=on_fail)
     assert fname is None
 
+    # Invalid on_fail.
+    on_fail = 'hello'
+    with pytest.raises(ValueError, match='Acceptable values for on_fail are'):
+        _find_matching_sidecar(bids_fpath, suffix='coordsystem',
+                               extension='.json', on_fail=on_fail)
+
 
 def test_bids_path_inference(return_bids_test_dir):
     """Test usage of BIDSPath object and fpath."""

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -281,9 +281,8 @@ def test_handle_info_reading():
 
     # find sidecar JSON fname
     bids_fname.update(datatype=suffix)
-    sidecar_fname = _find_matching_sidecar(bids_fname,
-                                           suffix=suffix, extension='.json',
-                                           allow_fail=True)
+    sidecar_fname = _find_matching_sidecar(bids_fname, suffix=suffix,
+                                           extension='.json')
 
     # assert that we get the same line frequency set
     raw = read_raw_bids(bids_path=bids_path)
@@ -345,17 +344,18 @@ def test_handle_eeg_coords_reading():
     raw.set_montage(montage)
     with pytest.warns(RuntimeWarning, match="Skipping EEG electrodes.tsv"):
         write_raw_bids(raw, bids_path, overwrite=True)
-        bids_path.update(root=bids_root)
-        coordsystem_fname = _find_matching_sidecar(bids_path,
-                                                   suffix='coordsystem',
-                                                   extension='.json',
-                                                   allow_fail=True)
-        electrodes_fname = _find_matching_sidecar(bids_path,
-                                                  suffix='electrodes',
-                                                  extension='.tsv',
-                                                  allow_fail=True)
-        assert coordsystem_fname is None
-        assert electrodes_fname is None
+
+    bids_path.update(root=bids_root)
+    coordsystem_fname = _find_matching_sidecar(bids_path,
+                                               suffix='coordsystem',
+                                               extension='.json',
+                                               on_fail='warn')
+    electrodes_fname = _find_matching_sidecar(bids_path,
+                                              suffix='electrodes',
+                                              extension='.tsv',
+                                              on_fail='warn')
+    assert coordsystem_fname is None
+    assert electrodes_fname is None
 
     # create montage in head frame and set should result in
     # warning if landmarks not set
@@ -381,8 +381,7 @@ def test_handle_eeg_coords_reading():
     # modify coordinate frame to not-captrak
     coordsystem_fname = _find_matching_sidecar(bids_path,
                                                suffix='coordsystem',
-                                               extension='.json',
-                                               allow_fail=True)
+                                               extension='.json')
     _update_sidecar(coordsystem_fname, 'EEGCoordinateSystem', 'besa')
     with pytest.warns(RuntimeWarning, match='EEG Coordinate frame is not '
                                             'accepted BIDS keyword'):
@@ -448,12 +447,10 @@ def test_handle_ieeg_coords_reading(bids_path):
     bids_fname.update(root=bids_root)
     coordsystem_fname = _find_matching_sidecar(bids_fname,
                                                suffix='coordsystem',
-                                               extension='.json',
-                                               allow_fail=True)
+                                               extension='.json')
     electrodes_fname = _find_matching_sidecar(bids_fname,
                                               suffix='electrodes',
-                                              extension='.tsv',
-                                              allow_fail=True)
+                                              extension='.tsv')
     orig_electrodes_dict = _from_tsv(electrodes_fname,
                                      [str, float, float, float, str])
 

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -929,11 +929,12 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate):
     with pytest.warns(RuntimeWarning, match='Skipping EEG electrodes.tsv... '
                                             'Setting montage not possible'):
         write_raw_bids(raw, bids_fname, overwrite=True)
-        electrodes_fpath = _find_matching_sidecar(bids_fname,
-                                                  suffix='electrodes',
-                                                  extension='.tsv',
-                                                  allow_fail=True)
-        assert electrodes_fpath is None
+
+    electrodes_fpath = _find_matching_sidecar(bids_fname,
+                                              suffix='electrodes',
+                                              extension='.tsv',
+                                              on_fail='ignore')
+    assert electrodes_fpath is None
 
     # with landmarks, eeg montage is written
     eeg_montage = mne.channels.make_dig_montage(ch_pos=ch_pos,


### PR DESCRIPTION
PR Description
--------------

`read_raw_bids()` repeatedly calls `_find_matching_sidecar()` to collect all potentially available sidecar files. If a sidecar is not found, a warning will be emitted in `master`. However, some of them will **never** be present; specifically, I've never had an MEG dataset that comes with an `electrodes.tsv`, which is used in iEEG. So the behavior on `master` is currently for me:

```python
from mne_bids import BIDSPath, read_raw_bids

import mne
mne.set_log_level('warning')

root = '/Users/hoechenberger/mne_data/MNE-sample-data-bids'
bids_path = BIDSPath(subject='01', session='01', task='audiovisual',
                     run='01', suffix='meg', extension='.fif', datatype='meg',
                     root=root)
read_raw_bids(bids_path)
```

Output:
```
/Users/hoechenberger/Development/mne-bids/mne_bids/path.py:910: RuntimeWarning: Did not find any electrodes.tsv associated with sub-01_ses-01_task-audiovisual_run-01.

The search_str was "/Users/hoechenberger/mne_data/MNE-sample-data-bids/sub-01/**/sub-01_ses-01*electrodes.tsv"
  warn(msg)
```

With this PR branch, there is **no warning** anymore.


Summary of the changes:

- Replace the `allow_fail` kwarg of  `_find_matching_sidecar()` with `on_fail`, which allows for `warn`, `raise`, and `ignore`; the latter can be used to disable warnings if the sidecar file was not found.
- When `read_raw_bids()` tries to retrieve the `electrodes.tsv` sidecar for a non-iEEG dataset (inferred from the BIDSPath's suffix), set `on_fail='ignore'`; otherwise, set it to `'warn'` (previous behavior)
- Some test cases were too lenient with  `_find_matching_sidecar()`, I have corrected that; and also tuned some tests in a few other places.


Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
