### PR TITLE
[MRG] Support cross-talk and fine-calibration files

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -59,11 +59,10 @@ jobs:
       run: |
         cd ..
         git clone --depth 1 https://github.com/bids-standard/bids-validator
-        cd bids-validator
+        cd bids-validator/bids-validator
         git checkout master
-        yarn
-        echo "::add-path::$(pwd)/bids-validator/bin"
-        cd ../mne-bids
+        npm install -g
+        cd ../../mne-bids
 
     - name: Display versions and environment information
       run: |

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -48,12 +48,14 @@ jobs:
         git clone --depth 1 https://github.com/mne-tools/mne-python.git -b master
         pip install --no-deps -e ./mne-python
 
-    - name: Install BIDS validator (stable)
-      if: "matrix.os != 'ubuntu-latest'"
-      run: |
-        npm install -g bids-validator
+    # XXX Revert once bids-validator 1.5.3 has been released
+    # - name: Install BIDS validator (stable)
+    #   if: "matrix.os != 'ubuntu-latest'"
+    #   run: |
+    #     npm install -g bids-validator
+    # - name: Install BIDS validator (master)
+    #   if: "matrix.os == 'ubuntu-latest'"
     - name: Install BIDS validator (master)
-      if: "matrix.os == 'ubuntu-latest'"
       run: |
         cd ..
         git clone --depth 1 https://github.com/bids-standard/bids-validator

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -19,6 +19,7 @@ jobs:
       matrix:
         os: [ubuntu-18.04, ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.8]
+        bids-validator: [master, stable]
 
     env:
       TZ: Europe/Berlin
@@ -48,14 +49,13 @@ jobs:
         git clone --depth 1 https://github.com/mne-tools/mne-python.git -b master
         pip install --no-deps -e ./mne-python
 
-    # XXX Revert once bids-validator 1.5.4 has been released
-    # - name: Install BIDS validator (stable)
-    #   if: "matrix.os != 'ubuntu-latest'"
-    #   run: |
-    #     npm install -g bids-validator
-    # - name: Install BIDS validator (master)
-    #   if: "matrix.os == 'ubuntu-latest'"
+    - name: Install BIDS validator (stable)
+      if: "matrix.bids-validator == 'stable'"
+      run: |
+        npm install -g bids-validator
+
     - name: Install BIDS validator (master)
+      if: "matrix.bids-validator == 'master'"
       run: |
         cd ..
         git clone --depth 1 https://github.com/bids-standard/bids-validator

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -48,7 +48,7 @@ jobs:
         git clone --depth 1 https://github.com/mne-tools/mne-python.git -b master
         pip install --no-deps -e ./mne-python
 
-    # XXX Revert once bids-validator 1.5.3 has been released
+    # XXX Revert once bids-validator 1.5.4 has been released
     # - name: Install BIDS validator (stable)
     #   if: "matrix.os != 'ubuntu-latest'"
     #   run: |

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -59,10 +59,8 @@ jobs:
       run: |
         cd ..
         git clone --depth 1 https://github.com/bids-standard/bids-validator
-        cd bids-validator/bids-validator
-        git checkout master
-        npm install -g
-        cd ../../mne-bids
+        npm install -g bids-validator/bids-validator
+        cd mne-bids
 
     - name: Display versions and environment information
       run: |

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -76,8 +76,10 @@ jobs:
       run: pip install --no-deps .
     - name: Run pytest
       run: |
-        echo "bids-validator"; bids-validator --version
+        export BIDS_VALIDATOR_VERSION=`bids-validator --version`
+        echo $BIDS_VALIDATOR_VERSION
         python -m pytest . --cov=mne_bids mne_bids/tests/ mne_bids/commands/tests/ --cov-report=xml --cov-config=setup.cfg --verbose --ignore mne-python
+      shell: bash  
     - name: Run style & documentation tests
       if: "matrix.os == 'ubuntu-latest'"
       run: make pep

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -77,7 +77,7 @@ jobs:
     - name: Run pytest
       run: |
         export BIDS_VALIDATOR_VERSION=`bids-validator --version`
-        echo $BIDS_VALIDATOR_VERSION
+        echo Using bids-validator $BIDS_VALIDATOR_VERSION
         python -m pytest . --cov=mne_bids mne_bids/tests/ mne_bids/commands/tests/ --cov-report=xml --cov-config=setup.cfg --verbose --ignore mne-python
       shell: bash  
     - name: Run style & documentation tests

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -29,6 +29,8 @@ MNE BIDS
 
    write_raw_bids
    read_raw_bids
+   write_fine_calibration
+   write_cross_talk
    BIDSPath
    make_dataset_description
    make_report

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -29,8 +29,8 @@ MNE BIDS
 
    write_raw_bids
    read_raw_bids
-   write_fine_calibration
-   write_cross_talk
+   write_meg_calibration
+   write_meg_crosstalk
    BIDSPath
    make_dataset_description
    make_report

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -42,6 +42,7 @@ Changelog
 - Allow :func:`mne_bids.write_raw_bids` to write EEG/iEEG files from Persyst using ``mne.io.read_raw_persyst`` function, by `Adam Li`_ (`#546 <https://github.com/mne-tools/mne-bids/pull/546>`_)
 - All functions :func:`mne_bids.write_anat`, :func:`mne_bids.make_report`, :func:`mne_bids.get_entity_vals` and :func:`mne_bids.get_datatypes` use now kwarg ``root`` instead of ``bids_root``, `Adam Li`_ (`#556 <https://github.com/mne-tools/mne-bids/pull/556>`_)
 - :func:`mne_bids.print_dir_tree` now works if a ``pathlib.Path`` object is passed, by `Adam Li`_ (`#555 <https://github.com/mne-tools/mne-bids/pull/555>`_)
+- Allow writing of Elekta/Neuromag/MEGIN fine-calibration and cross-talk data via the new functions :func:`mne_bids.write_fine_calibration` and :func:`mne_bids.write_cross_talk`, and retrieval of the file locations via :attr:`BIDSPath.fine_calibration_fpath` and :attr:`BIDSPath.cross_talk_fpath`, by `Richard Höchenberger`_ (`#562 <https://github.com/mne-tools/mne-bids/pull/562>`_)
 
 Bug
 ~~~

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -42,7 +42,7 @@ Changelog
 - Allow :func:`mne_bids.write_raw_bids` to write EEG/iEEG files from Persyst using ``mne.io.read_raw_persyst`` function, by `Adam Li`_ (`#546 <https://github.com/mne-tools/mne-bids/pull/546>`_)
 - All functions :func:`mne_bids.write_anat`, :func:`mne_bids.make_report`, :func:`mne_bids.get_entity_vals` and :func:`mne_bids.get_datatypes` use now kwarg ``root`` instead of ``bids_root``, `Adam Li`_ (`#556 <https://github.com/mne-tools/mne-bids/pull/556>`_)
 - :func:`mne_bids.print_dir_tree` now works if a ``pathlib.Path`` object is passed, by `Adam Li`_ (`#555 <https://github.com/mne-tools/mne-bids/pull/555>`_)
-- Allow writing of Elekta/Neuromag/MEGIN fine-calibration and cross-talk data via the new functions :func:`mne_bids.write_meg_calibration` and :func:`mne_bids.write_meg_cross_talk`, and retrieval of the file locations via :attr:`BIDSPath.meg_calibration_fpath` and :attr:`BIDSPath.meg_cross_talk_fpath`, by `Richard Höchenberger`_ (`#562 <https://github.com/mne-tools/mne-bids/pull/562>`_)
+- Allow writing of Elekta/Neuromag/MEGIN fine-calibration and crosstalk data via the new functions :func:`mne_bids.write_meg_calibration` and :func:`mne_bids.write_meg_crosstalk`, and retrieval of the file locations via :attr:`BIDSPath.meg_calibration_fpath` and :attr:`BIDSPath.meg_crosstalk_fpath`, by `Richard Höchenberger`_ (`#562 <https://github.com/mne-tools/mne-bids/pull/562>`_)
 
 Bug
 ~~~

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -42,7 +42,7 @@ Changelog
 - Allow :func:`mne_bids.write_raw_bids` to write EEG/iEEG files from Persyst using ``mne.io.read_raw_persyst`` function, by `Adam Li`_ (`#546 <https://github.com/mne-tools/mne-bids/pull/546>`_)
 - All functions :func:`mne_bids.write_anat`, :func:`mne_bids.make_report`, :func:`mne_bids.get_entity_vals` and :func:`mne_bids.get_datatypes` use now kwarg ``root`` instead of ``bids_root``, `Adam Li`_ (`#556 <https://github.com/mne-tools/mne-bids/pull/556>`_)
 - :func:`mne_bids.print_dir_tree` now works if a ``pathlib.Path`` object is passed, by `Adam Li`_ (`#555 <https://github.com/mne-tools/mne-bids/pull/555>`_)
-- Allow writing of Elekta/Neuromag/MEGIN fine-calibration and cross-talk data via the new functions :func:`mne_bids.write_fine_calibration` and :func:`mne_bids.write_cross_talk`, and retrieval of the file locations via :attr:`BIDSPath.fine_calibration_fpath` and :attr:`BIDSPath.cross_talk_fpath`, by `Richard Höchenberger`_ (`#562 <https://github.com/mne-tools/mne-bids/pull/562>`_)
+- Allow writing of Elekta/Neuromag/MEGIN fine-calibration and cross-talk data via the new functions :func:`mne_bids.write_meg_calibration` and :func:`mne_bids.write_meg_cross_talk`, and retrieval of the file locations via :attr:`BIDSPath.meg_calibration_fpath` and :attr:`BIDSPath.meg_cross_talk_fpath`, by `Richard Höchenberger`_ (`#562 <https://github.com/mne-tools/mne-bids/pull/562>`_)
 
 Bug
 ~~~

--- a/examples/convert_mne_sample.py
+++ b/examples/convert_mne_sample.py
@@ -31,7 +31,7 @@ import mne
 from mne.datasets import sample
 
 from mne_bids import (write_raw_bids, read_raw_bids, write_meg_calibration,
-                      write_meg_cross_talk, BIDSPath, print_dir_tree)
+                      write_meg_crosstalk, BIDSPath, print_dir_tree)
 
 ###############################################################################
 # Now we can read the MNE sample data. We define an `event_id` based on our
@@ -71,15 +71,15 @@ write_raw_bids(raw, bids_path, events_data=events_data,
                event_id=event_id, overwrite=True)
 
 ###############################################################################
-# The sample MEG dataset comes with fine-calibration and cross-talk files that
+# The sample MEG dataset comes with fine-calibration and crosstalk files that
 # are required when processing Elekta/Neuromag/MEGIN data using MaxFilter®.
 # Let's store these data in appropriate places, too.
 
-fine_cal_fname = op.join(data_path, 'SSS', 'sss_cal_mgh.dat')
-cross_talk_fname = op.join(data_path, 'SSS', 'ct_sparse_mgh.fif')
+cal_fname = op.join(data_path, 'SSS', 'sss_cal_mgh.dat')
+ct_fname = op.join(data_path, 'SSS', 'ct_sparse_mgh.fif')
 
-write_meg_calibration(fine_cal_fname, bids_path)
-write_meg_cross_talk(cross_talk_fname, bids_path)
+write_meg_calibration(cal_fname, bids_path)
+write_meg_crosstalk(ct_fname, bids_path)
 
 ###############################################################################
 # Now let's see the structure of the BIDS folder we created.
@@ -102,11 +102,11 @@ epochs = mne.Epochs(raw, events, event_id)
 epochs['Auditory'].average().plot()
 
 ###############################################################################
-# It is trivial to retrieve the path of the fine-calibration and cross-talk
+# It is trivial to retrieve the path of the fine-calibration and crosstalk
 # files, too.
 
 print(bids_path.meg_calibration_fpath)
-print(bids_path.meg_cross_talk_fpath)
+print(bids_path.meg_crosstalk_fpath)
 
 ###############################################################################
 # The README created by :func:`write_raw_bids` also takes care of the citation

--- a/examples/convert_mne_sample.py
+++ b/examples/convert_mne_sample.py
@@ -30,8 +30,8 @@ import os.path as op
 import mne
 from mne.datasets import sample
 
-from mne_bids import (write_raw_bids, read_raw_bids, write_fine_calibration,
-                      write_cross_talk, BIDSPath, print_dir_tree)
+from mne_bids import (write_raw_bids, read_raw_bids, write_meg_calibration,
+                      write_meg_cross_talk, BIDSPath, print_dir_tree)
 
 ###############################################################################
 # Now we can read the MNE sample data. We define an `event_id` based on our
@@ -78,8 +78,8 @@ write_raw_bids(raw, bids_path, events_data=events_data,
 fine_cal_fname = op.join(data_path, 'SSS', 'sss_cal_mgh.dat')
 cross_talk_fname = op.join(data_path, 'SSS', 'ct_sparse_mgh.fif')
 
-write_fine_calibration(fine_cal_fname, bids_path)
-write_cross_talk(cross_talk_fname, bids_path)
+write_meg_calibration(fine_cal_fname, bids_path)
+write_meg_cross_talk(cross_talk_fname, bids_path)
 
 ###############################################################################
 # Now let's see the structure of the BIDS folder we created.
@@ -105,8 +105,8 @@ epochs['Auditory'].average().plot()
 # It is trivial to retrieve the path of the fine-calibration and cross-talk
 # files, too.
 
-print(bids_path.fine_calibration_fpath)
-print(bids_path.cross_talk_fpath)
+print(bids_path.meg_calibration_fpath)
+print(bids_path.meg_cross_talk_fpath)
 
 ###############################################################################
 # The README created by :func:`write_raw_bids` also takes care of the citation

--- a/mne_bids/__init__.py
+++ b/mne_bids/__init__.py
@@ -8,4 +8,5 @@ from mne_bids.path import (BIDSPath, get_datatypes, get_entity_vals,
 from mne_bids.read import get_head_mri_trans, read_raw_bids
 from mne_bids.utils import (get_anonymization_daysback)
 from mne_bids.write import (make_dataset_description, write_anat,
-                            write_raw_bids, mark_bad_channels)
+                            write_raw_bids, mark_bad_channels,
+                            write_fine_calibration, write_cross_talk)

--- a/mne_bids/__init__.py
+++ b/mne_bids/__init__.py
@@ -9,4 +9,4 @@ from mne_bids.read import get_head_mri_trans, read_raw_bids
 from mne_bids.utils import (get_anonymization_daysback)
 from mne_bids.write import (make_dataset_description, write_anat,
                             write_raw_bids, mark_bad_channels,
-                            write_fine_calibration, write_cross_talk)
+                            write_meg_calibration, write_meg_cross_talk)

--- a/mne_bids/__init__.py
+++ b/mne_bids/__init__.py
@@ -9,4 +9,4 @@ from mne_bids.read import get_head_mri_trans, read_raw_bids
 from mne_bids.utils import (get_anonymization_daysback)
 from mne_bids.write import (make_dataset_description, write_anat,
                             write_raw_bids, mark_bad_channels,
-                            write_meg_calibration, write_meg_cross_talk)
+                            write_meg_calibration, write_meg_crosstalk)

--- a/mne_bids/commands/mne_bids_calibration_to_bids.py
+++ b/mne_bids/commands/mne_bids_calibration_to_bids.py
@@ -1,0 +1,60 @@
+r"""Write Elekta/Neuromag/MEGIN fine-calibration data to BIDS.
+
+example usage:
+$ mne_bids calibration_to_bids --subject_id=01 --session=test
+--bids_root=bids_root --file=sss_cal.dat
+
+"""
+# Authors: Richard Höchenberger <richard.hoechenberger@gmail.com>
+#
+# License: BSD (3-clause)
+
+from mne.utils import logger
+
+import mne_bids
+from mne_bids import BIDSPath, write_fine_calibration
+
+
+def run():
+    """Run the calibration_to_bids command."""
+    from mne.commands.utils import get_optparser
+
+    parser = get_optparser(__file__, usage="usage: %prog options args",
+                           prog_prefix='mne_bids',
+                           version=mne_bids.__version__)
+
+    parser.add_option('--bids_root', dest='bids_root',
+                      help='The path of the folder containing the BIDS '
+                           'dataset')
+    parser.add_option('--subject_id', dest='subject',
+                      help=('Subject name'))
+    parser.add_option('--session_id', dest='session',
+                      help='Session name')
+    parser.add_option('--file', dest='fname',
+                      help='The path of the cross-talk file')
+    parser.add_option('--verbose', dest='verbose', action='store_true',
+                      help='Whether do generate additional diagnostic output')
+
+    opt, args = parser.parse_args()
+    if args:
+        parser.print_help()
+        parser.error(f'Please do not specify arguments without flags. '
+                     f'Got: {args}.\n')
+
+    if opt.bids_root is None:
+        parser.print_help()
+        parser.error('You must specify bids_root')
+    if opt.subject is None:
+        parser.print_help()
+        parser.error('You must specify a subject')
+
+    bids_path = BIDSPath(subject=opt.subject, session=opt.session,
+                         root=opt.bids_root)
+
+    logger.info(f'Writing fine-calibration file {bids_path.basename} …')
+    write_fine_calibration(fine_calibration=opt.fname, bids_path=bids_path,
+                           verbose=opt.verbose)
+
+
+if __name__ == '__main__':  # pragma: no cover
+    run()

--- a/mne_bids/commands/mne_bids_calibration_to_bids.py
+++ b/mne_bids/commands/mne_bids_calibration_to_bids.py
@@ -12,7 +12,7 @@ $ mne_bids calibration_to_bids --subject_id=01 --session=test
 from mne.utils import logger
 
 import mne_bids
-from mne_bids import BIDSPath, write_fine_calibration
+from mne_bids import BIDSPath, write_meg_calibration
 
 
 def run():
@@ -52,7 +52,7 @@ def run():
                          root=opt.bids_root)
 
     logger.info(f'Writing fine-calibration file {bids_path.basename} …')
-    write_fine_calibration(fine_calibration=opt.fname, bids_path=bids_path,
+    write_meg_calibration(fine_calibration=opt.fname, bids_path=bids_path,
                            verbose=opt.verbose)
 
 

--- a/mne_bids/commands/mne_bids_calibration_to_bids.py
+++ b/mne_bids/commands/mne_bids_calibration_to_bids.py
@@ -31,7 +31,7 @@ def run():
     parser.add_option('--session_id', dest='session',
                       help='Session name')
     parser.add_option('--file', dest='fname',
-                      help='The path of the cross-talk file')
+                      help='The path of the crosstalk file')
     parser.add_option('--verbose', dest='verbose', action='store_true',
                       help='Whether do generate additional diagnostic output')
 
@@ -52,8 +52,8 @@ def run():
                          root=opt.bids_root)
 
     logger.info(f'Writing fine-calibration file {bids_path.basename} …')
-    write_meg_calibration(fine_calibration=opt.fname, bids_path=bids_path,
-                           verbose=opt.verbose)
+    write_meg_calibration(calibration=opt.fname, bids_path=bids_path,
+                          verbose=opt.verbose)
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/mne_bids/commands/mne_bids_crosstalk_to_bids.py
+++ b/mne_bids/commands/mne_bids_crosstalk_to_bids.py
@@ -1,4 +1,4 @@
-"""Write Elekta/Neuromag/MEGIN cross-talk data to BIDS.
+"""Write Elekta/Neuromag/MEGIN crosstalk data to BIDS.
 
 example usage:
 $ mne_bids crosstalk_to_bids --subject_id=01 --session=test
@@ -12,7 +12,7 @@ $ mne_bids crosstalk_to_bids --subject_id=01 --session=test
 from mne.utils import logger
 
 import mne_bids
-from mne_bids import BIDSPath, write_meg_cross_talk
+from mne_bids import BIDSPath, write_meg_crosstalk
 
 
 def run():
@@ -31,7 +31,7 @@ def run():
     parser.add_option('--session_id', dest='session',
                       help='Session name')
     parser.add_option('--file', dest='fname',
-                      help='The path of the cross-talk file')
+                      help='The path of the crosstalk file')
     parser.add_option('--verbose', dest='verbose', action='store_true',
                       help='Whether do generate additional diagnostic output')
 
@@ -51,8 +51,9 @@ def run():
     bids_path = BIDSPath(subject=opt.subject, session=opt.session,
                          root=opt.bids_root)
 
-    logger.info(f'Writing cross-talk file {bids_path.basename} …')
-    write_meg_cross_talk(fname=opt.fname, bids_path=bids_path, verbose=opt.verbose)
+    logger.info(f'Writing crosstalk file {bids_path.basename} …')
+    write_meg_crosstalk(fname=opt.fname, bids_path=bids_path,
+                        verbose=opt.verbose)
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/mne_bids/commands/mne_bids_crosstalk_to_bids.py
+++ b/mne_bids/commands/mne_bids_crosstalk_to_bids.py
@@ -1,7 +1,7 @@
 """Write Elekta/Neuromag/MEGIN cross-talk data to BIDS.
 
 example usage:
-$ mne_bids crosstsalk_to_bids --subject_id=01 --session=test
+$ mne_bids crosstalk_to_bids --subject_id=01 --session=test
 --bids_root=bids_root --file=ct_sparse.fif
 
 """
@@ -12,7 +12,7 @@ $ mne_bids crosstsalk_to_bids --subject_id=01 --session=test
 from mne.utils import logger
 
 import mne_bids
-from mne_bids import BIDSPath, write_cross_talk
+from mne_bids import BIDSPath, write_meg_cross_talk
 
 
 def run():
@@ -52,7 +52,7 @@ def run():
                          root=opt.bids_root)
 
     logger.info(f'Writing cross-talk file {bids_path.basename} …')
-    write_cross_talk(fname=opt.fname, bids_path=bids_path, verbose=opt.verbose)
+    write_meg_cross_talk(fname=opt.fname, bids_path=bids_path, verbose=opt.verbose)
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/mne_bids/commands/mne_bids_crosstalk_to_bids.py
+++ b/mne_bids/commands/mne_bids_crosstalk_to_bids.py
@@ -1,0 +1,59 @@
+"""Write Elekta/Neuromag/MEGIN cross-talk data to BIDS.
+
+example usage:
+$ mne_bids crosstsalk_to_bids --subject_id=01 --session=test
+--bids_root=bids_root --file=ct_sparse.fif
+
+"""
+# Authors: Richard Höchenberger <richard.hoechenberger@gmail.com>
+#
+# License: BSD (3-clause)
+
+from mne.utils import logger
+
+import mne_bids
+from mne_bids import BIDSPath, write_cross_talk
+
+
+def run():
+    """Run the crosstalk_to_bids command."""
+    from mne.commands.utils import get_optparser
+
+    parser = get_optparser(__file__, usage="usage: %prog options args",
+                           prog_prefix='mne_bids',
+                           version=mne_bids.__version__)
+
+    parser.add_option('--bids_root', dest='bids_root',
+                      help='The path of the folder containing the BIDS '
+                           'dataset')
+    parser.add_option('--subject_id', dest='subject',
+                      help=('Subject name'))
+    parser.add_option('--session_id', dest='session',
+                      help='Session name')
+    parser.add_option('--file', dest='fname',
+                      help='The path of the cross-talk file')
+    parser.add_option('--verbose', dest='verbose', action='store_true',
+                      help='Whether do generate additional diagnostic output')
+
+    opt, args = parser.parse_args()
+    if args:
+        parser.print_help()
+        parser.error(f'Please do not specify arguments without flags. '
+                     f'Got: {args}.\n')
+
+    if opt.bids_root is None:
+        parser.print_help()
+        parser.error('You must specify bids_root')
+    if opt.subject is None:
+        parser.print_help()
+        parser.error('You must specify a subject')
+
+    bids_path = BIDSPath(subject=opt.subject, session=opt.session,
+                         root=opt.bids_root)
+
+    logger.info(f'Writing cross-talk file {bids_path.basename} …')
+    write_cross_talk(fname=opt.fname, bids_path=bids_path, verbose=opt.verbose)
+
+
+if __name__ == '__main__':  # pragma: no cover
+    run()

--- a/mne_bids/commands/tests/test_cli.py
+++ b/mne_bids/commands/tests/test_cli.py
@@ -201,7 +201,7 @@ def test_calibration_to_bids(tmpdir):
     with ArgvSetter(args):
         mne_bids_calibration_to_bids.run()
 
-    assert bids_path.fine_calibration_fpath.exists()
+    assert bids_path.meg_calibration_fpath.exists()
 
 
 def test_crosstalk_to_bids(tmpdir):
@@ -221,7 +221,7 @@ def test_crosstalk_to_bids(tmpdir):
             '--bids_root', output_path)
     with ArgvSetter(args):
         mne_bids_crosstalk_to_bids.run()
-    assert bids_path.cross_talk_fpath.exists()
+    assert bids_path.meg_cross_talk_fpath.exists()
 
 
 run_tests_if_main()

--- a/mne_bids/commands/tests/test_cli.py
+++ b/mne_bids/commands/tests/test_cli.py
@@ -212,16 +212,16 @@ def test_crosstalk_to_bids(tmpdir):
 
     output_path = str(tmpdir)
     data_path = Path(testing.data_path())
-    cross_talk_fname = data_path / 'SSS' / 'ct_sparse.fif'
+    crosstalk_fname = data_path / 'SSS' / 'ct_sparse.fif'
     bids_path = BIDSPath(subject=subject_id, root=output_path)
 
     # Write fine-calibration file and check that it was actually written.
     # Write fine-calibration file and check that it was actually written.
-    args = ('--file', cross_talk_fname, '--subject', subject_id,
+    args = ('--file', crosstalk_fname, '--subject', subject_id,
             '--bids_root', output_path)
     with ArgvSetter(args):
         mne_bids_crosstalk_to_bids.run()
-    assert bids_path.meg_cross_talk_fpath.exists()
+    assert bids_path.meg_crosstalk_fpath.exists()
 
 
 run_tests_if_main()

--- a/mne_bids/config.py
+++ b/mne_bids/config.py
@@ -110,7 +110,8 @@ SUFFIX_TO_DATATYPE = {
 ALLOWED_FILENAME_EXTENSIONS = (
     ALLOWED_INPUT_EXTENSIONS +
     ['.json', '.tsv', '.tsv.gz', '.nii', '.nii.gz'] +
-    ['.pos', '.eeg', '.vmrk']  # extra datatype-specific metadata files
+    ['.pos', '.eeg', '.vmrk'] +  # extra datatype-specific metadata files.
+    ['.dat']  # Elekta/Neuromag fine-calibration files.
 )
 
 # allowed BIDS path entities

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -663,7 +663,7 @@ class BIDSPath(object):
         return _get_matched_empty_room(self)
 
     @property
-    def fine_calibration_fpath(self):
+    def meg_calibration_fpath(self):
         """Find the matching Elekta/Neuromag/MEGIN fine-calibration file.
 
         This requires that at least ``root`` and ``subject`` are set, and that
@@ -690,7 +690,7 @@ class BIDSPath(object):
         return path
 
     @property
-    def cross_talk_fpath(self):
+    def meg_cross_talk_fpath(self):
         """Find the matching Elekta/Neuromag/MEGIN cross-talk file.
 
         This requires that at least ``root`` and ``subject`` are set, and that

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -690,8 +690,8 @@ class BIDSPath(object):
         return path
 
     @property
-    def meg_cross_talk_fpath(self):
-        """Find the matching Elekta/Neuromag/MEGIN cross-talk file.
+    def meg_crosstalk_fpath(self):
+        """Find the matching Elekta/Neuromag/MEGIN crosstalk file.
 
         This requires that at least ``root`` and ``subject`` are set, and that
         ``datatype`` is either ``'meg'`` or ``None``.
@@ -699,14 +699,13 @@ class BIDSPath(object):
         Returns
         -------
         path : pathlib.Path | None
-            The path of the cross-talk file, or ``None`` if it couldn't be
+            The path of the crosstalk file, or ``None`` if it couldn't be
             found.
         """
         if self.root is None or self.subject is None:
             raise ValueError('root and subject must be set.')
         if self.datatype not in (None, 'meg'):
-            raise ValueError('Can only find cross-talk file for MEG '
-                             'datasets.')
+            raise ValueError('Can only find crosstalk file for MEG datasets.')
 
         path = BIDSPath(subject=self.subject, session=self.session,
                         acquisition='crosstalk', suffix='meg',

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -662,6 +662,60 @@ class BIDSPath(object):
         """
         return _get_matched_empty_room(self)
 
+    @property
+    def fine_calibration_fpath(self):
+        """Find the matching Elekta/Neuromag/MEGIN fine-calibration file.
+
+        This requires that at least ``root`` and ``subject`` are set, and that
+        ``datatype`` is either ``'meg'`` or ``None``.
+
+        Returns
+        -------
+        path : pathlib.Path | None
+            The path of the fine-calibration file, or ``None`` if it couldn't
+            be found.
+        """
+        if self.root is None or self.subject is None:
+            raise ValueError('root and subject must be set.')
+        if self.datatype not in (None, 'meg'):
+            raise ValueError('Can only find fine-calibration file for MEG '
+                             'datasets.')
+
+        path = BIDSPath(subject=self.subject, session=self.session,
+                        acquisition='calibration', suffix='meg',
+                        extension='.dat', datatype='meg', root=self.root).fpath
+        if not path.exists():
+            path = None
+
+        return path
+
+    @property
+    def cross_talk_fpath(self):
+        """Find the matching Elekta/Neuromag/MEGIN cross-talk file.
+
+        This requires that at least ``root`` and ``subject`` are set, and that
+        ``datatype`` is either ``'meg'`` or ``None``.
+
+        Returns
+        -------
+        path : pathlib.Path | None
+            The path of the cross-talk file, or ``None`` if it couldn't be
+            found.
+        """
+        if self.root is None or self.subject is None:
+            raise ValueError('root and subject must be set.')
+        if self.datatype not in (None, 'meg'):
+            raise ValueError('Can only find cross-talk file for MEG '
+                             'datasets.')
+
+        path = BIDSPath(subject=self.subject, session=self.session,
+                        acquisition='crosstalk', suffix='meg',
+                        extension='.fif', datatype='meg', root=self.root).fpath
+        if not path.exists():
+            path = None
+
+        return path
+
 
 def _get_matching_bidspaths_from_filesystem(bids_path):
     """Get matching file paths for a BIDS path.

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -800,7 +800,7 @@ def test_fine_calibration_fpath(return_bids_test_dir):
     assert bids_path_.fine_calibration_fpath is None
 
 
-def cross_talk_fpath(return_bids_test_dir):
+def test_cross_talk_fpath(return_bids_test_dir):
     bids_root = return_bids_test_dir
 
     # File exists, so BIDSPath.cross_talk_fpath should return a non-None

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -27,7 +27,7 @@ from mne.io import anonymize_info
 
 from mne_bids import (get_datatypes, get_entity_vals, print_dir_tree,
                       BIDSPath, write_raw_bids, read_raw_bids,
-                      write_fine_calibration, write_cross_talk)
+                      write_meg_calibration, write_meg_cross_talk)
 from mne_bids.path import (_parse_ext, get_entities_from_fname,
                            _find_best_candidates, _find_matching_sidecar,
                            _filter_fnames)
@@ -70,8 +70,8 @@ def return_bids_test_dir(tmpdir_factory):
         write_raw_bids(raw, name, events_data=events_fname,
                        event_id=event_id, overwrite=True)
 
-    write_fine_calibration(fine_cal_fname, bids_path=bids_path)
-    write_cross_talk(cross_talk_fname, bids_path=bids_path)
+    write_meg_calibration(fine_cal_fname, bids_path=bids_path)
+    write_meg_cross_talk(cross_talk_fname, bids_path=bids_path)
     return bids_root
 
 
@@ -775,29 +775,29 @@ def test_fine_calibration_fpath(return_bids_test_dir):
     # File exists, so BIDSPath.fine_calibration_fpath should return a non-None
     # value.
     bids_path_ = bids_path.copy().update(subject='01', root=bids_root)
-    assert bids_path_.fine_calibration_fpath is not None
+    assert bids_path_.meg_calibration_fpath is not None
 
     # subject not set.
     bids_path_ = bids_path.copy().update(root=bids_root, subject=None)
     with pytest.raises(ValueError, match='root and subject must be set'):
-        bids_path_.fine_calibration_fpath
+        bids_path_.meg_calibration_fpath
 
     # root not set.
     bids_path_ = bids_path.copy().update(subject='01', root=None)
     with pytest.raises(ValueError, match='root and subject must be set'):
-        bids_path_.fine_calibration_fpath
+        bids_path_.meg_calibration_fpath
 
     # datatype is not 'meg''.
     bids_path_ = bids_path.copy().update(subject='01', root=bids_root,
                                          datatype='eeg')
     with pytest.raises(ValueError, match='Can only find .* for MEG'):
-        bids_path_.fine_calibration_fpath
+        bids_path_.meg_calibration_fpath
 
     # Delete the fine-calibration file. BIDSPath.fine_calibration_file should
     # then return None.
     bids_path_ = bids_path.copy().update(subject='01', root=bids_root)
-    Path(bids_path_.fine_calibration_fpath).unlink()
-    assert bids_path_.fine_calibration_fpath is None
+    Path(bids_path_.meg_calibration_fpath).unlink()
+    assert bids_path_.meg_calibration_fpath is None
 
 
 def test_cross_talk_fpath(return_bids_test_dir):
@@ -806,26 +806,26 @@ def test_cross_talk_fpath(return_bids_test_dir):
     # File exists, so BIDSPath.cross_talk_fpath should return a non-None
     # value.
     bids_path_ = bids_path.copy().update(subject='01', root=bids_root)
-    assert bids_path_.cross_talk_fpath is not None
+    assert bids_path_.meg_cross_talk_fpath is not None
 
     # subject not set.
     bids_path_ = bids_path.copy().update(root=bids_root, subject=None)
     with pytest.raises(ValueError, match='root and subject must be set'):
-        bids_path_.cross_talk_fpath
+        bids_path_.meg_cross_talk_fpath
 
     # root not set.
     bids_path_ = bids_path.copy().update(subject='01', root=None)
     with pytest.raises(ValueError, match='root and subject must be set'):
-        bids_path_.cross_talk_fpath
+        bids_path_.meg_cross_talk_fpath
 
     # datatype is not 'meg''.
     bids_path_ = bids_path.copy().update(subject='01', root=bids_root,
                                          datatype='eeg')
     with pytest.raises(ValueError, match='Can only find .* for MEG'):
-        bids_path_.cross_talk_fpath
+        bids_path_.meg_cross_talk_fpath
 
     # Delete the cross-talk file. BIDSPath.cross_talk_file should then return
     # None.
     bids_path_ = bids_path.copy().update(subject='01', root=bids_root)
-    Path(bids_path_.cross_talk_fpath).unlink()
-    assert bids_path_.cross_talk_fpath is None
+    Path(bids_path_.meg_cross_talk_fpath).unlink()
+    assert bids_path_.meg_cross_talk_fpath is None

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -27,7 +27,7 @@ from mne.io import anonymize_info
 
 from mne_bids import (get_datatypes, get_entity_vals, print_dir_tree,
                       BIDSPath, write_raw_bids, read_raw_bids,
-                      write_meg_calibration, write_meg_cross_talk)
+                      write_meg_calibration, write_meg_crosstalk)
 from mne_bids.path import (_parse_ext, get_entities_from_fname,
                            _find_best_candidates, _find_matching_sidecar,
                            _filter_fnames)
@@ -58,8 +58,8 @@ def return_bids_test_dir(tmpdir_factory):
                 'Visual/Right': 4, 'Smiley': 5, 'Button': 32}
     events_fname = op.join(data_path, 'MEG', 'sample',
                            'sample_audvis_trunc_raw-eve.fif')
-    fine_cal_fname = op.join(data_path, 'SSS', 'sss_cal_mgh.dat')
-    cross_talk_fname = op.join(data_path, 'SSS', 'ct_sparse.fif')
+    cal_fname = op.join(data_path, 'SSS', 'sss_cal_mgh.dat')
+    crosstalk_fname = op.join(data_path, 'SSS', 'ct_sparse.fif')
 
     raw = mne.io.read_raw_fif(raw_fname)
     raw.info['line_freq'] = 60
@@ -70,8 +70,8 @@ def return_bids_test_dir(tmpdir_factory):
         write_raw_bids(raw, name, events_data=events_fname,
                        event_id=event_id, overwrite=True)
 
-    write_meg_calibration(fine_cal_fname, bids_path=bids_path)
-    write_meg_cross_talk(cross_talk_fname, bids_path=bids_path)
+    write_meg_calibration(cal_fname, bids_path=bids_path)
+    write_meg_crosstalk(crosstalk_fname, bids_path=bids_path)
     return bids_root
 
 
@@ -769,10 +769,10 @@ def test_bids_path_label_vs_index_entity():
     BIDSPath(subject='01', split=1)  # ok as <index> entity
 
 
-def test_fine_calibration_fpath(return_bids_test_dir):
+def test_meg_calibration_fpath(return_bids_test_dir):
     bids_root = return_bids_test_dir
 
-    # File exists, so BIDSPath.fine_calibration_fpath should return a non-None
+    # File exists, so BIDSPath.meg_calibration_fpath should return a non-None
     # value.
     bids_path_ = bids_path.copy().update(subject='01', root=bids_root)
     assert bids_path_.meg_calibration_fpath is not None
@@ -793,39 +793,39 @@ def test_fine_calibration_fpath(return_bids_test_dir):
     with pytest.raises(ValueError, match='Can only find .* for MEG'):
         bids_path_.meg_calibration_fpath
 
-    # Delete the fine-calibration file. BIDSPath.fine_calibration_file should
-    # then return None.
+    # Delete the fine-calibration file. BIDSPath.meg_calibration_fpath
+    # should then return None.
     bids_path_ = bids_path.copy().update(subject='01', root=bids_root)
     Path(bids_path_.meg_calibration_fpath).unlink()
     assert bids_path_.meg_calibration_fpath is None
 
 
-def test_cross_talk_fpath(return_bids_test_dir):
+def test_meg_crosstalk_fpath(return_bids_test_dir):
     bids_root = return_bids_test_dir
 
-    # File exists, so BIDSPath.cross_talk_fpath should return a non-None
+    # File exists, so BIDSPath.crosstalk_fpath should return a non-None
     # value.
     bids_path_ = bids_path.copy().update(subject='01', root=bids_root)
-    assert bids_path_.meg_cross_talk_fpath is not None
+    assert bids_path_.meg_crosstalk_fpath is not None
 
     # subject not set.
     bids_path_ = bids_path.copy().update(root=bids_root, subject=None)
     with pytest.raises(ValueError, match='root and subject must be set'):
-        bids_path_.meg_cross_talk_fpath
+        bids_path_.meg_crosstalk_fpath
 
     # root not set.
     bids_path_ = bids_path.copy().update(subject='01', root=None)
     with pytest.raises(ValueError, match='root and subject must be set'):
-        bids_path_.meg_cross_talk_fpath
+        bids_path_.meg_crosstalk_fpath
 
     # datatype is not 'meg''.
     bids_path_ = bids_path.copy().update(subject='01', root=bids_root,
                                          datatype='eeg')
     with pytest.raises(ValueError, match='Can only find .* for MEG'):
-        bids_path_.meg_cross_talk_fpath
+        bids_path_.meg_crosstalk_fpath
 
-    # Delete the cross-talk file. BIDSPath.cross_talk_file should then return
-    # None.
+    # Delete the crosstalk file. BIDSPath.meg_crosstalk_fpath should then
+    # return None.
     bids_path_ = bids_path.copy().update(subject='01', root=bids_root)
-    Path(bids_path_.meg_cross_talk_fpath).unlink()
-    assert bids_path_.meg_cross_talk_fpath is None
+    Path(bids_path_.meg_crosstalk_fpath).unlink()
+    assert bids_path_.meg_crosstalk_fpath is None

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -26,7 +26,8 @@ from mne.utils import _TempDir, check_version
 from mne.io import anonymize_info
 
 from mne_bids import (get_datatypes, get_entity_vals, print_dir_tree,
-                      BIDSPath, write_raw_bids, read_raw_bids)
+                      BIDSPath, write_raw_bids, read_raw_bids,
+                      write_fine_calibration, write_cross_talk)
 from mne_bids.path import (_parse_ext, get_entities_from_fname,
                            _find_best_candidates, _find_matching_sidecar,
                            _filter_fnames)
@@ -57,6 +58,8 @@ def return_bids_test_dir(tmpdir_factory):
                 'Visual/Right': 4, 'Smiley': 5, 'Button': 32}
     events_fname = op.join(data_path, 'MEG', 'sample',
                            'sample_audvis_trunc_raw-eve.fif')
+    fine_cal_fname = op.join(data_path, 'SSS', 'sss_cal_mgh.dat')
+    cross_talk_fname = op.join(data_path, 'SSS', 'ct_sparse.fif')
 
     raw = mne.io.read_raw_fif(raw_fname)
     raw.info['line_freq'] = 60
@@ -67,6 +70,8 @@ def return_bids_test_dir(tmpdir_factory):
         write_raw_bids(raw, name, events_data=events_fname,
                        event_id=event_id, overwrite=True)
 
+    write_fine_calibration(fine_cal_fname, bids_path=bids_path)
+    write_cross_talk(cross_talk_fname, bids_path=bids_path)
     return bids_root
 
 
@@ -81,7 +86,7 @@ def test_get_keys(return_bids_test_dir):
                           ('subject', [subject_id], None),
                           ('session', [session_id], None),
                           ('run', [run, '02'], None),
-                          ('acquisition', [], None),
+                          ('acquisition', ['calibration', 'crosstalk'], None),
                           ('task', [task], None),
                           ('subject', [], dict(ignore_subjects=[subject_id])),
                           ('subject', [], dict(ignore_subjects=subject_id)),
@@ -557,7 +562,7 @@ def test_match(return_bids_test_dir):
 
     bids_path_01 = BIDSPath(root=bids_root)
     paths = bids_path_01.match()
-    assert len(paths) == 7
+    assert len(paths) == 9
     assert all('sub-01_ses-01' in p.basename for p in paths)
     assert all([p.root == bids_root for p in paths])
 
@@ -762,3 +767,65 @@ def test_bids_path_label_vs_index_entity():
         BIDSPath(root=1, subject='01')
     BIDSPath(subject='01', run=1)  # ok as <index> entity
     BIDSPath(subject='01', split=1)  # ok as <index> entity
+
+
+def test_fine_calibration_fpath(return_bids_test_dir):
+    bids_root = return_bids_test_dir
+
+    # File exists, so BIDSPath.fine_calibration_fpath should return a non-None
+    # value.
+    bids_path_ = bids_path.copy().update(subject='01', root=bids_root)
+    assert bids_path_.fine_calibration_fpath is not None
+
+    # subject not set.
+    bids_path_ = bids_path.copy().update(root=bids_root, subject=None)
+    with pytest.raises(ValueError, match='root and subject must be set'):
+        bids_path_.fine_calibration_fpath
+
+    # root not set.
+    bids_path_ = bids_path.copy().update(subject='01', root=None)
+    with pytest.raises(ValueError, match='root and subject must be set'):
+        bids_path_.fine_calibration_fpath
+
+    # datatype is not 'meg''.
+    bids_path_ = bids_path.copy().update(subject='01', root=bids_root,
+                                         datatype='eeg')
+    with pytest.raises(ValueError, match='Can only find .* for MEG'):
+        bids_path_.fine_calibration_fpath
+
+    # Delete the fine-calibration file. BIDSPath.fine_calibration_file should
+    # then return None.
+    bids_path_ = bids_path.copy().update(subject='01', root=bids_root)
+    Path(bids_path_.fine_calibration_fpath).unlink()
+    assert bids_path_.fine_calibration_fpath is None
+
+
+def cross_talk_fpath(return_bids_test_dir):
+    bids_root = return_bids_test_dir
+
+    # File exists, so BIDSPath.cross_talk_fpath should return a non-None
+    # value.
+    bids_path_ = bids_path.copy().update(subject='01', root=bids_root)
+    assert bids_path_.cross_talk_fpath is not None
+
+    # subject not set.
+    bids_path_ = bids_path.copy().update(root=bids_root, subject=None)
+    with pytest.raises(ValueError, match='root and subject must be set'):
+        bids_path_.cross_talk_fpath
+
+    # root not set.
+    bids_path_ = bids_path.copy().update(subject='01', root=None)
+    with pytest.raises(ValueError, match='root and subject must be set'):
+        bids_path_.cross_talk_fpath
+
+    # datatype is not 'meg''.
+    bids_path_ = bids_path.copy().update(subject='01', root=bids_root,
+                                         datatype='eeg')
+    with pytest.raises(ValueError, match='Can only find .* for MEG'):
+        bids_path_.cross_talk_fpath
+
+    # Delete the cross-talk file. BIDSPath.cross_talk_file should then return
+    # None.
+    bids_path_ = bids_path.copy().update(subject='01', root=bids_root)
+    Path(bids_path_.cross_talk_fpath).unlink()
+    assert bids_path_.cross_talk_fpath is None

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -42,7 +42,7 @@ from mne.io.kit.kit import get_kit_info
 from mne_bids import (write_raw_bids, read_raw_bids, BIDSPath,
                       write_anat, make_dataset_description,
                       mark_bad_channels, write_meg_calibration,
-                      write_meg_cross_talk)
+                      write_meg_crosstalk)
 from mne_bids.utils import (_stamp_to_dt, _get_anonymization_daysback,
                             get_anonymization_daysback)
 from mne_bids.tsv_handler import _from_tsv, _to_tsv
@@ -1632,7 +1632,7 @@ def test_mark_bad_channels(_bids_validate,
                     LooseVersion(os.environ['BIDS_VALIDATOR_VERSION']) <
                     LooseVersion('1.5.5'),
                     reason=('requires bids-validator 1.5.5 or newer'))
-def test_write_fine_calibration(_bids_validate):
+def test_write_meg_calibration(_bids_validate):
     """Test writing of the Elekta/Neuromag fine-calibration file."""
     bids_root = _TempDir()
     bids_path = _bids_path.copy().update(root=bids_root)
@@ -1647,22 +1647,22 @@ def test_write_fine_calibration(_bids_validate):
     fine_cal_fname = data_path / 'SSS' / 'sss_cal_mgh.dat'
 
     # Test passing a filename.
-    write_meg_calibration(fine_calibration=fine_cal_fname,
-                           bids_path=bids_path)
+    write_meg_calibration(calibration=fine_cal_fname,
+                          bids_path=bids_path)
     _bids_validate(bids_root)
 
     # Test passing a dict.
-    fine_calibration = mne.preprocessing.read_fine_calibration(fine_cal_fname)
-    write_meg_calibration(fine_calibration=fine_calibration,
-                           bids_path=bids_path)
+    calibration = mne.preprocessing.read_fine_calibration(fine_cal_fname)
+    write_meg_calibration(calibration=calibration,
+                          bids_path=bids_path)
     _bids_validate(bids_root)
 
     # Test passing in incompatible dict.
-    fine_calibration = mne.preprocessing.read_fine_calibration(fine_cal_fname)
-    del fine_calibration['locs']
+    calibration = mne.preprocessing.read_fine_calibration(fine_cal_fname)
+    del calibration['locs']
     with pytest.raises(ValueError, match='not .* proper fine-calibration'):
-        write_meg_calibration(fine_calibration=fine_calibration,
-                               bids_path=bids_path)
+        write_meg_calibration(calibration=calibration,
+                              bids_path=bids_path)
 
     # subject not set.
     bids_path = bids_path.copy().update(root=bids_root, subject=None)
@@ -1685,7 +1685,7 @@ def test_write_fine_calibration(_bids_validate):
                     LooseVersion(os.environ['BIDS_VALIDATOR_VERSION']) <
                     LooseVersion('1.5.5'),
                     reason=('requires bids-validator 1.5.5 or newer'))
-def test_write_cross_talk(_bids_validate):
+def test_write_meg_crosstalk(_bids_validate):
     """Test writing of the Elekta/Neuromag fine-calibration file."""
     bids_root = _TempDir()
     bids_path = _bids_path.copy().update(root=bids_root)
@@ -1696,23 +1696,23 @@ def test_write_cross_talk(_bids_validate):
     raw = _read_raw_fif(raw_fname, verbose=False)
     write_raw_bids(raw, bids_path=bids_path, verbose=False)
 
-    cross_talk_fname = data_path / 'SSS' / 'ct_sparse.fif'
+    crosstalk_fname = data_path / 'SSS' / 'ct_sparse.fif'
 
-    write_meg_cross_talk(fname=cross_talk_fname, bids_path=bids_path)
+    write_meg_crosstalk(fname=crosstalk_fname, bids_path=bids_path)
     _bids_validate(bids_root)
 
     # subject not set.
     bids_path = bids_path.copy().update(root=bids_root, subject=None)
     with pytest.raises(ValueError, match='must have root and subject set'):
-        write_meg_cross_talk(cross_talk_fname, bids_path)
+        write_meg_crosstalk(crosstalk_fname, bids_path)
 
     # root not set.
     bids_path = bids_path.copy().update(subject='01', root=None)
     with pytest.raises(ValueError, match='must have root and subject set'):
-        write_meg_cross_talk(cross_talk_fname, bids_path)
+        write_meg_crosstalk(crosstalk_fname, bids_path)
 
     # datatype is not 'meg'.
     bids_path = bids_path.copy().update(subject='01', root=bids_root,
                                         datatype='eeg')
     with pytest.raises(ValueError, match='Can only write .* for MEG'):
-        write_meg_cross_talk(cross_talk_fname, bids_path)
+        write_meg_crosstalk(crosstalk_fname, bids_path)

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -1642,9 +1642,23 @@ def test_write_fine_calibration(_bids_validate):
 
     fine_cal_fname = data_path / 'SSS' / 'sss_cal_mgh.dat'
 
+    # Test passing a filename.
     write_fine_calibration(fine_calibration=fine_cal_fname,
                            bids_path=bids_path)
     _bids_validate(bids_root)
+
+    # Test passing a dict.
+    fine_calibration = mne.preprocessing.read_fine_calibration(fine_cal_fname)
+    write_fine_calibration(fine_calibration=fine_calibration,
+                           bids_path=bids_path)
+    _bids_validate(bids_root)
+
+    # Test passing in incompatible dict.
+    fine_calibration = mne.preprocessing.read_fine_calibration(fine_cal_fname)
+    del fine_calibration['locs']
+    with pytest.raises(ValueError, match='not .* proper fine-calibration'):
+        write_fine_calibration(fine_calibration=fine_calibration,
+                               bids_path=bids_path)
 
     # subject not set.
     bids_path = bids_path.copy().update(root=bids_root, subject=None)

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -1630,8 +1630,8 @@ def test_mark_bad_channels(_bids_validate,
 
 @pytest.mark.skipif('BIDS_VALIDATOR_VERSION' in os.environ and
                     LooseVersion(os.environ['BIDS_VALIDATOR_VERSION']) <
-                    LooseVersion('1.5.4'),
-                    reason=('requires bids-validator 1.5.4 or newer'))
+                    LooseVersion('1.5.5'),
+                    reason=('requires bids-validator 1.5.5 or newer'))
 def test_write_fine_calibration(_bids_validate):
     """Test writing of the Elekta/Neuromag fine-calibration file."""
     bids_root = _TempDir()
@@ -1683,8 +1683,8 @@ def test_write_fine_calibration(_bids_validate):
 
 @pytest.mark.skipif('BIDS_VALIDATOR_VERSION' in os.environ and
                     LooseVersion(os.environ['BIDS_VALIDATOR_VERSION']) <
-                    LooseVersion('1.5.4'),
-                    reason=('requires bids-validator 1.5.4 or newer'))
+                    LooseVersion('1.5.5'),
+                    reason=('requires bids-validator 1.5.5 or newer'))
 def test_write_cross_talk(_bids_validate):
     """Test writing of the Elekta/Neuromag fine-calibration file."""
     bids_root = _TempDir()

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -1631,7 +1631,7 @@ def test_mark_bad_channels(_bids_validate,
 @pytest.mark.skipif('BIDS_VALIDATOR_VERSION' in os.environ and
                     LooseVersion(os.environ['BIDS_VALIDATOR_VERSION']) <
                     LooseVersion('1.5.4'),
-                    reason=('requires bids-validator 1.5.4 or newer')
+                    reason=('requires bids-validator 1.5.4 or newer'))
 def test_write_fine_calibration(_bids_validate):
     """Test writing of the Elekta/Neuromag fine-calibration file."""
     bids_root = _TempDir()
@@ -1684,7 +1684,7 @@ def test_write_fine_calibration(_bids_validate):
 @pytest.mark.skipif('BIDS_VALIDATOR_VERSION' in os.environ and
                     LooseVersion(os.environ['BIDS_VALIDATOR_VERSION']) <
                     LooseVersion('1.5.4'),
-                    reason=('requires bids-validator 1.5.4 or newer')
+                    reason=('requires bids-validator 1.5.4 or newer'))
 def test_write_cross_talk(_bids_validate):
     """Test writing of the Elekta/Neuromag fine-calibration file."""
     bids_root = _TempDir()

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -41,8 +41,8 @@ from mne.io.kit.kit import get_kit_info
 
 from mne_bids import (write_raw_bids, read_raw_bids, BIDSPath,
                       write_anat, make_dataset_description,
-                      mark_bad_channels, write_fine_calibration,
-                      write_cross_talk)
+                      mark_bad_channels, write_meg_calibration,
+                      write_meg_cross_talk)
 from mne_bids.utils import (_stamp_to_dt, _get_anonymization_daysback,
                             get_anonymization_daysback)
 from mne_bids.tsv_handler import _from_tsv, _to_tsv
@@ -1647,13 +1647,13 @@ def test_write_fine_calibration(_bids_validate):
     fine_cal_fname = data_path / 'SSS' / 'sss_cal_mgh.dat'
 
     # Test passing a filename.
-    write_fine_calibration(fine_calibration=fine_cal_fname,
+    write_meg_calibration(fine_calibration=fine_cal_fname,
                            bids_path=bids_path)
     _bids_validate(bids_root)
 
     # Test passing a dict.
     fine_calibration = mne.preprocessing.read_fine_calibration(fine_cal_fname)
-    write_fine_calibration(fine_calibration=fine_calibration,
+    write_meg_calibration(fine_calibration=fine_calibration,
                            bids_path=bids_path)
     _bids_validate(bids_root)
 
@@ -1661,24 +1661,24 @@ def test_write_fine_calibration(_bids_validate):
     fine_calibration = mne.preprocessing.read_fine_calibration(fine_cal_fname)
     del fine_calibration['locs']
     with pytest.raises(ValueError, match='not .* proper fine-calibration'):
-        write_fine_calibration(fine_calibration=fine_calibration,
+        write_meg_calibration(fine_calibration=fine_calibration,
                                bids_path=bids_path)
 
     # subject not set.
     bids_path = bids_path.copy().update(root=bids_root, subject=None)
     with pytest.raises(ValueError, match='must have root and subject set'):
-        write_fine_calibration(fine_cal_fname, bids_path)
+        write_meg_calibration(fine_cal_fname, bids_path)
 
     # root not set.
     bids_path = bids_path.copy().update(subject='01', root=None)
     with pytest.raises(ValueError, match='must have root and subject set'):
-        write_fine_calibration(fine_cal_fname, bids_path)
+        write_meg_calibration(fine_cal_fname, bids_path)
 
     # datatype is not 'meg.
     bids_path = bids_path.copy().update(subject='01', root=bids_root,
                                         datatype='eeg')
     with pytest.raises(ValueError, match='Can only write .* for MEG'):
-        write_fine_calibration(fine_cal_fname, bids_path)
+        write_meg_calibration(fine_cal_fname, bids_path)
 
 
 @pytest.mark.skipif('BIDS_VALIDATOR_VERSION' in os.environ and
@@ -1698,21 +1698,21 @@ def test_write_cross_talk(_bids_validate):
 
     cross_talk_fname = data_path / 'SSS' / 'ct_sparse.fif'
 
-    write_cross_talk(fname=cross_talk_fname, bids_path=bids_path)
+    write_meg_cross_talk(fname=cross_talk_fname, bids_path=bids_path)
     _bids_validate(bids_root)
 
     # subject not set.
     bids_path = bids_path.copy().update(root=bids_root, subject=None)
     with pytest.raises(ValueError, match='must have root and subject set'):
-        write_cross_talk(cross_talk_fname, bids_path)
+        write_meg_cross_talk(cross_talk_fname, bids_path)
 
     # root not set.
     bids_path = bids_path.copy().update(subject='01', root=None)
     with pytest.raises(ValueError, match='must have root and subject set'):
-        write_cross_talk(cross_talk_fname, bids_path)
+        write_meg_cross_talk(cross_talk_fname, bids_path)
 
     # datatype is not 'meg'.
     bids_path = bids_path.copy().update(subject='01', root=bids_root,
                                         datatype='eeg')
     with pytest.raises(ValueError, match='Can only write .* for MEG'):
-        write_cross_talk(cross_talk_fname, bids_path)
+        write_meg_cross_talk(cross_talk_fname, bids_path)

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -1628,6 +1628,10 @@ def test_mark_bad_channels(_bids_validate,
         assert description in tsv_data['status_description']
 
 
+@pytest.mark.skipif('BIDS_VALIDATOR_VERSION' in os.environ and
+                    LooseVersion(os.environ['BIDS_VALIDATOR_VERSION']) <
+                    LooseVersion('1.5.4'),
+                    reason=('requires bids-validator 1.5.4 or newer')
 def test_write_fine_calibration(_bids_validate):
     """Test writing of the Elekta/Neuromag fine-calibration file."""
     bids_root = _TempDir()
@@ -1677,6 +1681,10 @@ def test_write_fine_calibration(_bids_validate):
         write_fine_calibration(fine_cal_fname, bids_path)
 
 
+@pytest.mark.skipif('BIDS_VALIDATOR_VERSION' in os.environ and
+                    LooseVersion(os.environ['BIDS_VALIDATOR_VERSION']) <
+                    LooseVersion('1.5.4'),
+                    reason=('requires bids-validator 1.5.4 or newer')
 def test_write_cross_talk(_bids_validate):
     """Test writing of the Elekta/Neuromag fine-calibration file."""
     bids_root = _TempDir()

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1496,7 +1496,7 @@ def mark_bad_channels(ch_names, descriptions=None, *, bids_path,
     raw.save(raw.filenames[0], overwrite=True, verbose=False)
 
 
-def write_fine_calibration(fine_calibration, bids_path, verbose=None):
+def write_meg_calibration(fine_calibration, bids_path, verbose=None):
     """Write the Elekta/Neuromag/MEGIN fine-calibration matrix to disk.
 
     Parameters
@@ -1517,7 +1517,7 @@ def write_fine_calibration(fine_calibration, bids_path, verbose=None):
     --------
     >>> fine_cal = mne.preprocessing.read_fine_calibration('sss_cal.dat')
     >>> bids_path = BIDSPath(subject='01', session='test', root='/data')
-    >>> write_fine_calibration(fine_cal, bids_path)
+    >>> write_meg_calibration(fine_cal, bids_path)
     """
     if bids_path.root is None or bids_path.subject is None:
         raise ValueError('bids_path must have root and subject set.')
@@ -1553,7 +1553,7 @@ def write_fine_calibration(fine_calibration, bids_path, verbose=None):
                                              calibration=fine_calibration)
 
 
-def write_cross_talk(fname, bids_path, verbose=None):
+def write_meg_cross_talk(fname, bids_path, verbose=None):
     """Write the Elekta/Neuromag/MEGIN cross-talk information to disk.
 
     Parameters
@@ -1572,7 +1572,7 @@ def write_cross_talk(fname, bids_path, verbose=None):
     --------
     >>> cross_talk = mne.preprocessing.read_fine_calibration('ct_sparse.fif')
     >>> bids_path = BIDSPath(subject='01', session='test', root='/data')
-    >>> write_cross_talk(cross_talk, bids_path)
+    >>> write_meg_cross_talk(cross_talk, bids_path)
     """
     if bids_path.root is None or bids_path.subject is None:
         raise ValueError('bids_path must have root and subject set.')

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1529,6 +1529,16 @@ def write_fine_calibration(fine_calibration, bids_path, verbose=None):
                    item_name='fine_calibration',
                    type_name='path or dictionary')
 
+    if (isinstance(fine_calibration, dict) and
+            ('ch_names' not in fine_calibration or
+             'locs' not in fine_calibration or
+             'imb_cals' not in fine_calibration)):
+        raise ValueError('The dictionary you passed does not appear to be a '
+                         'proper fine-calibration dict. Please only pass the '
+                         'output of '
+                         'mne.preprocessing.read_fine_calibration(), or a '
+                         'filename.')
+
     if not isinstance(fine_calibration, dict):
         fine_calibration = (mne.preprocessing
                             .read_fine_calibration(fine_calibration))

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1496,12 +1496,12 @@ def mark_bad_channels(ch_names, descriptions=None, *, bids_path,
     raw.save(raw.filenames[0], overwrite=True, verbose=False)
 
 
-def write_meg_calibration(fine_calibration, bids_path, verbose=None):
+def write_meg_calibration(calibration, bids_path, verbose=None):
     """Write the Elekta/Neuromag/MEGIN fine-calibration matrix to disk.
 
     Parameters
     ----------
-    fine_calibration : path-like | dict
+    calibration : path-like | dict
         Either the path of the ``.dat`` file containing the file-calibration
         matrix, or the dictionary returned by
         :func:`mne.preprocessing.read_fine_calibration`.
@@ -1515,9 +1515,9 @@ def write_meg_calibration(fine_calibration, bids_path, verbose=None):
 
     Examples
     --------
-    >>> fine_cal = mne.preprocessing.read_fine_calibration('sss_cal.dat')
+    >>> calibration = mne.preprocessing.read_fine_calibration('sss_cal.dat')
     >>> bids_path = BIDSPath(subject='01', session='test', root='/data')
-    >>> write_meg_calibration(fine_cal, bids_path)
+    >>> write_meg_calibration(calibration, bids_path)
     """
     if bids_path.root is None or bids_path.subject is None:
         raise ValueError('bids_path must have root and subject set.')
@@ -1525,23 +1525,22 @@ def write_meg_calibration(fine_calibration, bids_path, verbose=None):
         raise ValueError('Can only write fine-calibration information for MEG '
                          'datasets.')
 
-    _validate_type(fine_calibration, types=('path-like', dict),
-                   item_name='fine_calibration',
+    _validate_type(calibration, types=('path-like', dict),
+                   item_name='calibration',
                    type_name='path or dictionary')
 
-    if (isinstance(fine_calibration, dict) and
-            ('ch_names' not in fine_calibration or
-             'locs' not in fine_calibration or
-             'imb_cals' not in fine_calibration)):
+    if (isinstance(calibration, dict) and
+            ('ch_names' not in calibration or
+             'locs' not in calibration or
+             'imb_cals' not in calibration)):
         raise ValueError('The dictionary you passed does not appear to be a '
                          'proper fine-calibration dict. Please only pass the '
                          'output of '
                          'mne.preprocessing.read_fine_calibration(), or a '
                          'filename.')
 
-    if not isinstance(fine_calibration, dict):
-        fine_calibration = (mne.preprocessing
-                            .read_fine_calibration(fine_calibration))
+    if not isinstance(calibration, dict):
+        calibration = mne.preprocessing.read_fine_calibration(calibration)
 
     out_path = BIDSPath(subject=bids_path.subject, session=bids_path.session,
                         acquisition='calibration', suffix='meg',
@@ -1550,16 +1549,16 @@ def write_meg_calibration(fine_calibration, bids_path, verbose=None):
     logger.info(f'Writing fine-calibration file to {out_path}')
     out_path.mkdir()
     mne.preprocessing.write_fine_calibration(fname=str(out_path),
-                                             calibration=fine_calibration)
+                                             calibration=calibration)
 
 
-def write_meg_cross_talk(fname, bids_path, verbose=None):
-    """Write the Elekta/Neuromag/MEGIN cross-talk information to disk.
+def write_meg_crosstalk(fname, bids_path, verbose=None):
+    """Write the Elekta/Neuromag/MEGIN crosstalk information to disk.
 
     Parameters
     ----------
     fname : path-like
-        The path of the ``FIFF`` file containing the cross-talk information.
+        The path of the ``FIFF`` file containing the crosstalk information.
     bids_path : BIDSPath
         A :class:`mne_bids.BIDSPath` instance with at least ``root`` and
         ``subject`` set,  and that ``datatype`` is either ``'meg'`` or
@@ -1570,9 +1569,9 @@ def write_meg_cross_talk(fname, bids_path, verbose=None):
 
     Examples
     --------
-    >>> cross_talk = mne.preprocessing.read_fine_calibration('ct_sparse.fif')
+    >>> crosstalk_fname = 'ct_sparse.fif'
     >>> bids_path = BIDSPath(subject='01', session='test', root='/data')
-    >>> write_meg_cross_talk(cross_talk, bids_path)
+    >>> write_megcrosstalk(crosstalk_fname, bids_path)
     """
     if bids_path.root is None or bids_path.subject is None:
         raise ValueError('bids_path must have root and subject set.')
@@ -1582,13 +1581,13 @@ def write_meg_cross_talk(fname, bids_path, verbose=None):
 
     _validate_type(fname, types=('path-like',), item_name='fname')
 
-    # MNE doesn't have public reader and writer functions for cross-talk data,
+    # MNE doesn't have public reader and writer functions for crosstalk data,
     # so just copy the original file. Use shutil.copyfile() to only copy file
     # contents, but not metadata & permissions.
     out_path = BIDSPath(subject=bids_path.subject, session=bids_path.session,
                         acquisition='crosstalk', suffix='meg',
                         extension='.fif', datatype='meg', root=bids_path.root)
 
-    logger.info(f'Writing cross-talk file to {out_path}')
+    logger.info(f'Writing crosstalk file to {out_path}')
     out_path.mkdir()
     shutil.copyfile(src=fname, dst=str(out_path))

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -11,7 +11,7 @@ import json
 import os
 import os.path as op
 from datetime import datetime, timezone
-import shutil as sh
+import shutil
 from collections import defaultdict, OrderedDict
 
 import numpy as np
@@ -28,7 +28,8 @@ try:
 except ImportError:
     from mne._digitization._utils import _get_fid_coords
 from mne.channels.channels import _unit2human
-from mne.utils import check_version, has_nibabel, logger, warn
+from mne.utils import check_version, has_nibabel, logger, warn, _validate_type
+import mne.preprocessing
 
 from mne_bids.pick import coil_type
 from mne_bids.dig import _write_dig_bids, _coordsystem_json
@@ -1134,7 +1135,7 @@ def write_raw_bids(raw, bids_path, events_data=None,
                      bids_path.session, bids_path.task, bids_path.run,
                      raw._init_kwargs)
     else:
-        sh.copyfile(raw_fname, bids_path)
+        shutil.copyfile(raw_fname, bids_path)
 
     # write to the scans.tsv file the output file written
     scan_relative_fpath = op.join(bids_path.datatype, bids_path.fpath.name)
@@ -1493,3 +1494,91 @@ def mark_bad_channels(ch_names, descriptions=None, *, bids_path,
     raw.info['bads'] = bads
     # XXX (How) will this handle split files?
     raw.save(raw.filenames[0], overwrite=True, verbose=False)
+
+
+def write_fine_calibration(fine_calibration, bids_path, verbose=None):
+    """Write the Elekta/Neuromag/MEGIN fine-calibration matrix to disk.
+
+    Parameters
+    ----------
+    fine_calibration : path-like | dict
+        Either the path of the ``.dat`` file containing the file-calibration
+        matrix, or the dictionary returned by
+        :func:`mne.preprocessing.read_fine_calibration`.
+    bids_path : BIDSPath
+        A :class:`mne_bids.BIDSPath` instance with at least ``root`` and
+        ``subject`` set,  and that ``datatype`` is either ``'meg'`` or
+        ``None``.
+    verbose : bool | None
+         If a boolean, whether or not to produce verbose output. If ``None``,
+         use the default log level.
+
+    Examples
+    --------
+    >>> fine_cal = mne.preprocessing.read_fine_calibration('sss_cal.dat')
+    >>> bids_path = BIDSPath(subject='01', session='test', root='/data')
+    >>> write_fine_calibration(fine_cal, bids_path)
+    """
+    if bids_path.root is None or bids_path.subject is None:
+        raise ValueError('bids_path must have root and subject set.')
+    if bids_path.datatype not in (None, 'meg'):
+        raise ValueError('Can only write fine-calibration information for MEG '
+                         'datasets.')
+
+    _validate_type(fine_calibration, types=('path-like', dict),
+                   item_name='fine_calibration',
+                   type_name='path or dictionary')
+
+    if not isinstance(fine_calibration, dict):
+        fine_calibration = (mne.preprocessing
+                            .read_fine_calibration(fine_calibration))
+
+    out_path = BIDSPath(subject=bids_path.subject, session=bids_path.session,
+                        acquisition='calibration', suffix='meg',
+                        extension='.dat', datatype='meg', root=bids_path.root)
+
+    logger.info(f'Writing fine-calibration file to {out_path}')
+    out_path.mkdir()
+    mne.preprocessing.write_fine_calibration(fname=str(out_path),
+                                             calibration=fine_calibration)
+
+
+def write_cross_talk(fname, bids_path, verbose=None):
+    """Write the Elekta/Neuromag/MEGIN cross-talk information to disk.
+
+    Parameters
+    ----------
+    fname : path-like
+        The path of the ``FIFF`` file containing the cross-talk information.
+    bids_path : BIDSPath
+        A :class:`mne_bids.BIDSPath` instance with at least ``root`` and
+        ``subject`` set,  and that ``datatype`` is either ``'meg'`` or
+        ``None``.
+    verbose : bool | None
+         If a boolean, whether or not to produce verbose output. If ``None``,
+         use the default log level.
+
+    Examples
+    --------
+    >>> cross_talk = mne.preprocessing.read_fine_calibration('ct_sparse.fif')
+    >>> bids_path = BIDSPath(subject='01', session='test', root='/data')
+    >>> write_cross_talk(cross_talk, bids_path)
+    """
+    if bids_path.root is None or bids_path.subject is None:
+        raise ValueError('bids_path must have root and subject set.')
+    if bids_path.datatype not in (None, 'meg'):
+        raise ValueError('Can only write fine-calibration information for MEG '
+                         'datasets.')
+
+    _validate_type(fname, types=('path-like',), item_name='fname')
+
+    # MNE doesn't have public reader and writer functions for cross-talk data,
+    # so just copy the original file. Use shutil.copyfile() to only copy file
+    # contents, but not metadata & permissions.
+    out_path = BIDSPath(subject=bids_path.subject, session=bids_path.session,
+                        acquisition='crosstalk', suffix='meg',
+                        extension='.fif', datatype='meg', root=bids_path.root)
+
+    logger.info(f'Writing cross-talk file to {out_path}')
+    out_path.mkdir()
+    shutil.copyfile(src=fname, dst=str(out_path))


### PR DESCRIPTION
PR Description
--------------

Adds support for Elekta/Neuromag/MEGIN cross-talk and fine-calibration files. Closes #495.

- `mne_bids.write_cross_talk()`
- `mne_bids.write_fine_calibration()`
- `BIDSPath.cross_talk_fpath` property*
- `BIDSPath.fine_calibration_fpath` property*
- CLI: `mne_bids crosstalk_to_bids`
- CLI: `mne_bids calibration_to_bids`


BIDS spec:
https://bids-specification.readthedocs.io/en/latest/99-appendices/06-meg-file-formats.html#neuromagelektamegin


Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
