### PR TITLE
[MRG] Fix match function to perform matches based on suffix and datatype

### DIFF
--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -601,13 +601,15 @@ class BIDSPath(object):
         # Only keep files (not directories), and omit the JSON sidecars.
         fnames = [f.name for f in fnames
                   if f.is_file() and f.suffix != '.json']
-        fnames = _filter_fnames(fnames, extension=self.extension,
+        fnames = _filter_fnames(fnames, suffix=self.suffix,
+                                extension=self.extension,
                                 **self.entities)
 
         bids_paths = []
         for fname in fnames:
             entities = get_entities_from_fname(fname)
-            extension = fname.suffix if fname.suffix else None
+            _, extension = _parse_ext(fname, verbose=False)
+            # suffix = fname.suffix if fname.suffix else None
             bids_path = BIDSPath(root=self.root, datatype=self.datatype,
                                  extension=extension, **entities)
             bids_paths.append(bids_path)

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -607,10 +607,17 @@ class BIDSPath(object):
 
         bids_paths = []
         for fname in fnames:
+            # get all BIDS entities from the filename
             entities = get_entities_from_fname(fname)
+
+            # extension is not an entity, so get it explicitly
             _, extension = _parse_ext(fname, verbose=False)
-            # suffix = fname.suffix if fname.suffix else None
-            bids_path = BIDSPath(root=self.root, datatype=self.datatype,
+
+            # get datatype
+            fpath = list(self.root.rglob(f'*{fname}*'))[0]
+            datatype = _infer_datatype_from_path(fpath)
+
+            bids_path = BIDSPath(root=self.root, datatype=datatype,
                                  extension=extension, **entities)
             bids_paths.append(bids_path)
 
@@ -832,6 +839,19 @@ def _parse_ext(raw_fname, verbose=False):
         ext = '.nii.gz'
         fname = fname[:-4]  # cut off the .nii
     return fname, ext
+
+
+def _infer_datatype_from_path(fname):
+    # get the parent
+    datatype = Path(fname).parent.name
+
+    if any([datatype.startswith(entity) for entity in ['sub', 'ses']]):
+        datatype = None
+
+    if not datatype:
+        datatype = None
+
+    return datatype
 
 
 def get_entities_from_fname(fname):

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -612,7 +612,7 @@ def test_match(return_bids_test_dir):
     assert paths[0].extension == '.tsv'
     assert paths[0].suffix == 'channels'
 
-    # Check handling of `datatype` when explicitly passe din
+    # Check handling of `datatype` when explicitly passed in
     print_dir_tree(bids_root)
     bids_path_01 = BIDSPath(root=bids_root, run='01',
                             suffix='channels', extension='.tsv',

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -596,6 +596,22 @@ def test_match(return_bids_test_dir):
     assert len(paths) == 1
     assert paths[0].extension == '.fif'
 
+    # Check handling of `extension` and `suffix`, part 1: no suffix
+    bids_path_01 = BIDSPath(root=bids_root, run='01', extension='.tsv',
+                            datatype='meg')
+    paths = bids_path_01.match()
+    assert len(paths) == 2
+    assert paths[0].extension == '.tsv'
+
+    # Check handling of `extension` and `suffix`, part 1: no suffix
+    bids_path_01 = BIDSPath(root=bids_root, run='01',
+                            suffix='channels', extension='.tsv',
+                            datatype='meg')
+    paths = bids_path_01.match()
+    assert len(paths) == 1
+    assert paths[0].extension == '.tsv'
+    assert paths[0].suffix == 'channels'
+
 
 @pytest.mark.filterwarnings(warning_str['meas_date_set_to_none'])
 @pytest.mark.filterwarnings(warning_str['channel_unit_changed'])

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -612,6 +612,27 @@ def test_match(return_bids_test_dir):
     assert paths[0].extension == '.tsv'
     assert paths[0].suffix == 'channels'
 
+    # Check handling of `datatype`
+    print_dir_tree(bids_root)
+    bids_path_01 = BIDSPath(root=bids_root, run='01',
+                            suffix='channels', extension='.tsv',
+                            datatype='meg')
+    paths = bids_path_01.match()
+    print(paths)
+    assert len(paths) == 1
+    assert paths[0].extension == '.tsv'
+    assert paths[0].suffix == 'channels'
+    assert Path(paths[0]).parent.name == 'meg'
+
+    # Check handling of `datatype`, no datatype passed in
+    bids_path_01 = BIDSPath(root=bids_root, run='01',
+                            suffix='channels', extension='.tsv')
+    paths = bids_path_01.match()
+    assert len(paths) == 1
+    assert paths[0].extension == '.tsv'
+    assert paths[0].suffix == 'channels'
+    assert Path(paths[0]).parent.name == 'meg'
+
 
 @pytest.mark.filterwarnings(warning_str['meas_date_set_to_none'])
 @pytest.mark.filterwarnings(warning_str['channel_unit_changed'])

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -603,7 +603,7 @@ def test_match(return_bids_test_dir):
     assert len(paths) == 2
     assert paths[0].extension == '.tsv'
 
-    # Check handling of `extension` and `suffix`, part 1: no suffix
+    # Check handling of `extension` and `suffix`, part 1: suffix passed
     bids_path_01 = BIDSPath(root=bids_root, run='01',
                             suffix='channels', extension='.tsv',
                             datatype='meg')
@@ -612,7 +612,7 @@ def test_match(return_bids_test_dir):
     assert paths[0].extension == '.tsv'
     assert paths[0].suffix == 'channels'
 
-    # Check handling of `datatype`
+    # Check handling of `datatype` when explicitly passe din
     print_dir_tree(bids_root)
     bids_path_01 = BIDSPath(root=bids_root, run='01',
                             suffix='channels', extension='.tsv',
@@ -625,6 +625,8 @@ def test_match(return_bids_test_dir):
     assert Path(paths[0]).parent.name == 'meg'
 
     # Check handling of `datatype`, no datatype passed in
+    # should be exactly the same if there is only one datatype
+    # present in the dataset
     bids_path_01 = BIDSPath(root=bids_root, run='01',
                             suffix='channels', extension='.tsv')
     paths = bids_path_01.match()


### PR DESCRIPTION
PR Description
--------------

Closes: #568 

Also closes: #570 

Need to decide:

1. add suffix to BIDSPath.entities list
2. remove suffix from get_entities_from_fname, which would break a lot of things
3. Or adjust code inside match() as is done right now.

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
