### PR TITLE
[MRG] Fixing write_raw_bids to write events.tsv if they are encoded in annotations

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -46,7 +46,7 @@ Changelog
 - Allow :func:`mne_bids.write_raw_bids` to write EEG/iEEG files from Nihon Kohden using ``mne.io.read_raw_nihon`` function, by `Adam Li`_ (`#567 <https://github.com/mne-tools/mne-bids/pull/567>`_)
 - Allow :func:`mne_bids.get_entity_vals` to ignore datatypes using ``ignore_datatypes`` kwarg, by `Adam Li`_ (`#578 <https://github.com/mne-tools/mne-bids/pull/578>`_)
 - Add ``with_key`` keyword argument to :func:`mne_bids.get_entity_vals` to allow returning the full entity strings, by `Adam Li`_ (`#578 <https://github.com/mne-tools/mne-bids/pull/578>`_)
-- :func:`mne_bids.write_raw_bids` now also writes :attr:`mne.io.Raw.annotations` to ``*_events.tsv``, by `Adam Li`_ (`#582 <https://github.com/mne-tools/mne-bids/pull/582>`_)
+- :func:`mne_bids.write_raw_bids` now also writes :attr:`mne.io.Raw.annotations` to ``*_events.tsv``, by `Adam Li`_ and `Richard Höchenberger`_ (`#582 <https://github.com/mne-tools/mne-bids/pull/582>`_)
 
 Bug
 ~~~

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -67,6 +67,8 @@ Bug
 - Fix :func:`mne_bids.write_raw_bids` failed BIDS validator for ``raw.info['dig'] = []`` by `Alex Rockhill`_ (`#505 <https://github.com/mne-tools/mne-bids/pull/505>`_)
 - Fix bug in :func:`mne_bids.BIDSPath.fpath` where no data file was returned when the suffix was not assigned, by `Alex Rockhill`_ (`#542 <https://github.com/mne-tools/mne-bids/pull/542>`_)
 - Ensure :func:`mne_bids.print_dir_tree` prints files and directories in alphabetical order, by `Richard Höchenberger`_ (`#563 <https://github.com/mne-tools/mne-bids/pull/563>`_)
+- Ensure :func:`mne_bids.write_raw_bids` writes events encoded in annotations of the raw file, by `Adam Li`_ (`#582 <https://github.com/mne-tools/mne-bids/pull/582>`_)
+
 
 API
 ~~~

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -46,6 +46,7 @@ Changelog
 - Allow :func:`mne_bids.write_raw_bids` to write EEG/iEEG files from Nihon Kohden using ``mne.io.read_raw_nihon`` function, by `Adam Li`_ (`#567 <https://github.com/mne-tools/mne-bids/pull/567>`_)
 - Allow :func:`mne_bids.get_entity_vals` to ignore datatypes using ``ignore_datatypes`` kwarg, by `Adam Li`_ (`#578 <https://github.com/mne-tools/mne-bids/pull/578>`_)
 - Add ``with_key`` keyword argument to :func:`mne_bids.get_entity_vals` to allow returning the full entity strings, by `Adam Li`_ (`#578 <https://github.com/mne-tools/mne-bids/pull/578>`_)
+- :func:`mne_bids.write_raw_bids` now also writes  :class:`mne.Annotations` if present in the raw file, by `Adam Li`_ (`#582 <https://github.com/mne-tools/mne-bids/pull/582>`_)
 
 Bug
 ~~~
@@ -67,8 +68,6 @@ Bug
 - Fix :func:`mne_bids.write_raw_bids` failed BIDS validator for ``raw.info['dig'] = []`` by `Alex Rockhill`_ (`#505 <https://github.com/mne-tools/mne-bids/pull/505>`_)
 - Fix bug in :func:`mne_bids.BIDSPath.fpath` where no data file was returned when the suffix was not assigned, by `Alex Rockhill`_ (`#542 <https://github.com/mne-tools/mne-bids/pull/542>`_)
 - Ensure :func:`mne_bids.print_dir_tree` prints files and directories in alphabetical order, by `Richard Höchenberger`_ (`#563 <https://github.com/mne-tools/mne-bids/pull/563>`_)
-- :func:`mne_bids.write_raw_bids` now also writes  :class:`mne.Annotations` if present in the raw file, by `Adam Li`_ (`#582 <https://github.com/mne-tools/mne-bids/pull/582>`_)
-
 
 API
 ~~~

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -46,7 +46,7 @@ Changelog
 - Allow :func:`mne_bids.write_raw_bids` to write EEG/iEEG files from Nihon Kohden using ``mne.io.read_raw_nihon`` function, by `Adam Li`_ (`#567 <https://github.com/mne-tools/mne-bids/pull/567>`_)
 - Allow :func:`mne_bids.get_entity_vals` to ignore datatypes using ``ignore_datatypes`` kwarg, by `Adam Li`_ (`#578 <https://github.com/mne-tools/mne-bids/pull/578>`_)
 - Add ``with_key`` keyword argument to :func:`mne_bids.get_entity_vals` to allow returning the full entity strings, by `Adam Li`_ (`#578 <https://github.com/mne-tools/mne-bids/pull/578>`_)
-- :func:`mne_bids.write_raw_bids` now also writes :class:`mne.Annotations` if present in the raw file, by `Adam Li`_ (`#582 <https://github.com/mne-tools/mne-bids/pull/582>`_)
+- :func:`mne_bids.write_raw_bids` now also writes :attr:`mne.Raw.annotations` to ``*_events.tsv``, by `Adam Li`_ (`#582 <https://github.com/mne-tools/mne-bids/pull/582>`_)
 
 Bug
 ~~~

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -67,7 +67,7 @@ Bug
 - Fix :func:`mne_bids.write_raw_bids` failed BIDS validator for ``raw.info['dig'] = []`` by `Alex Rockhill`_ (`#505 <https://github.com/mne-tools/mne-bids/pull/505>`_)
 - Fix bug in :func:`mne_bids.BIDSPath.fpath` where no data file was returned when the suffix was not assigned, by `Alex Rockhill`_ (`#542 <https://github.com/mne-tools/mne-bids/pull/542>`_)
 - Ensure :func:`mne_bids.print_dir_tree` prints files and directories in alphabetical order, by `Richard Höchenberger`_ (`#563 <https://github.com/mne-tools/mne-bids/pull/563>`_)
-- Ensure :func:`mne_bids.write_raw_bids` writes events encoded in annotations of the raw file, by `Adam Li`_ (`#582 <https://github.com/mne-tools/mne-bids/pull/582>`_)
+- :func:`mne_bids.write_raw_bids` now also writes  :class:`mne.Annotations` if present in the raw file, by `Adam Li`_ (`#582 <https://github.com/mne-tools/mne-bids/pull/582>`_)
 
 
 API

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -46,7 +46,7 @@ Changelog
 - Allow :func:`mne_bids.write_raw_bids` to write EEG/iEEG files from Nihon Kohden using ``mne.io.read_raw_nihon`` function, by `Adam Li`_ (`#567 <https://github.com/mne-tools/mne-bids/pull/567>`_)
 - Allow :func:`mne_bids.get_entity_vals` to ignore datatypes using ``ignore_datatypes`` kwarg, by `Adam Li`_ (`#578 <https://github.com/mne-tools/mne-bids/pull/578>`_)
 - Add ``with_key`` keyword argument to :func:`mne_bids.get_entity_vals` to allow returning the full entity strings, by `Adam Li`_ (`#578 <https://github.com/mne-tools/mne-bids/pull/578>`_)
-- :func:`mne_bids.write_raw_bids` now also writes :attr:`mne.Raw.annotations` to ``*_events.tsv``, by `Adam Li`_ (`#582 <https://github.com/mne-tools/mne-bids/pull/582>`_)
+- :func:`mne_bids.write_raw_bids` now also writes :attr:`mne.io.Raw.annotations` to ``*_events.tsv``, by `Adam Li`_ (`#582 <https://github.com/mne-tools/mne-bids/pull/582>`_)
 
 Bug
 ~~~

--- a/examples/convert_eeg_to_bids.py
+++ b/examples/convert_eeg_to_bids.py
@@ -99,10 +99,6 @@ edf_path = eegbci.load_data(subject=subject, runs=run)[0]
 raw = mne.io.read_raw_edf(edf_path, preload=False)
 raw.info['line_freq'] = 50  # specify power line frequency as required by BIDS
 
-# For converting the data to BIDS, we need to convert the the annotations
-# stored in the file to a 2D numpy array of events.
-events, event_id = mne.events_from_annotations(raw)
-
 ###############################################################################
 # For the sake of the example we will also pretend that we have the electrode
 # coordinates for the data recordings.
@@ -166,18 +162,16 @@ bids_root = os.path.join(mne_data_dir, 'eegmmidb_bids_eeg_example')
 sh.rmtree(bids_root, ignore_errors=True)
 
 ###############################################################################
-# Now we just need to specify a few more EEG details to get something sensible:
+# The data contains annotations; therefore, which will be converted to events
+# automatically by MNE-BIDS when writing the BIDS data:
 
-# Brief description of the event markers present in the data. This will become
-# the ``trial_type`` column in our BIDS ```events.tsv``.
-# From the online documentation of our downloaded data we know that in the
-# rest "eyes closed" task, there is only a single event marker: "0"
-event_id = {'rest': 0}
+print(raw.annotations)
 
-# Now convert our data to be in a new BIDS dataset.
+###############################################################################
+# Finally, let's write the BIDS data!
+
 bids_path = BIDSPath(subject=subject_id, task=task, root=bids_root)
-write_raw_bids(raw, bids_path, event_id=event_id,
-               events_data=events, overwrite=True)
+write_raw_bids(raw, bids_path, overwrite=True)
 
 ###############################################################################
 # What does our fresh BIDS directory look like?

--- a/examples/convert_eeg_to_bids.py
+++ b/examples/convert_eeg_to_bids.py
@@ -162,7 +162,7 @@ bids_root = os.path.join(mne_data_dir, 'eegmmidb_bids_eeg_example')
 sh.rmtree(bids_root, ignore_errors=True)
 
 ###############################################################################
-# The data contains annotations; therefore, which will be converted to events
+# The data contains annotations; which will be converted to events
 # automatically by MNE-BIDS when writing the BIDS data:
 
 print(raw.annotations)

--- a/examples/convert_group_studies.py
+++ b/examples/convert_group_studies.py
@@ -53,15 +53,6 @@ mne_data_dir = mne.get_config('MNE_DATASETS_EEGBCI_PATH')
 data_dir = op.join(mne_data_dir, 'MNE-eegbci-data')
 
 ###############################################################################
-# Define event_ids, this is knowledge we get from the online documentation of
-# the data as well.
-
-event_id = {
-    'imagine_motion_fist/left': 1,
-    'imagine_motion_fist/right': 2,
-}
-
-###############################################################################
 # Let us loop over the subjects and create BIDS-compatible folder
 
 # Make a path where we can save the data to
@@ -93,7 +84,11 @@ for raw, bids_path in zip(raw_list, bids_list):
     # single subject and the relation between subjects. Be sure to
     # change or delete this number before putting code online, you
     # wouldn't want to inadvertently de-anonymize your data.
-    write_raw_bids(raw, bids_path, event_id=event_id,
+    #
+    # Note that we do not need to pass any events, as teh dataset is already
+    # equipped witn annotations, which wll be converted to BIDS events
+    # automatically.
+    write_raw_bids(raw, bids_path,
                    anonymize=dict(daysback=daysback_min + 2117),
                    overwrite=True)
 

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -889,9 +889,16 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate):
     raw = reader(raw_fname)
     events, events_id = mne.events_from_annotations(raw, event_id=None)
     bids_output_path = write_raw_bids(raw, bids_path, overwrite=True)
+    event_id = {'Auditory/Left': 1, 'Auditory/Right': 2, 'Visual/Left': 3,
+                'Visual/Right': 4, 'Smiley': 5, 'Button': 32}
 
-    with pytest.raises(RuntimeError, match='Events data passed'):
+    with pytest.raises(RuntimeError,
+                       match='You passed events_data, but no event_id '):
         write_raw_bids(raw, bids_path, events_data=events)
+
+    with pytest.raises(RuntimeError,
+                       match='You passed event_id, but no events_data'):
+        write_raw_bids(raw, bids_path, event_id=event_id)
 
     # check events.tsv is written
     events_tsv_fname = bids_output_path.copy().update(suffix='events',

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -1525,11 +1525,13 @@ def test_write_does_not_alter_events_inplace():
     raw = _read_raw_fif(raw_fname)
     events = mne.read_events(events_fname)
     events_orig = events.copy()
+    event_id = {'Auditory/Left': 1, 'Auditory/Right': 2, 'Visual/Left': 3,
+                'Visual/Right': 4, 'Smiley': 5, 'Button': 32}
 
     bids_root = _TempDir()
     bids_path = _bids_path.copy().update(root=bids_root)
     write_raw_bids(raw=raw, bids_path=bids_path,
-                   events_data=events, overwrite=True)
+                   events_data=events, event_id=event_id, overwrite=True)
 
     assert np.array_equal(events, events_orig)
 

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -894,20 +894,22 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate):
     # they should be written even if write_raw_bids does not
     # pass in events
     events, events_id = mne.events_from_annotations(raw, event_id=None)
-    if events_id != {} and 'stim' not in raw:
-        temp_bids_root = _TempDir()
-        test_events_bids_path = bids_path.copy().update(root=temp_bids_root)
-        bids_output_path = write_raw_bids(raw, test_events_bids_path,
-                                          overwrite=True)
+    temp_bids_root = _TempDir()
+    test_events_bids_path = bids_path.copy().update(root=temp_bids_root)
+    bids_output_path = write_raw_bids(raw, test_events_bids_path,
+                                      overwrite=True)
 
-        # check events.tsv is written
-        events_tsv_fname = bids_output_path.copy().update(suffix='events',
-                                                          extension='.tsv')
+    # check events.tsv is written
+    events_tsv_fname = bids_output_path.copy().update(suffix='events',
+                                                      extension='.tsv')
+    if events.size == 0:
+        assert not op.exists(events_tsv_fname)
+    else:
         assert op.exists(events_tsv_fname)
 
-        raw2 = read_raw_bids(bids_path=bids_output_path)
-        events2, _ = mne.events_from_annotations(raw2)
-        assert_array_equal(events2[:, 0], events[:, 0])
+    raw2 = read_raw_bids(bids_path=bids_output_path)
+    events2, _ = mne.events_from_annotations(raw2)
+    assert_array_equal(events2[:, 0], events[:, 0])
 
     # alter some channels manually
     raw.rename_channels({raw.info['ch_names'][0]: 'EOGtest'})

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -899,6 +899,9 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate):
     bids_output_path = write_raw_bids(raw, test_events_bids_path,
                                       overwrite=True)
 
+    with pytest.raises(RuntimeError, match='Events data passed'):
+        write_raw_bids(raw, test_events_bids_path, events_data=events)
+
     # check events.tsv is written
     events_tsv_fname = bids_output_path.copy().update(suffix='events',
                                                       extension='.tsv')

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -232,12 +232,12 @@ def _read_events(events_data, event_id, raw, verbose=None):
     # get events from annotations
     events_annot, event_id_annot = events_from_annotations(raw, event_id,
                                                            verbose=verbose)
-    if event_id is not None:
-        events = np.concatenate((events, events_annot), axis=0)
-        event_id.update(event_id_annot)
-    else:
+    if event_id is None:
         events = events_annot
         event_id = event_id_annot
+    else:
+        events = np.concatenate((events, events_annot), axis=0)
+        event_id.update(event_id_annot)
 
     if events.size == 0:
         warn('No events found or provided. Please make sure to'

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -14,12 +14,12 @@ from datetime import datetime, date, timedelta, timezone
 from os import path as op
 
 import numpy as np
-from mne import read_events, find_events, events_from_annotations
+from mne import (read_events, events_from_annotations)
 from mne.channels import make_standard_montage
 from mne.io.constants import FIFF
 from mne.io.kit.kit import get_kit_info
 from mne.io.pick import pick_types
-from mne.utils import check_version, warn, logger
+from mne.utils import warn, logger
 
 from mne_bids.tsv_handler import _to_tsv, _tsv_to_str
 
@@ -189,7 +189,7 @@ def _check_key_val(key, val):
     return key, val
 
 
-def _read_events(events_data, event_id, raw, ext, verbose=None):
+def _read_events(events_data, event_id, raw, verbose=None):
     """Read in events data.
 
     Parameters
@@ -203,8 +203,6 @@ def _read_events(events_data, event_id, raw, ext, verbose=None):
         mapping a description key to an integer valued event code.
     raw : instance of Raw
         The data as MNE-Python Raw object.
-    ext : str
-        The extension of the original data file.
     verbose : bool | str | int | None
         If not None, override default verbose level (see :func:`mne.verbose`).
 
@@ -231,29 +229,21 @@ def _read_events(events_data, event_id, raw, ext, verbose=None):
     else:
         events = np.empty(shape=(0, 3))
 
-    # get events from the stim channel
-    if 'stim' in raw:
-        events_stim = find_events(raw, min_duration=0.001,
-                                  initial_event=True, verbose=verbose)
-        events = np.concatenate((events, events_stim), axis =0)
-
     # get events from annotations
     events_annot, event_id_annot = events_from_annotations(raw, event_id,
                                                            verbose=verbose)
-    events = np.concatenate((events, events_annot))
-    if event_id is None:
-        event_id = event_id_annot
-    else:
+    if event_id is not None:
+        events = np.concatenate((events, events_annot), axis=0)
         event_id.update(event_id_annot)
+    else:
+        events = events_annot
+        event_id = event_id_annot
 
     if events.size == 0:
         warn('No events found or provided. Please make sure to'
              ' set channel type using raw.set_channel_types'
              ' or provide events_data.')
         events = None
-
-    print('Events data structure!', events)
-    print(event_id)
 
     return events, event_id
 

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -228,12 +228,18 @@ def _read_events(events_data, event_id, raw, ext, verbose=None):
                              f'found {events_data.shape[1]}')
         events = events_data
     elif 'stim' in raw:
+        print('USING STIM FOR EVENTS!!!! \n\n\n')
         events = find_events(raw, min_duration=0.001, initial_event=True,
                              verbose=verbose)
     elif ext in ['.vhdr', '.set'] and check_version('mne', '0.18'):
         events, event_id = events_from_annotations(raw, event_id,
                                                    verbose=verbose)
     else:
+        # any other file extension should try to get events from
+        # annotations
+        events, events_id = events_from_annotations(raw, event_id,
+                                                    verbose=verbose)
+    if events is None:
         warn('No events found or provided. Please make sure to'
              ' set channel type using raw.set_channel_types'
              ' or provide events_data.')

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -237,7 +237,9 @@ def _read_events(events_data, event_id, raw, verbose=None):
         event_id = event_id_annot
     else:
         events = np.concatenate((events, events_annot), axis=0)
-        events.sort(axis=0)
+        # Sort rows by onset sample.
+        # See https://stackoverflow.com/a/2828121/1944216
+        events = events[events[:, 0].argsort()]
         event_id.update(event_id_annot)
 
     if events.size == 0:

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -227,7 +227,7 @@ def _read_events(events_data, event_id, raw, verbose=None):
                              f'found {events_data.shape[1]}')
         events = events_data
     else:
-        events = np.empty(shape=(0, 3))
+        events = np.empty(shape=(0, 3), dtype=int)
 
     # get events from annotations
     events_annot, event_id_annot = events_from_annotations(raw, event_id,

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -971,8 +971,12 @@ def write_raw_bids(raw, bids_path, events_data=None,
                          'to set the root of the BIDS folder to read.')
 
     if events_data is not None and event_id is None:
-        raise RuntimeError('Events data passed in also requires '
-                           'event id to be passed in.')
+        raise RuntimeError('You passed events_data, but no event_id '
+                           'dictionary. You need to pass both, or neither.')
+
+    if event_id is not None and events_data is None:
+        raise RuntimeError('You passed event_id, but no events_data NumPy '
+                           'array. You need to pass both, or neither.')
 
     raw = raw.copy()
 

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -913,6 +913,14 @@ def write_raw_bids(raw, bids_path, events_data=None,
     updated and ``raw.info['meas_date']`` should not be ``None`` to allow
     computation of each participant's age correctly.
 
+    If an events file is not passed in, then events are looked for in the
+    ``stim`` channel and then the annotations. If you have events in both
+    the ``stim`` channel and annotations, it will not write both.
+
+    If your raw file has events encoded in the annotations that you would
+    not like to write, then you should explicitly set annotations to None by
+    ``raw.set_annotations(None)``.
+
     See Also
     --------
     mne.io.Raw.anonymize

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -914,8 +914,15 @@ def write_raw_bids(raw, bids_path, events_data=None,
     computation of each participant's age correctly.
 
     Events will be taken as the union of an events file (if passed in through
-    the ``events_data`` kwarg), ``stim`` channel and annotations of the raw
-    file.
+    the ``events_data`` kwarg), and annotations of the raw file. If you have
+    events encoded in the ``stim`` channel, then please extract it first.
+    For example, you might use
+
+    ..
+        # get events from the stim channel
+        events_stim = mne.find_events(raw, min_duration=0.001,
+                                      initial_event=True, verbose=verbose)
+
 
     If your raw file has events encoded in the annotations that you would
     not like to write, then you should explicitly set annotations to None by
@@ -1080,7 +1087,7 @@ def write_raw_bids(raw, bids_path, events_data=None,
         logger.warning(f'Writing of electrodes.tsv is not supported '
                        f'for data type "{bids_path.datatype}". Skipping ...')
 
-    events, event_id = _read_events(events_data, event_id, raw, ext,
+    events, event_id = _read_events(events_data, event_id, raw,
                                     verbose=verbose)
     if events is not None and len(events) > 0 and not emptyroom:
         _events_tsv(events, raw, events_path.fpath, event_id,
@@ -1499,8 +1506,7 @@ def mark_bad_channels(ch_names, descriptions=None, *, bids_path,
     # XXX (How) will this handle split files?
     if isinstance(raw, mne.io.brainvision.brainvision.RawBrainVision):
         events, event_id = _read_events(events_data=None, event_id=None,
-                                        raw=raw,
-                                        ext='.vhdr', verbose=False)
+                                        raw=raw, verbose=False)
         _write_raw_brainvision(raw, bids_path.fpath, events)
     elif isinstance(raw, mne.io.RawFIF):
         raw.save(raw.filenames[0], overwrite=True, verbose=False)

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -861,8 +861,8 @@ def write_raw_bids(raw, bids_path, events_data=None,
         The events file. If a string or a Path object, specifies the path of
         the events file. If an array, the MNE events array
         (shape: ``(n_events, 3)``).
-        If ``None``, events will be inferred from the stim channel using
-        `mne.find_events`.
+        If ``None``, events will be inferred from the annotations using
+        `mne.events_from_annotations`.
     event_id : dict | None
         The event ID dictionary used to create a `trial_type` column in
         ``*_events.tsv``.

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -963,6 +963,10 @@ def write_raw_bids(raw, bids_path, events_data=None,
                          'Please use `bids_path.update(root="<root>")` '
                          'to set the root of the BIDS folder to read.')
 
+    if events_data is not None and event_id is None:
+        raise RuntimeError('Events data passed in also requires '
+                           'event id to be passed in.')
+
     raw = raw.copy()
 
     raw_fname = raw.filenames[0]

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -913,9 +913,9 @@ def write_raw_bids(raw, bids_path, events_data=None,
     updated and ``raw.info['meas_date']`` should not be ``None`` to allow
     computation of each participant's age correctly.
 
-    If an events file is not passed in, then events are looked for in the
-    ``stim`` channel and then the annotations. If you have events in both
-    the ``stim`` channel and annotations, it will not write both.
+    Events will be taken as the union of an events file (if passed in through
+    the ``events_data`` kwarg), ``stim`` channel and annotations of the raw
+    file.
 
     If your raw file has events encoded in the annotations that you would
     not like to write, then you should explicitly set annotations to None by

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -814,8 +814,8 @@ def write_raw_bids(raw, bids_path, events_data=None,
                    file format is BIDS-supported for that datatype. Otherwise,
                    this function will convert to a BIDS-supported file format
                    while warning the user. For EEG and iEEG data, conversion
-                   will be to BrainVision format, for MEG conversion will be
-                   to FIF.
+                   will be to BrainVision format; for MEG, conversion will be
+                   to FIFF.
 
                  * ``mne-bids`` will infer the manufacturer information
                    from the file extension. If your file format is non-standard
@@ -857,8 +857,8 @@ def write_raw_bids(raw, bids_path, events_data=None,
         Note that the data type is automatically inferred from the raw
         object, as well as the extension. Data with MEG and other
         electrophysiology data in the same file will be stored as ``'meg'``.
-    events_data : str | pathlib.Path | array | None
-        The events file. If a string or a Path object, specifies the path of
+    events_data : path-like | array | None
+        If a string or a Path object, specifies the path of
         the events file. If an array, the MNE events array
         (shape: ``(n_events, 3)``).
         If ``None``, events will be inferred from the annotations using
@@ -956,6 +956,10 @@ def write_raw_bids(raw, bids_path, events_data=None,
     if not isinstance(bids_path, BIDSPath):
         raise RuntimeError('"bids_path" must be a BIDSPath object. Please '
                            'instantiate using mne_bids.BIDSPath().')
+
+    _validate_type(events_data, types=('path-like', np.ndarray, None),
+                   item_name='events_data',
+                   type_name='path-like, NumPy array, or None')
 
     # Check if the root is available
     if bids_path.root is None:


### PR DESCRIPTION
PR Description
--------------

Closes: #581 

Lmk if you have any ways of "compressing" the `_find_events` function, which has a lot of if/else. I'm not too familiar w/ `stim`, so left that alone.

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [x] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [x] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [x] PR description includes phrase "closes <#issue-number>"
