### PR TITLE
[MRG] electrodes.tsv weren't being written to datatype folder for ieeg

### DIFF
--- a/mne_bids/dig.py
+++ b/mne_bids/dig.py
@@ -301,9 +301,9 @@ def _write_dig_bids(electrodes_path, coordsystem_path, root,
 
     Parameters
     ----------
-    electrodes_path : str
+    electrodes_path : BIDSPath
         Filename to save the electrodes.tsv to.
-    coordsystem_path : str
+    coordsystem_path : BIDSPath
         Filename to save the coordsystem.json to.
     root : str | pathlib.Path
         Path to the data directory
@@ -320,11 +320,6 @@ def _write_dig_bids(electrodes_path, coordsystem_path, root,
     """
     # write electrodes data for iEEG and EEG
     unit = "m"  # defaults to meters
-
-    params = get_entities_from_fname(electrodes_path)
-    subject_id = params['subject']
-    session_id = params['session']
-    acquisition = params['acquisition']
 
     # get coordinate frame from digMontage
     digpoint = raw.info['dig'][0]
@@ -347,18 +342,8 @@ def _write_dig_bids(electrodes_path, coordsystem_path, root,
         if coord_frame is not None:
             # XXX: To improve when mne-python allows coord_frame='unknown'
             if coord_frame not in BIDS_IEEG_COORDINATE_FRAMES:
-                coordsystem_path = BIDSPath(
-                    subject=subject_id, session=session_id,
-                    acquisition=acquisition, space=coord_frame,
-                    datatype=datatype,
-                    suffix='coordsystem', extension='.json',
-                    root=root)
-                electrodes_path = BIDSPath(
-                    subject=subject_id, session=session_id,
-                    acquisition=acquisition, space=coord_frame,
-                    datatype=datatype,
-                    suffix='electrodes', extension='.tsv',
-                    root=root)
+                coordsystem_path.update(space=coord_frame)
+                electrodes_path.update(space=coord_frame)
                 coord_frame = 'Other'
 
             # Now write the data to the elec coords and the coordsystem

--- a/mne_bids/dig.py
+++ b/mne_bids/dig.py
@@ -20,7 +20,6 @@ from mne_bids.config import (BIDS_IEEG_COORDINATE_FRAMES,
 from mne_bids.tsv_handler import _from_tsv
 from mne_bids.utils import (_extract_landmarks, _scale_coord_to_meters,
                             _write_json, _write_tsv)
-from mne_bids import BIDSPath
 from mne_bids.path import get_entities_from_fname
 
 

--- a/mne_bids/dig.py
+++ b/mne_bids/dig.py
@@ -350,11 +350,13 @@ def _write_dig_bids(electrodes_path, coordsystem_path, root,
                 coordsystem_path = BIDSPath(
                     subject=subject_id, session=session_id,
                     acquisition=acquisition, space=coord_frame,
+                    datatype=datatype,
                     suffix='coordsystem', extension='.json',
                     root=root)
                 electrodes_path = BIDSPath(
                     subject=subject_id, session=session_id,
                     acquisition=acquisition, space=coord_frame,
+                    datatype=datatype,
                     suffix='electrodes', extension='.tsv',
                     root=root)
                 coord_frame = 'Other'

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1097,7 +1097,7 @@ def write_raw_bids(raw, bids_path, events_data=None,
         # We only write electrodes.tsv and accompanying coordsystem.json
         # if we have an available DigMontage
         if raw.info['dig'] is not None and raw.info['dig']:
-            _write_dig_bids(electrodes_path.fpath, coordsystem_path.fpath,
+            _write_dig_bids(electrodes_path, coordsystem_path,
                             bids_path.root, raw, bids_path.datatype,
                             overwrite, verbose)
     else:


### PR DESCRIPTION
PR Description
--------------

I was writing some `electrodes.tsv` files and they were being output to the session directory rather then under `ieeg/`. Simple one line fix.

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
