### PR TITLE
[MRG] ENH: print_dir_tree can now return a str instead of only printing

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -24,14 +24,14 @@ xxx
 
 Authors
 ~~~~~~~
-xxx
+* `Stefan Appelhoff`_
 
 Detailed list of changes
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 Enhancements
 ^^^^^^^^^^^^
-xxx
+- The function :func:`mne_bids.print_dir_tree` has a new parameter ``return_str`` which allows it to return a str of the dir tree instead of printing it, by `Stefan Appelhoff`_ (`#600 <https://github.com/mne-tools/mne-bids/pull/600>`_)
 
 Bug fixes
 ^^^^^^^^^

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -156,6 +156,17 @@ def test_print_dir_tree(capsys):
     # test if pathlib.Path object
     print_dir_tree(Path(test_dir))
 
+    # test returning a string
+    out = print_dir_tree(test_dir, return_str=True, max_depth=1)
+    assert isinstance(out, str)
+    assert '|--- test_utils.py' in out.split('\n')
+    assert '|--- __pycache__{}'.format(os.sep) in out.split('\n')
+    assert '.pyc' not in out
+
+    # errors if return_str not a bool
+    with pytest.raises(ValueError, match='must be either True or False.'):
+        print_dir_tree(test_dir, return_str='yes')
+
 
 def test_make_folders():
     """Test that folders are created and named properly."""


### PR DESCRIPTION
closes #590 

This enhances `print_dir_tree` to optionally (default False) return a str instead of only printing.

We can then use this to

1. get a bids dir tree as a str
1. plot that tree using mpl's `plt.text`
1. set that plot as a thumbnail in the examples.

These three steps could be done either:

- as part of an example --> would be a bit clunky, admittedly
- during the docs build process --> would require a small python snippet that runs in the back to generate the figures and make sure the examples have the paths to those figures to set as thumbnails.

WDYT?

it's a treatment to make these thumbnails more meaningful:

![image](https://user-images.githubusercontent.com/9084751/96905412-b3428e00-1498-11eb-9c55-08493fd8a5cc.png)



Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [x] All CIs are happy
- [x] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [x] PR description includes phrase "closes <#issue-number>"
