### PR TITLE
[MRG] Fixes electrodes.tsv and coordsystem.json writing for EEG/iEEG to adhere to specification

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -32,6 +32,7 @@ Detailed list of changes
 Enhancements
 ^^^^^^^^^^^^
 - The function :func:`mne_bids.print_dir_tree` has a new parameter ``return_str`` which allows it to return a str of the dir tree instead of printing it, by `Stefan Appelhoff`_ (`#600 <https://github.com/mne-tools/mne-bids/pull/600>`_)
+- The function :func:`mne_bids.write_raw_bids` now outputs `electrodes.tsv` and `coordsystem.json` files for EEG/iEEG data that are BIDS compliant (only contain subject, session, acquisition, and space entities), by `Adam Li`_ (`#601 <https://github.com/mne-tools/mne-bids/pull/601>`_)
 
 Bug fixes
 ^^^^^^^^^

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -25,6 +25,7 @@ xxx
 Authors
 ~~~~~~~
 * `Stefan Appelhoff`_
+* `Adam Li`_
 
 Detailed list of changes
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -33,11 +33,10 @@ Detailed list of changes
 Enhancements
 ^^^^^^^^^^^^
 - The function :func:`mne_bids.print_dir_tree` has a new parameter ``return_str`` which allows it to return a str of the dir tree instead of printing it, by `Stefan Appelhoff`_ (`#600 <https://github.com/mne-tools/mne-bids/pull/600>`_)
-- The function :func:`mne_bids.write_raw_bids` now outputs `electrodes.tsv` and `coordsystem.json` files for EEG/iEEG data that are BIDS compliant (only contain subject, session, acquisition, and space entities), by `Adam Li`_ (`#601 <https://github.com/mne-tools/mne-bids/pull/601>`_)
 
 Bug fixes
 ^^^^^^^^^
-xxx
+- The function :func:`mne_bids.write_raw_bids` now outputs ``electrodes.tsv`` and ``coordsystem.json`` files for EEG/iEEG data that are BIDS compliant (only contain subject, session, acquisition, and space entities), by `Adam Li`_ (`#601 <https://github.com/mne-tools/mne-bids/pull/601>`_)
 
 API changes
 ^^^^^^^^^^^

--- a/mne_bids/dig.py
+++ b/mne_bids/dig.py
@@ -342,7 +342,7 @@ def _write_dig_bids(bids_path, raw, overwrite=False, verbose=True):
     electrodes_path = BIDSPath(**coord_file_entities, suffix='electrodes',
                                extension='.tsv')
     coordsystem_path = BIDSPath(**coord_file_entities, suffix='coordsystem',
-                               extension='.json')
+                                extension='.json')
 
     if verbose:
         print("Writing electrodes file to... ", electrodes_path)

--- a/mne_bids/dig.py
+++ b/mne_bids/dig.py
@@ -20,7 +20,7 @@ from mne_bids.config import (BIDS_IEEG_COORDINATE_FRAMES,
 from mne_bids.tsv_handler import _from_tsv
 from mne_bids.utils import (_extract_landmarks, _scale_coord_to_meters,
                             _write_json, _write_tsv)
-from mne_bids.path import get_entities_from_fname
+from mne_bids.path import get_entities_from_fname, BIDSPath
 
 
 def _handle_electrodes_reading(electrodes_fname, coord_frame,
@@ -291,8 +291,7 @@ def _coordsystem_json(*, raw, unit, hpi_coord_system, sensor_coord_system,
     _write_json(fname, fid_json, overwrite, verbose)
 
 
-def _write_dig_bids(electrodes_path, coordsystem_path, root,
-                    raw, datatype, overwrite=False, verbose=True):
+def _write_dig_bids(bids_path, raw, overwrite=False, verbose=True):
     """Write BIDS formatted DigMontage from Raw instance.
 
     Handles coordinatesystem.json and electrodes.tsv writing
@@ -300,17 +299,13 @@ def _write_dig_bids(electrodes_path, coordsystem_path, root,
 
     Parameters
     ----------
-    electrodes_path : BIDSPath
-        Filename to save the electrodes.tsv to.
-    coordsystem_path : BIDSPath
-        Filename to save the coordsystem.json to.
-    root : str | pathlib.Path
-        Path to the data directory
+    bids_path : BIDSPath
+        Path in the BIDS dataset to save the ``electrodes.tsv``
+        and ``coordsystem.json`` file for. ``datatype``
+        attribute must be ``eeg``, or ``ieeg``. For ``meg``
+        data, ``electrodes.tsv`` are not saved.
     raw : instance of Raw
         The data as MNE-Python Raw object.
-    datatype : str
-        Type of the data recording. Can be ``meg``, ``eeg``,
-        or ``ieeg``.
     overwrite : bool
         Whether to overwrite the existing file.
         Defaults to False.
@@ -332,6 +327,22 @@ def _write_dig_bids(electrodes_path, coordsystem_path, root,
     coord_frame_int = int(digpoint['coord_frame'])
     mne_coord_frame = MNE_FRAME_TO_STR.get(coord_frame_int, None)
     coord_frame = MNE_TO_BIDS_FRAMES.get(mne_coord_frame, None)
+
+    # create electrodes/coordsystem files using a subset of entities
+    # that are specified for these files in the specification
+    coord_file_entities = {
+        'root': bids_path.root,
+        'datatype': bids_path.datatype,
+        'subject': bids_path.subject,
+        'session': bids_path.session,
+        'acquisition': bids_path.acquisition,
+        'space': bids_path.space
+    }
+    datatype = bids_path.datatype
+    electrodes_path = BIDSPath(**coord_file_entities, suffix='electrodes',
+                               extension='.tsv')
+    coordsystem_path = BIDSPath(**coord_file_entities, suffix='coordsystem',
+                               extension='.json')
 
     if verbose:
         print("Writing electrodes file to... ", electrodes_path)

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -41,7 +41,7 @@ from mne.io.kit.kit import get_kit_info
 from mne_bids import (write_raw_bids, read_raw_bids, BIDSPath,
                       write_anat, make_dataset_description,
                       mark_bad_channels, write_meg_calibration,
-                      write_meg_crosstalk)
+                      write_meg_crosstalk, get_entities_from_fname)
 from mne_bids.utils import (_stamp_to_dt, _get_anonymization_daysback,
                             get_anonymization_daysback)
 from mne_bids.tsv_handler import _from_tsv, _to_tsv
@@ -865,6 +865,14 @@ def test_vhdr(_bids_validate):
     assert len(tsv.get('impedance', {})) > 0
     assert tsv['impedance'][-3:] == ['n/a', 'n/a', 'n/a']
     assert tsv['impedance'][:3] == ['5.0', '2.0', '4.0']
+
+    # electrodes file path should only contain
+    # sub/ses/acq/space at most
+    entities = get_entities_from_fname(electrodes_fpath)
+    assert all([entity is None for key, entity in entities.items()
+                if key not in ['subject', 'session',
+                               'acquisition', 'space',
+                               'suffix']])
 
 
 @pytest.mark.parametrize('dir_name, fname, reader', test_eegieeg_data)

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1038,10 +1038,6 @@ def write_raw_bids(raw, bids_path, events_data=None,
         acquisition=bids_path.acquisition, space=bids_path.space,
         datatype=bids_path.datatype, suffix='coordsystem', extension='.json')
 
-    # create *_electrodes.tsv
-    electrodes_path = bids_path.copy().update(
-        suffix='electrodes', extension='.tsv')
-
     # For the remaining files, we can use BIDSPath to alter.
     readme_fname = op.join(bids_path.root, 'README')
     participants_tsv_fname = op.join(bids_path.root, 'participants.tsv')
@@ -1097,9 +1093,7 @@ def write_raw_bids(raw, bids_path, events_data=None,
         # We only write electrodes.tsv and accompanying coordsystem.json
         # if we have an available DigMontage
         if raw.info['dig'] is not None and raw.info['dig']:
-            _write_dig_bids(electrodes_path, coordsystem_path,
-                            bids_path.root, raw, bids_path.datatype,
-                            overwrite, verbose)
+            _write_dig_bids(bids_path, raw, overwrite, verbose)
     else:
         logger.warning(f'Writing of electrodes.tsv is not supported '
                        f'for data type "{bids_path.datatype}". Skipping ...')


### PR DESCRIPTION
PR Description
--------------

Closes: #592 

- electrodes and coordsystem files for EEG and iEEG data should only have subject/session/acquisition/space/suffix defined.
- simplified the arguments for `_write_dig_bids` using BIDSPath.

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
