### PR TITLE
reveal issue when saving big file

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -38,6 +38,7 @@ Enhancements
 
 Bug fixes
 ^^^^^^^^^
+- Make sure large FIF files with splits are handled transparently on read and write, by `Alexandre Gramfort`_ (`#612 <https://github.com/mne-tools/mne-bids/pull/612>`_)
 - The function :func:`mne_bids.write_raw_bids` now outputs ``*_electrodes.tsv`` and ``*_coordsystem.json`` files for EEG/iEEG data that are BIDS-compliant (only contain subject, session, acquisition, and space entities), by `Adam Li`_ (`#601 <https://github.com/mne-tools/mne-bids/pull/601>`_)
 - Fix a bug in :func:`mne_bids.write_raw_bids`, where passing raw data with :class:`mne.Annotations` set and the ``event_id`` dictionary not containing the :class:`mne.Annotations` descriptions as keys would raise an error, by `Richard Höchenberger`_ (`#603 <https://github.com/mne-tools/mne-bids/pull/603>`_)
 

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -435,6 +435,14 @@ class BIDSPath(object):
                     matching_paths = [p for p in matching_paths
                                       if _parse_ext(p)[1] in valid_exts]
 
+                if (self.split is None and
+                        (not matching_paths or
+                         '_split-' in matching_paths[0])):
+                    # try finding FIF split files (only first one)
+                    this_self = self.copy().update(split='01')
+                    matching_paths = \
+                        _get_matching_bidspaths_from_filesystem(this_self)
+
                 # found no matching paths
                 if not matching_paths:
                     msg = (f'Could not locate a data file of a supported '

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -456,6 +456,7 @@ class BIDSPath(object):
                     raise RuntimeError(msg)
                 else:
                     bids_fpath = matching_paths[0]
+
             else:
                 bids_fpath = op.join(data_path, self.basename)
 

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -710,20 +710,28 @@ def test_bads_reading():
 
 
 @pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
-def test_write_read_big_file():
-    """Test that meaningful error on missing file."""
+def test_write_read_fif_split_file():
+    """Test split files are read correctly."""
     bids_root = _TempDir()
     tmp_dir = _TempDir()
     bids_path = _bids_path.copy().update(root=bids_root, datatype='meg')
     raw = _read_raw_fif(raw_fname, verbose=False)
     n_channels = len(raw.ch_names)
     n_times = int(2.2e9 / (n_channels * 4))  # enough to produce a split
-    data = np.ones((n_channels, n_times), dtype=np.float32)
+    data = np.empty((n_channels, n_times), dtype=np.float32)
     raw = mne.io.RawArray(data, raw.info)
     big_fif_fname = pathlib.Path(tmp_dir) / 'test_raw.fif'
     raw.save(big_fif_fname)
     raw = _read_raw_fif(big_fif_fname, verbose=False)
     write_raw_bids(raw, bids_path, verbose=False)
 
-    read_raw_bids(bids_path=bids_path)  # XXX crash
-    bids_path.fpath  # XXX crash
+    raw1 = read_raw_bids(bids_path=bids_path)
+    assert 'split-01' in str(bids_path.fpath)
+
+    bids_path.update(split='01')
+    raw2 = read_raw_bids(bids_path=bids_path)
+    bids_path.update(split='02')
+    raw3 = read_raw_bids(bids_path=bids_path)
+    assert len(raw) == len(raw1)
+    assert len(raw) == len(raw2)
+    assert len(raw) > len(raw3)


### PR DESCRIPTION
I had an issue today. Basically I read a big fif file that produces a split on write. When I try to read it back I need specify the split otherwise the reader fails. See my test.

The issue is that code that runs files without splits starts to break as soon as I have a big file for one subject.

Thoughts?

@adam2392 @hoechenberger @jasmainak @sappelhoff ?