### PR TITLE
FIX: properly access CoordinateSystemDescriptions using .lower()

### DIFF
--- a/mne_bids/config.py
+++ b/mne_bids/config.py
@@ -201,7 +201,15 @@ COORD_FRAME_DESCRIPTIONS = {
     '4dbti': 'ALS orientation and the origin between the ears',
     'kityokogawa': 'ALS orientation and the origin between the ears',
     'chietiitab': 'RAS orientation and the origin between the ears',
-    'captrak': 'RAS orientation and the origin between the ears',
+    'captrak': (
+        'The X-axis goes from the left preauricular point (LPA) through '
+        'the right preauricular point (RPA). '
+        'The Y-axis goes orthogonally to the X-axis through the nasion (NAS). '
+        'The Z-axis goes orthogonally to the XY-plane through the vertex of '
+        'the head. '
+        'This corresponds to a "RAS" orientation with the origin of the '
+        'coordinate system approximately between the ears. '
+        'See Appendix VIII in the BIDS specification.'),
     'mri': 'Defined by Freesurfer, the MRI (surface RAS) origin is at the '
            'center of a 256×256×256 1mm anisotropic volume '
            '(may not be in the center of the head).',

--- a/mne_bids/dig.py
+++ b/mne_bids/dig.py
@@ -251,7 +251,7 @@ def _coordsystem_json(*, raw, unit, hpi_coord_system, sensor_coord_system,
 
     # get the coordinate frame description
     sensor_coord_system_descr = (COORD_FRAME_DESCRIPTIONS
-                                 .get(sensor_coord_system, "n/a"))
+                                 .get(sensor_coord_system.lower(), "n/a"))
     if sensor_coord_system == 'Other' and verbose:
         print('Using the `Other` keyword for the CoordinateSystem field. '
               'Please specify the CoordinateSystemDescription field manually.')


### PR DESCRIPTION
While doing a conversion I noticed that "*CoordinateSystemDescription" does not get written out.

Fixed via a `.lower()` call and by adding a regression test.

While at it, I also improved one "CoordinateSystemDescription" for "CapTrak", because that's the only one I know well.


Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
