### PR TITLE
[MRG] ENH/FIX: write fractional secs and UTC indicator in scans_tsv, write n/a instead of nan in electrodes_tsv impedance column

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Node.js
-      uses: actions/setup-node@v1.4.2
+      uses: actions/setup-node@v1
       with:
         node-version: 12
     - name: Set up Python ${{ matrix.python-version }}

--- a/mne_bids/dig.py
+++ b/mne_bids/dig.py
@@ -136,7 +136,7 @@ def _get_impedances(raw, names):
     """Get the impedance values in kOhm from raw.impedances."""
     if not hasattr(raw, 'impedances'):  # pragma: no cover
         return ['n/a'] * len(names)
-    no_info = {'imp': 'n/a', 'imp_unit': 'kOhm'}
+    no_info = {'imp': np.nan, 'imp_unit': 'kOhm'}
     impedance_dicts = [raw.impedances.get(name, no_info) for name in names]
     # If we encounter a unit not defined in `scalings`, return NaN
     scalings = {'kOhm': 1, 'Ohm': 0.001}
@@ -144,6 +144,8 @@ def _get_impedances(raw, names):
         imp_dict['imp'] * scalings.get(imp_dict['imp_unit'], np.nan)
         for imp_dict in impedance_dicts
     ]
+    # replace np.nan with BIDS 'n/a' representation
+    impedances = [i if not np.isnan(i) else "n/a" for i in impedances]
     return impedances
 
 

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -51,7 +51,7 @@ def _get_matched_empty_room(bids_path):
                          'date set. Cannot get matching empty-room file.')
 
     ref_date = raw.info['meas_date']
-    if not isinstance(ref_date, datetime):
+    if not isinstance(ref_date, datetime):  # pragma: no cover
         # for MNE < v0.20
         ref_date = datetime.fromtimestamp(raw.info['meas_date'][0])
 

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -728,7 +728,7 @@ def test_find_empty_room(return_bids_test_dir):
     raw.copy().crop(0, 10).save(er_raw_fname, overwrite=True)
     er_raw = _read_raw_fif(er_raw_fname)
 
-    if not isinstance(er_raw.info['meas_date'], datetime):
+    if not isinstance(er_raw.info['meas_date'], datetime):  # pragma: no cover
         # mne < v0.20
         er_date = datetime.fromtimestamp(er_raw.info['meas_date'][0])
     else:

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -145,7 +145,7 @@ def _test_anonymize(raw, bids_path, events_fname=None, event_id=None):
     data = _from_tsv(scans_tsv)
     if data['acq_time'] is not None and data['acq_time'][0] != 'n/a':
         assert datetime.strptime(data['acq_time'][0],
-                                 '%Y-%m-%dT%H:%M:%S').year < 1925
+                                 '%Y-%m-%dT%H:%M:%S.%fZ').year < 1925
 
     return bids_root
 
@@ -401,7 +401,7 @@ def test_fif(_bids_validate):
         subject=subject_id, session=session_id,
         suffix='scans', extension='.tsv', root=bids_root)
     data = _from_tsv(scans_tsv)
-    assert data['acq_time'][0] == meas_date.strftime('%Y-%m-%dT%H:%M:%S')
+    assert data['acq_time'][0] == meas_date.strftime('%Y-%m-%dT%H:%M:%S.%fZ')
 
     # give the raw object some fake participant data (potentially overwriting)
     raw = _read_raw_fif(raw_fname)
@@ -628,7 +628,7 @@ def test_fif_anonymize(_bids_validate):
     # anonymize using MNE manually
     anonymized_info = anonymize_info(info=raw.info, daysback=30000,
                                      keep_his=True)
-    anon_date = anonymized_info['meas_date'].strftime("%Y-%m-%dT%H:%M:%S")
+    anon_date = anonymized_info['meas_date'].strftime("%Y-%m-%dT%H:%M:%S.%fZ")
     assert data['acq_time'][0] == anon_date
     _bids_validate(bids_root)
 

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -397,16 +397,17 @@ def _scans_tsv(raw, raw_fname, fname, overwrite=False, verbose=True):
         Set verbose output to True or False.
 
     """
-    # get measurement date from the data info
+    # get measurement date in UTC from the data info
     meas_date = raw.info['meas_date']
     if meas_date is None:
         acq_time = 'n/a'
-    elif isinstance(meas_date, (tuple, list, np.ndarray)):  # noqa: E501
+    # The "Z" indicates UTC time
+    elif isinstance(meas_date, (tuple, list, np.ndarray)):
         # for MNE < v0.20
-        acq_time = _stamp_to_dt(meas_date).strftime('%Y-%m-%dT%H:%M:%S')
+        acq_time = _stamp_to_dt(meas_date).strftime('%Y-%m-%dT%H:%M:%S.%fZ')
     elif isinstance(meas_date, datetime):
         # for MNE >= v0.20
-        acq_time = meas_date.strftime('%Y-%m-%dT%H:%M:%S')
+        acq_time = meas_date.strftime('%Y-%m-%dT%H:%M:%S.%fZ')
 
     data = OrderedDict([('filename', ['%s' % raw_fname.replace(os.sep, '/')]),
                         ('acq_time', [acq_time])])
@@ -415,7 +416,7 @@ def _scans_tsv(raw, raw_fname, fname, overwrite=False, verbose=True):
         orig_data = _from_tsv(fname)
         # if the file name is already in the file raise an error
         if raw_fname in orig_data['filename'] and not overwrite:
-            raise FileExistsError(f'"{raw_fname}" already exists in '  # noqa: E501 F821
+            raise FileExistsError(f'"{raw_fname}" already exists in '
                                   f'the scans list. Please set '
                                   f'overwrite to True.')
         # otherwise add the new data

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -402,7 +402,7 @@ def _scans_tsv(raw, raw_fname, fname, overwrite=False, verbose=True):
     if meas_date is None:
         acq_time = 'n/a'
     # The "Z" indicates UTC time
-    elif isinstance(meas_date, (tuple, list, np.ndarray)):
+    elif isinstance(meas_date, (tuple, list, np.ndarray)):  # pragma: no cover
         # for MNE < v0.20
         acq_time = _stamp_to_dt(meas_date).strftime('%Y-%m-%dT%H:%M:%S.%fZ')
     elif isinstance(meas_date, datetime):


### PR DESCRIPTION
We can be more accurate in writing `acq_time` in the `scans.tsv` files.

BIDS supports [optional] fractional seconds: `.%f`, and [optional] a UTC indicator: `Z`

Given that MNE-Python `meas_time` is always in UTC, it makes sense to write it that way, IMHO

See: https://bids-specification.readthedocs.io/en/latest/02-common-principles.html#units

> Date time information MUST be expressed in the following format YYYY-MM-DDThh:mm:ss[.000000][Z] (year, month, day, hour (24h), minute, second, optional fractional seconds, and optional UTC time indicator).


Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
    - **don't know .. should I add one?**
- ~PR description includes phrase "closes <#issue-number>"~
