### PR TITLE
[MRG] DOC: add sphinx-copybutton extension

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -37,9 +37,14 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinx_gallery.gen_gallery',
     'numpydoc',
+    'sphinx_copybutton',
     'gen_cli',  # custom extension, see ./sphinxext/gen_cli.py
     'gh_substitutions',  # custom extension, see ./sphinxext/gh_substitutions.py
 ]
+
+# configure sphinx-copybutton
+copybutton_prompt_text = r">>> |\.\.\. |\$ "
+copybutton_prompt_is_regexp = True
 
 # generate autosummary even if no references
 autosummary_generate = True

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,6 +1,7 @@
 nilearn
 sphinx_gallery
 sphinx_bootstrap_theme
+sphinx-copybutton
 numpydoc
 matplotlib
 pillow


### PR DESCRIPTION
This is a quality of life PR, for readers of the docs to more easily copy code blocks.

There will be a small "copy"  icon for each codeblock ... when clicking on it, users copy the code - automatically removing `>>>` and `$ `

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [x] All comments resolved
- [x] This is not your own PR
- [x] All CIs are happy
- [x] PR title starts with [MRG]
- ~[whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated~
- ~PR description includes phrase "closes <#issue-number>"~
