### PR TITLE
[MRG] Integrated EDF/BDF anonymization

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -72,6 +72,7 @@ mne_bids.copyfiles
    :toctree: generated/
 
    copyfile_brainvision
+   copyfile_edf
    copyfile_eeglab
    copyfile_ctf
    copyfile_bti

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -44,6 +44,7 @@ Enhancements
 - Writing BrainVision data via :func:`mne_bids.write_raw_bids` will now set the unit of EEG channels to µV for enhanced interoperability with other software, by `Alexandre Gramfort`_, `Stefan Appelhoff`_, and `Richard Höchenberger`_ (:gh:`610`)
 - New function :func:`mne_bids.stats.count_events` to easily summarize all the events present in a dataset, by `Alexandre Gramfort`_ (:gh:`629`)
 - Add :func:`mne_bids.update_sidecar_json` to allow updating sidecar JSON files with a template, by `Adam Li`_ and `Austin Hurst`_ (:gh:`601`)
+- Add support for anonymizing EDF and BDF files without converting to BrainVision format, by `Austin Hurst`_ (:gh:`636`)
 
 Bug fixes
 ^^^^^^^^^

--- a/mne_bids/copyfiles.py
+++ b/mne_bids/copyfiles.py
@@ -373,7 +373,7 @@ def copyfile_edf(src, dest, anonymize=None):
                  "startdate" field to 85 (i.e., 1985), the earliest possible
                  date for that field. However, the "Startdate" field in the
                  file's "local recording identification" and the date in the
-                 session's corresponding `scans.tsv` will be set correctly
+                 session's corresponding ``scans.tsv`` will be set correctly
                  according to the argument provided to the ``anonymize``
                  parameter. Note that it is possible that not all EDF/EDF+/BDF
                  reading software parses the accurate recording date, and

--- a/mne_bids/copyfiles.py
+++ b/mne_bids/copyfiles.py
@@ -146,11 +146,11 @@ def copyfile_ctf(src, dest):
 
     See Also
     --------
-    mne_bids.copyfiles.copyfile_brainvision
-    mne_bids.copyfiles.copyfile_bti
-    mne_bids.copyfiles.copyfile_edf
-    mne_bids.copyfiles.copyfile_eeglab
-    mne_bids.copyfiles.copyfile_kit
+    copyfile_brainvision
+    copyfile_bti
+    copyfile_edf
+    copyfile_eeglab
+    copyfile_kit
 
     """
     _copytree(src, dest)
@@ -189,11 +189,11 @@ def copyfile_kit(src, dest, subject_id, session_id,
 
     See Also
     --------
-    mne_bids.copyfiles.copyfile_brainvision
-    mne_bids.copyfiles.copyfile_bti
-    mne_bids.copyfiles.copyfile_ctf
-    mne_bids.copyfiles.copyfile_edf
-    mne_bids.copyfiles.copyfile_eeglab
+    copyfile_brainvision
+    copyfile_bti
+    copyfile_ctf
+    copyfile_edf
+    copyfile_eeglab
 
     """
     # create parent directories in case it does not exist yet
@@ -299,11 +299,11 @@ def copyfile_brainvision(vhdr_src, vhdr_dest, anonymize=None, verbose=False):
     See Also
     --------
     mne.io.anonymize_info
-    mne_bids.copyfiles.copyfile_bti
-    mne_bids.copyfiles.copyfile_ctf
-    mne_bids.copyfiles.copyfile_edf
-    mne_bids.copyfiles.copyfile_eeglab
-    mne_bids.copyfiles.copyfile_kit
+    copyfile_bti
+    copyfile_ctf
+    copyfile_edf
+    copyfile_eeglab
+    copyfile_kit
 
     """
     # Get extenstion of the brainvision file
@@ -413,11 +413,11 @@ def copyfile_edf(src, dest, anonymize=None):
     See Also
     --------
     mne.io.anonymize_info
-    mne_bids.copyfiles.copyfile_brainvision
-    mne_bids.copyfiles.copyfile_bti
-    mne_bids.copyfiles.copyfile_ctf
-    mne_bids.copyfiles.copyfile_eeglab
-    mne_bids.copyfiles.copyfile_kit
+    copyfile_brainvision
+    copyfile_bti
+    copyfile_ctf
+    copyfile_eeglab
+    copyfile_kit
 
     """
     # Ensure source & destination extensions are the same
@@ -513,11 +513,11 @@ def copyfile_eeglab(src, dest):
 
     See Also
     --------
-    mne_bids.copyfiles.copyfile_brainvision
-    mne_bids.copyfiles.copyfile_bti
-    mne_bids.copyfiles.copyfile_ctf
-    mne_bids.copyfiles.copyfile_edf
-    mne_bids.copyfiles.copyfile_kit
+    copyfile_brainvision
+    copyfile_bti
+    copyfile_ctf
+    copyfile_edf
+    copyfile_kit
 
     """
     # Get extenstion of the EEGLAB file
@@ -570,11 +570,11 @@ def copyfile_bti(raw, dest):
 
     See Also
     --------
-    mne_bids.copyfiles.copyfile_brainvision
-    mne_bids.copyfiles.copyfile_ctf
-    mne_bids.copyfiles.copyfile_edf
-    mne_bids.copyfiles.copyfile_eeglab
-    mne_bids.copyfiles.copyfile_kit
+    copyfile_brainvision
+    copyfile_ctf
+    copyfile_edf
+    copyfile_eeglab
+    copyfile_kit
 
     """
     pdf_fname = 'c,rfDC'

--- a/mne_bids/copyfiles.py
+++ b/mne_bids/copyfiles.py
@@ -344,6 +344,17 @@ def copyfile_brainvision(vhdr_src, vhdr_dest, anonymize=None, verbose=False):
 def copyfile_edf(src, dest, anonymize=None):
     """Copy an EDF, EDF+, or BDF file to a new location, optionally anonymize.
 
+    .. warning:: EDF/EDF+/BDF files contain two fields for recording dates:
+                 A generic "startdate" field that supports only 2-digit years,
+                 and a "Startdate" field as part of the "local recording
+                 identification", which supports 4-digit years.
+                 If you want to anonymize your file, MNE-BIDS will set the
+                 "startdate" field to 85 (i.e., 1985), the earliest possible
+                 date for that field. The "Startdate" field from "local
+                 recording identification" however, will be set correctly
+                 according to the argument provided to the ``anonymize``
+                 parameter.
+
     Parameters
     ----------
     src : str
@@ -363,9 +374,10 @@ def copyfile_edf(src, dest, anonymize=None):
             great enough to shift the date prior to 1925 to conform with BIDS
             anonymization rules. Due to limitations of the EDF/BDF format, the
             year of the anonymized date will always be set to 1985 in the
-            'meas_date' region of the file. The correctly-shifted year will be
-            written to the 'recording info' region of the header, which may not
-            be parsed by all EDF/BDF reader software.
+            'startdate' field of the file. The correctly-shifted year will be
+            written to the 'local recording identification' region of the
+            file header, which may not be parsed by all EDF/EDF+/BDF reader
+            softwares.
 
         `keep_his` : bool
             By default (False), all subject information next to the recording
@@ -418,7 +430,7 @@ def copyfile_edf(src, dest, anonymize=None):
         # changed to defaulting to the 4-digit field, this try-except
         # clause can be removed. See:
         # https://github.com/mne-tools/mne-python/issues/8544
-        
+
         try:
             real_year = datetime.strptime(startdate, "%d-%b-%Y").year
             newdate = raw.info['meas_date'].replace(year=real_year)

--- a/mne_bids/copyfiles.py
+++ b/mne_bids/copyfiles.py
@@ -418,7 +418,7 @@ def copyfile_edf(src, dest, anonymize=None):
         except ValueError as e:
             # If recording date can't be parsed by datetime (e.g. "X"), we
             # default to the date specified in the 'meas_date' field
-            if not "does not match format '%d-%b-%Y'" in str(e):
+            if "does not match format '%d-%b-%Y'" not in str(e):
                 raise e
         daysback, keep_his = _check_anonymize(anonymize, raw, '.edf')
         info = anonymize_info(raw.info, daysback=daysback, keep_his=keep_his)

--- a/mne_bids/copyfiles.py
+++ b/mne_bids/copyfiles.py
@@ -366,7 +366,8 @@ def copyfile_edf(src, dest, anonymize=None):
         `keep_his` : bool
             By default (False), all subject information next to the recording
             date will be overwritten as well. If True, keep subject information
-            apart from the recording date.
+            apart from the recording date. Participant names and birthdates
+            will always be anonymized if present, regardless of this setting.
 
     See Also
     --------

--- a/mne_bids/copyfiles.py
+++ b/mne_bids/copyfiles.py
@@ -19,7 +19,7 @@ import os.path as op
 import re
 
 import shutil as sh
-from datetime import datetime as dt
+from datetime import datetime
 
 from mne.io import read_raw_brainvision, read_raw_edf, anonymize_info
 from scipy.io import loadmat, savemat
@@ -341,8 +341,7 @@ def copyfile_brainvision(vhdr_src, vhdr_dest, anonymize=None, verbose=False):
 
 
 def copyfile_edf(src, dest, anonymize=None):
-    """Copy an EDF, EDF+, or BDF file to a new location, optionally anonymizing
-    participant/patient information.
+    """Copy an EDF, EDF+, or BDF file to a new location, optionally anonymize.
 
     Parameters
     ----------
@@ -404,15 +403,15 @@ def copyfile_edf(src, dest, anonymize=None):
         # Anonymize recording date, using 4-digit year from recording info
         # if possible (regular EDF year only stores last two digits)
         try:
-            actual_year = dt.datetime.strptime(startdate, "%d-%b-%Y").year
+            actual_year = datetime.datetime.strptime(startdate, "%d-%b-%Y").year
             newdate = raw.info['meas_date'].replace(year = actual_year)
             raw.info['meas_date'] = newdate
         except (ValueError, AttributeError):
             pass
         daysback, keep_his = _check_anonymize(anonymize, raw, '.edf')
         info = anonymize_info(raw.info, daysback=daysback, keep_his=keep_his)
-        startdate = dt.strftime(info['meas_date'], "%d-%b-%Y").upper()
-        meas_date = dt.strftime(info['meas_date'], "%d.%m.%y")
+        startdate = datetime.strftime(info['meas_date'], "%d-%b-%Y").upper()
+        meas_date = datetime.strftime(info['meas_date'], "%d.%m.%y")
 
         # Anonymize ID info and write to file
         if keep_his:

--- a/mne_bids/copyfiles.py
+++ b/mne_bids/copyfiles.py
@@ -412,11 +412,14 @@ def copyfile_edf(src, dest, anonymize=None):
         # Anonymize recording date, using 4-digit year from recording info
         # if possible (regular EDF year only stores last two digits)
         try:
-            real_year = datetime.datetime.strptime(startdate, "%d-%b-%Y").year
+            real_year = datetime.strptime(startdate, "%d-%b-%Y").year
             newdate = raw.info['meas_date'].replace(year=real_year)
             raw.info['meas_date'] = newdate
-        except (ValueError, AttributeError):
-            pass
+        except ValueError as e:
+            # If recording date can't be parsed by datetime (e.g. "X"), we
+            # default to the date specified in the 'meas_date' field
+            if not "does not match format '%d-%b-%Y'" in str(e):
+                raise e
         daysback, keep_his = _check_anonymize(anonymize, raw, '.edf')
         info = anonymize_info(raw.info, daysback=daysback, keep_his=keep_his)
         startdate = datetime.strftime(info['meas_date'], "%d-%b-%Y").upper()

--- a/mne_bids/copyfiles.py
+++ b/mne_bids/copyfiles.py
@@ -392,7 +392,7 @@ def copyfile_edf(src, dest, anonymize=None):
 
         # Get patient info, recording info, and recording date
         with open(dest, 'rb') as f:
-            f.seek(8) # id_info field starts 8 bytes in
+            f.seek(8)  # id_info field starts 8 bytes in
             id_info = f.read(80).decode('ascii').rstrip()
             rec_info = f.read(80).decode('ascii').rstrip()
 
@@ -407,8 +407,8 @@ def copyfile_edf(src, dest, anonymize=None):
         # Anonymize recording date, using 4-digit year from recording info
         # if possible (regular EDF year only stores last two digits)
         try:
-            actual_year = datetime.datetime.strptime(startdate, "%d-%b-%Y").year
-            newdate = raw.info['meas_date'].replace(year = actual_year)
+            real_year = datetime.datetime.strptime(startdate, "%d-%b-%Y").year
+            newdate = raw.info['meas_date'].replace(year=real_year)
             raw.info['meas_date'] = newdate
         except (ValueError, AttributeError):
             pass
@@ -419,13 +419,14 @@ def copyfile_edf(src, dest, anonymize=None):
 
         # Anonymize ID info and write to file
         if keep_his:
+            # Always remove participant birthdate and name to be safe
             id_info = [pid, sex, "X", "X"]
             rec_info = ["Startdate", startdate, admin_code, tech, equip]
         else:
             id_info = ["0", "X", "X", "X"]
-            rec_info = ["Startdate", startdate, "X", "mne_anonymize", "X"]
+            rec_info = ["Startdate", startdate, "X", "mne-bids_anonymize", "X"]
         with open(dest, 'r+b') as f:
-            f.seek(8) # id_info field starts 8 bytes in
+            f.seek(8)  # id_info field starts 8 bytes in
             f.write(bytes(" ".join(id_info).ljust(80), 'ascii'))
             f.write(bytes(" ".join(rec_info).ljust(80), 'ascii'))
             f.write(bytes(meas_date, 'ascii'))

--- a/mne_bids/copyfiles.py
+++ b/mne_bids/copyfiles.py
@@ -361,7 +361,11 @@ def copyfile_edf(src, dest, anonymize=None):
             differences between subjects can be kept by using the same number
             of `daysback` for all subject anonymizations. `daysback` should be
             great enough to shift the date prior to 1925 to conform with BIDS
-            anonymization rules.
+            anonymization rules. Due to limitations of the EDF/BDF format, the
+            year of the anonymized date will always be set to 1985 in the
+            'meas_date' region of the file. The correctly-shifted year will be
+            written to the 'recording info' region of the header, which may not
+            be parsed by all EDF/BDF reader software.
 
         `keep_his` : bool
             By default (False), all subject information next to the recording
@@ -416,7 +420,7 @@ def copyfile_edf(src, dest, anonymize=None):
         daysback, keep_his = _check_anonymize(anonymize, raw, '.edf')
         info = anonymize_info(raw.info, daysback=daysback, keep_his=keep_his)
         startdate = datetime.strftime(info['meas_date'], "%d-%b-%Y").upper()
-        meas_date = datetime.strftime(info['meas_date'], "%d.%m.%y")
+        meas_date = datetime.strftime(info['meas_date'], "%d.%m.85")
 
         # Anonymize ID info and write to file
         if keep_his:

--- a/mne_bids/copyfiles.py
+++ b/mne_bids/copyfiles.py
@@ -21,7 +21,8 @@ import re
 import shutil as sh
 from datetime import datetime
 
-from mne.io import read_raw_brainvision, read_raw_edf, anonymize_info
+from mne.io import (read_raw_brainvision, read_raw_edf, read_raw_bdf,
+                    anonymize_info)
 from scipy.io import loadmat, savemat
 
 from mne_bids.path import BIDSPath, _parse_ext, _mkdir_p
@@ -384,7 +385,10 @@ def copyfile_edf(src, dest, anonymize=None):
 
     # Anonymize EDF/BDF data, if requested
     if anonymize is not None:
-        raw = read_raw_edf(dest, preload=False, verbose=0)
+        if ext_src == '.bdf':
+            raw = read_raw_bdf(dest, preload=False, verbose=0)
+        else:
+            raw = read_raw_edf(dest, preload=False, verbose=0)
 
         # Get patient info, recording info, and recording date
         with open(dest, 'rb') as f:

--- a/mne_bids/copyfiles.py
+++ b/mne_bids/copyfiles.py
@@ -353,7 +353,10 @@ def copyfile_edf(src, dest, anonymize=None):
                  date for that field. The "Startdate" field from "local
                  recording identification" however, will be set correctly
                  according to the argument provided to the ``anonymize``
-                 parameter.
+                 parameter. Note that it is possible that not all EDF/EDF+/BDF
+                 reading software parses the accurate recording date, and
+                 that for some reading software, the wrong year (1985) may
+                 be parsed.
 
     Parameters
     ----------
@@ -422,23 +425,24 @@ def copyfile_edf(src, dest, anonymize=None):
         startdate, admin_code, tech, equip = rec_info.split(' ')[1:5]
 
         # Try to anonymize recording date using 4-digit year from
-        # "Startdate" field from "recording info" section, because
-        # The standard "startdate" field only supports 2-digit years.
+        # "Startdate" field from "local recording identification"
+        # section, because the generic "startdate" field only
+        # supports 2-digit years.
         #
         # XXX: recording dates are specified twice in EDF/EDF+/BDF,
         # MNE-Python currently parses the 2-digit year field. If that is
         # changed to defaulting to the 4-digit field, this try-except
         # clause can be removed. See:
         # https://github.com/mne-tools/mne-python/issues/8544
-
         try:
             real_year = datetime.strptime(startdate, "%d-%b-%Y").year
             newdate = raw.info['meas_date'].replace(year=real_year)
             raw.info['meas_date'] = newdate
         except ValueError as e:
-            # We could not parse the "Startdate" field from "recording info"
-            # section (e.g., because it was "X"). So fall back to using the
-            # standard "startdate" field that only supports 2-digit years.
+            # We could not parse the "Startdate" field from "local recording
+            # identification" section (e.g., because it was "X").
+            # So fall back to using the standard "startdate" field that only
+            # supports 2-digit years.
             # This is what MNE-Python currently parses and puts into
             # raw.info["meas_date"]
             if "does not match format '%d-%b-%Y'" not in str(e):

--- a/mne_bids/copyfiles.py
+++ b/mne_bids/copyfiles.py
@@ -409,15 +409,26 @@ def copyfile_edf(src, dest, anonymize=None):
         pid, sex, birthdate, name = id_info.split(' ')
         startdate, admin_code, tech, equip = rec_info.split(' ')[1:5]
 
-        # Anonymize recording date, using 4-digit year from recording info
-        # if possible (regular EDF year only stores last two digits)
+        # Try to anonymize recording date using 4-digit year from
+        # "Startdate" field from "recording info" section, because
+        # The standard "startdate" field only supports 2-digit years.
+        #
+        # XXX: recording dates are specified twice in EDF/EDF+/BDF,
+        # MNE-Python currently parses the 2-digit year field. If that is
+        # changed to defaulting to the 4-digit field, this try-except
+        # clause can be removed. See:
+        # https://github.com/mne-tools/mne-python/issues/8544
+        
         try:
             real_year = datetime.strptime(startdate, "%d-%b-%Y").year
             newdate = raw.info['meas_date'].replace(year=real_year)
             raw.info['meas_date'] = newdate
         except ValueError as e:
-            # If recording date can't be parsed by datetime (e.g. "X"), we
-            # default to the date specified in the 'meas_date' field
+            # We could not parse the "Startdate" field from "recording info"
+            # section (e.g., because it was "X"). So fall back to using the
+            # standard "startdate" field that only supports 2-digit years.
+            # This is what MNE-Python currently parses and puts into
+            # raw.info["meas_date"]
             if "does not match format '%d-%b-%Y'" not in str(e):
                 raise e
         daysback, keep_his = _check_anonymize(anonymize, raw, '.edf')

--- a/mne_bids/tests/test_copyfiles.py
+++ b/mne_bids/tests/test_copyfiles.py
@@ -126,8 +126,8 @@ def test_copyfile_edf():
 
     # Add some subject info to an EDF to test anonymization
     testfile = op.join(bids_root, 'test_copy.edf')
-    raw = mne.io.read_raw_edf(testfile)
-    date = datetime.datetime.strftime(raw.info['meas_date'], "%d-%b-%Y").upper()
+    raw_date = mne.io.read_raw_edf(testfile).info['meas_date']
+    date = datetime.datetime.strftime(raw_date, "%d-%b-%Y").upper()
     test_id_info = '023 F 02-AUG-1951 Jane'
     test_rec_info = 'Startdate {0} ID-123 John BioSemi_ActiveTwo'.format(date)
     with open(testfile, 'r+b') as f:
@@ -172,7 +172,7 @@ def test_copyfile_edf():
     rec = 'Startdate {0} ID-123 John BioSemi_ActiveTwo'.format(anon_startdate)
     assert id_info == "023 F X X"
     assert rec_info == rec
-    
+
 
 def test_copyfile_eeglab():
     """Test the copying of EEGlab set and fdt files."""

--- a/mne_bids/tests/test_copyfiles.py
+++ b/mne_bids/tests/test_copyfiles.py
@@ -27,6 +27,7 @@ from mne_bids.path import _parse_ext
 from mne_bids.copyfiles import (_get_brainvision_encoding,
                                 _get_brainvision_paths,
                                 copyfile_brainvision,
+                                copyfile_edf,
                                 copyfile_eeglab,
                                 copyfile_kit)
 
@@ -110,6 +111,63 @@ def test_copyfile_brainvision():
     raw = mne.io.read_raw_brainvision(new_name)
     new_date = raw.info['meas_date']
     assert new_date == (prev_date - datetime.timedelta(days=32459))
+
+
+def test_copyfile_edf():
+    """Test the anonymization of EDF/BDF files"""
+    bids_root = _TempDir()
+    data_path = op.join(base_path, 'edf', 'tests', 'data')
+
+    # Test regular copying
+    for ext in ['.edf', '.bdf']:
+        raw_fname = op.join(data_path, 'test' + ext)
+        new_name = op.join(bids_root, 'test_copy' + ext)
+        copyfile_edf(raw_fname, new_name)
+
+    # Add some subject info to an EDF to test anonymization
+    testfile = op.join(bids_root, 'test_copy.edf')
+    raw = mne.io.read_raw_edf(testfile)
+    date = datetime.datetime.strftime(raw.info['meas_date'], "%d-%b-%Y").upper()
+    test_id_info = '023 F 02-AUG-1951 Jane'
+    test_rec_info = 'Startdate {0} ID-123 John BioSemi_ActiveTwo'.format(date)
+    with open(testfile, 'r+b') as f:
+        f.seek(8)
+        f.write(bytes(test_id_info.ljust(80), 'ascii'))
+        f.write(bytes(test_rec_info.ljust(80), 'ascii'))
+
+    # Test date anonymization
+    bids_root2 = _TempDir()
+    infile = op.join(bids_root, 'test_copy.edf')
+    outfile = op.join(bids_root2, 'test_copy_anon.edf')
+    anonymize = {'daysback': 32459, 'keep_his': False}
+    copyfile_edf(infile, outfile, anonymize)
+    raw = mne.io.read_raw_edf(infile)
+    raw_anon = mne.io.read_raw_edf(outfile)
+    prev_date = raw.info['meas_date']
+    new_date = raw_anon.info['meas_date']
+    assert new_date == (prev_date - datetime.timedelta(days=32459))
+
+    # Test full ID info anonymization
+    anon_startdate = datetime.datetime.strftime(new_date, "%d-%b-%Y").upper()
+    with open(outfile, 'rb') as f:
+        f.seek(8)
+        id_info = f.read(80).decode('ascii').rstrip()
+        rec_info = f.read(80).decode('ascii').rstrip()
+    assert id_info == "0 X X X"
+    assert rec_info == "Startdate {0} X mne_anonymize X".format(anon_startdate)
+
+    # Test partial ID info anonymization
+    outfile2 = op.join(bids_root2, 'test_copy_anon_partial.edf')
+    anonymize = {'daysback': 32459, 'keep_his': True}
+    copyfile_edf(infile, outfile2, anonymize)
+    with open(outfile2, 'rb') as f:
+        f.seek(8)
+        id_info = f.read(80).decode('ascii').rstrip()
+        rec_info = f.read(80).decode('ascii').rstrip()
+    rec = 'Startdate {0} ID-123 John BioSemi_ActiveTwo'.format(anon_startdate)
+    assert id_info == "023 F X X"
+    assert rec_info == rec
+    
 
 
 def test_copyfile_eeglab():

--- a/mne_bids/tests/test_copyfiles.py
+++ b/mne_bids/tests/test_copyfiles.py
@@ -158,8 +158,9 @@ def test_copyfile_edf():
         f.seek(8)
         id_info = f.read(80).decode('ascii').rstrip()
         rec_info = f.read(80).decode('ascii').rstrip()
+    rec_info_tmp = "Startdate {0} X mne-bids_anonymize X"
     assert id_info == "0 X X X"
-    assert rec_info == "Startdate {0} X mne_anonymize X".format(anon_startdate)
+    assert rec_info == rec_info_tmp.format(anon_startdate)
 
     # Test partial ID info anonymization
     outfile2 = op.join(bids_root2, 'test_copy_anon_partial.edf')

--- a/mne_bids/tests/test_copyfiles.py
+++ b/mne_bids/tests/test_copyfiles.py
@@ -124,6 +124,12 @@ def test_copyfile_edf():
         new_name = op.join(bids_root, 'test_copy' + ext)
         copyfile_edf(raw_fname, new_name)
 
+    # IO error testing
+    with pytest.raises(ValueError, match='Need to move data with same'):
+        raw_fname = op.join(data_path, 'test.edf')
+        new_name = op.join(bids_root, 'test_copy.bdf')
+        copyfile_edf(raw_fname, new_name)
+
     # Add some subject info to an EDF to test anonymization
     testfile = op.join(bids_root, 'test_copy.edf')
     raw_date = mne.io.read_raw_edf(testfile).info['meas_date']

--- a/mne_bids/tests/test_copyfiles.py
+++ b/mne_bids/tests/test_copyfiles.py
@@ -146,7 +146,7 @@ def test_copyfile_edf():
     bids_root2 = _TempDir()
     infile = op.join(bids_root, 'test_copy.edf')
     outfile = op.join(bids_root2, 'test_copy_anon.edf')
-    anonymize = {'daysback': 32459, 'keep_his': False}
+    anonymize = {'daysback': 33459, 'keep_his': False}
     copyfile_edf(infile, outfile, anonymize)
     prev_date = _edf_get_real_date(infile)
     new_date = _edf_get_real_date(outfile)
@@ -163,7 +163,7 @@ def test_copyfile_edf():
 
     # Test partial ID info anonymization
     outfile2 = op.join(bids_root2, 'test_copy_anon_partial.edf')
-    anonymize = {'daysback': 32459, 'keep_his': True}
+    anonymize = {'daysback': 33459, 'keep_his': True}
     copyfile_edf(infile, outfile2, anonymize)
     with open(outfile2, 'rb') as f:
         f.seek(8)

--- a/mne_bids/tests/test_copyfiles.py
+++ b/mne_bids/tests/test_copyfiles.py
@@ -150,7 +150,7 @@ def test_copyfile_edf():
     copyfile_edf(infile, outfile, anonymize)
     prev_date = _edf_get_real_date(infile)
     new_date = _edf_get_real_date(outfile)
-    assert new_date == (prev_date - datetime.timedelta(days=32459))
+    assert new_date == (prev_date - datetime.timedelta(days=33459))
 
     # Test full ID info anonymization
     anon_startdate = datetime.datetime.strftime(new_date, "%d-%b-%Y").upper()

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -1077,7 +1077,8 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate):
         kwargs = dict(raw=raw, bids_path=bids_path,
                       anonymize=dict(daysback=daysback), overwrite=True)
         if dir_name == 'EDF':
-            with pytest.warns(RuntimeWarning, match=r'^Due to EDF.*'):
+            match = r"^EDF\/EDF\+\/BDF files contain two fields .*"
+            with pytest.warns(RuntimeWarning, match=match):
                 write_raw_bids(**kwargs)
         elif dir_name == 'Persyst':
             with pytest.warns(RuntimeWarning,
@@ -1180,7 +1181,8 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate):
                 write_raw_bids(**kwargs)
                 output_path = _test_anonymize(raw, bids_path)
         elif dir_name == 'EDF':
-            with pytest.warns(RuntimeWarning, match=r'^Due to EDF.*'):
+            match = r"^EDF\/EDF\+\/BDF files contain two fields .*"
+            with pytest.warns(RuntimeWarning, match=match):
                 write_raw_bids(**kwargs)  # Just copies.
                 output_path = _test_anonymize(raw, bids_path)
         else:
@@ -1244,7 +1246,8 @@ def test_bdf(_bids_validate):
 
     # test anonymize and convert
     raw = _read_raw_bdf(raw_fname)
-    with pytest.warns(RuntimeWarning, match=r'^Due to EDF.*'):
+    match = r"^EDF\/EDF\+\/BDF files contain two fields .*"
+    with pytest.warns(RuntimeWarning, match=match):
         output_path = _test_anonymize(raw, bids_path)
     _bids_validate(output_path)
 

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -1077,7 +1077,8 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate):
         kwargs = dict(raw=raw, bids_path=bids_path,
                       anonymize=dict(daysback=daysback), overwrite=True)
         if dir_name == 'EDF':
-            write_raw_bids(**kwargs)
+            with pytest.warns(RuntimeWarning, match=r'^Due to EDF.*'):          
+                write_raw_bids(**kwargs)
         elif dir_name == 'Persyst':
             with pytest.warns(RuntimeWarning,
                               match='Encountered data in "double" format'):
@@ -1179,8 +1180,9 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate):
                 write_raw_bids(**kwargs)
                 output_path = _test_anonymize(raw, bids_path)
         elif dir_name == 'EDF':
-            write_raw_bids(**kwargs)  # Just copies.
-            output_path = _test_anonymize(raw, bids_path)
+            with pytest.warns(RuntimeWarning, match=r'^Due to EDF.*'):          
+                write_raw_bids(**kwargs)  # Just copies.
+                output_path = _test_anonymize(raw, bids_path)
         else:
             with pytest.warns(RuntimeWarning,
                               match='Encountered data in "double" format'):
@@ -1242,7 +1244,8 @@ def test_bdf(_bids_validate):
 
     # test anonymize and convert
     raw = _read_raw_bdf(raw_fname)
-    output_path = _test_anonymize(raw, bids_path)
+    with pytest.warns(RuntimeWarning, match=r'^Due to EDF.*'): 
+        output_path = _test_anonymize(raw, bids_path)
     _bids_validate(output_path)
 
 

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -1088,8 +1088,9 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate):
                 write_raw_bids(**kwargs)
 
         data = _from_tsv(scans_tsv)
-        bids_fname = bids_path.copy().update(suffix='eeg',
-                                             extension='.vhdr')
+        bids_fname = bids_path.copy()
+        if dir_name != 'EDF':
+            bids_fname = bids_fname.update(suffix='eeg', extension='.vhdr')
         assert any([bids_fname.basename in fname
                     for fname in data['filename']])
 

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -1077,7 +1077,7 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate):
         kwargs = dict(raw=raw, bids_path=bids_path,
                       anonymize=dict(daysback=daysback), overwrite=True)
         if dir_name == 'EDF':
-            with pytest.warns(RuntimeWarning, match=r'^Due to EDF.*'):          
+            with pytest.warns(RuntimeWarning, match=r'^Due to EDF.*'):
                 write_raw_bids(**kwargs)
         elif dir_name == 'Persyst':
             with pytest.warns(RuntimeWarning,
@@ -1180,7 +1180,7 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate):
                 write_raw_bids(**kwargs)
                 output_path = _test_anonymize(raw, bids_path)
         elif dir_name == 'EDF':
-            with pytest.warns(RuntimeWarning, match=r'^Due to EDF.*'):          
+            with pytest.warns(RuntimeWarning, match=r'^Due to EDF.*'):
                 write_raw_bids(**kwargs)  # Just copies.
                 output_path = _test_anonymize(raw, bids_path)
         else:
@@ -1244,7 +1244,7 @@ def test_bdf(_bids_validate):
 
     # test anonymize and convert
     raw = _read_raw_bdf(raw_fname)
-    with pytest.warns(RuntimeWarning, match=r'^Due to EDF.*'): 
+    with pytest.warns(RuntimeWarning, match=r'^Due to EDF.*'):
         output_path = _test_anonymize(raw, bids_path)
     _bids_validate(output_path)
 

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1214,11 +1214,13 @@ def write_raw_bids(raw, bids_path, events_data=None,
         copyfile_brainvision(raw_fname, bids_path, anonymize=anonymize)
     elif ext in ['.edf', '.bdf']:
         if anonymize is not None:
-            warn("Due to EDF/EDF+/BDF file limitations, anonymized dates can "
-                 "only be properly written to the 'starttime' field in the "
-                 "recording info of the file. Regardles of the chosen "
-                 "'daysback' value, the year of the file's meas_date will "
-                 "always be set to 1985 when anonymized.")
+            warn("EDF/EDF+/BDF files contain two fields for recording dates."
+                  "Due to file format limitations, one of these fields only "
+                  "supports 2-digit years. The date for that field will be "
+                  "set to the year 1985, the earliest possible date. "
+                  "EDF/EDF+/BDF reading software should parse the second "
+                  "field for recording dates, which contains the properly "
+                  "anonymized date as calculated with `daysback`.")
         copyfile_edf(raw_fname, bids_path, anonymize=anonymize)
     # EEGLAB .set might be accompanied by a .fdt - find out and copy it too
     elif ext == '.set':

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1113,12 +1113,13 @@ def write_raw_bids(raw, bids_path, events_data=None,
                 warn('Converting to FIF for anonymization')
             convert = True
             bids_path.update(extension='.fif')
-        elif bids_path.datatype in ['eeg', 'ieeg'] and ext != '.vhdr':
-            if verbose:
-                warn('Converting data files to BrainVision format '
-                     'for anonymization')
-            convert = True
-            bids_path.update(extension='.vhdr')
+        elif bids_path.datatype in ['eeg', 'ieeg']:
+            if ext not in ['.vhdr', '.edf', '.bdf']:
+                if verbose:
+                    warn('Converting data files to BrainVision format '
+                         'for anonymization')
+                convert = True
+                bids_path.update(extension='.vhdr')
 
     # Read in Raw object and extract metadata from Raw object if needed
     orient = ORIENTATION.get(ext, 'n/a')

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1213,6 +1213,12 @@ def write_raw_bids(raw, bids_path, events_data=None,
     elif ext == '.vhdr':
         copyfile_brainvision(raw_fname, bids_path, anonymize=anonymize)
     elif ext in ['.edf', '.bdf']:
+        if anonymize is not None:
+            warn("Due to EDF/EDF+/BDF file limitations, anonymized dates can "
+                 "only be properly written to the 'starttime' field in the "
+                 "recording info of the file. Regardles of the chosen "
+                 "'daysback' value, the year of the file's meas_date will "
+                 "always be set to 1985 when anonymized.")
         copyfile_edf(raw_fname, bids_path, anonymize=anonymize)
     # EEGLAB .set might be accompanied by a .fdt - find out and copy it too
     elif ext == '.set':

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -42,7 +42,8 @@ from mne_bids.utils import (_write_json, _write_tsv, _write_text,
 from mne_bids import read_raw_bids
 from mne_bids.path import BIDSPath, _parse_ext, _mkdir_p, _path_to_str
 from mne_bids.copyfiles import (copyfile_brainvision, copyfile_eeglab,
-                                copyfile_ctf, copyfile_bti, copyfile_kit)
+                                copyfile_ctf, copyfile_bti, copyfile_kit,
+                                copyfile_edf)
 from mne_bids.tsv_handler import (_from_tsv, _drop, _contains_row,
                                   _combine_rows)
 from mne_bids.read import (_get_bads_from_tsv_data, _find_matching_sidecar,
@@ -1210,6 +1211,8 @@ def write_raw_bids(raw, bids_path, events_data=None,
     # BrainVision is multifile, copy over all of them and fix pointers
     elif ext == '.vhdr':
         copyfile_brainvision(raw_fname, bids_path, anonymize=anonymize)
+    elif ext in ['.edf', '.bdf']:
+        copyfile_edf(raw_fname, bids_path, anonymize=anonymize)
     # EEGLAB .set might be accompanied by a .fdt - find out and copy it too
     elif ext == '.set':
         copyfile_eeglab(raw_fname, bids_path)

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1215,12 +1215,12 @@ def write_raw_bids(raw, bids_path, events_data=None,
     elif ext in ['.edf', '.bdf']:
         if anonymize is not None:
             warn("EDF/EDF+/BDF files contain two fields for recording dates."
-                  "Due to file format limitations, one of these fields only "
-                  "supports 2-digit years. The date for that field will be "
-                  "set to the year 1985, the earliest possible date. "
-                  "EDF/EDF+/BDF reading software should parse the second "
-                  "field for recording dates, which contains the properly "
-                  "anonymized date as calculated with `daysback`.")
+                 "Due to file format limitations, one of these fields only "
+                 "supports 2-digit years. The date for that field will be "
+                 "set to 85 (i.e., 1985), the earliest possible date. "
+                 "EDF/EDF+/BDF reading software should parse the second "
+                 "field for recording dates, which contains the accurately "
+                 "anonymized date as calculated with `daysback`.")
         copyfile_edf(raw_fname, bids_path, anonymize=anonymize)
     # EEGLAB .set might be accompanied by a .fdt - find out and copy it too
     elif ext == '.set':


### PR DESCRIPTION
PR Description
--------------

Closes #469.

This PR adds support for anonymizing EDF, EDF+, and BDF files without needing to convert to BrainVision format, without adding any extra dependencies.

Basically, because the id info, recording info, and recording date are guaranteed to be in the same regions of the header as per the [EDF/EDF+ spec](https://www.edfplus.info/specs/edfplus.html) and the [BDF spec](https://www.biosemi.com/faq/file_format.htm) and are stored in plain-text ASCII, we can read and write these directly using Python without any external parsing library. Let me know what you think!

**Some notes:**

- `mne.io.read_raw_edf` actually doesn't parse a lot of EDF+ header info (incorrectly parses sex as name, ignores birthdate and actual name of patient, doesn't parse or save recording info at all), so in this PR I'm just reading, parsing, and anonymizing most of it directly from the header ('daysback' is still handled by mne's `anonymize_info`, but the rest is done manually). A PR to improve EDF parsing in MNE proper would remove the need for this, but I've neglected my PhD applications enough this month as it is!

- The actual 'meas_date' field for EDF/BDF files is stored in the format 'dd.mm.yy', meaning that it only stores the last two digits of the recording year. According to the EDF+ spec the earliest possible year is 1985, with "84" wrapping around to "2084", making it impossible to follow the BIDS-EEG recommendation of making time-shifted dates earlier than 1925. However, the spec also has field for recording startdate in the recording info field of the header in the format 'dd-MMM-yyyy' (e.g. 19-NOV-2020), meaning that the correctly anonymized recording year can be stored there. Unfortunately, mne.io's EDF/BDF reader only parses the truncated meas_date field (and also wraps the recording year incorrectly) so that should eventually be fixed over there.

- I wasn't 100% sure what should be retained when using the `keep_his` parameter, but my gut guess was to preserve everything except participant name and birthdate (I figured those are the two things you would absolutely never want to leave in when anonymizing data for public use). Let me know if you think it looks sane otherwise.

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [x] All comments resolved
- [x] This is not your own PR
- [x] All CIs are happy
- [x] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [x] PR description includes phrase "closes <#issue-number>"
