### PR TITLE
[MRG] Add Annotations support to MNE-BIDS Inspector; marking bad channels now only alters sidecar, not raw data

### DIFF
--- a/examples/mark_bad_channels.py
+++ b/examples/mark_bad_channels.py
@@ -4,11 +4,13 @@
 =========================================================
 
 You can use MNE-BIDS interactively inspect your  MEG or (i)EEG data.
-Problematic channels can be marked as "bad", for
-example if the connected sensor produced mostly noise – or no signal at
-all. Similarly, you can declare channels as "good", should you discover they
-were incorrectly marked as bad. Bad channel selection can also be performed
-non-interactively.
+Problematic channels can be marked as "bad", for example if the connected
+sensor produced mostly noise – or no signal at all. Similarly, you can declare
+channels as "good", should you discover they were incorrectly marked as bad.
+Bad channel selection can also be performed non-interactively.
+
+Furthermore, you can view and edit the experimental events and mark time
+time segments as "bad".
 """
 
 # Authors: Richard Höchenberger <richard.hoechenberger@gmail.com>
@@ -30,6 +32,9 @@ from mne_bids import (BIDSPath, write_raw_bids, read_raw_bids,
 
 data_path = mne.datasets.sample.data_path()
 raw_fname = op.join(data_path, 'MEG', 'sample', 'sample_audvis_raw.fif')
+events_fname = op.join(data_path, 'MEG', 'sample', 'sample_audvis_raw-eve.fif')
+event_id = {'Auditory/Left': 1, 'Auditory/Right': 2, 'Visual/Left': 3,
+            'Visual/Right': 4, 'Smiley': 5, 'Button': 32}
 bids_root = op.join(data_path, '..', 'MNE-sample-data-bids')
 bids_path = BIDSPath(subject='01', session='01', task='audiovisual', run='01',
                      root=bids_root)
@@ -49,7 +54,8 @@ if op.exists(bids_root):
 
 raw = mne.io.read_raw_fif(raw_fname, verbose=False)
 raw.info['line_freq'] = 60  # Specify power line frequency as required by BIDS.
-write_raw_bids(raw, bids_path=bids_path, overwrite=True, verbose=False)
+write_raw_bids(raw, bids_path=bids_path, events_data=events_fname,
+               event_id=event_id, overwrite=True, verbose=False)
 
 ###############################################################################
 # Interactive use
@@ -61,7 +67,8 @@ write_raw_bids(raw, bids_path=bids_path, overwrite=True, verbose=False)
 # with the data, a small popup window will allow you to toggle the projectors
 # on and off. If you changed the selection of bad channels, you will be
 # prompted whether you would like to save the changes when closing the main
-# window.
+# window. Your raw data and the `*_channels.tsv` sidecar file will be updated
+# upon saving.
 
 inspect_dataset(bids_path)
 
@@ -72,6 +79,16 @@ inspect_dataset(bids_path)
 # apply filters with a 1-Hz high-pass cutoff, and a 30-Hz low-pass cutoff:
 
 inspect_dataset(bids_path, l_freq=1., h_freq=30.)
+
+###############################################################################
+# By pressing the ``A`` key, you can toggle annotation mode to add, edit, or
+# remove experimental events, or to mark entire time periods as bad. Please see
+# the `MNE-Python Annotations tutorial`_ for an introduction to the interactive
+# interface. If you're closing the main window after changing the annotations,
+# you will be prompted whether you wish to save the changes. Your raw data and
+# the `*_events.tsv` sidecar file will be updated upon saving.
+#
+# .. _MNE-Python Annotations tutorial: https://mne.tools/stable/auto_tutorials/raw/plot_30_annotate_raw.html#annotating-raw-objects-interactively
 
 ###############################################################################
 # Non-interactive (programmatic) bad channel selection

--- a/examples/mark_bad_channels.py
+++ b/examples/mark_bad_channels.py
@@ -10,7 +10,7 @@ channels as "good", should you discover they were incorrectly marked as bad.
 Bad channel selection can also be performed non-interactively.
 
 Furthermore, you can view and edit the experimental events and mark time
-time segments as "bad".
+segments as "bad".
 """
 
 # Authors: Richard Höchenberger <richard.hoechenberger@gmail.com>

--- a/examples/mark_bad_channels.py
+++ b/examples/mark_bad_channels.py
@@ -11,7 +11,9 @@ Bad channel selection can also be performed non-interactively.
 
 Furthermore, you can view and edit the experimental events and mark time
 segments as "bad".
-"""
+
+.. _MNE-Python Annotations tutorial: https://mne.tools/stable/auto_tutorials/raw/plot_30_annotate_raw.html#annotating-raw-objects-interactively
+"""  # noqa:E501
 
 # Authors: Richard Höchenberger <richard.hoechenberger@gmail.com>
 # License: BSD (3-clause)
@@ -88,9 +90,6 @@ inspect_dataset(bids_path, l_freq=1., h_freq=30.)
 # you will be prompted whether you wish to save the changes. Your raw data and
 # the `*_events.tsv` sidecar file will be updated upon saving.
 #
-# .. _MNE-Python Annotations tutorial: https://mne.tools/stable/auto_tutorials/raw/plot_30_annotate_raw.html#annotating-raw-objects-interactively  # noqa:E501
-
-###############################################################################
 # Non-interactive (programmatic) bad channel selection
 # ----------------------------------------------------
 #

--- a/examples/mark_bad_channels.py
+++ b/examples/mark_bad_channels.py
@@ -88,7 +88,7 @@ inspect_dataset(bids_path, l_freq=1., h_freq=30.)
 # you will be prompted whether you wish to save the changes. Your raw data and
 # the `*_events.tsv` sidecar file will be updated upon saving.
 #
-# .. _MNE-Python Annotations tutorial: https://mne.tools/stable/auto_tutorials/raw/plot_30_annotate_raw.html#annotating-raw-objects-interactively
+# .. _MNE-Python Annotations tutorial: https://mne.tools/stable/auto_tutorials/raw/plot_30_annotate_raw.html#annotating-raw-objects-interactively  # noqa:E501
 
 ###############################################################################
 # Non-interactive (programmatic) bad channel selection

--- a/mne_bids/commands/tests/test_cli.py
+++ b/mne_bids/commands/tests/test_cli.py
@@ -134,8 +134,7 @@ def test_mark_bad_chanels_single_file(tmpdir):
 
     args = tuple(args)
     with ArgvSetter(args):
-        with pytest.warns(RuntimeWarning, match='The unit for chann*'):
-            mne_bids_mark_bad_channels.run()
+        mne_bids_mark_bad_channels.run()
 
     # Check the data was properly written
     with pytest.warns(RuntimeWarning, match='The unit for chann*'):
@@ -147,8 +146,7 @@ def test_mark_bad_chanels_single_file(tmpdir):
             '--bids_root', output_path, '--type', datatype,
             '--ch_name', '', '--overwrite')
     with ArgvSetter(args):
-        with pytest.warns(RuntimeWarning, match='The unit for chann*'):
-            mne_bids_mark_bad_channels.run()
+        mne_bids_mark_bad_channels.run()
 
     # Check the data was properly written
     with pytest.warns(RuntimeWarning, match='The unit for chann*'):
@@ -188,8 +186,7 @@ def test_mark_bad_chanels_multiple_files(tmpdir):
 
     args = tuple(args)
     with ArgvSetter(args):
-        with pytest.warns(RuntimeWarning, match='The unit for chann*'):
-            mne_bids_mark_bad_channels.run()
+        mne_bids_mark_bad_channels.run()
 
     # Check the data was properly written
     for subject in subjects:

--- a/mne_bids/commands/tests/test_cli.py
+++ b/mne_bids/commands/tests/test_cli.py
@@ -138,7 +138,8 @@ def test_mark_bad_chanels_single_file(tmpdir):
             mne_bids_mark_bad_channels.run()
 
     # Check the data was properly written
-    raw = read_raw_bids(bids_path=bids_path)
+    with pytest.warns(RuntimeWarning, match='The unit for chann*'):
+        raw = read_raw_bids(bids_path=bids_path)
     assert set(old_bads + ch_names) == set(raw.info['bads'])
 
     # Test resettig bad channels.
@@ -146,10 +147,12 @@ def test_mark_bad_chanels_single_file(tmpdir):
             '--bids_root', output_path, '--type', datatype,
             '--ch_name', '', '--overwrite')
     with ArgvSetter(args):
-        mne_bids_mark_bad_channels.run()
+        with pytest.warns(RuntimeWarning, match='The unit for chann*'):
+            mne_bids_mark_bad_channels.run()
 
     # Check the data was properly written
-    raw = read_raw_bids(bids_path=bids_path)
+    with pytest.warns(RuntimeWarning, match='The unit for chann*'):
+        raw = read_raw_bids(bids_path=bids_path)
     assert raw.info['bads'] == []
 
 
@@ -190,7 +193,9 @@ def test_mark_bad_chanels_multiple_files(tmpdir):
 
     # Check the data was properly written
     for subject in subjects:
-        raw = read_raw_bids(bids_path=bids_path.copy().update(subject=subject))
+        with pytest.warns(RuntimeWarning, match='The unit for chann*'):
+            raw = read_raw_bids(bids_path=bids_path.copy()
+                                .update(subject=subject))
         assert set(old_bads + ch_names) == set(raw.info['bads'])
 
 

--- a/mne_bids/inspect.py
+++ b/mne_bids/inspect.py
@@ -4,7 +4,7 @@ import mne
 from mne.utils import logger
 
 from mne_bids import read_raw_bids, mark_bad_channels
-from mne_bids.read import _from_tsv, _read_events, _find_matching_sidecar
+from mne_bids.read import _from_tsv, _read_events
 from mne_bids.write import _write_raw_brainvision, _events_tsv
 from mne_bids.config import ALLOWED_DATATYPE_EXTENSIONS
 

--- a/mne_bids/inspect.py
+++ b/mne_bids/inspect.py
@@ -280,8 +280,8 @@ def _save_bads(*, bads, bids_path, verbose):
 
 
 def _save_annotations(*, annotations, bids_path, verbose):
-    # Read the raw data, set our new Annotations, and convert them to events
-    # which we can then stored in the *_events.tsv sidecar.
+    # Attach the new Annotations to our raw data so we can easily convert them
+    # to events, which will be stored in the *_events.tsv sidecar.
     extra_params = dict()
     if bids_path.extension == '.fif':
         extra_params['allow_maxshield'] = True
@@ -289,7 +289,6 @@ def _save_annotations(*, annotations, bids_path, verbose):
     raw = read_raw_bids(bids_path=bids_path, extra_params=extra_params,
                         verbose='warning')
     raw.set_annotations(annotations)
-
     events, durs, descrs = _read_events(events_data=None, event_id=None,
                                         raw=raw, verbose=False)
 

--- a/mne_bids/inspect.py
+++ b/mne_bids/inspect.py
@@ -1,11 +1,16 @@
 from pathlib import Path
 
+import mne
+from mne.utils import logger
+
 from mne_bids import read_raw_bids, mark_bad_channels
-from mne_bids.read import _from_tsv
+from mne_bids.read import _from_tsv, _read_events, _find_matching_sidecar
+from mne_bids.write import _write_raw_brainvision, _events_tsv
 from mne_bids.config import ALLOWED_DATATYPE_EXTENSIONS
 
 
-def inspect_dataset(bids_path, l_freq=None, h_freq=None, verbose=None):
+def inspect_dataset(bids_path, l_freq=None, h_freq=None,
+                    show_annotations=True, verbose=None):
     """Inspect and annotate BIDS raw data.
 
     This function allows you to browse MEG, EEG, and iEEG raw data stored in a
@@ -16,10 +21,12 @@ def inspect_dataset(bids_path, l_freq=None, h_freq=None, verbose=None):
 
     .. warning:: This functionality is still experimental and will be extended
                  in the future. Its API will likely change. Planned features
-                 include modification of annotations and automated bad channel
-                 detection.
+                 include automated bad channel detection and visualization of
+                 MRI images.
 
     .. note:: Currently, only MEG, EEG, and iEEG data can be inspected.
+
+    To add or modify annotations, press ``A`` to toggle annotation mode.
 
     Parameters
     ----------
@@ -40,6 +47,10 @@ def inspect_dataset(bids_path, l_freq=None, h_freq=None, verbose=None):
         The low-pass filter cutoff frequency to apply when displaying the
         data. This can be useful when inspecting data with high-frequency
         artifacts. If ``None``, no low-pass filter will be applied.
+    show_annotations : bool
+        Whether to show annotations (events, bad segments, …) or not. If
+        ``False``, toggling annotations mode by pressing ``A`` will be disabled
+        as well.
     verbose : bool | None
         If a boolean, whether or not to produce verbose output. If ``None``,
         use the default log level.
@@ -54,7 +65,7 @@ def inspect_dataset(bids_path, l_freq=None, h_freq=None, verbose=None):
 
     for bids_path_ in bids_paths:
         _inspect_raw(bids_path=bids_path_, l_freq=l_freq, h_freq=h_freq,
-                     verbose=verbose)
+                     show_annotations=show_annotations, verbose=verbose)
 
 
 # XXX This this should probably be refactored into a class attribute someday.
@@ -63,7 +74,7 @@ _global_vars = dict(raw_fig=None,
                     mne_close_key=None)
 
 
-def _inspect_raw(*, bids_path, l_freq, h_freq, verbose=None):
+def _inspect_raw(*, bids_path, l_freq, h_freq, show_annotations, verbose=None):
     """Raw data inspection."""
     # Delay the import
     import matplotlib
@@ -72,6 +83,7 @@ def _inspect_raw(*, bids_path, l_freq, h_freq, verbose=None):
     raw = read_raw_bids(bids_path, extra_params=dict(allow_maxshield=True),
                         verbose='error')
     old_bads = raw.info['bads'].copy()
+    old_annotations = raw.annotations.copy()
 
     fig = raw.plot(title=f'{bids_path.root.name}: {bids_path.basename}',
                    highpass=l_freq, lowpass=h_freq, show_options=True,
@@ -81,12 +93,24 @@ def _inspect_raw(*, bids_path, l_freq, h_freq, verbose=None):
     # closed, our dialog box will pop up, asking whether to save changes.
     def _handle_close(event):
         mne_raw_fig = event.canvas.figure
+        # XXX Investigate why we need to use .inst in one instance and not in
+        # XXX the other!
         new_bads = mne_raw_fig.mne.info['bads'].copy()
+        new_annotations = mne_raw_fig.mne.inst.annotations.copy()
 
-        _save_bads_if_changed(old_bads=old_bads,
-                              new_bads=new_bads,
-                              bids_path=bids_path,
-                              verbose=verbose)
+        if not new_annotations:
+            # Ensure it's not an empty list, but an empty set of Annotations.
+            new_annotations = (mne_raw_fig.mne.inst.copy()
+                               .set_annotations(None)
+                               .annotations
+                               .copy())
+
+        _save_raw_if_changed(old_bads=old_bads,
+                             new_bads=new_bads,
+                             old_annotations=old_annotations,
+                             new_annotations=new_annotations,
+                             bids_path=bids_path,
+                             verbose=verbose)
         _global_vars['raw_fig'] = None
         _global_vars['mne_close_key'] = None
 
@@ -97,6 +121,18 @@ def _inspect_raw(*, bids_path, l_freq, h_freq, verbose=None):
     fig.canvas.mpl_connect('close_event', _handle_close)
     fig.canvas.mpl_connect('key_press_event', _keypress_callback)
 
+    if not show_annotations:
+        # Remove annotations and kill `_toggle_annotation_fig` method, since
+        # we cannot directly and easily remove the associated `a` keyboard
+        # event callback.
+        fig._clear_annotations()
+        fig._toggle_annotation_fig = lambda x: None
+        # Ensure it's not an empty list, but an empty set of Annotations.
+        old_annotations = (raw.copy()
+                           .set_annotations(None)
+                           .annotations
+                           .copy())
+
     if matplotlib.get_backend() != 'agg':
         plt.show(block=True)
 
@@ -104,16 +140,28 @@ def _inspect_raw(*, bids_path, l_freq, h_freq, verbose=None):
     _global_vars['mne_close_key'] = fig.mne.close_key
 
 
-def _save_bads_if_changed(*, old_bads, new_bads, bids_path, verbose):
+def _save_raw_if_changed(*, old_bads, new_bads,
+                         old_annotations, new_annotations,
+                         bids_path, verbose):
     if set(old_bads) == set(new_bads):
+        bads = None
+    else:
+        bads = new_bads
+
+    if old_annotations == new_annotations:
+        annotations = None
+    else:
+        annotations = new_annotations
+
+    if bads is None and annotations is None:
         # Nothing has changed, so we can just exit.
         return None
 
-    return _save_bads_dialog_box(bads=new_bads, bids_path=bids_path,
-                                 verbose=verbose)
+    return _save_raw_dialog_box(bads=bads, annotations=annotations,
+                                bids_path=bids_path, verbose=verbose)
 
 
-def _save_bads_dialog_box(*, bads, bids_path, verbose):
+def _save_raw_dialog_box(*, bads, annotations, bids_path, verbose):
     """Display a dialog box asking whether to save the changes."""
     # Delay the imports
     import matplotlib
@@ -122,9 +170,18 @@ def _save_bads_dialog_box(*, bads, bids_path, verbose):
     from mne.viz.utils import figure_nobar
 
     title = 'Save changes?'
-    message = (f'You have modified the bad channel selection of\n'
-               f'{bids_path.basename}.\n\nWould you like to save these '
-               f'changes to the\nBIDS dataset?')
+    message = 'You have modified '
+    if bads is not None and annotations is None:
+        message += 'the bad channel selection '
+    elif bads is None and annotations is not None:
+        message += 'the bad segments selection '
+    else:
+        message += 'the bad channel and\nsegments selection '
+
+    message += (f'of\n'
+                f'{bids_path.basename}.\n\n'
+                f'Would you like to save these changes to the\n'
+                f'BIDS dataset?')
     icon_fname = Path(__file__).parent / 'assets' / 'help-128px.png'
     icon = plt.imread(icon_fname)
 
@@ -166,7 +223,12 @@ def _save_bads_dialog_box(*, bads, bids_path, verbose):
     def _save_callback(event):
         plt.close(event.canvas.figure)  # Close dialog
         _global_vars['dialog_fig'] = None
-        _save_bads(bads=bads, bids_path=bids_path, verbose=verbose)
+
+        if bads is not None:
+            _save_bads(bads=bads, bids_path=bids_path, verbose=verbose)
+        if annotations is not None:
+            _save_annotations(annotations=annotations, bids_path=bids_path,
+                              verbose=verbose)
 
     def _dont_save_callback(event):
         plt.close(event.canvas.figure)  # Close dialog
@@ -205,7 +267,7 @@ def _save_bads(*, bads, bids_path, verbose):
         else:
             # Channel has been manually marked as bad during inspection, assign
             # default description.
-            description = 'Manual inspection via MNE-BIDS'
+            description = 'Interactive inspection via MNE-BIDS'
 
         descriptions.append(description)
 
@@ -213,3 +275,45 @@ def _save_bads(*, bads, bids_path, verbose):
     # be marked as good.
     mark_bad_channels(ch_names=bads, descriptions=descriptions,
                       bids_path=bids_path, overwrite=True, verbose=verbose)
+
+
+def _save_annotations(*, annotations, bids_path, verbose):
+    # Read the raw data, set our new Annotations, and convert them to events
+    # which we can then stored in the *_events.tsv sidecar.
+    extra_params = dict(preload=True)
+    if bids_path.extension == '.fif':
+        extra_params['allow_maxshield'] = True
+
+    raw = read_raw_bids(bids_path=bids_path, extra_params=extra_params,
+                        verbose='warning')
+    raw.set_annotations(annotations)
+
+    events, durs, descrs = _read_events(events_data=None, event_id=None,
+                                        raw=raw, verbose=False)
+
+    # Write raw data.
+    if isinstance(raw, mne.io.brainvision.brainvision.RawBrainVision):
+        # XXX We should write durations too, this is supported by pybv.
+        _write_raw_brainvision(raw, bids_path.fpath, events)
+    elif isinstance(raw, mne.io.RawFIF):
+        raw.save(raw.filenames[0], overwrite=True, split_naming='bids',
+                 verbose=False)
+    else:
+        raise RuntimeError('Can only write events / annotations for '
+                           'FIFF and BrainVision files for now. Please '
+                           'mark bad channels manually.')
+
+    # Write sidecar – or remove it if no events are left.
+    events_tsv_fname = (bids_path.copy()
+                        .update(suffix='events',
+                                extension='.tsv')
+                        .fpath)
+
+    if len(events) > 0:
+        _events_tsv(events=events, durations=durs, raw=raw,
+                    fname=events_tsv_fname, trial_type=descrs,
+                    overwrite=True, verbose=verbose)
+    elif events_tsv_fname.exists():
+        logger.info(f'No events remaining after interactive inspection, '
+                    f'removing {events_tsv_fname.name}')
+        events_tsv_fname.unlink()

--- a/mne_bids/inspect.py
+++ b/mne_bids/inspect.py
@@ -175,10 +175,13 @@ def _save_raw_dialog_box(*, bads, annotations, bids_path, verbose):
     message = 'You have modified '
     if bads is not None and annotations is None:
         message += 'the bad channel selection '
+        figsize = (7.5, 2.5)
     elif bads is None and annotations is not None:
         message += 'the bad segments selection '
+        figsize = (7.5, 2.5)
     else:
-        message += 'the bad channel and\nsegments selection '
+        message += 'the bad channel and\nannotations selection '
+        figsize = (8.5, 3)
 
     message += (f'of\n'
                 f'{bids_path.basename}.\n\n'
@@ -187,7 +190,7 @@ def _save_raw_dialog_box(*, bads, annotations, bids_path, verbose):
     icon_fname = Path(__file__).parent / 'assets' / 'help-128px.png'
     icon = plt.imread(icon_fname)
 
-    fig = figure_nobar(figsize=(7.5, 2))
+    fig = figure_nobar(figsize=figsize)
     fig.canvas.set_window_title('MNE-BIDS Inspector')
     fig.suptitle(title, y=0.95, fontsize='xx-large', fontweight='bold')
 

--- a/mne_bids/inspect.py
+++ b/mne_bids/inspect.py
@@ -126,7 +126,7 @@ def _inspect_raw(*, bids_path, l_freq, h_freq, show_annotations, verbose=None):
         # we cannot directly and easily remove the associated `a` keyboard
         # event callback.
         fig._clear_annotations()
-        fig._toggle_annotation_fig = lambda x: None
+        fig._toggle_annotation_fig = lambda: None
         # Ensure it's not an empty list, but an empty set of Annotations.
         old_annotations = (raw.copy()
                            .set_annotations(None)

--- a/mne_bids/inspect.py
+++ b/mne_bids/inspect.py
@@ -106,7 +106,6 @@ def _inspect_raw(*, bids_path, l_freq, h_freq, show_annotations, verbose=None):
                 onset=[], duration=[], description=[],
                 orig_time=mne_raw_fig.mne.info['meas_date']
             )
-
         _save_raw_if_changed(old_bads=old_bads,
                              new_bads=new_bads,
                              old_annotations=old_annotations,
@@ -114,7 +113,6 @@ def _inspect_raw(*, bids_path, l_freq, h_freq, show_annotations, verbose=None):
                              bids_path=bids_path,
                              verbose=verbose)
         _global_vars['raw_fig'] = None
-        _global_vars['mne_close_key'] = None
 
     def _keypress_callback(event):
         if event.key == _global_vars['mne_close_key']:
@@ -240,7 +238,7 @@ def _save_raw_dialog_box(*, bads, annotations, bids_path, verbose):
         _global_vars['dialog_fig'] = None
 
     def _keypress_callback(event):
-        if event.key == 'return':
+        if event.key in ['enter', 'return']:
             _save_callback(event)
         elif event.key == _global_vars['mne_close_key']:
             _dont_save_callback(event)

--- a/mne_bids/inspect.py
+++ b/mne_bids/inspect.py
@@ -5,7 +5,7 @@ from mne.utils import logger
 
 from mne_bids import read_raw_bids, mark_bad_channels
 from mne_bids.read import _from_tsv, _read_events
-from mne_bids.write import _write_raw_brainvision, _events_tsv
+from mne_bids.write import _events_tsv
 from mne_bids.config import ALLOWED_DATATYPE_EXTENSIONS
 
 

--- a/mne_bids/inspect.py
+++ b/mne_bids/inspect.py
@@ -280,7 +280,7 @@ def _save_bads(*, bads, bids_path, verbose):
 def _save_annotations(*, annotations, bids_path, verbose):
     # Read the raw data, set our new Annotations, and convert them to events
     # which we can then stored in the *_events.tsv sidecar.
-    extra_params = dict(preload=True)
+    extra_params = dict()
     if bids_path.extension == '.fif':
         extra_params['allow_maxshield'] = True
 
@@ -290,18 +290,6 @@ def _save_annotations(*, annotations, bids_path, verbose):
 
     events, durs, descrs = _read_events(events_data=None, event_id=None,
                                         raw=raw, verbose=False)
-
-    # Write raw data.
-    if isinstance(raw, mne.io.brainvision.brainvision.RawBrainVision):
-        # XXX We should write durations too, this is supported by pybv.
-        _write_raw_brainvision(raw, bids_path.fpath, events)
-    elif isinstance(raw, mne.io.RawFIF):
-        raw.save(raw.filenames[0], overwrite=True, split_naming='bids',
-                 verbose=False)
-    else:
-        raise RuntimeError('Can only write events / annotations for '
-                           'FIFF and BrainVision files for now. Please '
-                           'mark bad channels manually.')
 
     # Write sidecar – or remove it if no events are left.
     events_tsv_fname = (bids_path.copy()

--- a/mne_bids/inspect.py
+++ b/mne_bids/inspect.py
@@ -93,8 +93,8 @@ def _inspect_raw(*, bids_path, l_freq, h_freq, show_annotations, verbose=None):
     # closed, our dialog box will pop up, asking whether to save changes.
     def _handle_close(event):
         mne_raw_fig = event.canvas.figure
-        # XXX Investigate why we need to use .inst in one instance and not in
-        # XXX the other!
+        # Bads alterations are only transferred to `inst` once the figure is
+        # closed; Annotation changes are immediately reflected in `inst`
         new_bads = mne_raw_fig.mne.info['bads'].copy()
         new_annotations = mne_raw_fig.mne.inst.annotations.copy()
 

--- a/mne_bids/inspect.py
+++ b/mne_bids/inspect.py
@@ -100,10 +100,10 @@ def _inspect_raw(*, bids_path, l_freq, h_freq, show_annotations, verbose=None):
 
         if not new_annotations:
             # Ensure it's not an empty list, but an empty set of Annotations.
-            new_annotations = (mne_raw_fig.mne.inst.copy()
-                               .set_annotations(None)
-                               .annotations
-                               .copy())
+            new_annotations = mne.Annotations(
+                onset=[], duration=[], description=[],
+                orig_time=mne_raw_fig.mne.info['meas_date']
+            )
 
         _save_raw_if_changed(old_bads=old_bads,
                              new_bads=new_bads,
@@ -128,10 +128,10 @@ def _inspect_raw(*, bids_path, l_freq, h_freq, show_annotations, verbose=None):
         fig._clear_annotations()
         fig._toggle_annotation_fig = lambda: None
         # Ensure it's not an empty list, but an empty set of Annotations.
-        old_annotations = (raw.copy()
-                           .set_annotations(None)
-                           .annotations
-                           .copy())
+        old_annotations = mne.Annotations(
+            onset=[], duration=[], description=[],
+            orig_time=raw.info['meas_date']
+        )
 
     if matplotlib.get_backend() != 'agg':
         plt.show(block=True)

--- a/mne_bids/inspect.py
+++ b/mne_bids/inspect.py
@@ -80,8 +80,10 @@ def _inspect_raw(*, bids_path, l_freq, h_freq, show_annotations, verbose=None):
     import matplotlib
     import matplotlib.pyplot as plt
 
-    raw = read_raw_bids(bids_path, extra_params=dict(allow_maxshield=True),
-                        verbose='error')
+    extra_params = dict()
+    if bids_path.extension == '.fif':
+        extra_params['allow_maxshield'] = True
+    raw = read_raw_bids(bids_path, extra_params=extra_params, verbose='error')
     old_bads = raw.info['bads'].copy()
     old_annotations = raw.annotations.copy()
 

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -336,28 +336,10 @@ def _handle_channels_reading(channels_fname, bids_fname, raw):
     # Set the channel types in the raw data according to channels.tsv
     raw.set_channel_types(channel_type_dict)
 
-    # Check whether there is the optional "status" column from which to infer
-    # good and bad channels
+    # Set bad channels based on _channels.tsv sidecar
     if 'status' in channels_dict:
-        # find bads from channels.tsv
-        bads_from_tsv = _get_bads_from_tsv_data(channels_dict)
-
-        if raw.info['bads'] and set(bads_from_tsv) != set(raw.info['bads']):
-            warn(f'Encountered conflicting information on channel status '
-                 f'between {op.basename(channels_fname)} and the associated '
-                 f'raw data file.\n'
-                 f'Channels marked as bad in '
-                 f'{op.basename(channels_fname)}: {bads_from_tsv}\n'
-                 f'Channels marked as bad in '
-                 f'raw.info["bads"]: {raw.info["bads"]}\n'
-                 f'Setting list of bad channels to: {bads_from_tsv}')
-
-        raw.info['bads'] = bads_from_tsv
-    elif raw.info['bads']:
-        # We do have info['bads'], but no `status` in channels.tsv
-        logger.info(f'No "status" column found in '
-                    f'{op.basename(channels_fname)}; using list of bad '
-                    f'channels found in raw.info["bads"]: {raw.info["bads"]}')
+        bads = _get_bads_from_tsv_data(channels_dict)
+        raw.info['bads'] = bads
 
     return raw
 

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -74,7 +74,7 @@ def _read_events(events_data, event_id, raw, verbose=None):
         ``raw.annotations``.
     event_id : dict | None
         The event id dict used to create a 'trial_type' column in events.tsv,
-        mapping a description key to an integer valued event code.
+        mapping a description key to an integer-valued event code.
     raw : instance of Raw
         The data as MNE-Python Raw object.
     verbose : bool | str | int | None

--- a/mne_bids/tests/test_inspect.py
+++ b/mne_bids/tests/test_inspect.py
@@ -23,10 +23,8 @@ _bids_path = BIDSPath(subject='01', session='01', run='01', task='testing',
                       datatype='meg')
 
 
-@pytest.fixture(scope='session')
-def return_bids_test_dir(tmpdir_factory):
+def setup_bids_test_dir(bids_root):
     """Return path to a written test BIDS dir."""
-    bids_root = str(tmpdir_factory.mktemp('mnebids_utils_test_bids_ds'))
     data_path = testing.data_path()
     raw_fname = op.join(data_path, 'MEG', 'sample',
                         'sample_audvis_trunc_raw.fif')
@@ -58,7 +56,7 @@ def return_bids_test_dir(tmpdir_factory):
 @requires_version('mne', '0.22')
 @pytest.mark.parametrize('save_changes', (True, False))
 @pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
-def test_inspect_single_file(return_bids_test_dir, save_changes):
+def test_inspect_single_file(tmp_path, save_changes):
     """Test inspecting a dataset consisting of only a single file."""
     from mne.utils._testing import _click_ch_name
     import matplotlib
@@ -66,7 +64,8 @@ def test_inspect_single_file(return_bids_test_dir, save_changes):
     matplotlib.use('Agg')
     plt.close('all')
 
-    bids_path = _bids_path.copy().update(root=return_bids_test_dir)
+    bids_root = setup_bids_test_dir(tmp_path)
+    bids_path = _bids_path.copy().update(root=bids_root)
     raw = read_raw_bids(bids_path=bids_path, verbose='error')
     old_bads = raw.info['bads'].copy()
 
@@ -100,14 +99,15 @@ def test_inspect_single_file(return_bids_test_dir, save_changes):
 @requires_matplotlib
 @requires_version('mne', '0.22')
 @pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
-def test_inspect_multiple_files(return_bids_test_dir):
+def test_inspect_multiple_files(tmp_path):
     """Test inspecting a dataset consisting of more than one file."""
     import matplotlib
     import matplotlib.pyplot as plt
     matplotlib.use('Agg')
     plt.close('all')
 
-    bids_path = _bids_path.copy().update(root=return_bids_test_dir)
+    bids_root = setup_bids_test_dir(tmp_path)
+    bids_path = _bids_path.copy().update(root=bids_root)
 
     # Create a second subject
     raw = read_raw_bids(bids_path=bids_path, verbose='error')
@@ -124,7 +124,7 @@ def test_inspect_multiple_files(return_bids_test_dir):
 @requires_matplotlib
 @requires_version('mne', '0.22')
 @pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
-def test_inspect_set_and_unset_bads(return_bids_test_dir):
+def test_inspect_set_and_unset_bads(tmp_path):
     """Test marking channels as bad and later marking them as good again."""
     from mne.utils._testing import _click_ch_name
     import matplotlib
@@ -132,7 +132,8 @@ def test_inspect_set_and_unset_bads(return_bids_test_dir):
     matplotlib.use('Agg')
     plt.close('all')
 
-    bids_path = _bids_path.copy().update(root=return_bids_test_dir)
+    bids_root = setup_bids_test_dir(tmp_path)
+    bids_path = _bids_path.copy().update(root=bids_root)
     raw = read_raw_bids(bids_path=bids_path, verbose='error')
     orig_bads = raw.info['bads'].copy()
 
@@ -162,20 +163,23 @@ def test_inspect_set_and_unset_bads(return_bids_test_dir):
 
     # Check marking the channels as good has actually worked.
     expected_bads = orig_bads + ['MEG 0113']
-    assert set(orig_bads) == set(expected_bads)
+    raw = read_raw_bids(bids_path=bids_path, verbose='error')
+    new_bads = raw.info['bads']
+    assert set(new_bads) == set(expected_bads)
 
 
 @requires_matplotlib
 @requires_version('mne', '0.22')
 @pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
-def test_inspect_annotations(return_bids_test_dir):
+def test_inspect_annotations(tmp_path):
     """Test inspection of Annotations."""
     import matplotlib
     import matplotlib.pyplot as plt
     matplotlib.use('Agg')
     plt.close('all')
 
-    bids_path = _bids_path.copy().update(root=return_bids_test_dir)
+    bids_root = setup_bids_test_dir(tmp_path)
+    bids_path = _bids_path.copy().update(root=bids_root)
     raw = read_raw_bids(bids_path=bids_path, verbose='error')
     orig_annotations = raw.annotations.copy()
 
@@ -232,14 +236,15 @@ def test_inspect_annotations(return_bids_test_dir):
 @requires_matplotlib
 @requires_version('mne', '0.22')
 @pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
-def test_inspect_annotations_remove_all(return_bids_test_dir):
+def test_inspect_annotations_remove_all(tmp_path):
     """Test behavior if all Annotations are removed by the user."""
     import matplotlib
     import matplotlib.pyplot as plt
     matplotlib.use('Agg')
     plt.close('all')
 
-    bids_path = _bids_path.copy().update(root=return_bids_test_dir)
+    bids_root = setup_bids_test_dir(tmp_path)
+    bids_path = _bids_path.copy().update(root=bids_root)
     events_tsv_fpath = (bids_path.copy()
                         .update(suffix='events', extension='.tsv')
                         .fpath)
@@ -301,13 +306,81 @@ def test_inspect_annotations_remove_all(return_bids_test_dir):
 
 @requires_matplotlib
 @requires_version('mne', '0.22')
+@pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
+def test_inspect_dont_show_annotations(tmp_path):
+    """Test if show_annotations=False works."""
+    import matplotlib
+    import matplotlib.pyplot as plt
+    matplotlib.use('Agg')
+    plt.close('all')
+
+    bids_root = setup_bids_test_dir(tmp_path)
+    bids_path = _bids_path.copy().update(root=bids_root)
+    inspect_dataset(bids_path, show_annotations=False)
+    raw_fig = mne_bids.inspect._global_vars['raw_fig']
+    assert not raw_fig.mne.annotations
+
+
+@requires_matplotlib
+@requires_version('mne', '0.22')
+@pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
+def test_inspect_bads_and_annotations(tmp_path):
+    """Test adding bads and Annotations in one go."""
+    from mne.utils._testing import _click_ch_name
+    import matplotlib
+    import matplotlib.pyplot as plt
+    matplotlib.use('Agg')
+    plt.close('all')
+
+    bids_root = setup_bids_test_dir(tmp_path)
+    bids_path = _bids_path.copy().update(root=bids_root)
+    raw = read_raw_bids(bids_path=bids_path, verbose='error')
+    orig_bads = raw.info['bads'].copy()
+
+    inspect_dataset(bids_path)
+    raw_fig = mne_bids.inspect._global_vars['raw_fig']
+
+    # Mark some channels as bad by clicking on their name.
+    _click_ch_name(raw_fig, ch_index=0, button=1)
+
+    # Add custom Annotation.
+    data_ax = raw_fig.mne.ax_main
+    raw_fig.canvas.key_press_event('a')  # Toggle Annotation mode
+    ann_fig = raw_fig.mne.fig_annotation
+    for key in 'test':  # Annotation will be named: BAD_test
+        ann_fig.canvas.key_press_event(key)
+    ann_fig.canvas.key_press_event('enter')
+
+    _fake_click(raw_fig, data_ax, [1., 1.], xform='data', button=1,
+                kind='press')
+    _fake_click(raw_fig, data_ax, [5., 1.], xform='data', button=1,
+                kind='motion')
+    _fake_click(raw_fig, data_ax, [5., 1.], xform='data', button=1,
+                kind='release')
+
+    # Close window and save changes.
+    raw_fig.canvas.key_press_event(raw_fig.mne.close_key)
+    fig_dialog = mne_bids.inspect._global_vars['dialog_fig']
+    fig_dialog.canvas.key_press_event('return')
+
+    # Check that the changes were saved.
+    raw = read_raw_bids(bids_path=bids_path, verbose='error')
+    new_bads = raw.info['bads']
+    expected_bads = orig_bads + ['MEG 0113']
+    assert set(new_bads) == set(expected_bads)
+    assert 'BAD_test' in raw.annotations.description
+
+
+@requires_matplotlib
+@requires_version('mne', '0.22')
 @pytest.mark.parametrize(('l_freq', 'h_freq'),
                          [(None, None),
                           (1, None),
                           (None, 30),
                           (1, 30)])
 @pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
-def test_inspect_freq_filter(return_bids_test_dir, l_freq, h_freq):
+def test_inspect_freq_filter(tmp_path, l_freq, h_freq):
     """Test frequency filter for Raw display."""
-    bids_path = _bids_path.copy().update(root=return_bids_test_dir)
+    bids_root = setup_bids_test_dir(tmp_path)
+    bids_path = _bids_path.copy().update(root=bids_root)
     inspect_dataset(bids_path, l_freq=l_freq, h_freq=h_freq)

--- a/mne_bids/tests/test_inspect.py
+++ b/mne_bids/tests/test_inspect.py
@@ -170,7 +170,6 @@ def test_inspect_set_and_unset_bads(tmp_path):
 
 def _add_annotation(raw_fig):
     """Add an Annotation to a Raw plot."""
-    # Create Annotation.
     data_ax = raw_fig.mne.ax_main
     raw_fig.canvas.key_press_event('a')  # Toggle Annotation mode
     ann_fig = raw_fig.mne.fig_annotation

--- a/mne_bids/tests/test_inspect.py
+++ b/mne_bids/tests/test_inspect.py
@@ -8,6 +8,7 @@ import mne
 from mne.datasets import testing
 from mne.utils import requires_version
 from mne.utils._testing import requires_module
+from mne.viz.utils import _fake_click
 
 from mne_bids import (BIDSPath, read_raw_bids, write_raw_bids, inspect_dataset,
                       write_meg_calibration, write_meg_crosstalk)
@@ -58,6 +59,7 @@ def return_bids_test_dir(tmpdir_factory):
 @pytest.mark.parametrize('save_changes', (True, False))
 @pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
 def test_inspect_single_file(return_bids_test_dir, save_changes):
+    """Test inspecting a dataset consisting of only a single file."""
     from mne.utils._testing import _click_ch_name
     import matplotlib
     matplotlib.use('Agg')
@@ -97,6 +99,7 @@ def test_inspect_single_file(return_bids_test_dir, save_changes):
 @requires_version('mne', '0.22')
 @pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
 def test_inspect_multiple_files(return_bids_test_dir):
+    """Test inspecting a dataset consisting of more than one file."""
     import matplotlib
     matplotlib.use('Agg')
 
@@ -116,6 +119,178 @@ def test_inspect_multiple_files(return_bids_test_dir):
 
 @requires_matplotlib
 @requires_version('mne', '0.22')
+@pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
+def test_inspect_set_and_unset_bads(return_bids_test_dir):
+    """Test marking channels as bad and later marking them as good again."""
+    from mne.utils._testing import _click_ch_name
+    import matplotlib
+    matplotlib.use('Agg')
+
+    bids_path = _bids_path.copy().update(root=return_bids_test_dir)
+    raw = read_raw_bids(bids_path=bids_path, verbose='error')
+    orig_bads = raw.info['bads'].copy()
+
+    # Mark some channels as bad by clicking on their name.
+    inspect_dataset(bids_path)
+    raw_fig = mne_bids.inspect._global_vars['raw_fig']
+    _click_ch_name(raw_fig, ch_index=0, button=1)
+    _click_ch_name(raw_fig, ch_index=1, button=1)
+    _click_ch_name(raw_fig, ch_index=4, button=1)
+
+    # Close window and save changes.
+    raw_fig.canvas.key_press_event(raw_fig.mne.close_key)
+    fig_dialog = mne_bids.inspect._global_vars['dialog_fig']
+    fig_dialog.canvas.key_press_event('return')
+
+    # Inspect the data again, click on two of the bad channels to mark them as
+    # good.
+    inspect_dataset(bids_path)
+    raw_fig = mne_bids.inspect._global_vars['raw_fig']
+    _click_ch_name(raw_fig, ch_index=1, button=1)
+    _click_ch_name(raw_fig, ch_index=4, button=1)
+
+    # Close window and save changes.
+    raw_fig.canvas.key_press_event(raw_fig.mne.close_key)
+    fig_dialog = mne_bids.inspect._global_vars['dialog_fig']
+    fig_dialog.canvas.key_press_event('return')
+
+    # Check marking the channels as good has actually worked.
+    expected_bads = orig_bads + ['MEG 0113']
+    assert set(orig_bads) == set(expected_bads)
+
+
+@requires_matplotlib
+@requires_version('mne', '0.22')
+@pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
+def test_inspect_annotations(return_bids_test_dir):
+    """Test inspection of Annotations."""
+    import matplotlib
+    matplotlib.use('Agg')
+
+    bids_path = _bids_path.copy().update(root=return_bids_test_dir)
+    raw = read_raw_bids(bids_path=bids_path, verbose='error')
+    orig_annotations = raw.annotations.copy()
+
+    inspect_dataset(bids_path)
+    raw_fig = mne_bids.inspect._global_vars['raw_fig']
+
+    # Create Annotation.
+    data_ax = raw_fig.mne.ax_main
+    raw_fig.canvas.key_press_event('a')  # Toggle Annotation mode
+    ann_fig = raw_fig.mne.fig_annotation
+    for key in 'test':  # Annotation will be named: BAD_test
+        ann_fig.canvas.key_press_event(key)
+    ann_fig.canvas.key_press_event('enter')
+
+    # Draw a 4 second long Annotation.
+    _fake_click(raw_fig, data_ax, [1., 1.], xform='data', button=1,
+                kind='press')
+    _fake_click(raw_fig, data_ax, [5., 1.], xform='data', button=1,
+                kind='motion')
+    _fake_click(raw_fig, data_ax, [5., 1.], xform='data', button=1,
+                kind='release')
+
+    # Close window and save changes.
+    raw_fig.canvas.key_press_event(raw_fig.mne.close_key)
+    fig_dialog = mne_bids.inspect._global_vars['dialog_fig']
+    fig_dialog.canvas.key_press_event('return')
+
+    # Ensure changes were saved.
+    raw = read_raw_bids(bids_path=bids_path, verbose='error')
+    assert 'BAD_test' in raw.annotations.description
+    annot_idx = raw.annotations.description == 'BAD_test'
+    assert raw.annotations.duration[annot_idx].squeeze() == 4
+
+    # Remove the Annotation.
+    inspect_dataset(bids_path)
+    raw_fig = mne_bids.inspect._global_vars['raw_fig']
+    data_ax = raw_fig.mne.ax_main
+    raw_fig.canvas.key_press_event('a')  # Toggle Annotation mode
+    ann_fig = raw_fig.mne.fig_annotation
+    _fake_click(raw_fig, data_ax, [1., 1.], xform='data', button=3,
+                kind='press')
+
+    # Close window and save changes.
+    raw_fig.canvas.key_press_event(raw_fig.mne.close_key)
+    fig_dialog = mne_bids.inspect._global_vars['dialog_fig']
+    fig_dialog.canvas.key_press_event('return')
+
+    # Ensure changes were saved.
+    raw = read_raw_bids(bids_path=bids_path, verbose='error')
+    assert 'BAD_test' not in raw.annotations.description
+    assert raw.annotations == orig_annotations
+
+
+@requires_matplotlib
+@requires_version('mne', '0.22')
+@pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
+def test_inspect_annotations_remove_all(return_bids_test_dir):
+    """Test behavior if all Annotations are removed by the user."""
+    import matplotlib
+    matplotlib.use('Agg')
+
+    bids_path = _bids_path.copy().update(root=return_bids_test_dir)
+    events_tsv_fpath = (bids_path.copy()
+                        .update(suffix='events', extension='.tsv')
+                        .fpath)
+
+    # Remove all Annotations.
+    raw = read_raw_bids(bids_path=bids_path, verbose='error')
+    raw.set_annotations(None)
+    raw.load_data()
+    raw.save(raw.filenames[0], overwrite=True)
+    # Delete events.tsv sidecar.
+    (bids_path.copy()
+     .update(suffix='events', extension='.tsv')
+     .fpath
+     .unlink())
+
+    # Add custom Annotation.
+    inspect_dataset(bids_path)
+    raw_fig = mne_bids.inspect._global_vars['raw_fig']
+
+    data_ax = raw_fig.mne.ax_main
+    raw_fig.canvas.key_press_event('a')  # Toggle Annotation mode
+    ann_fig = raw_fig.mne.fig_annotation
+    for key in 'test':  # Annotation will be named: BAD_test
+        ann_fig.canvas.key_press_event(key)
+    ann_fig.canvas.key_press_event('enter')
+
+    _fake_click(raw_fig, data_ax, [1., 1.], xform='data', button=1,
+                kind='press')
+    _fake_click(raw_fig, data_ax, [5., 1.], xform='data', button=1,
+                kind='motion')
+    _fake_click(raw_fig, data_ax, [5., 1.], xform='data', button=1,
+                kind='release')
+
+    # Close window and save changes.
+    raw_fig.canvas.key_press_event(raw_fig.mne.close_key)
+    fig_dialog = mne_bids.inspect._global_vars['dialog_fig']
+    fig_dialog.canvas.key_press_event('return')
+
+    # events.tsv sidecar should have been created.
+    assert events_tsv_fpath.exists()
+
+    # Remove the Annotation.
+    inspect_dataset(bids_path)
+    raw_fig = mne_bids.inspect._global_vars['raw_fig']
+    data_ax = raw_fig.mne.ax_main
+    raw_fig.canvas.key_press_event('a')  # Toggle Annotation mode
+    ann_fig = raw_fig.mne.fig_annotation
+    _fake_click(raw_fig, data_ax, [1., 1.], xform='data', button=3,
+                kind='press')
+
+    # Close window and save changes.
+    raw_fig.canvas.key_press_event(raw_fig.mne.close_key)
+    fig_dialog = mne_bids.inspect._global_vars['dialog_fig']
+    fig_dialog.canvas.key_press_event('return')
+
+    # events.tsv sidecar should not exist anymore.
+    assert not events_tsv_fpath.exists()
+
+
+@requires_matplotlib
+@requires_version('mne', '0.22')
 @pytest.mark.parametrize(('l_freq', 'h_freq'),
                          [(None, None),
                           (1, None),
@@ -123,5 +298,6 @@ def test_inspect_multiple_files(return_bids_test_dir):
                           (1, 30)])
 @pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
 def test_inspect_freq_filter(return_bids_test_dir, l_freq, h_freq):
+    """Test frequency filter for Raw display."""
     bids_path = _bids_path.copy().update(root=return_bids_test_dir)
     inspect_dataset(bids_path, l_freq=l_freq, h_freq=h_freq)

--- a/mne_bids/tests/test_inspect.py
+++ b/mne_bids/tests/test_inspect.py
@@ -62,7 +62,9 @@ def test_inspect_single_file(return_bids_test_dir, save_changes):
     """Test inspecting a dataset consisting of only a single file."""
     from mne.utils._testing import _click_ch_name
     import matplotlib
+    import matplotlib.pyplot as plt
     matplotlib.use('Agg')
+    plt.close('all')
 
     bids_path = _bids_path.copy().update(root=return_bids_test_dir)
     raw = read_raw_bids(bids_path=bids_path, verbose='error')
@@ -101,7 +103,9 @@ def test_inspect_single_file(return_bids_test_dir, save_changes):
 def test_inspect_multiple_files(return_bids_test_dir):
     """Test inspecting a dataset consisting of more than one file."""
     import matplotlib
+    import matplotlib.pyplot as plt
     matplotlib.use('Agg')
+    plt.close('all')
 
     bids_path = _bids_path.copy().update(root=return_bids_test_dir)
 
@@ -124,7 +128,9 @@ def test_inspect_set_and_unset_bads(return_bids_test_dir):
     """Test marking channels as bad and later marking them as good again."""
     from mne.utils._testing import _click_ch_name
     import matplotlib
+    import matplotlib.pyplot as plt
     matplotlib.use('Agg')
+    plt.close('all')
 
     bids_path = _bids_path.copy().update(root=return_bids_test_dir)
     raw = read_raw_bids(bids_path=bids_path, verbose='error')
@@ -165,7 +171,9 @@ def test_inspect_set_and_unset_bads(return_bids_test_dir):
 def test_inspect_annotations(return_bids_test_dir):
     """Test inspection of Annotations."""
     import matplotlib
+    import matplotlib.pyplot as plt
     matplotlib.use('Agg')
+    plt.close('all')
 
     bids_path = _bids_path.copy().update(root=return_bids_test_dir)
     raw = read_raw_bids(bids_path=bids_path, verbose='error')
@@ -227,7 +235,9 @@ def test_inspect_annotations(return_bids_test_dir):
 def test_inspect_annotations_remove_all(return_bids_test_dir):
     """Test behavior if all Annotations are removed by the user."""
     import matplotlib
+    import matplotlib.pyplot as plt
     matplotlib.use('Agg')
+    plt.close('all')
 
     bids_path = _bids_path.copy().update(root=return_bids_test_dir)
     events_tsv_fpath = (bids_path.copy()

--- a/mne_bids/tests/test_inspect.py
+++ b/mne_bids/tests/test_inspect.py
@@ -168,6 +168,25 @@ def test_inspect_set_and_unset_bads(tmp_path):
     assert set(new_bads) == set(expected_bads)
 
 
+def _add_annotation(raw_fig):
+    """Add an Annotation to a Raw plot."""
+    # Create Annotation.
+    data_ax = raw_fig.mne.ax_main
+    raw_fig.canvas.key_press_event('a')  # Toggle Annotation mode
+    ann_fig = raw_fig.mne.fig_annotation
+    for key in 'test':  # Annotation will be named: BAD_test
+        ann_fig.canvas.key_press_event(key)
+    ann_fig.canvas.key_press_event('enter')
+
+    # Draw a 4 second long Annotation.
+    _fake_click(raw_fig, data_ax, [1., 1.], xform='data', button=1,
+                kind='press')
+    _fake_click(raw_fig, data_ax, [5., 1.], xform='data', button=1,
+                kind='motion')
+    _fake_click(raw_fig, data_ax, [5., 1.], xform='data', button=1,
+                kind='release')
+
+
 @requires_matplotlib
 @requires_version('mne', '0.22')
 @pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
@@ -185,22 +204,7 @@ def test_inspect_annotations(tmp_path):
 
     inspect_dataset(bids_path)
     raw_fig = mne_bids.inspect._global_vars['raw_fig']
-
-    # Create Annotation.
-    data_ax = raw_fig.mne.ax_main
-    raw_fig.canvas.key_press_event('a')  # Toggle Annotation mode
-    ann_fig = raw_fig.mne.fig_annotation
-    for key in 'test':  # Annotation will be named: BAD_test
-        ann_fig.canvas.key_press_event(key)
-    ann_fig.canvas.key_press_event('enter')
-
-    # Draw a 4 second long Annotation.
-    _fake_click(raw_fig, data_ax, [1., 1.], xform='data', button=1,
-                kind='press')
-    _fake_click(raw_fig, data_ax, [5., 1.], xform='data', button=1,
-                kind='motion')
-    _fake_click(raw_fig, data_ax, [5., 1.], xform='data', button=1,
-                kind='release')
+    _add_annotation(raw_fig)
 
     # Close window and save changes.
     raw_fig.canvas.key_press_event(raw_fig.mne.close_key)
@@ -218,7 +222,6 @@ def test_inspect_annotations(tmp_path):
     raw_fig = mne_bids.inspect._global_vars['raw_fig']
     data_ax = raw_fig.mne.ax_main
     raw_fig.canvas.key_press_event('a')  # Toggle Annotation mode
-    ann_fig = raw_fig.mne.fig_annotation
     _fake_click(raw_fig, data_ax, [1., 1.], xform='data', button=3,
                 kind='press')
 
@@ -263,20 +266,7 @@ def test_inspect_annotations_remove_all(tmp_path):
     # Add custom Annotation.
     inspect_dataset(bids_path)
     raw_fig = mne_bids.inspect._global_vars['raw_fig']
-
-    data_ax = raw_fig.mne.ax_main
-    raw_fig.canvas.key_press_event('a')  # Toggle Annotation mode
-    ann_fig = raw_fig.mne.fig_annotation
-    for key in 'test':  # Annotation will be named: BAD_test
-        ann_fig.canvas.key_press_event(key)
-    ann_fig.canvas.key_press_event('enter')
-
-    _fake_click(raw_fig, data_ax, [1., 1.], xform='data', button=1,
-                kind='press')
-    _fake_click(raw_fig, data_ax, [5., 1.], xform='data', button=1,
-                kind='motion')
-    _fake_click(raw_fig, data_ax, [5., 1.], xform='data', button=1,
-                kind='release')
+    _add_annotation(raw_fig)
 
     # Close window and save changes.
     raw_fig.canvas.key_press_event(raw_fig.mne.close_key)
@@ -291,7 +281,6 @@ def test_inspect_annotations_remove_all(tmp_path):
     raw_fig = mne_bids.inspect._global_vars['raw_fig']
     data_ax = raw_fig.mne.ax_main
     raw_fig.canvas.key_press_event('a')  # Toggle Annotation mode
-    ann_fig = raw_fig.mne.fig_annotation
     _fake_click(raw_fig, data_ax, [1., 1.], xform='data', button=3,
                 kind='press')
 
@@ -344,19 +333,7 @@ def test_inspect_bads_and_annotations(tmp_path):
     _click_ch_name(raw_fig, ch_index=0, button=1)
 
     # Add custom Annotation.
-    data_ax = raw_fig.mne.ax_main
-    raw_fig.canvas.key_press_event('a')  # Toggle Annotation mode
-    ann_fig = raw_fig.mne.fig_annotation
-    for key in 'test':  # Annotation will be named: BAD_test
-        ann_fig.canvas.key_press_event(key)
-    ann_fig.canvas.key_press_event('enter')
-
-    _fake_click(raw_fig, data_ax, [1., 1.], xform='data', button=1,
-                kind='press')
-    _fake_click(raw_fig, data_ax, [5., 1.], xform='data', button=1,
-                kind='motion')
-    _fake_click(raw_fig, data_ax, [5., 1.], xform='data', button=1,
-                kind='release')
+    _add_annotation(raw_fig)
 
     # Close window and save changes.
     raw_fig.canvas.key_press_event(raw_fig.mne.close_key)

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -1830,10 +1830,7 @@ def test_mark_bad_channels_files():
 
     # mark bad channels that get stored as uV in write_brain_vision
     bads = ['CP5', 'CP6']
-
-    with pytest.warns(RuntimeWarning,
-                      match='Encountered data in "short" format'):
-        mark_bad_channels(bads, bids_path=bids_path, overwrite=False)
+    mark_bad_channels(bads, bids_path=bids_path, overwrite=False)
     raw.info['bads'].extend(bads)
 
     # the raw data should match if you drop the bads
@@ -1842,7 +1839,7 @@ def test_mark_bad_channels_files():
     raw_2.drop_channels(raw_2.info['bads'])
     assert_array_almost_equal(raw.get_data(), raw_2.get_data())
 
-    # EDF won't work
+    # test EDF too
     dir_name = 'EDF'
     fname = 'test_reduced.edf'
     bids_root = _TempDir()
@@ -1850,13 +1847,8 @@ def test_mark_bad_channels_files():
     data_path = op.join(testing.data_path(), dir_name)
     raw_fname = op.join(data_path, fname)
     raw = _read_raw_edf(raw_fname)
-
-    # write edf
     write_raw_bids(raw, bids_path, overwrite=True)
-
-    # try to mark bad channels
-    with pytest.raises(RuntimeError, match='Can only mark bad'):
-        mark_bad_channels(raw.ch_names[0], bids_path=bids_path)
+    mark_bad_channels(raw.ch_names[0], bids_path=bids_path)
 
 
 def test_write_meg_calibration(_bids_validate):

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -39,15 +39,14 @@ from mne_bids.utils import (_write_json, _write_tsv, _write_text,
                             _age_on_date, _infer_eeg_placement_scheme,
                             _handle_datatype, _get_ch_type_mapping,
                             _check_anonymize, _stamp_to_dt)
-from mne_bids import read_raw_bids
-from mne_bids.path import BIDSPath, _parse_ext, _mkdir_p, _path_to_str
+from mne_bids import BIDSPath
+from mne_bids.path import _parse_ext, _mkdir_p, _path_to_str
 from mne_bids.copyfiles import (copyfile_brainvision, copyfile_eeglab,
                                 copyfile_ctf, copyfile_bti, copyfile_kit,
                                 copyfile_edf)
 from mne_bids.tsv_handler import (_from_tsv, _drop, _contains_row,
                                   _combine_rows)
-from mne_bids.read import (_get_bads_from_tsv_data, _find_matching_sidecar,
-                           _read_events)
+from mne_bids.read import _find_matching_sidecar, _read_events
 
 from mne_bids.config import (ORIENTATION, UNITS, MANUFACTURERS,
                              IGNORED_CHANNELS, ALLOWED_DATATYPE_EXTENSIONS,
@@ -1531,10 +1530,6 @@ def mark_bad_channels(ch_names, descriptions=None, *, bids_path,
     channels_fname = _find_matching_sidecar(bids_path, suffix='channels',
                                             extension='.tsv')
     tsv_data = _from_tsv(channels_fname)
-    if 'status' in tsv_data:
-        bads_tsv = _get_bads_from_tsv_data(tsv_data)
-    else:
-        bads_tsv = []
 
     # Read sidecar and create required columns if they do not exist.
     if 'status' not in tsv_data:

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -171,11 +171,6 @@ def _events_tsv(events, durations, raw, fname, trial_type, overwrite=False,
         Defaults to False.
     verbose : bool
         Set verbose output to True or False.
-
-    Notes
-    -----
-    The function writes durations of zero for each event.
-
     """
     # Start by filling all data that we know into an ordered dictionary
     first_samp = raw.first_samp
@@ -1596,8 +1591,8 @@ def mark_bad_channels(ch_names, descriptions=None, *, bids_path,
                                     raw=raw, verbose=False)
         _write_raw_brainvision(raw, bids_path.fpath, events)
     elif isinstance(raw, mne.io.RawFIF):
-        # XXX (How) will this handle split files?
-        raw.save(raw.filenames[0], overwrite=True, verbose=False)
+        raw.save(raw.filenames[0], overwrite=True, split_naming='bids',
+                 verbose=False)
     else:
         raise RuntimeError('Can only mark bad channels for '
                            'FIFF and BrainVision files for now. Please '

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1527,14 +1527,7 @@ def mark_bad_channels(ch_names, descriptions=None, *, bids_path,
                          'Please use `bids_path.update(root="<root>")` '
                          'to set the root of the BIDS folder to read.')
 
-    # Read raw and sidecar file.
-    extra_params = dict()
-    if bids_path.extension == '.fif':
-        extra_params['allow_maxshield'] = True
-    raw = read_raw_bids(bids_path=bids_path, extra_params=extra_params,
-                        verbose=False)
-    bads_raw = raw.info['bads']
-
+    # Read sidecar file.
     channels_fname = _find_matching_sidecar(bids_path, suffix='channels',
                                             extension='.tsv')
     tsv_data = _from_tsv(channels_fname)
@@ -1562,13 +1555,6 @@ def mark_bad_channels(ch_names, descriptions=None, *, bids_path,
         logger.info('Resetting status and description for all channels.')
         tsv_data['status'] = ['good'] * len(tsv_data['name'])
         tsv_data['status_description'] = ['n/a'] * len(tsv_data['name'])
-    elif not overwrite and not bads_tsv and bads_raw:
-        # No bads are marked in channels.tsv, but in raw.info['bads'], and
-        # the user requested to UPDATE (overwrite=False) the channel status.
-        # -> Inject bads from info['bads'] into channels.tsv before proceeding!
-        for ch_name in bads_raw:
-            idx = tsv_data['name'].index(ch_name)
-            tsv_data['status'][idx] = 'bad'
 
     # Now actually mark the user-requested channels as bad.
     for ch_name, description in zip(ch_names, descriptions):


### PR DESCRIPTION
PR Description
--------------

This adds support for interactively editing Annotations (BIDS events) via `mne_bids.inspect_dataset()`. Will update the raw file and `events.tsv`.

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
