### PR TITLE
[MRG] Fixing bug when participants file is a subset of what mne-bids writes

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -58,7 +58,7 @@ Bug fixes
 - Fix a bug in :func:`mne_bids.write_raw_bids`, where original format of data was not kept when writing to FIFF, by `Alexandre Gramfort`_, `Stefan Appelhoff`_, and `Richard Höchenberger`_ (:gh:`610`)
 - Fix a bug where conversion to BrainVision format was done even when non-Volt channel types were present in the data (BrainVision conversion is done by ``pybv``, which currently only supports Volt channel types), by `Stefan Appelhoff`_ (:gh:`619`)
 - Ensure sidecar files (`.tsv` and `.json`) are always read and written in UTF-8, by `Richard Höchenberger`_ (:gh:`625`)
-- Fix a bug where participants.tsv file was not being appended to correctly when they contained a subset of ``hand``, ``age`` and ``sex``, by `Adam Li`_ (:gh:`648`)
+- Fix a bug where ``participants.tsv`` was not being appended to correctly when it contained a subset of ``hand``, ``age`` and ``sex``, by `Adam Li`_ (:gh:`648`)
 
 API changes
 ^^^^^^^^^^^

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -58,7 +58,7 @@ Bug fixes
 - Fix a bug in :func:`mne_bids.write_raw_bids`, where original format of data was not kept when writing to FIFF, by `Alexandre Gramfort`_, `Stefan Appelhoff`_, and `Richard Höchenberger`_ (:gh:`610`)
 - Fix a bug where conversion to BrainVision format was done even when non-Volt channel types were present in the data (BrainVision conversion is done by ``pybv``, which currently only supports Volt channel types), by `Stefan Appelhoff`_ (:gh:`619`)
 - Ensure sidecar files (`.tsv` and `.json`) are always read and written in UTF-8, by `Richard Höchenberger`_ (:gh:`625`)
-- Fix a bug where participants files were not being appended to correctly when they contained a subset of ``hand``, ``age`` and ``sex``, by `Adam Li`_ (:gh:`648`)
+- Fix a bug where participants.tsv file was not being appended to correctly when they contained a subset of ``hand``, ``age`` and ``sex``, by `Adam Li`_ (:gh:`648`)
 
 API changes
 ^^^^^^^^^^^

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -58,6 +58,7 @@ Bug fixes
 - Fix a bug in :func:`mne_bids.write_raw_bids`, where original format of data was not kept when writing to FIFF, by `Alexandre Gramfort`_, `Stefan Appelhoff`_, and `Richard Höchenberger`_ (:gh:`610`)
 - Fix a bug where conversion to BrainVision format was done even when non-Volt channel types were present in the data (BrainVision conversion is done by ``pybv``, which currently only supports Volt channel types), by `Stefan Appelhoff`_ (:gh:`619`)
 - Ensure sidecar files (`.tsv` and `.json`) are always read and written in UTF-8, by `Richard Höchenberger`_ (:gh:`625`)
+- Fix a bug where participants files were not being appended to correctly when they contained a subset of ``hand``, ``age`` and ``sex``, by `Adam Li`_ (:gh:``)
 
 API changes
 ^^^^^^^^^^^

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -58,7 +58,7 @@ Bug fixes
 - Fix a bug in :func:`mne_bids.write_raw_bids`, where original format of data was not kept when writing to FIFF, by `Alexandre Gramfort`_, `Stefan Appelhoff`_, and `Richard Höchenberger`_ (:gh:`610`)
 - Fix a bug where conversion to BrainVision format was done even when non-Volt channel types were present in the data (BrainVision conversion is done by ``pybv``, which currently only supports Volt channel types), by `Stefan Appelhoff`_ (:gh:`619`)
 - Ensure sidecar files (`.tsv` and `.json`) are always read and written in UTF-8, by `Richard Höchenberger`_ (:gh:`625`)
-- Fix a bug where participants files were not being appended to correctly when they contained a subset of ``hand``, ``age`` and ``sex``, by `Adam Li`_ (:gh:``)
+- Fix a bug where participants files were not being appended to correctly when they contained a subset of ``hand``, ``age`` and ``sex``, by `Adam Li`_ (:gh:`648`)
 
 API changes
 ^^^^^^^^^^^

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -121,8 +121,13 @@ def _test_anonymize(raw, bids_path, events_fname=None, event_id=None):
     return bids_root
 
 
-def test_write_participants():
-    """Test that participants data is written correctly."""
+def test_write_participants(_bids_validate):
+    """Test participants.tsv/.json file writing.
+
+    Test that user modifications of the participants
+    files are kept, and mne-bids correctly writes all
+    the subject info it can using ``raw.info['subject_info']``.
+    """
     data_path = testing.data_path()
     raw_fname = op.join(data_path, 'MEG', 'sample',
                         'sample_audvis_trunc_raw.fif')
@@ -150,14 +155,59 @@ def test_write_participants():
     data.pop('hand')
     _to_tsv(data, participants_tsv)
 
+    # write in now another subject
     bids_path.update(subject='02')
-    write_raw_bids(raw, bids_path)
+    write_raw_bids(raw, bids_path, verbose=False)
     data = _from_tsv(participants_tsv)
 
     # hand should have been written properly with now 'n/a' for sub-01
     # but 'L' for sub-02
     assert data['hand'][data['participant_id'].index('sub-01')] == 'n/a'
     assert data['hand'][data['participant_id'].index('sub-02')] == 'L'
+
+    # check to make sure participant data is overwritten, but keeps the fields
+    # if there are extra fields that were user defined
+    data = _from_tsv(participants_tsv)
+    participant_idx = data['participant_id'].index(f'sub-{subject_id}')
+    # create a new test column in participants file tsv
+    data['subject_test_col1'] = ['n/a'] * len(data['participant_id'])
+    data['subject_test_col1'][participant_idx] = 'S'
+    data['test_col2'] = ['n/a'] * len(data['participant_id'])
+    orig_key_order = list(data.keys())
+    _to_tsv(data, participants_tsv)
+    # crate corresponding json entry
+    participants_json_fpath = op.join(bids_root, 'participants.json')
+    json_field = {
+        'Description': 'trial-outcome',
+        'Levels': {
+            'S': 'success',
+            'F': 'failure'
+        }
+    }
+    _update_sidecar(participants_json_fpath, 'subject_test_col1', json_field)
+    # bids root should still be valid because json reflects changes in tsv
+    _bids_validate(bids_root)
+    write_raw_bids(raw, bids_path, overwrite=True)
+    data = _from_tsv(participants_tsv)
+    with open(participants_json_fpath, 'r', encoding='utf-8') as fin:
+        participants_json = json.load(fin)
+    assert 'subject_test_col1' in participants_json
+    assert data['subject_test_col1'][participant_idx] == 'S'
+    # in addition assert the original ordering of the new overwritten file
+    assert list(data.keys()) == orig_key_order
+
+    # if overwrite is False, then nothing should change from the above
+    with pytest.raises(FileExistsError, match='already exists'):
+        raw.info['subject_info'] = None
+        write_raw_bids(raw, bids_path, overwrite=False)
+    data = _from_tsv(participants_tsv)
+    with open(participants_json_fpath, 'r', encoding='utf-8') as fin:
+        participants_json = json.load(fin)
+    assert 'subject_test_col1' in participants_json
+    assert data['age'][data['participant_id'].index('sub-01')] == '1'
+    assert data['subject_test_col1'][participant_idx] == 'S'
+    # in addition assert the original ordering of the new overwritten file
+    assert list(data.keys()) == orig_key_order
 
 
 def test_write_correct_inputs():
@@ -415,58 +465,8 @@ def test_fif(_bids_validate):
 
     # give the raw object some fake participant data (potentially overwriting)
     raw = _read_raw_fif(raw_fname)
-    raw.info['subject_info'] = {'his_id': subject_id2,
-                                'birthday': (1993, 1, 26), 'sex': 1, 'hand': 2}
     write_raw_bids(raw, bids_path, events_data=events,
                    event_id=event_id, overwrite=True)
-    # assert age of participant is correct
-    participants_tsv = op.join(bids_root, 'participants.tsv')
-    data = _from_tsv(participants_tsv)
-    assert data['age'][data['participant_id'].index('sub-01')] == '9'
-
-    # check to make sure participant data is overwritten, but keeps the fields
-    data = _from_tsv(participants_tsv)
-    participant_idx = data['participant_id'].index(f'sub-{subject_id}')
-    # create a new test column in participants file tsv
-    data['subject_test_col1'] = ['n/a'] * len(data['participant_id'])
-    data['subject_test_col1'][participant_idx] = 'S'
-    data['test_col2'] = ['n/a'] * len(data['participant_id'])
-    orig_key_order = list(data.keys())
-    _to_tsv(data, participants_tsv)
-    # crate corresponding json entry
-    participants_json_fpath = op.join(bids_root, 'participants.json')
-    json_field = {
-        'Description': 'trial-outcome',
-        'Levels': {
-            'S': 'success',
-            'F': 'failure'
-        }
-    }
-    _update_sidecar(participants_json_fpath, 'subject_test_col1', json_field)
-    # bids root should still be valid because json reflects changes in tsv
-    _bids_validate(bids_root)
-    write_raw_bids(raw, bids_path, overwrite=True)
-    data = _from_tsv(participants_tsv)
-    with open(participants_json_fpath, 'r', encoding='utf-8') as fin:
-        participants_json = json.load(fin)
-    assert 'subject_test_col1' in participants_json
-    assert data['age'][data['participant_id'].index('sub-01')] == '9'
-    assert data['subject_test_col1'][participant_idx] == 'S'
-    # in addition assert the original ordering of the new overwritten file
-    assert list(data.keys()) == orig_key_order
-
-    # if overwrite is False, then nothing should change from the above
-    with pytest.raises(FileExistsError, match='already exists'):
-        raw.info['subject_info'] = None
-        write_raw_bids(raw, bids_path, overwrite=False)
-    data = _from_tsv(participants_tsv)
-    with open(participants_json_fpath, 'r', encoding='utf-8') as fin:
-        participants_json = json.load(fin)
-    assert 'subject_test_col1' in participants_json
-    assert data['age'][data['participant_id'].index('sub-01')] == '9'
-    assert data['subject_test_col1'][participant_idx] == 'S'
-    # in addition assert the original ordering of the new overwritten file
-    assert list(data.keys()) == orig_key_order
 
     # try and write preloaded data
     raw = _read_raw_fif(raw_fname, preload=True)

--- a/mne_bids/tsv_handler.py
+++ b/mne_bids/tsv_handler.py
@@ -24,8 +24,10 @@ def _combine_rows(data1, data2, drop_column=None):
         The new combined data.
     """
     data = deepcopy(data1)
+    # next extend the values in data1 with values in data2
     for key, value in data2.items():
         data[key].extend(value)
+
     # Make sure that if there are any columns in data1 that didn't get new
     # data they are populated with "n/a"'s.
     for key in set(data1.keys()) - set(data2.keys()):
@@ -68,7 +70,11 @@ def _contains_row(data, row_data):
     """
     mask = None
     for key, row_value in row_data.items():
-        data_value = np.array(data[key])
+        data_value = np.array(data.get(key))
+
+        # if any of the columns don't even exist, return False
+        if data_value is None:
+            return False
 
         # Cast row_value to the same dtype as data_value to avoid a NumPy
         # FutureWarning, see

--- a/mne_bids/tsv_handler.py
+++ b/mne_bids/tsv_handler.py
@@ -70,11 +70,9 @@ def _contains_row(data, row_data):
     """
     mask = None
     for key, row_value in row_data.items():
+        # if any of the columns don't even exist in the keys
+        # this data_value will return False
         data_value = np.array(data.get(key))
-
-        # if any of the columns don't even exist, return False
-        if data_value is None:
-            return False
 
         # Cast row_value to the same dtype as data_value to avoid a NumPy
         # FutureWarning, see

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -310,7 +310,6 @@ def _participants_tsv(raw, subject_id, fname, overwrite=False,
             raise FileExistsError(f'"{subject_id}" already exists in '  # noqa: E501 F821
                                   f'the participant list. Please set '
                                   f'overwrite to True.')
-        col_name = 'participant_id'
 
         # Append any columns the original data did not have
         # that mne-bids is trying to write. This handles
@@ -326,6 +325,7 @@ def _participants_tsv(raw, subject_id, fname, overwrite=False,
         # Append any additional columns that original data had.
         # Keep the original order of the data by looping over
         # the original OrderedDict keys
+        col_name = 'participant_id'
         for key in orig_data.keys():
             if key in data:
                 continue

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -310,11 +310,22 @@ def _participants_tsv(raw, subject_id, fname, overwrite=False,
             raise FileExistsError(f'"{subject_id}" already exists in '  # noqa: E501 F821
                                   f'the participant list. Please set '
                                   f'overwrite to True.')
+        col_name = 'participant_id'
+
+        # Append any columns the original data did not have
+        # that mne-bids is trying to write. This handles
+        # the edge case where users write participants data for
+        # a subset of `hand`, `age` and `sex`.
+        for key in data.keys():
+            if key in orig_data:
+                continue
+
+            # add 'n/a' if any missing columns
+            orig_data[key] = ['n/a'] * len(next(iter(data.values())))
 
         # Append any additional columns that original data had.
         # Keep the original order of the data by looping over
         # the original OrderedDict keys
-        col_name = 'participant_id'
         for key in orig_data.keys():
             if key in data:
                 continue


### PR DESCRIPTION
PR Description
--------------

Closes: #623 

Had some time off :).

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
