### PR TITLE
[MRG, BUG] Fix deface when images are not in the same space as T1 (e.g. T2)

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -29,6 +29,7 @@ Authors
 * `Richard Höchenberger`_
 * `Alexandre Gramfort`_
 * `Austin Hurst`_
+* `Alex Rockhill`_
 
 Detailed list of changes
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -60,6 +61,7 @@ Bug fixes
 - Ensure sidecar files (`.tsv` and `.json`) are always read and written in UTF-8, by `Richard Höchenberger`_ (:gh:`625`)
 - Fix a bug where ``participants.tsv`` was not being appended to correctly when it contained a subset of ``hand``, ``age`` and ``sex``, by `Adam Li`_ (:gh:`648`)
 - :func:`mne_bids.copyfiles.copyfile_eeglab` didn't handle certain EEGLAB files correctly, by `Richard Höchenberger`_ (:gh:`653`)
+- Fix bug where images with different orientations than the T1 used to define the landmarks were defaced improperly, by `Alex Rockhill`_ (:gh:`651`)
 
 API changes
 ^^^^^^^^^^^

--- a/examples/convert_mri_and_trans.py
+++ b/examples/convert_mri_and_trans.py
@@ -206,6 +206,27 @@ plot_anat(t1_nii_fname, axes=ax, title='Defaced')
 plt.show()
 
 ###############################################################################
+# We can also deface the FLASH.
+flash_bids_path = write_anat(
+    image=flash_mgh_fname,  # path to the MRI scan
+    bids_path=flash_bids_path,
+    raw=raw,  # the raw MEG data file connected to the MRI
+    trans=trans,  # our transformation matrix
+    deface=True,
+    overwrite=True,
+    verbose=True  # this will print out the sidecar file
+)
+anat_dir = flash_bids_path.directory
+
+# Our MRI written to BIDS, we got `anat_dir` from our `write_anat` function
+flash_nii_fname = op.join(anat_dir, 'sub-01_ses-01_FLASH.nii.gz')
+
+# Plot it
+fig, ax = plt.subplots()
+plot_anat(flash_nii_fname, axes=ax, title='Defaced')
+plt.show()
+
+###############################################################################
 # .. LINKS
 #
 # .. _coregistration GUI:

--- a/examples/convert_mri_and_trans.py
+++ b/examples/convert_mri_and_trans.py
@@ -211,7 +211,7 @@ plt.show()
 # digitization points, the points are relative to the T1-defined coordinate
 # system (called surface or TkReg RAS). Thus, you can either pass the T1
 # as `t1w` or use your favorite 3D image viewer (e.g. freeview) to find the
-# fiducials in FLASH voxel space.
+# fiducials in FLASH voxel space or scanner RAS coordinates.
 
 # first option: pass the T1 as an argument
 flash_bids_path = write_anat(
@@ -249,6 +249,34 @@ landmarks = mne.channels.make_dig_montage(
     nasion=flash_voxel_landmarks[1],
     rpa=flash_voxel_landmarks[2],
     coord_frame='mri_voxel'
+)
+flash_bids_path = write_anat(
+    image=flash_mgh_fname,  # path to the MRI scan
+    bids_path=flash_bids_path,
+    landmarks=landmarks,
+    deface=True,
+    overwrite=True,
+    verbose=True  # this will print out the sidecar file
+)
+
+# Plot it
+fig, ax = plt.subplots()
+plot_anat(flash_nii_fname, axes=ax, title='Defaced', vmax=800)
+plt.show()
+
+# third option: pass FLASH scanner RAS coordinates
+# find with 3D image viewer (e.g. freeview)
+# Note that, in freeview, this is "RAS" and not "TkReg RAS"
+flash_ras_landmarks = \
+    np.array([[-74.53102838, 19.62854953, -52.2888194],
+              [-1.89454315, 103.69850925, 4.97120376],
+              [72.01200673, 21.09274883, -57.53678375]])
+
+landmarks = mne.channels.make_dig_montage(
+    lpa=flash_ras_landmarks[0],
+    nasion=flash_ras_landmarks[1],
+    rpa=flash_ras_landmarks[2],
+    coord_frame='ras'
 )
 flash_bids_path = write_anat(
     image=flash_mgh_fname,  # path to the MRI scan

--- a/examples/convert_mri_and_trans.py
+++ b/examples/convert_mri_and_trans.py
@@ -258,7 +258,7 @@ plt.show()
 # Option 2 : Use manual landmarks coordinates in scanner RAS for FLASH image
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 #
-# find with 3D image viewer (e.g. freeview)
+# You can find such landmarks with a 3D image viewer (e.g. freeview).
 # Note that, in freeview, this is called "RAS" and not "TkReg RAS"
 flash_ras_landmarks = \
     np.array([[-74.53102838, 19.62854953, -52.2888194],

--- a/examples/convert_mri_and_trans.py
+++ b/examples/convert_mri_and_trans.py
@@ -332,7 +332,7 @@ plt.show()
 # Let's now pass it in voxel coordinates
 flash_mri_hdr = nib.load(flash_mgh_fname).header
 flash_vox_pos = mne.transforms.apply_trans(
-    flash_mri_hdr.get_ras2vox(), ras_pos)
+    flash_mri_hdr.get_ras2vox(), ras_pos * 1e3)
 
 montage_flash_vox = mne.channels.make_dig_montage(
     lpa=flash_vox_pos[0],

--- a/examples/convert_mri_and_trans.py
+++ b/examples/convert_mri_and_trans.py
@@ -263,7 +263,7 @@ plt.show()
 flash_ras_landmarks = \
     np.array([[-74.53102838, 19.62854953, -52.2888194],
               [-1.89454315, 103.69850925, 4.97120376],
-              [72.01200673, 21.09274883, -57.53678375]])
+              [72.01200673, 21.09274883, -57.53678375]]) / 1e3  # mm -> m
 
 landmarks = mne.channels.make_dig_montage(
     lpa=flash_ras_landmarks[0],
@@ -304,7 +304,7 @@ head_pos = np.asarray((raw.info['dig'][0]['r'],
 ras_pos = head_to_mri(pos=head_pos,
                       subject='sample',
                       mri_head_t=trans,
-                      subjects_dir=op.join(data_path, 'subjects'))
+                      subjects_dir=op.join(data_path, 'subjects')) / 1e3
 
 montage_ras = mne.channels.make_dig_montage(
     lpa=ras_pos[0],

--- a/examples/convert_mri_and_trans.py
+++ b/examples/convert_mri_and_trans.py
@@ -211,7 +211,7 @@ flash_bids_path = write_anat(
     bids_path=flash_bids_path,
     raw=raw,  # the raw MEG data file connected to the MRI
     trans=trans,  # our transformation matrix
-    deface=dict(inset=5),  # adjust due to obliquity of image
+    deface=dict(inset=5, theta=25),  # adjust due to obliquity of image
     overwrite=True,
     verbose=True  # this will print out the sidecar file
 )

--- a/examples/convert_mri_and_trans.py
+++ b/examples/convert_mri_and_trans.py
@@ -293,7 +293,7 @@ plt.show()
 flash_bids_path = write_anat(
     image=flash_mgh_fname,  # path to the MRI scan
     bids_path=flash_bids_path,
-    landmarks=montage_t1_vox,
+    landmarks=montage_flash_vox,
     deface=True,
     overwrite=True,
     verbose=True  # this will print out the sidecar file

--- a/examples/convert_mri_and_trans.py
+++ b/examples/convert_mri_and_trans.py
@@ -118,6 +118,7 @@ t1w_bids_path = \
 t1w_bids_path = write_anat(
     image=t1_mgh_fname,  # path to the MRI scan
     bids_path=t1w_bids_path,
+    t1w=t1_mgh_fname,  # will be found with default 'auto' as well
     raw=raw,  # the raw MEG data file connected to the MRI
     trans=trans,  # our transformation matrix
     verbose=True  # this will print out the sidecar file
@@ -188,6 +189,7 @@ write_anat(
 t1w_bids_path = write_anat(
     image=t1_mgh_fname,  # path to the MRI scan
     bids_path=bids_path,
+    t1w=t1_mgh_fname,  # will be found with default 'auto' as well
     raw=raw,  # the raw MEG data file connected to the MRI
     trans=trans,  # our transformation matrix
     deface=True,
@@ -209,7 +211,8 @@ plt.show()
 flash_bids_path = write_anat(
     image=flash_mgh_fname,  # path to the MRI scan
     bids_path=flash_bids_path,
-    t1w=t1_mgh_fname,
+    t1w=t1_mgh_fname,  # need the freesurfer recon T1
+                       # because the FLASH isn't in the same space
     raw=raw,  # the raw MEG data file connected to the MRI
     trans=trans,  # our transformation matrix
     deface=True,

--- a/examples/convert_mri_and_trans.py
+++ b/examples/convert_mri_and_trans.py
@@ -180,7 +180,6 @@ flash_bids_path = \
 write_anat(
     image=flash_mgh_fname,
     bids_path=flash_bids_path,
-    raw=raw,
     verbose=True
 )
 
@@ -212,7 +211,7 @@ flash_bids_path = write_anat(
     bids_path=flash_bids_path,
     raw=raw,  # the raw MEG data file connected to the MRI
     trans=trans,  # our transformation matrix
-    deface=True,
+    deface=dict(inset=10),  # adjust due to obliquity of image
     overwrite=True,
     verbose=True  # this will print out the sidecar file
 )

--- a/examples/convert_mri_and_trans.py
+++ b/examples/convert_mri_and_trans.py
@@ -209,6 +209,7 @@ plt.show()
 flash_bids_path = write_anat(
     image=flash_mgh_fname,  # path to the MRI scan
     bids_path=flash_bids_path,
+    t1w=t1_mgh_fname,
     raw=raw,  # the raw MEG data file connected to the MRI
     trans=trans,  # our transformation matrix
     deface=True,

--- a/examples/convert_mri_and_trans.py
+++ b/examples/convert_mri_and_trans.py
@@ -211,7 +211,7 @@ flash_bids_path = write_anat(
     bids_path=flash_bids_path,
     raw=raw,  # the raw MEG data file connected to the MRI
     trans=trans,  # our transformation matrix
-    deface=dict(inset=0),  # adjust due to obliquity of image
+    deface=dict(inset=5),  # adjust due to obliquity of image
     overwrite=True,
     verbose=True  # this will print out the sidecar file
 )

--- a/examples/convert_mri_and_trans.py
+++ b/examples/convert_mri_and_trans.py
@@ -210,11 +210,35 @@ plt.show()
 # coordinates than the T1. Since, in the example dataset, we used the head
 # surface (which was reconstructed by freesurfer from the T1) to align the
 # digitization points, the points are relative to the T1-defined coordinate
-# system (called surface or TkReg RAS). Thus, you can either find the
-# fiducials in FLASH voxel space or scanner RAS coordinates using your
-# favorite 3D image view (e.g. freeview) or by applying the `trans`.
+# system (called surface or TkReg RAS). Thus, you can you can provide the T1
+# or you can find the fiducials in FLASH voxel space or scanner RAS coordinates
+# using your favorite 3D image view (e.g. freeview), or you can also read the
+# fiducial coordinates from the `raw` and apply the `trans` yourself.
 
-# pass FLASH scanner RAS coordinates
+###############################################################################
+# Pass `t1w` with `raw` and `trans`
+flash_bids_path = write_anat(
+    image=flash_mgh_fname,  # path to the MRI scan
+    bids_path=flash_bids_path,
+    raw=raw,
+    trans=trans,
+    t1w=t1_mgh_fname,
+    deface=True,
+    overwrite=True,
+    verbose=True  # this will print out the sidecar file
+)
+
+# Our MRI written to BIDS, we got `anat_dir` from our `write_anat` function
+flash_nii_fname = op.join(anat_dir, 'sub-01_ses-01_FLASH.nii.gz')
+
+# Plot it
+fig, ax = plt.subplots()
+plot_anat(flash_nii_fname, axes=ax, title='Defaced', vmax=800)
+plt.show()
+
+###############################################################################
+# Pass FLASH scanner RAS coordinates
+
 # find with 3D image viewer (e.g. freeview)
 # Note that, in freeview, this is "RAS" and not "TkReg RAS"
 flash_ras_landmarks = \
@@ -237,13 +261,14 @@ flash_bids_path = write_anat(
     overwrite=True,
     verbose=True  # this will print out the sidecar file
 )
-# Our MRI written to BIDS, we got `anat_dir` from our `write_anat` function
-flash_nii_fname = op.join(anat_dir, 'sub-01_ses-01_FLASH.nii.gz')
 
 # Plot it
 fig, ax = plt.subplots()
 plot_anat(flash_nii_fname, axes=ax, title='Defaced', vmax=800)
 plt.show()
+
+###############################################################################
+# Extract the landmarks in scanner RAS or mri voxel space yourself
 
 # Get Landmarks from MEG file, 0, 1, and 2 correspond to LPA, NAS, RPA
 # and the 'r' key will provide us with the xyz coordinates

--- a/examples/convert_mri_and_trans.py
+++ b/examples/convert_mri_and_trans.py
@@ -211,7 +211,7 @@ flash_bids_path = write_anat(
     bids_path=flash_bids_path,
     raw=raw,  # the raw MEG data file connected to the MRI
     trans=trans,  # our transformation matrix
-    deface=dict(inset=5),  # adjust due to obliquity of image
+    deface=dict(inset=0),  # adjust due to obliquity of image
     overwrite=True,
     verbose=True  # this will print out the sidecar file
 )

--- a/examples/convert_mri_and_trans.py
+++ b/examples/convert_mri_and_trans.py
@@ -211,7 +211,7 @@ flash_bids_path = write_anat(
     bids_path=flash_bids_path,
     raw=raw,  # the raw MEG data file connected to the MRI
     trans=trans,  # our transformation matrix
-    deface=dict(inset=10),  # adjust due to obliquity of image
+    deface=dict(inset=5),  # adjust due to obliquity of image
     overwrite=True,
     verbose=True  # this will print out the sidecar file
 )
@@ -222,7 +222,7 @@ flash_nii_fname = op.join(anat_dir, 'sub-01_ses-01_FLASH.nii.gz')
 
 # Plot it
 fig, ax = plt.subplots()
-plot_anat(flash_nii_fname, axes=ax, title='Defaced')
+plot_anat(flash_nii_fname, axes=ax, title='Defaced', vmax=800)
 plt.show()
 
 ###############################################################################

--- a/examples/convert_mri_and_trans.py
+++ b/examples/convert_mri_and_trans.py
@@ -211,7 +211,7 @@ flash_bids_path = write_anat(
     bids_path=flash_bids_path,
     raw=raw,  # the raw MEG data file connected to the MRI
     trans=trans,  # our transformation matrix
-    deface=dict(inset=5, theta=25),  # adjust due to obliquity of image
+    deface=True,
     overwrite=True,
     verbose=True  # this will print out the sidecar file
 )

--- a/mne_bids/tests/test_copyfiles.py
+++ b/mne_bids/tests/test_copyfiles.py
@@ -80,7 +80,8 @@ def test_get_brainvision_paths():
     assert tail == 'test.vmrk'
 
 
-@pytest.mark.filterwarnings('ignore:.*:PytestUnraisableExceptionWarning')
+@pytest.mark.filterwarnings('ignore:.*Exception ignored.*:'
+                            'PytestUnraisableExceptionWarning')
 def test_copyfile_brainvision():
     """Test the copying of BrainVision vhdr, vmrk and eeg files."""
     bids_root = _TempDir()

--- a/mne_bids/tests/test_copyfiles.py
+++ b/mne_bids/tests/test_copyfiles.py
@@ -80,6 +80,7 @@ def test_get_brainvision_paths():
     assert tail == 'test.vmrk'
 
 
+@pytest.mark.filterwarnings('ignore:pytest.PytestUnraisableExceptionWarning:*')
 def test_copyfile_brainvision():
     """Test the copying of BrainVision vhdr, vmrk and eeg files."""
     bids_root = _TempDir()

--- a/mne_bids/tests/test_copyfiles.py
+++ b/mne_bids/tests/test_copyfiles.py
@@ -80,7 +80,7 @@ def test_get_brainvision_paths():
     assert tail == 'test.vmrk'
 
 
-@pytest.mark.filterwarnings('ignore:pytest.PytestUnraisableExceptionWarning:*')
+@pytest.mark.filterwarnings('ignore:.*:PytestUnraisableExceptionWarning')
 def test_copyfile_brainvision():
     """Test the copying of BrainVision vhdr, vmrk and eeg files."""
     bids_root = _TempDir()

--- a/mne_bids/tests/test_copyfiles.py
+++ b/mne_bids/tests/test_copyfiles.py
@@ -81,7 +81,7 @@ def test_get_brainvision_paths():
 
 
 @pytest.mark.filterwarnings('ignore:.*Exception ignored.*:'
-                            'PytestUnraisableExceptionWarning')
+                            'pytest.PytestUnraisableExceptionWarning')
 def test_copyfile_brainvision():
     """Test the copying of BrainVision vhdr, vmrk and eeg files."""
     bids_root = _TempDir()

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -228,7 +228,7 @@ def test_get_head_mri_trans():
 
     t1w_bidspath = BIDSPath(subject=subject_id, session=session_id,
                             acquisition=acq, root=bids_root)
-    t1w_bidspath = write_anat(t1w_mgh, bids_path=t1w_bidspath, t1w=t1w_mgh,
+    t1w_bidspath = write_anat(t1w_mgh, bids_path=t1w_bidspath,
                               raw=raw, trans=trans, verbose=True)
     anat_dir = t1w_bidspath.directory
 
@@ -245,7 +245,7 @@ def test_get_head_mri_trans():
     with pytest.raises(RuntimeError, match='AnatomicalLandmarkCoordinates'):
         raw.info['dig'][0]['r'] = np.ones(3) * np.nan
         sh.rmtree(anat_dir)
-        bids_path = write_anat(t1w_mgh, bids_path=t1w_bidspath, t1w=t1w_mgh,
+        bids_path = write_anat(t1w_mgh, bids_path=t1w_bidspath,
                                raw=raw, trans=trans, verbose=True)
         estimated_trans = get_head_mri_trans(bids_path=bids_path)
 
@@ -581,7 +581,7 @@ def test_get_head_mri_trans_ctf(fname):
 
     t1w_bids_path = BIDSPath(subject=subject_id, session=session_id,
                              acquisition=acq, root=bids_root)
-    write_anat(t1w_mgh, bids_path=t1w_bids_path, t1w=t1w_mgh,
+    write_anat(t1w_mgh, bids_path=t1w_bids_path,
                raw=raw_ctf, trans=trans)
 
     # Try to get trans back through fitting points

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -228,7 +228,7 @@ def test_get_head_mri_trans():
 
     t1w_bidspath = BIDSPath(subject=subject_id, session=session_id,
                             acquisition=acq, root=bids_root)
-    t1w_bidspath = write_anat(t1w_mgh, bids_path=t1w_bidspath,
+    t1w_bidspath = write_anat(t1w_mgh, bids_path=t1w_bidspath, t1w=t1w_mgh,
                               raw=raw, trans=trans, verbose=True)
     anat_dir = t1w_bidspath.directory
 
@@ -245,8 +245,8 @@ def test_get_head_mri_trans():
     with pytest.raises(RuntimeError, match='AnatomicalLandmarkCoordinates'):
         raw.info['dig'][0]['r'] = np.ones(3) * np.nan
         sh.rmtree(anat_dir)
-        bids_path = write_anat(t1w_mgh, bids_path=t1w_bidspath, raw=raw,
-                               trans=trans, verbose=True)
+        bids_path = write_anat(t1w_mgh, bids_path=t1w_bidspath, t1w=t1w_mgh,
+                               raw=raw, trans=trans, verbose=True)
         estimated_trans = get_head_mri_trans(bids_path=bids_path)
 
 
@@ -581,7 +581,7 @@ def test_get_head_mri_trans_ctf(fname):
 
     t1w_bids_path = BIDSPath(subject=subject_id, session=session_id,
                              acquisition=acq, root=bids_root)
-    write_anat(t1w_mgh, bids_path=t1w_bids_path,
+    write_anat(t1w_mgh, bids_path=t1w_bids_path, t1w=t1w_mgh,
                raw=raw_ctf, trans=trans)
 
     # Try to get trans back through fitting points

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -1544,9 +1544,9 @@ def test_write_anat(_bids_validate):
         coord_frame='head')
 
     mri_scanner_ras_landmarks = mne.channels.make_dig_montage(
-        lpa=np.array([-74.53101434, 19.62855196, -52.28881913]),
-        nasion=np.array([-1.89452708, 103.69850393, 4.97122087]),
-        rpa=np.array([72.01202598, 21.09274957, -57.53678129]),
+        lpa=np.array([-0.07453101, 0.01962855, -0.05228882]),
+        nasion=np.array([-0.00189453, 0.1036985, 0.00497122]),
+        rpa=np.array([0.07201203, 0.02109275, -0.05753678]),
         coord_frame='ras')
 
     # test meg landmarks

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -1371,7 +1371,7 @@ def test_write_anat(_bids_validate):
 
     bids_path = BIDSPath(subject=subject_id, session=session_id,
                          acquisition=acq, root=bids_root)
-    bids_path = write_anat(t1w_mgh, bids_path=bids_path, t1w=t1w_mgh,
+    bids_path = write_anat(t1w_mgh, bids_path=bids_path,
                            raw=raw, trans=trans, deface=True, verbose=True,
                            overwrite=True)
     anat_dir = bids_path.directory
@@ -1409,7 +1409,7 @@ def test_write_anat(_bids_validate):
     # Now try some anat writing that will fail
     # We already have some MRI data there
     with pytest.raises(IOError, match='`overwrite` is set to False'):
-        write_anat(t1w_mgh, bids_path=bids_path, t1w=t1w_mgh,
+        write_anat(t1w_mgh, bids_path=bids_path,
                    raw=raw, trans=trans, verbose=True, deface=False,
                    overwrite=False)
 
@@ -1420,7 +1420,7 @@ def test_write_anat(_bids_validate):
 
     # pass some invalid type as T1 MRI
     with pytest.raises(ValueError, match='must be a path to an MRI'):
-        write_anat(9999999999999, bids_path=bids_path, t1w=t1w_mgh, raw=raw,
+        write_anat(9999999999999, bids_path=bids_path, raw=raw,
                    trans=trans, verbose=True, deface=False, overwrite=True)
 
     with pytest.warns(RuntimeWarning, match='Ignoring `raw`'):
@@ -1441,7 +1441,7 @@ def test_write_anat(_bids_validate):
     ex = TypeError
 
     with pytest.raises(ex, match=match):
-        write_anat(t1w_mgh, bids_path=bids_path, t1w=t1w_mgh, raw=raw,
+        write_anat(t1w_mgh, bids_path=bids_path, raw=raw,
                    trans=wrong_type, verbose=True, deface=False,
                    overwrite=True)
 
@@ -1449,11 +1449,11 @@ def test_write_anat(_bids_validate):
     wrong_fname = 'not_a_trans'
     match = 'trans file "{}" not found'.format(wrong_fname)
     with pytest.raises(IOError, match=match):
-        write_anat(t1w_mgh, bids_path=bids_path, t1w=t1w_mgh, raw=raw,
+        write_anat(t1w_mgh, bids_path=bids_path, raw=raw,
                    trans=wrong_fname, verbose=True, overwrite=True)
 
     # However, reading trans if it is a string pointing to trans is fine
-    write_anat(t1w_mgh, bids_path=bids_path, t1w=t1w_mgh, raw=raw,
+    write_anat(t1w_mgh, bids_path=bids_path, raw=raw,
                trans=trans_fname, verbose=True, deface=False,
                overwrite=True)
 
@@ -1467,18 +1467,18 @@ def test_write_anat(_bids_validate):
     # specify trans but not raw
     with pytest.raises(ValueError, match='must be specified if `trans`'):
         bids_path.update(session=session_id)
-        write_anat(t1w_mgh, bids_path=bids_path, t1w=t1w_mgh, raw=None,
+        write_anat(t1w_mgh, bids_path=bids_path, raw=None,
                    trans=trans, verbose=True, deface=False, overwrite=True)
 
     # test deface
-    bids_path = write_anat(t1w_mgh, bids_path=bids_path, t1w=t1w_mgh,
+    bids_path = write_anat(t1w_mgh, bids_path=bids_path,
                            raw=raw, trans=trans_fname,
                            verbose=True, deface=True, overwrite=True)
     anat_dir = bids_path.directory
     t1w = nib.load(op.join(anat_dir, 'sub-01_ses-01_T1w.nii.gz'))
     vox_sum = t1w.get_fdata().sum()
 
-    bids_path = write_anat(t1w_mgh, bids_path=bids_path, t1w=t1w_mgh,
+    bids_path = write_anat(t1w_mgh, bids_path=bids_path,
                            raw=raw, trans=trans_fname,
                            verbose=True, deface=dict(inset=25.),
                            overwrite=True)
@@ -1488,7 +1488,7 @@ def test_write_anat(_bids_validate):
 
     assert vox_sum > vox_sum2
 
-    bids_path = write_anat(t1w_mgh, bids_path=bids_path, t1w=t1w_mgh,
+    bids_path = write_anat(t1w_mgh, bids_path=bids_path,
                            raw=raw, trans=trans_fname,
                            verbose=True, deface=dict(theta=45),
                            overwrite=True)
@@ -1500,37 +1500,32 @@ def test_write_anat(_bids_validate):
 
     flash_mgh = \
         op.join(data_path, 'subjects', 'sample', 'mri', 'flash', 'mef05.mgz')
-    with pytest.raises(ValueError, match='did not contain "T1"'):
-        write_anat(flash_mgh, bids_path=bids_path, raw=raw,
-                   trans=trans, verbose=True, deface=True, overwrite=True)
+    bids_path.update(suffix='FLASH')
+    with pytest.raises(ValueError, match='`trans` only applies to the T1'):
+        write_anat(flash_mgh, bids_path=bids_path, raw=raw, trans=trans,
+                   deface=True, verbose=True, overwrite=True)
 
-    flash_img = nib.load(flash_mgh)
-    with pytest.raises(ValueError, match='did not contain "T1"'):
-        write_anat(flash_img, bids_path=bids_path, raw=raw,
-                   trans=trans, verbose=True, deface=True, overwrite=True)
-
+    bids_path.update(suffix='T1w')
     with pytest.raises(ValueError, match='must be provided to deface'):
-        write_anat(t1w_mgh, bids_path=bids_path, t1w=t1w_mgh,
+        write_anat(t1w_mgh, bids_path=bids_path,
                    verbose=True, deface=True, overwrite=True)
 
     with pytest.raises(ValueError, match='inset must be numeric'):
-        write_anat(t1w_mgh, bids_path=bids_path, t1w=t1w_mgh, raw=raw,
-                   trans=trans, verbose=True, deface=dict(inset='small'),
-                   overwrite=True)
+        write_anat(t1w_mgh, bids_path=bids_path, raw=raw, trans=trans,
+                   deface=dict(inset='small'), verbose=True, overwrite=True)
 
     with pytest.raises(ValueError, match='inset should be positive'):
-        write_anat(t1w_mgh, bids_path=bids_path, t1w=t1w_mgh, raw=raw,
+        write_anat(t1w_mgh, bids_path=bids_path, raw=raw,
                    trans=trans, verbose=True, deface=dict(inset=-2.),
                    overwrite=True)
 
     with pytest.raises(ValueError, match='theta must be numeric'):
-        write_anat(t1w_mgh, bids_path=bids_path, t1w=t1w_mgh, raw=raw,
+        write_anat(t1w_mgh, bids_path=bids_path, raw=raw,
                    trans=trans, verbose=True, deface=dict(theta='big'),
                    overwrite=True)
 
-    with pytest.raises(ValueError,
-                       match='theta should be between 0 and 90 degrees'):
-        write_anat(t1w_mgh, bids_path=bids_path, t1w=t1w_mgh, raw=raw,
+    with pytest.raises(ValueError, match='theta should be between 0 and 90'):
+        write_anat(t1w_mgh, bids_path=bids_path, raw=raw,
                    trans=trans, verbose=True, deface=dict(theta=100),
                    overwrite=True)
 
@@ -1561,7 +1556,7 @@ def test_write_anat(_bids_validate):
 
     # test mri voxel landmarks
     bids_path.update(acquisition=acq)
-    bids_path = write_anat(t1w_mgh, bids_path=bids_path, t1w=t1w_mgh,
+    bids_path = write_anat(t1w_mgh, bids_path=bids_path,
                            deface=True, landmarks=mri_voxel_landmarks,
                            verbose=True, overwrite=True)
     anat_dir = bids_path.directory
@@ -1571,7 +1566,7 @@ def test_write_anat(_bids_validate):
     vox1 = t1w1.get_fdata()
 
     # test mri landmarks
-    bids_path = write_anat(t1w_mgh, bids_path=bids_path, t1w=t1w_mgh,
+    bids_path = write_anat(t1w_mgh, bids_path=bids_path,
                            deface=True, landmarks=mri_landmarks,
                            verbose=True, overwrite=True)
     anat_dir = bids_path.directory
@@ -1586,7 +1581,7 @@ def test_write_anat(_bids_validate):
 
     # crash for raw also
     with pytest.raises(ValueError, match='Please use either `landmarks`'):
-        write_anat(t1w_mgh, bids_path=bids_path, t1w=t1w_mgh, raw=raw,
+        write_anat(t1w_mgh, bids_path=bids_path, raw=raw,
                    trans=trans, deface=True, landmarks=mri_landmarks,
                    verbose=True, overwrite=True)
 
@@ -1594,14 +1589,14 @@ def test_write_anat(_bids_validate):
     for landmarks in (mri_landmarks, mri_voxel_landmarks,
                       mri_scanner_ras_landmarks):
         with pytest.raises(ValueError, match='`trans` was provided'):
-            write_anat(t1w_mgh, bids_path=bids_path, t1w=t1w_mgh, trans=trans,
+            write_anat(t1w_mgh, bids_path=bids_path, trans=trans,
                        deface=True, landmarks=landmarks, verbose=True,
                        overwrite=True)
 
     # test meg landmarks
     tmp_dir = _TempDir()
     meg_landmarks.save(op.join(tmp_dir, 'meg_landmarks.fif'))
-    bids_path = write_anat(t1w_mgh, bids_path=bids_path, t1w=t1w_mgh,
+    bids_path = write_anat(t1w_mgh, bids_path=bids_path,
                            deface=True, trans=trans,
                            landmarks=op.join(tmp_dir, 'meg_landmarks.fif'),
                            verbose=True, overwrite=True)
@@ -1615,7 +1610,7 @@ def test_write_anat(_bids_validate):
 
     # test mri scanner ras landmarks
     bids_path = write_anat(
-        t1w_mgh, bids_path=bids_path, t1w=t1w_mgh, deface=True,
+        t1w_mgh, bids_path=bids_path, deface=True,
         landmarks=mri_scanner_ras_landmarks, verbose=True, overwrite=True)
     anat_dir = bids_path.directory
     _bids_validate(bids_root)
@@ -1627,7 +1622,7 @@ def test_write_anat(_bids_validate):
 
     # test raise error on meg_landmarks with no trans
     with pytest.raises(ValueError, match='Head space landmarks provided'):
-        write_anat(t1w_mgh, bids_path=bids_path, t1w=t1w_mgh, deface=True,
+        write_anat(t1w_mgh, bids_path=bids_path, deface=True,
                    landmarks=meg_landmarks, verbose=True, overwrite=True)
 
     # test unsupported (any coord_frame other than head and mri) coord_frame
@@ -1637,16 +1632,20 @@ def test_write_anat(_bids_validate):
     fail_landmarks.dig[2]['coord_frame'] = 3
 
     with pytest.raises(ValueError, match='Coordinate frame not recognized'):
-        write_anat(t1w_mgh, bids_path=bids_path, t1w=t1w_mgh, deface=True,
+        write_anat(t1w_mgh, bids_path=bids_path, deface=True,
                    landmarks=fail_landmarks, verbose=True, overwrite=True)
 
     bids_path = BIDSPath(subject=subject_id, session=session_id,
                          suffix='FLASH', root=bids_root)
     write_anat(flash_mgh, bids_path=bids_path, overwrite=True)
-    write_anat(flash_mgh, bids_path=bids_path, t1w=t1w_mgh,
-               raw=raw, trans=trans, overwrite=True)
+    write_anat(flash_mgh, bids_path=bids_path,
+               landmarks=mri_scanner_ras_landmarks, overwrite=True)
     assert op.exists(op.join(anat_dir, 'sub-01_ses-01_FLASH.nii.gz'))
     _bids_validate(bids_root)
+
+    with pytest.raises(ValueError, match='must be passed in `mri_voxel`'):
+        write_anat(flash_mgh, bids_path=bids_path,
+                   landmarks=mri_landmarks, overwrite=True)
 
 
 def test_write_raw_pathlike():
@@ -1704,8 +1703,7 @@ def test_write_anat_pathlike():
     t1w_mgh_fname = Path(data_path) / 'subjects' / 'sample' / 'mri' / 'T1.mgz'
     bids_path = BIDSPath(subject=subject_id, session=session_id,
                          acquisition=acq, root=bids_root)
-    bids_path = write_anat(t1w_mgh_fname, bids_path=bids_path,
-                           t1w=t1w_mgh_fname, raw=raw,
+    bids_path = write_anat(t1w_mgh_fname, bids_path=bids_path, raw=raw,
                            trans=trans, deface=True, verbose=True,
                            overwrite=True)
 

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -1531,11 +1531,10 @@ def test_write_anat(_bids_validate):
         rpa=[17.23812, 53.08294, 47.01789],
         coord_frame='mri_voxel')
 
-    s = 1e3  # as it shoult be in meters
     mri_landmarks = mne.channels.make_dig_montage(
-        lpa=np.array([-69.26, 10.59, -25.00]) / s,
-        nasion=np.array([-1.89452708, 103.69850393, 4.97122087]) / s,
-        rpa=np.array([77.29, 12.05, -30.25]) / s,
+        lpa=[-0.06925741, 0.01058946, -0.02500086],
+        nasion=[0.00337909, 0.09465943, 0.03225916],
+        rpa=[0.07728562, 0.01205367, -0.03024882],
         coord_frame='mri')
 
     meg_landmarks = mne.channels.make_dig_montage(
@@ -1544,11 +1543,10 @@ def test_write_anat(_bids_validate):
         rpa=[7.52676800e-02, 0.00000000e+00, 5.58793545e-09],
         coord_frame='head')
 
-    s = 1  # XXX to me it should 1e3 as it shoult be in meters
     mri_scanner_ras_landmarks = mne.channels.make_dig_montage(
-        lpa=np.array([-74.53101434, 19.62855196, -52.28881913]) / s,
-        nasion=np.array([-1.89452708, 103.69850393, 4.97122087]) / s,
-        rpa=np.array([72.01202598, 21.09274957, -57.53678129]) / s,
+        lpa=np.array([-74.53101434, 19.62855196, -52.28881913]),
+        nasion=np.array([-1.89452708, 103.69850393, 4.97122087]),
+        rpa=np.array([72.01202598, 21.09274957, -57.53678129]),
         coord_frame='ras')
 
     # test meg landmarks
@@ -1566,17 +1564,13 @@ def test_write_anat(_bids_validate):
                       mri_scanner_ras_landmarks,
                       meg_landmarks_fif]:
 
-        this_trans = None
-        in_head = False
-        if (isinstance(landmarks, str) or
-                landmarks.dig[0]['coord_frame'] == 4):
-            # Trans is required if landmarks are in head
-            this_trans = trans
-            in_head = True
+        in_head = True if isinstance(landmarks, str) else \
+            landmarks.dig[0]['coord_frame'] == FIFF.FIFFV_COORD_HEAD
 
+        # Trans is required if landmarks are in head
         bids_path = write_anat(t1w_mgh, bids_path=bids_path,
                                deface=True, landmarks=landmarks,
-                               trans=this_trans,
+                               trans=trans if in_head else None,
                                verbose=True, overwrite=True)
         anat_dir = bids_path.directory
         _bids_validate(bids_root)

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -1582,20 +1582,18 @@ def test_write_anat(_bids_validate):
 
         assert np.mean(all_img_data[0] == img_data) > 0.98
 
-        if in_head:
-            continue
+        if not in_head:
+            # crash for raw also
+            with pytest.raises(ValueError, match='use either `landmarks`'):
+                write_anat(t1w_mgh, bids_path=bids_path, raw=raw,
+                           trans=trans, deface=True, landmarks=landmarks,
+                           verbose=True, overwrite=True)
 
-        # crash for raw also
-        with pytest.raises(ValueError, match='Please use either `landmarks`'):
-            write_anat(t1w_mgh, bids_path=bids_path, raw=raw,
-                       trans=trans, deface=True, landmarks=landmarks,
-                       verbose=True, overwrite=True)
-
-        # crash for trans also
-        with pytest.raises(ValueError, match='`trans` was provided'):
-            write_anat(t1w_mgh, bids_path=bids_path, trans=trans,
-                       deface=True, landmarks=landmarks, verbose=True,
-                       overwrite=True)
+            # crash for trans also
+            with pytest.raises(ValueError, match='`trans` was provided'):
+                write_anat(t1w_mgh, bids_path=bids_path, trans=trans,
+                           deface=True, landmarks=landmarks, verbose=True,
+                           overwrite=True)
 
     # test raise error on meg_landmarks with no trans
     with pytest.raises(ValueError, match='Head space landmarks provided'):

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -1418,6 +1418,10 @@ def test_write_anat(_bids_validate):
         write_anat(9999999999999, bids_path=bids_path, t1w=t1w_mgh, raw=raw,
                    trans=trans, verbose=True, deface=False, overwrite=True)
 
+    with pytest.warns(RuntimeWarning, match='Ignoring `raw`'):
+        write_anat(t1w_mgh, bids_path=bids_path, raw=raw,
+                   verbose=True, overwrite=True)
+
     # Return without writing sidecar
     sh.rmtree(anat_dir)
     write_anat(t1w_mgh, bids_path=bids_path)
@@ -1496,7 +1500,7 @@ def test_write_anat(_bids_validate):
                    trans=trans, verbose=True, deface=True, overwrite=True)
 
     with pytest.raises(ValueError, match='must be provided to deface'):
-        write_anat(t1w_mgh, bids_path=bids_path, t1w=t1w_mgh, raw=raw,
+        write_anat(t1w_mgh, bids_path=bids_path, t1w=t1w_mgh,
                    verbose=True, deface=True, overwrite=True)
 
     with pytest.raises(ValueError, match='inset must be numeric'):
@@ -1574,6 +1578,11 @@ def test_write_anat(_bids_validate):
     with pytest.raises(ValueError, match='`trans` was provided'):
         write_anat(t1w_mgh, bids_path=bids_path, t1w=t1w_mgh, trans=trans,
                    deface=True, landmarks=mri_landmarks, verbose=True,
+                   overwrite=True)
+
+    with pytest.raises(ValueError, match='`trans` was provided'):
+        write_anat(t1w_mgh, bids_path=bids_path, t1w=t1w_mgh, trans=trans,
+                   deface=True, landmarks=mri_voxel_landmarks, verbose=True,
                    overwrite=True)
 
     # test meg landmarks

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -69,7 +69,8 @@ warning_str = dict(
     meas_date_set_to_none="ignore:.*'meas_date' set to None:RuntimeWarning:"
                           "mne",
     nasion_not_found='ignore:.*nasion not found:RuntimeWarning:mne',
-    unraisable_exception='ignore:.*:PytestUnraisableExceptionWarning'
+    unraisable_exception='ignore:.*Exception ignored.*:'
+                         'PytestUnraisableExceptionWarning'
 )
 
 

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -69,6 +69,7 @@ warning_str = dict(
     meas_date_set_to_none="ignore:.*'meas_date' set to None:RuntimeWarning:"
                           "mne",
     nasion_not_found='ignore:.*nasion not found:RuntimeWarning:mne',
+    unraisable_exception='ignore:pytest.PytestUnraisableExceptionWarning:*'
 )
 
 
@@ -824,7 +825,8 @@ def test_bti(_bids_validate):
     _bids_validate(output_path)
 
 
-@pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
+@pytest.mark.filterwarnings(warning_str['channel_unit_changed'],
+                            warning_str['unraisable_exception'])
 def test_vhdr(_bids_validate):
     """Test write_raw_bids conversion for BrainVision data."""
     bids_root = _TempDir()

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -69,7 +69,7 @@ warning_str = dict(
     meas_date_set_to_none="ignore:.*'meas_date' set to None:RuntimeWarning:"
                           "mne",
     nasion_not_found='ignore:.*nasion not found:RuntimeWarning:mne',
-    unraisable_exception='ignore:pytest.PytestUnraisableExceptionWarning:*'
+    unraisable_exception='pytest.PytestUnraisableExceptionWarning:'
 )
 
 

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -1490,7 +1490,7 @@ def test_write_anat(_bids_validate):
 
     bids_path = write_anat(t1w_mgh, bids_path=bids_path, t1w=t1w_mgh,
                            raw=raw, trans=trans_fname,
-                           verbose=True, deface=dict(theta=25),
+                           verbose=True, deface=dict(theta=45),
                            overwrite=True)
     anat_dir3 = bids_path.directory
     t1w3 = nib.load(op.join(anat_dir3, 'sub-01_ses-01_T1w.nii.gz'))
@@ -1614,12 +1614,9 @@ def test_write_anat(_bids_validate):
     assert abs(vox1 - vox3).sum() / abs(vox1).sum() < 0.2
 
     # test mri scanner ras landmarks
-    mri_scanner_ras_landmarks.save(
-        op.join(tmp_dir, 'mri_scanner_ras_landmarks.fif'))
     bids_path = write_anat(
         t1w_mgh, bids_path=bids_path, t1w=t1w_mgh, deface=True,
-        landmarks=op.join(tmp_dir, 'mri_scanner_ras_landmarks.fif'),
-        verbose=True, overwrite=True)
+        landmarks=mri_scanner_ras_landmarks, verbose=True, overwrite=True)
     anat_dir = bids_path.directory
     _bids_validate(bids_root)
 

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -69,7 +69,7 @@ warning_str = dict(
     meas_date_set_to_none="ignore:.*'meas_date' set to None:RuntimeWarning:"
                           "mne",
     nasion_not_found='ignore:.*nasion not found:RuntimeWarning:mne',
-    unraisable_exception='pytest.PytestUnraisableExceptionWarning:'
+    unraisable_exception='ignore:.*:PytestUnraisableExceptionWarning'
 )
 
 

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -1400,7 +1400,6 @@ def test_write_anat(_bids_validate):
         coords = anat_dict[point_list[i]]
         np.testing.assert_array_equal(np.asarray(coords, dtype=int),
                                       point)
-
         # BONUS: test also that we can find the matching sidecar
         side_fname = _find_matching_sidecar(sidecar_basename,
                                             suffix='T1w',
@@ -1490,11 +1489,15 @@ def test_write_anat(_bids_validate):
 
     assert vox_sum > vox_sum3
 
-    with pytest.raises(ValueError,
-                       match='The raw object, trans and raw or the landmarks'):
+    flash_mgh = \
+        op.join(data_path, 'subjects', 'sample', 'mri', 'flash', 'mef05.mgz')
+    with pytest.raises(ValueError, match='did not contain "T1"'):
+        write_anat(flash_mgh, bids_path=bids_path, raw=raw,
+                   trans=trans, verbose=True, deface=True, overwrite=True)
+
+    with pytest.raises(ValueError, match='must be provided to deface'):
         write_anat(t1w_mgh, bids_path=bids_path, raw=raw,
-                   trans=None, verbose=True, deface=True,
-                   overwrite=True)
+                   verbose=True, deface=True, overwrite=True)
 
     with pytest.raises(ValueError, match='inset must be numeric'):
         write_anat(t1w_mgh, bids_path=bids_path, raw=raw,
@@ -1602,14 +1605,10 @@ def test_write_anat(_bids_validate):
         write_anat(t1w_mgh, bids_path=bids_path, deface=True,
                    landmarks=fail_landmarks, verbose=True, overwrite=True)
 
-    # Get the FLASH MRI data file
-    flash_mgh = \
-        op.join(data_path, 'subjects', 'sample', 'mri', 'flash', 'mef05.mgz')
-
     bids_path = BIDSPath(subject=subject_id, session=session_id,
                          suffix='FLASH', root=bids_root)
-    write_anat(flash_mgh, bids_path=bids_path,
-               raw=raw, overwrite=True)
+    write_anat(flash_mgh, bids_path=bids_path, t1w=t1w_mgh,
+               raw=raw, trans=trans, overwrite=True)
     assert op.exists(op.join(anat_dir, 'sub-01_ses-01_FLASH.nii.gz'))
     _bids_validate(bids_root)
 

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -1502,8 +1502,12 @@ def test_write_anat(_bids_validate):
     assert vox_sum > vox_sum3
 
     with pytest.raises(ValueError, match='must be provided to deface'):
-        write_anat(t1w_mgh, bids_path=bids_path,
-                   verbose=True, deface=True, overwrite=True)
+        write_anat(t1w_mgh, bids_path=bids_path, deface=True,
+                   verbose=True, overwrite=True)
+
+    with pytest.raises(ValueError, match='`raw` must be specified'):
+        write_anat(t1w_mgh, bids_path=bids_path, deface=True, trans=trans,
+                   verbose=True, overwrite=True)
 
     with pytest.raises(ValueError, match='inset must be numeric'):
         write_anat(t1w_mgh, bids_path=bids_path, raw=raw, trans=trans,

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -1432,7 +1432,7 @@ def test_write_anat(_bids_validate):
     ex = TypeError
 
     with pytest.raises(ex, match=match):
-        write_anat(t1w_mgh, bids_path=bids_path, raw=raw,
+        write_anat(t1w_mgh, bids_path=bids_path, t1w=t1w_mgh, raw=raw,
                    trans=wrong_type, verbose=True, deface=False,
                    overwrite=True)
 

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -1413,6 +1413,11 @@ def test_write_anat(_bids_validate):
                    raw=raw, trans=trans, verbose=True, deface=False,
                    overwrite=False)
 
+    # check overwrite no JSON
+    with pytest.raises(IOError, match='it already exists'):
+        write_anat(t1w_mgh, bids_path=bids_path, verbose=True,
+                   overwrite=False)
+
     # pass some invalid type as T1 MRI
     with pytest.raises(ValueError, match='must be a path to an MRI'):
         write_anat(9999999999999, bids_path=bids_path, t1w=t1w_mgh, raw=raw,
@@ -1497,6 +1502,11 @@ def test_write_anat(_bids_validate):
         op.join(data_path, 'subjects', 'sample', 'mri', 'flash', 'mef05.mgz')
     with pytest.raises(ValueError, match='did not contain "T1"'):
         write_anat(flash_mgh, bids_path=bids_path, raw=raw,
+                   trans=trans, verbose=True, deface=True, overwrite=True)
+
+    flash_img = nib.load(flash_mgh)
+    with pytest.raises(ValueError, match='did not contain "T1"'):
+        write_anat(flash_img, bids_path=bids_path, raw=raw,
                    trans=trans, verbose=True, deface=True, overwrite=True)
 
     with pytest.raises(ValueError, match='must be provided to deface'):

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -1371,7 +1371,7 @@ def test_write_anat(_bids_validate):
 
     bids_path = BIDSPath(subject=subject_id, session=session_id,
                          acquisition=acq, root=bids_root)
-    bids_path = write_anat(t1w_mgh, bids_path=bids_path,
+    bids_path = write_anat(t1w_mgh, bids_path=bids_path, t1w=t1w_mgh,
                            raw=raw, trans=trans, deface=True, verbose=True,
                            overwrite=True)
     anat_dir = bids_path.directory
@@ -1409,13 +1409,13 @@ def test_write_anat(_bids_validate):
     # Now try some anat writing that will fail
     # We already have some MRI data there
     with pytest.raises(IOError, match='`overwrite` is set to False'):
-        write_anat(t1w_mgh, bids_path=bids_path,
+        write_anat(t1w_mgh, bids_path=bids_path, t1w=t1w_mgh,
                    raw=raw, trans=trans, verbose=True, deface=False,
                    overwrite=False)
 
     # pass some invalid type as T1 MRI
     with pytest.raises(ValueError, match='must be a path to an MRI'):
-        write_anat(9999999999999, bids_path=bids_path, raw=raw,
+        write_anat(9999999999999, bids_path=bids_path, t1w=t1w_mgh, raw=raw,
                    trans=trans, verbose=True, deface=False, overwrite=True)
 
     # Return without writing sidecar
@@ -1440,11 +1440,11 @@ def test_write_anat(_bids_validate):
     wrong_fname = 'not_a_trans'
     match = 'trans file "{}" not found'.format(wrong_fname)
     with pytest.raises(IOError, match=match):
-        write_anat(t1w_mgh, bids_path=bids_path, raw=raw,
+        write_anat(t1w_mgh, bids_path=bids_path, t1w=t1w_mgh, raw=raw,
                    trans=wrong_fname, verbose=True, overwrite=True)
 
     # However, reading trans if it is a string pointing to trans is fine
-    write_anat(t1w_mgh, bids_path=bids_path, raw=raw,
+    write_anat(t1w_mgh, bids_path=bids_path, t1w=t1w_mgh, raw=raw,
                trans=trans_fname, verbose=True, deface=False,
                overwrite=True)
 
@@ -1458,18 +1458,18 @@ def test_write_anat(_bids_validate):
     # specify trans but not raw
     with pytest.raises(ValueError, match='must be specified if `trans`'):
         bids_path.update(session=session_id)
-        write_anat(t1w_mgh, bids_path=bids_path, raw=None,
+        write_anat(t1w_mgh, bids_path=bids_path, t1w=t1w_mgh, raw=None,
                    trans=trans, verbose=True, deface=False, overwrite=True)
 
     # test deface
-    bids_path = write_anat(t1w_mgh, bids_path=bids_path,
+    bids_path = write_anat(t1w_mgh, bids_path=bids_path, t1w=t1w_mgh,
                            raw=raw, trans=trans_fname,
                            verbose=True, deface=True, overwrite=True)
     anat_dir = bids_path.directory
     t1w = nib.load(op.join(anat_dir, 'sub-01_ses-01_T1w.nii.gz'))
     vox_sum = t1w.get_fdata().sum()
 
-    bids_path = write_anat(t1w_mgh, bids_path=bids_path,
+    bids_path = write_anat(t1w_mgh, bids_path=bids_path, t1w=t1w_mgh,
                            raw=raw, trans=trans_fname,
                            verbose=True, deface=dict(inset=25.),
                            overwrite=True)
@@ -1479,7 +1479,7 @@ def test_write_anat(_bids_validate):
 
     assert vox_sum > vox_sum2
 
-    bids_path = write_anat(t1w_mgh, bids_path=bids_path,
+    bids_path = write_anat(t1w_mgh, bids_path=bids_path, t1w=t1w_mgh,
                            raw=raw, trans=trans_fname,
                            verbose=True, deface=dict(theta=25),
                            overwrite=True)
@@ -1492,31 +1492,31 @@ def test_write_anat(_bids_validate):
     flash_mgh = \
         op.join(data_path, 'subjects', 'sample', 'mri', 'flash', 'mef05.mgz')
     with pytest.raises(ValueError, match='did not contain "T1"'):
-        write_anat(flash_mgh, bids_path=bids_path, raw=raw,
+        write_anat(flash_mgh, bids_path=bids_path, t1w=t1w_mgh, raw=raw,
                    trans=trans, verbose=True, deface=True, overwrite=True)
 
     with pytest.raises(ValueError, match='must be provided to deface'):
-        write_anat(t1w_mgh, bids_path=bids_path, raw=raw,
+        write_anat(t1w_mgh, bids_path=bids_path, t1w=t1w_mgh, raw=raw,
                    verbose=True, deface=True, overwrite=True)
 
     with pytest.raises(ValueError, match='inset must be numeric'):
-        write_anat(t1w_mgh, bids_path=bids_path, raw=raw,
+        write_anat(t1w_mgh, bids_path=bids_path, t1w=t1w_mgh, raw=raw,
                    trans=trans, verbose=True, deface=dict(inset='small'),
                    overwrite=True)
 
     with pytest.raises(ValueError, match='inset should be positive'):
-        write_anat(t1w_mgh, bids_path=bids_path, raw=raw,
+        write_anat(t1w_mgh, bids_path=bids_path, t1w=t1w_mgh, raw=raw,
                    trans=trans, verbose=True, deface=dict(inset=-2.),
                    overwrite=True)
 
     with pytest.raises(ValueError, match='theta must be numeric'):
-        write_anat(t1w_mgh, bids_path=bids_path, raw=raw,
+        write_anat(t1w_mgh, bids_path=bids_path, t1w=t1w_mgh, raw=raw,
                    trans=trans, verbose=True, deface=dict(theta='big'),
                    overwrite=True)
 
     with pytest.raises(ValueError,
                        match='theta should be between 0 and 90 degrees'):
-        write_anat(t1w_mgh, bids_path=bids_path, raw=raw,
+        write_anat(t1w_mgh, bids_path=bids_path, t1w=t1w_mgh, raw=raw,
                    trans=trans, verbose=True, deface=dict(theta=100),
                    overwrite=True)
 
@@ -1541,7 +1541,7 @@ def test_write_anat(_bids_validate):
 
     # test mri voxel landmarks
     bids_path.update(acquisition=acq)
-    bids_path = write_anat(t1w_mgh, bids_path=bids_path,
+    bids_path = write_anat(t1w_mgh, bids_path=bids_path, t1w=t1w_mgh,
                            deface=True, landmarks=mri_voxel_landmarks,
                            verbose=True, overwrite=True)
     anat_dir = bids_path.directory
@@ -1551,9 +1551,9 @@ def test_write_anat(_bids_validate):
     vox1 = t1w1.get_fdata()
 
     # test mri landmarks
-    bids_path = write_anat(t1w_mgh, bids_path=bids_path, deface=True,
-                           landmarks=mri_landmarks, verbose=True,
-                           overwrite=True)
+    bids_path = write_anat(t1w_mgh, bids_path=bids_path, t1w=t1w_mgh,
+                           deface=True, landmarks=mri_landmarks,
+                           verbose=True, overwrite=True)
     anat_dir = bids_path.directory
     _bids_validate(bids_root)
 
@@ -1566,20 +1566,21 @@ def test_write_anat(_bids_validate):
 
     # crash for raw also
     with pytest.raises(ValueError, match='Please use either `landmarks`'):
-        write_anat(t1w_mgh, bids_path=bids_path, raw=raw, trans=trans,
-                   deface=True, landmarks=mri_landmarks, verbose=True,
-                   overwrite=True)
+        write_anat(t1w_mgh, bids_path=bids_path, t1w=t1w_mgh, raw=raw,
+                   trans=trans, deface=True, landmarks=mri_landmarks,
+                   verbose=True, overwrite=True)
 
     # crash for trans also
     with pytest.raises(ValueError, match='`trans` was provided'):
-        write_anat(t1w_mgh, bids_path=bids_path, trans=trans, deface=True,
-                   landmarks=mri_landmarks, verbose=True, overwrite=True)
+        write_anat(t1w_mgh, bids_path=bids_path, t1w=t1w_mgh, trans=trans,
+                   deface=True, landmarks=mri_landmarks, verbose=True,
+                   overwrite=True)
 
     # test meg landmarks
     tmp_dir = _TempDir()
     meg_landmarks.save(op.join(tmp_dir, 'meg_landmarks.fif'))
-    bids_path = write_anat(t1w_mgh, bids_path=bids_path, deface=True,
-                           trans=trans,
+    bids_path = write_anat(t1w_mgh, bids_path=bids_path, t1w=t1w_mgh,
+                           deface=True, trans=trans,
                            landmarks=op.join(tmp_dir, 'meg_landmarks.fif'),
                            verbose=True, overwrite=True)
     anat_dir = bids_path.directory
@@ -1592,7 +1593,7 @@ def test_write_anat(_bids_validate):
 
     # test raise error on meg_landmarks with no trans
     with pytest.raises(ValueError, match='Head space landmarks provided'):
-        write_anat(t1w_mgh, bids_path=bids_path, deface=True,
+        write_anat(t1w_mgh, bids_path=bids_path, t1w=t1w_mgh, deface=True,
                    landmarks=meg_landmarks, verbose=True, overwrite=True)
 
     # test unsupported (any coord_frame other than head and mri) coord_frame
@@ -1607,6 +1608,7 @@ def test_write_anat(_bids_validate):
 
     bids_path = BIDSPath(subject=subject_id, session=session_id,
                          suffix='FLASH', root=bids_root)
+    write_anat(flash_mgh, bids_path=bids_path, overwrite=True)
     write_anat(flash_mgh, bids_path=bids_path, t1w=t1w_mgh,
                raw=raw, trans=trans, overwrite=True)
     assert op.exists(op.join(anat_dir, 'sub-01_ses-01_FLASH.nii.gz'))
@@ -1668,7 +1670,8 @@ def test_write_anat_pathlike():
     t1w_mgh_fname = Path(data_path) / 'subjects' / 'sample' / 'mri' / 'T1.mgz'
     bids_path = BIDSPath(subject=subject_id, session=session_id,
                          acquisition=acq, root=bids_root)
-    bids_path = write_anat(t1w_mgh_fname, bids_path=bids_path, raw=raw,
+    bids_path = write_anat(t1w_mgh_fname, bids_path=bids_path,
+                           t1w=t1w_mgh_fname, raw=raw,
                            trans=trans, deface=True, verbose=True,
                            overwrite=True)
 

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -70,7 +70,7 @@ warning_str = dict(
                           "mne",
     nasion_not_found='ignore:.*nasion not found:RuntimeWarning:mne',
     unraisable_exception='ignore:.*Exception ignored.*:'
-                         'PytestUnraisableExceptionWarning'
+                         'pytest.PytestUnraisableExceptionWarning'
 )
 
 

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -1492,7 +1492,7 @@ def test_write_anat(_bids_validate):
     flash_mgh = \
         op.join(data_path, 'subjects', 'sample', 'mri', 'flash', 'mef05.mgz')
     with pytest.raises(ValueError, match='did not contain "T1"'):
-        write_anat(flash_mgh, bids_path=bids_path, t1w=t1w_mgh, raw=raw,
+        write_anat(flash_mgh, bids_path=bids_path, raw=raw,
                    trans=trans, verbose=True, deface=True, overwrite=True)
 
     with pytest.raises(ValueError, match='must be provided to deface'):

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -1603,7 +1603,7 @@ def test_write_anat(_bids_validate):
     fail_landmarks.dig[2]['coord_frame'] = 3
 
     with pytest.raises(ValueError, match='Coordinate frame not recognized'):
-        write_anat(t1w_mgh, bids_path=bids_path, deface=True,
+        write_anat(t1w_mgh, bids_path=bids_path, t1w=t1w_mgh, deface=True,
                    landmarks=fail_landmarks, verbose=True, overwrite=True)
 
     bids_path = BIDSPath(subject=subject_id, session=session_id,

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1415,24 +1415,6 @@ def write_anat(image, bids_path, t1w='auto', raw=None, trans=None,
             # here to keep the try block as short as possible.
             image = nib.load(image)
 
-    if t1w == 'auto':
-        if 'T1' not in image.get_filename():
-            raise ValueError('`image` argument filepath did not contain "T1", '
-                             'please supply the T1 image as `t1w`')
-        else:
-            t1_img = image
-    else:
-        if type(t1w) not in nib.all_image_classes:
-            # assume image is T1 if auto and check later
-            try:
-                t1w = _path_to_str(t1w)
-            except ValueError:
-                raise ValueError('`t1w` must be a path to a T1 data '
-                                 'file or a nibabel image object, but it is '
-                                 'of type "{}"'.format(type(image)))
-            else:
-                t1_img = nib.load(t1w)
-
     image = nib.Nifti1Image(image.dataobj, image.affine)
     # XYZT_UNITS = NIFT_UNITS_MM (10 in binary or 2 in decimal)
     # seems to be the default for Nifti files
@@ -1442,6 +1424,24 @@ def write_anat(image, bids_path, t1w='auto', raw=None, trans=None,
 
     # Check if we have necessary conditions for writing a sidecar JSON
     if trans is not None or landmarks is not None:
+        # load the T1 image if not already loaded, deal with auto setting
+        if t1w == 'auto':
+            if 'T1' not in image.get_filename():
+                raise ValueError('`image` argument filepath did not contain '
+                                 '"T1", please supply the T1 image as `t1w`')
+            else:
+                t1_img = image
+        else:
+            if type(t1w) not in nib.all_image_classes:
+                # assume image is T1 if auto and check later
+                try:
+                    t1w = _path_to_str(t1w)
+                except ValueError:
+                    raise ValueError('`t1w` must be a path to a T1 data '
+                                     'file or a nibabel image object, but it '
+                                     'is of type "{}"'.format(type(image)))
+                else:
+                    t1_img = nib.load(t1w)
         t1_mgh = nib.MGHImage(t1_img.dataobj, t1_img.affine)
 
         if landmarks is not None:

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -501,12 +501,14 @@ def _mri_landmarks_to_mri_voxels(mri_landmarks, t1_mgh):
 
 def _mri_voxels_to_mri_scanner_ras(mri_landmarks, img_mgh):
     """Convert landmarks from MRI voxel space to MRI scanner RAS space.
+
     Parameters
     ----------
     mri_landmarks : array, shape (3, 3)
         The MRI RAS landmark data: rows LPA, NAS, RPA, columns x, y, z.
     img_mgh : nib.MGHImage
         The image data in MGH format.
+
     Returns
     -------
     mri_landmarks : array, shape (3, 3)

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -510,28 +510,6 @@ def _mri_landmarks_to_mri_voxels(mri_landmarks, t1_mgh):
     return mri_landmarks
 
 
-def _mri_voxels_to_mri_landmarks(mri_landmarks, t1_mgh):
-    """Convert landmarks from MRI surface RAS space to MRI voxel space.
-
-    Parameters
-    ----------
-    mri_landmarks : array, shape (3, 3)
-        The MRI RAS landmark data: rows LPA, NAS, RPA, columns x, y, z.
-    t1_mgh : nib.MGHImage
-        The image data in MGH format.
-
-    Returns
-    -------
-    mri_landmarks : array, shape (3, 3)
-        The MRI voxel-space landmark data.
-    """
-    # Get landmarks in voxel space, using the T1 data
-    vox2ras_tkr = t1_mgh.header.get_vox2ras_tkr()
-    ras2vox_tkr = linalg.inv(vox2ras_tkr)
-    mri_landmarks = apply_trans(ras2vox_tkr, mri_landmarks)  # in vox
-    return mri_landmarks
-
-
 def _mri_voxels_to_mri_scanner_ras(mri_landmarks, img_mgh):
     """Convert landmarks from MRI voxel space to MRI scanner RAS space.
 

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -667,7 +667,7 @@ def _deface(image, landmarks, deface):
         raise ImportError('This function requires nibabel.')
     import nibabel as nib
 
-    inset, theta = (20, 35.)
+    inset, theta = (5, 15.)
     if isinstance(deface, dict):
         if 'inset' in deface:
             inset = deface['inset']
@@ -1354,10 +1354,10 @@ def write_anat(image, bids_path, raw=None, trans=None, landmarks=None,
         If dict, accepts the following keys:
 
         - `inset`: how far back in voxels to start defacing
-          relative to the nasion (default 20)
+          relative to the nasion (default 5)
 
         - `theta`: is the angle of the defacing shear in degrees relative
-          to vertical (default 35).
+          to vertical (default 15).
 
     landmarks: instance of DigMontage | str
         The DigMontage or filepath to a DigMontage with landmarks that can be

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1369,10 +1369,9 @@ def write_anat(image, bids_path, t1w='auto', raw=None, trans=None,
         raise ImportError('This function requires nibabel.')
     import nibabel as nib
 
-    if deface and (t1w is None or (trans is None or raw is None) and
-            landmarks is None):
-        raise ValueError('`t1w` and either `raw` and `trans` or '
-                         '`landmarks` must be provided to deface the image')
+    if deface and (trans is None or raw is None) and landmarks is None:
+        raise ValueError('Either `raw` and `trans` or `landmarks` '
+                         'must be provided to deface the image')
 
     # Check if the root is available
     if bids_path.root is None:

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -474,12 +474,14 @@ def _mri_voxels_to_ras(mri_landmarks, t1_mgh):
 
 def _mri_landmarks_to_mri_voxels(mri_landmarks, t1_mgh):
     """Convert landmarks from MRI RAS space to MRI voxel space.
+
     Parameters
     ----------
     mri_landmarks : array, shape (3, 3)
         The MRI RAS landmark data: rows LPA, NAS, RPA, columns x, y, z.
     t1_mgh : nib.MGHImage
         The image data in MGH format.
+
     Returns
     -------
     mri_landmarks : array, shape (3, 3)

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1426,7 +1426,8 @@ def write_anat(image, bids_path, t1w='auto', raw=None, trans=None,
     if trans is not None or landmarks is not None:
         # load the T1 image if not already loaded, deal with auto setting
         if t1w == 'auto':
-            if 'T1' not in image.get_filename():
+            t1_fname = image.get_filename()
+            if t1_fname is None or 'T1' not in t1_fname:
                 raise ValueError('`image` argument filepath did not contain '
                                  '"T1", please supply the T1 image as `t1w`')
             t1_img = image

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -451,27 +451,6 @@ def _meg_landmarks_to_mri_landmarks(meg_landmarks, trans):
     return apply_trans(trans, meg_landmarks, move=True) * 1e3
 
 
-def _mri_voxels_to_ras(mri_landmarks, t1_mgh):
-    """Convert landmarks from MRI voxel space to MRI RAS space.
-
-    Parameters
-    ----------
-    mri_landmarks : array, shape (3, 3)
-        The MRI RAS landmark data: rows LPA, NAS, RPA, columns x, y, z.
-    t1_mgh : nib.MGHImage
-        The image data in MGH format.
-
-    Returns
-    -------
-    mri_landmarks : array, shape (3, 3)
-        The MRI voxel-space landmark data.
-    """
-    # Get landmarks in voxel space, using the T1 data
-    vox2ras_tkr = t1_mgh.header.get_vox2ras_tkr()
-    mri_landmarks = apply_trans(vox2ras_tkr, mri_landmarks)  # in vox
-    return mri_landmarks
-
-
 def _mri_landmarks_to_mri_voxels(mri_landmarks, t1_mgh):
     """Convert landmarks from MRI RAS space to MRI voxel space.
 

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1429,8 +1429,7 @@ def write_anat(image, bids_path, t1w='auto', raw=None, trans=None,
             if 'T1' not in image.get_filename():
                 raise ValueError('`image` argument filepath did not contain '
                                  '"T1", please supply the T1 image as `t1w`')
-            else:
-                t1_img = image
+            t1_img = image
         else:
             if type(t1w) not in nib.all_image_classes:
                 # assume image is T1 if auto and check later

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1399,7 +1399,9 @@ def write_anat(image, bids_path, raw=None, trans=None, landmarks=None,
                                      'data is in mri space. Please use '
                                      'only one of these.')
                 if coord_frame == FIFF.FIFFV_MNE_COORD_MRI_VOXEL:
-                    landmarks = _mri_voxels_to_ras(landmarks * 1e3, img_mgh)
+                    landmarks = _mri_voxels_to_ras(landmarks, img_mgh)
+                else:
+                    landmarks *= 1e3
                 mri_landmarks = landmarks
             else:
                 raise ValueError('Coordinate frame not recognized, '

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1426,6 +1426,8 @@ def write_anat(image, bids_path, raw=None, trans=None, landmarks=None,
                                      '`trans` required')
                 mri_landmarks = _meg_landmarks_to_mri_landmarks(
                     landmarks, trans)
+                mri_landmarks = _mri_landmarks_to_mri_voxels(
+                    mri_landmarks, img_mgh)
             elif coord_frame in (FIFF.FIFFV_MNE_COORD_MRI_VOXEL,
                                  FIFF.FIFFV_COORD_MRI):
                 if trans is not None:

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1498,12 +1498,14 @@ def write_anat(image, bids_path, raw=None, trans=None, landmarks=None,
                 landmarks = _mri_landmarks_to_mri_voxels(landmarks, t1w_mgh)
                 # go to T1 scanner space from T1 voxel space
                 landmarks = _mri_voxels_to_mri_scanner_ras(landmarks, t1w_mgh)
+                landmarks *= 1e-3  # mm -> m
                 coord_frame = FIFF.FIFFV_MNE_COORD_RAS
 
             # convert to voxels from surface or scanner RAS depending on above
             if coord_frame == FIFF.FIFFV_MNE_COORD_RAS:
                 # go from scanner RAS to image voxels
-                landmarks = _mri_scanner_ras_to_mri_voxels(landmarks, img_mgh)
+                landmarks = _mri_scanner_ras_to_mri_voxels(
+                    landmarks * 1e3, img_mgh)
             else:  # must be T1, going from surface RAS->voxels
                 landmarks = _mri_landmarks_to_mri_voxels(landmarks, img_mgh)
 

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1283,7 +1283,7 @@ def write_anat(image, bids_path, raw=None, trans=None, landmarks=None,
         `trans` and `raw` must not be `None` if True.
         If dict, accepts the following keys:
 
-        - `inset`: how far back in millimeters to start defacing
+        - `inset`: how far back in voxels to start defacing
           relative to the nasion (default 20)
 
         - `theta`: is the angle of the defacing shear in degrees relative

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1431,8 +1431,9 @@ def write_anat(image, bids_path, t1w='auto', raw=None, trans=None,
                                  '"T1", please supply the T1 image as `t1w`')
             t1_img = image
         else:
-            if type(t1w) not in nib.all_image_classes:
-                # assume image is T1 if auto and check later
+            if type(t1w) in nib.all_image_classes:
+                t1_img = t1w
+            else:
                 try:
                     t1w = _path_to_str(t1w)
                 except ValueError:
@@ -1441,6 +1442,7 @@ def write_anat(image, bids_path, t1w='auto', raw=None, trans=None,
                                      'is of type "{}"'.format(type(image)))
                 else:
                     t1_img = nib.load(t1w)
+        # Make MGH image for header properties
         t1_mgh = nib.MGHImage(t1_img.dataobj, t1_img.affine)
 
         if landmarks is not None:

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -678,7 +678,7 @@ def _deface(image, landmarks, deface):
         raise ImportError('This function requires nibabel.')
     import nibabel as nib
 
-    inset, theta = (20, 20.)
+    inset, theta = (20, 35.)
     if isinstance(deface, dict):
         if 'inset' in deface:
             inset = deface['inset']
@@ -1367,7 +1367,7 @@ def write_anat(image, bids_path, t1w='auto', raw=None, trans=None,
           relative to the nasion (default 20)
 
         - `theta`: is the angle of the defacing shear in degrees relative
-          to vertical (default 20).
+          to vertical (default 35).
 
     landmarks: instance of DigMontage | str
         The DigMontage or filepath to a DigMontage with landmarks that can be


### PR DESCRIPTION
PR Description
--------------

Moves away from landmarks into T1 space which doesn't have to be RAS and keeps images in RAS to deface for any image. Address https://github.com/mne-tools/mne-bids/issues/650.

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [x] All CIs are happy
- [x] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [x] PR description includes phrase "closes <#issue-number>"
