### PR TITLE
[MAINT] Remove now-unnecessary try-catch block

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -6,7 +6,7 @@ Installation
 Dependencies
 ------------
 
-* ``mne`` (>=0.21)
+* ``mne`` (>=0.21.2)
 * ``numpy`` (>=1.14)
 * ``scipy`` (>=0.18.1, or >=1.5.0 for certain operations with EEGLAB data)
 * ``nibabel`` (>=2.2, optional, for processing MRI data)

--- a/mne_bids/copyfiles.py
+++ b/mne_bids/copyfiles.py
@@ -454,29 +454,7 @@ def copyfile_edf(src, dest, anonymize=None):
         pid, sex, birthdate, name = id_info.split(' ')
         startdate, admin_code, tech, equip = rec_info.split(' ')[1:5]
 
-        # Try to anonymize recording date using 4-digit year from
-        # "Startdate" field from "local recording identification"
-        # section, because the generic "startdate" field only
-        # supports 2-digit years.
-        #
-        # XXX: recording dates are specified twice in EDF/EDF+/BDF,
-        # MNE-Python currently parses the 2-digit year field. If that is
-        # changed to defaulting to the 4-digit field, this try-except
-        # clause can be removed. See:
-        # https://github.com/mne-tools/mne-python/issues/8544
-        try:
-            true_year = datetime.strptime(startdate, '%d-%b-%Y').year
-            newdate = raw.info['meas_date'].replace(year=true_year)
-            raw.info['meas_date'] = newdate
-        except ValueError as e:
-            # We could not parse the "Startdate" field from "local recording
-            # identification" section (e.g., because it was "X").
-            # So fall back to using the standard "startdate" field that only
-            # supports 2-digit years.
-            # This is what MNE-Python currently parses and puts into
-            # raw.info["meas_date"]
-            if "does not match format '%d-%b-%Y'" not in str(e):
-                raise e
+        # Try to anonymize the recording date
         daysback, keep_his = _check_anonymize(anonymize, raw, '.edf')
         info = anonymize_info(raw.info, daysback=daysback, keep_his=keep_his)
         startdate = datetime.strftime(info['meas_date'], '%d-%b-%Y').upper()

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ if __name__ == "__main__":
           long_description_content_type='text/markdown',
           python_requires='~=3.6',
           install_requires=[
-              'mne >=0.21',
+              'mne >=0.21.2',
               'numpy >=1.14',
               'scipy >=0.18.1',
           ],


### PR DESCRIPTION
PR Description
--------------
Closes #639. Basically, I used an unsightly hack to get around a limitation in MNE that has now been fixed as of 0.21.2, so I just bumped the version requirement and removed it.

Note that I also used a similar workaround in the tests for EDF anonymization (reading and parsing the date from the file header directly instead of using raw.info['meas_date'], see below), but I'm unsure if that benefits from replacing since my approach there saves parsing two whole EDF files just to compare their recording dates.

https://github.com/mne-tools/mne-bids/blob/0ca3229f900c24e42e64fe5c58a8c93ae968590a/mne_bids/tests/test_copyfiles.py#L147-L162

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
