### PR TITLE
[MRG] Allow write_raw_bids to specify a file format explicitly

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -36,7 +36,7 @@ Enhancements
 API changes
 ^^^^^^^^^^^
 
-- xxx
+- Add ``format`` kwarg to :func:`write_raw_bids` that allows users to specify if they want to force conversion to ``BrainVision`` or ``FIF`` file format, by `Adam Li`_ (:gh:`672`)
 
 Requirements
 ^^^^^^^^^^^^

--- a/mne_bids/config.py
+++ b/mne_bids/config.py
@@ -11,7 +11,14 @@ EPHY_ALLOWED_DATATYPES = ['meg', 'eeg', 'ieeg']
 
 ALLOWED_DATATYPES = EPHY_ALLOWED_DATATYPES + ['anat', 'beh']
 
-CONVERT_FORMATS = ['auto', 'BrainVision', 'FIF']
+MEG_CONVERT_FORMATS = ['FIF', 'auto']
+EEG_CONVERT_FORMATS = ['BrainVision', 'auto']
+IEEG_CONVERT_FORMATS = ['BrainVision', 'auto']
+CONVERT_FORMATS = {
+    'meg': MEG_CONVERT_FORMATS,
+    'eeg': EEG_CONVERT_FORMATS,
+    'ieeg': IEEG_CONVERT_FORMATS
+}
 
 # Orientation of the coordinate system dependent on manufacturer
 ORIENTATION = {

--- a/mne_bids/config.py
+++ b/mne_bids/config.py
@@ -11,6 +11,8 @@ EPHY_ALLOWED_DATATYPES = ['meg', 'eeg', 'ieeg']
 
 ALLOWED_DATATYPES = EPHY_ALLOWED_DATATYPES + ['anat', 'beh']
 
+CONVERT_FORMATS = ['auto', 'BrainVision', 'FIF']
+
 # Orientation of the coordinate system dependent on manufacturer
 ORIENTATION = {
     '.con': 'KitYokogawa',

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -2267,8 +2267,6 @@ def test_convert_dataset_format(dir_name, fname, reader):
     kwargs = dict(raw=raw, bids_path=bids_path, overwrite=True)
     if dir_name == 'EDF':
         kwargs['format'] = 'BrainVision'
-        # XXX: remove when pybv0.5 merged in
-        raw.drop_channels('Status')
         with pytest.warns(RuntimeWarning,
                           match='Encountered data in "int" format'):
             bids_output_path = write_raw_bids(**kwargs)

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -2294,7 +2294,21 @@ def test_convert_dataset_format(dir_name, fname, reader):
         assert raw.filenames[0].endswith('.fif')
         assert bids_output_path.extension == '.fif'
 
+    # only accepted keywords will work for the 'format' parameter
     with pytest.raises(ValueError, match='The input "format" .* is '
-                                         'not an accepted input format'):
+                                         'not an accepted input format for '
+                                         '`write_raw_bids`'):
         kwargs['format'] = 'blah'
+        write_raw_bids(**kwargs)
+
+    # write should fail when trying to convert to wrong data format for
+    # the datatype inside the file (e.g. EEG -> 'FIF' or MEG -> 'BrainVision')
+    with pytest.raises(ValueError, match='The input "format" .* is not an '
+                                         'accepted input format for '
+                                         '.* datatype.'):
+        if dir_name == 'CTF':
+            new_format = 'BrainVision'
+        else:
+            new_format = 'FIF'
+        kwargs['format'] = new_format
         write_raw_bids(**kwargs)

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -2267,7 +2267,11 @@ def test_convert_dataset_format(dir_name, fname, reader):
     kwargs = dict(raw=raw, bids_path=bids_path, overwrite=True)
     if dir_name == 'EDF':
         kwargs['format'] = 'BrainVision'
-        bids_output_path = write_raw_bids(**kwargs)
+        # XXX: remove when pybv0.5 merged in
+        raw.drop_channels('Status')
+        with pytest.warns(RuntimeWarning,
+                          match='Encountered data in "int" format'):
+            bids_output_path = write_raw_bids(**kwargs)
     elif dir_name == 'NihonKohden':
         kwargs['format'] = 'BrainVision'
         with pytest.warns(RuntimeWarning,
@@ -2286,6 +2290,8 @@ def test_convert_dataset_format(dir_name, fname, reader):
     # write_raw_bids should have converted the dataset to desired format
     raw = read_raw_bids(bids_output_path)
     if kwargs['format'] == 'BrainVision':
-        assert raw.filenames[0].endswith('.vhdr')
+        assert raw.filenames[0].endswith('.eeg')
+        assert bids_output_path.extension == '.vhdr'
     elif kwargs['format'] == 'FIF':
         assert raw.filenames[0].endswith('.fif')
+        assert bids_output_path.extension == '.fif'

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -2253,7 +2253,7 @@ def test_convert_brainvision(dir_name, fname, reader, _bids_validate):
 @pytest.mark.parametrize('dir_name, fname, reader', test_convert_data)
 @pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
 def test_convert_dataset_format(dir_name, fname, reader):
-    """Test explicit conversion of data format for MEG/EEG/iEEG."""
+    """Test force-converting files to RECOMMENDED formats."""
     bids_root = _TempDir()
 
     data_path = op.join(testing.data_path(), dir_name)
@@ -2295,3 +2295,7 @@ def test_convert_dataset_format(dir_name, fname, reader):
     elif kwargs['format'] == 'FIF':
         assert raw.filenames[0].endswith('.fif')
         assert bids_output_path.extension == '.fif'
+
+    with pytest.raises(ValueError, match='The "format"*'):
+        kwargs['format'] = 'blah'
+        write_raw_bids(**kwargs)

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -2294,6 +2294,7 @@ def test_convert_dataset_format(dir_name, fname, reader):
         assert raw.filenames[0].endswith('.fif')
         assert bids_output_path.extension == '.fif'
 
-    with pytest.raises(ValueError, match='The "format"*'):
+    with pytest.raises(ValueError, match='The input "format" .* is '
+                                         'not an accepted input format'):
         kwargs['format'] = 'blah'
         write_raw_bids(**kwargs)

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1274,8 +1274,6 @@ def write_raw_bids(raw, bids_path, events_data=None,
         elif all(format not in values for values in CONVERT_FORMATS.values()):
             raise ValueError(f'The input "format" {format} is not an '
                              f'accepted input format for `write_raw_bids`. '
-                             f'For example, if you passed in "EDF", mne-bids '
-                             f'does not currently have conversion to EDF. '
                              f'Please use one of {CONVERT_FORMATS[datatype]} '
                              f'for {datatype} datatype.')
         elif format not in CONVERT_FORMATS[datatype]:

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1007,8 +1007,8 @@ def write_raw_bids(raw, bids_path, events_data=None,
         If `'auto'` (default), there is no explicit change in how the file is
         converted to BIDS. The native format is used. If a str, then will
         accept RECOMMENDED BIDS file formats. For example, EEG and iEEG
-        RECOMMENDED formats are ``BrainVision`` and ``EDF``. If ``'BrainVision'``
-        is passed in, then file will be converted to the
+        RECOMMENDED formats are ``BrainVision`` and ``EDF``. If
+        ``'BrainVision'`` is passed in, then file will be converted to the
         ``BrainVision`` file format even if the file is originally in ``EDF``
         file format. For MEG, ``'FIF'`` will convert file to ``FIF`` format.
     overwrite : bool

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1097,11 +1097,6 @@ def write_raw_bids(raw, bids_path, events_data=None,
         raise RuntimeError('You passed event_id, but no events_data NumPy '
                            'array. You need to pass both, or neither.')
 
-    if format not in CONVERT_FORMATS:
-        raise ValueError(f'The "format" {format} is not an '
-                         f'accepted format. Please use one of '
-                         f'{CONVERT_FORMATS}')
-
     raw = raw.copy()
 
     raw_fname = raw.filenames[0]
@@ -1276,6 +1271,12 @@ def write_raw_bids(raw, bids_path, events_data=None,
         elif format == 'FIF' and bids_path.datatype == 'meg':
             convert = True
             bids_path.update(extension='.fif')
+        elif format not in CONVERT_FORMATS:
+            raise ValueError(f'The input "format" {format} is not an '
+                             f'accepted input format for `write_raw_bids`. '
+                             f'For example, if you passed in "EDF", mne-bids '
+                             f'does not currently have conversion to EDF. '
+                             f'Please use one of {CONVERT_FORMATS}.')
 
     # File saving branching logic
     if convert:

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1271,12 +1271,18 @@ def write_raw_bids(raw, bids_path, events_data=None,
         elif format == 'FIF' and bids_path.datatype == 'meg':
             convert = True
             bids_path.update(extension='.fif')
-        elif format not in CONVERT_FORMATS:
+        elif all(format not in values for values in CONVERT_FORMATS.values()):
             raise ValueError(f'The input "format" {format} is not an '
                              f'accepted input format for `write_raw_bids`. '
                              f'For example, if you passed in "EDF", mne-bids '
                              f'does not currently have conversion to EDF. '
-                             f'Please use one of {CONVERT_FORMATS}.')
+                             f'Please use one of {CONVERT_FORMATS[datatype]} '
+                             f'for {datatype} datatype.')
+        elif format not in CONVERT_FORMATS[datatype]:
+            raise ValueError(f'The input "format" {format} is not an '
+                             f'accepted input format for {datatype} datatype. '
+                             f'Please use one of {CONVERT_FORMATS[datatype]} '
+                             f'for {datatype} datatype.')
 
     # File saving branching logic
     if convert:

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1004,13 +1004,13 @@ def write_raw_bids(raw, bids_path, events_data=None,
             information apart from the recording date.
 
     format : 'auto' | 'BrainVision' | 'FIF'
-        If `'auto'` (default), there is no explicit change in how the file is
-        converted to BIDS. The native format is used. If a str, then will
-        accept RECOMMENDED BIDS file formats. For example, EEG and iEEG
-        RECOMMENDED formats are ``BrainVision`` and ``EDF``. If
-        ``'BrainVision'`` is passed in, then file will be converted to the
-        ``BrainVision`` file format even if the file is originally in ``EDF``
-        file format. For MEG, ``'FIF'`` will convert file to ``FIF`` format.
+        Controls the file format of the data after BIDS conversion. If
+        ``'auto'``, MNE-BIDS will attempt to convert the input data to BIDS
+        without a change of the original file format. A conversion to a
+        different file format (BrainVision, or FIF) will only take place when
+        the original file format lacks some necessary features. When a str is
+        passed, a conversion can be forced to the BrainVision format for EEG,
+        or the FIF format for MEG data.
     overwrite : bool
         Whether to overwrite existing files or data in files.
         Defaults to ``False``.


### PR DESCRIPTION
PR Description
--------------

Closes: #659 

Note: EDF format is not supported due to the lack of a robust EDF format writer.

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
