### PR TITLE
[MRG] Fixing quickstart doc bug, write_raw_bids doc bug, and coordsystem.json overwriting error

### DIFF
--- a/doc/use.rst
+++ b/doc/use.rst
@@ -15,7 +15,7 @@ Python
     >>> from mne_bids import BIDSPath, write_raw_bids
     >>> raw = mne.io.read_raw_fif('my_old_file.fif')
     >>> bids_path = BIDSPath(subject='01', session='01, run='05',
-                             datatype='meg', bids_root='./bids_dataset')
+                             datatype='meg', root='./bids_dataset')
     >>> write_raw_bids(raw, bids_path=bids_path)
 
 Command Line Interface

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -48,7 +48,7 @@ Bug fixes
 
 - Fix writing MEGIN Triux files, by `Alexandre Gramfort`_ (:gh:`674`)
 - Anonymization of EDF files in :func:`write_raw_bids` will now convert recording date to ``01-01-1985 00:00:00`` if anonymization takes place, while setting the recording date in the ``scans.tsv`` file to the anonymized date, thus making the file EDF/EDFBrowser compliant, by `Adam Li`_ (:gh:`669`)
-- :func:`mne.write_raw_bids` will not overwrite an existing ``coordsystem.json`` anymore, unless explicitly requested, by `Adam Li`_ (:gh:`675`)
+- :func:`mne_bids.write_raw_bids` will not overwrite an existing ``coordsystem.json`` anymore, unless explicitly requested, by `Adam Li`_ (:gh:`675`)
 
 :doc:`Find out what was new in previous releases <whats_new_previous_releases>`
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -48,7 +48,7 @@ Bug fixes
 
 - Fix writing MEGIN Triux files, by `Alexandre Gramfort`_ (:gh:`674`)
 - Anonymization of EDF files in :func:`write_raw_bids` will now convert recording date to ``01-01-1985 00:00:00`` if anonymization takes place, while setting the recording date in the ``scans.tsv`` file to the anonymized date, thus making the file EDF/EDFBrowser compliant, by `Adam Li`_ (:gh:`669`)
-- Add fix to MEG ``coordsystem.json`` file writing, where an error will be thrown if ``coordsystem.json`` file path exists, but contents differ, by `Adam Li`_ (:gh:`675`)
+- :func:`mne.write_raw_bids` will not overwrite an existing ``coordsystem.json`` anymore, unless explicitly requested, by `Adam Li`_ (:gh:`675`)
 
 :doc:`Find out what was new in previous releases <whats_new_previous_releases>`
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -48,6 +48,7 @@ Bug fixes
 
 - Fix writing MEGIN Triux files, by `Alexandre Gramfort`_ (:gh:`674`)
 - Anonymization of EDF files in :func:`write_raw_bids` will now convert recording date to ``01-01-1985 00:00:00`` if anonymization takes place, while setting the recording date in the ``scans.tsv`` file to the anonymized date, thus making the file EDF/EDFBrowser compliant, by `Adam Li`_ (:gh:`669`)
+- Add fix to MEG ``coordsystem.json`` file writing, where an error will be thrown if ``coordsystem.json`` file path exists, but contents differ, by `Adam Li`_ (:gh:`675`)
 
 :doc:`Find out what was new in previous releases <whats_new_previous_releases>`
 

--- a/mne_bids/dig.py
+++ b/mne_bids/dig.py
@@ -207,7 +207,23 @@ def _electrodes_tsv(raw, fname, datatype, overwrite=False, verbose=True):
     if hasattr(raw, 'impedances'):
         data['impedance'] = _get_impedances(raw, names)
 
-    _write_tsv(fname, data, overwrite=overwrite, verbose=verbose)
+    # note that any coordsystem.json file shared within sessions
+    # will be the same across all runs (currently). So
+    # overwrite is set to True always
+    # XXX: improve later when BIDS is updated
+    # check that there already exists a coordsystem.json
+    if Path(fname).exists() and not overwrite:
+        electrodes_tsv = _from_tsv(fname)
+
+        # data values are passed to str to make equality check work
+        if any([list(map(str, vals1)) != list(vals2) for vals1, vals2 in
+                zip(data.values(), electrodes_tsv.values())]):
+            raise RuntimeError(
+                f'Trying to write electrodes.tsv, but it already '
+                f'exists at {fname} and the contents do not match. '
+                f'You must differentiate this electrodes.tsv file '
+                f'from the existing one, or set "overwrite" to True.')
+    _write_tsv(fname, data, overwrite=True, verbose=verbose)
 
 
 def _coordsystem_json(*, raw, unit, hpi_coord_system, sensor_coord_system,

--- a/mne_bids/dig.py
+++ b/mne_bids/dig.py
@@ -5,6 +5,7 @@
 # License: BSD (3-clause)
 import json
 from collections import OrderedDict
+from pathlib import Path
 
 import mne
 import numpy as np
@@ -290,6 +291,23 @@ def _coordsystem_json(*, raw, unit, hpi_coord_system, sensor_coord_system,
             'iEEGCoordinateUnits': unit,  # m (MNE), mm, cm , or pixels
         }
 
+    # note that any coordsystem.json file shared within sessions
+    # will be the same across all runs (currently). So
+    # overwrite is set to True always
+    # XXX: improve later when BIDS is updated
+    # check that there already exists a coordsystem.json
+    if datatype == 'meg' and Path(fname).exists():
+        with open(fname, 'r') as fin:
+            coordsystem_dict = json.load(fin)
+        if fid_json != coordsystem_dict:
+            raise RuntimeError(f'Trying to write coordsystem.json, but '
+                               f'it already exists at {fname} and the '
+                               f'contents do not match. You must '
+                               f'differentiate this coordsystem.json '
+                               f'file from the existing one, or set '
+                               f'"overwrite" to True.')
+        # set overwrite to True
+        overwrite = True
     _write_json(fname, fid_json, overwrite, verbose)
 
 

--- a/mne_bids/dig.py
+++ b/mne_bids/dig.py
@@ -215,7 +215,7 @@ def _electrodes_tsv(raw, fname, datatype, overwrite=False, verbose=True):
     if Path(fname).exists() and not overwrite:
         electrodes_tsv = _from_tsv(fname)
 
-        # data values are passed to str to make equality check work
+        # cast values to str to make equality check work
         if any([list(map(str, vals1)) != list(vals2) for vals1, vals2 in
                 zip(data.values(), electrodes_tsv.values())]):
             raise RuntimeError(

--- a/mne_bids/dig.py
+++ b/mne_bids/dig.py
@@ -306,9 +306,7 @@ def _coordsystem_json(*, raw, unit, hpi_coord_system, sensor_coord_system,
                                f'differentiate this coordsystem.json '
                                f'file from the existing one, or set '
                                f'"overwrite" to True.')
-        # set overwrite to True
-        overwrite = True
-    _write_json(fname, fid_json, overwrite, verbose)
+    _write_json(fname, fid_json, overwrite=True, verbose=verbose)
 
 
 def _write_dig_bids(bids_path, raw, overwrite=False, verbose=True):

--- a/mne_bids/dig.py
+++ b/mne_bids/dig.py
@@ -297,7 +297,7 @@ def _coordsystem_json(*, raw, unit, hpi_coord_system, sensor_coord_system,
     # XXX: improve later when BIDS is updated
     # check that there already exists a coordsystem.json
     if datatype == 'meg' and Path(fname).exists() and not overwrite:
-        with open(fname, 'r') as fin:
+        with open(fname, 'r', encoding='utf-8-sig') as fin:
             coordsystem_dict = json.load(fin)
         if fid_json != coordsystem_dict:
             raise RuntimeError(f'Trying to write coordsystem.json, but '

--- a/mne_bids/dig.py
+++ b/mne_bids/dig.py
@@ -296,7 +296,7 @@ def _coordsystem_json(*, raw, unit, hpi_coord_system, sensor_coord_system,
     # overwrite is set to True always
     # XXX: improve later when BIDS is updated
     # check that there already exists a coordsystem.json
-    if datatype == 'meg' and Path(fname).exists() and not overwrite:
+    if Path(fname).exists() and not overwrite:
         with open(fname, 'r', encoding='utf-8-sig') as fin:
             coordsystem_dict = json.load(fin)
         if fid_json != coordsystem_dict:

--- a/mne_bids/dig.py
+++ b/mne_bids/dig.py
@@ -300,12 +300,11 @@ def _coordsystem_json(*, raw, unit, hpi_coord_system, sensor_coord_system,
         with open(fname, 'r', encoding='utf-8-sig') as fin:
             coordsystem_dict = json.load(fin)
         if fid_json != coordsystem_dict:
-            raise RuntimeError(f'Trying to write coordsystem.json, but '
-                               f'it already exists at {fname} and the '
-                               f'contents do not match. You must '
-                               f'differentiate this coordsystem.json '
-                               f'file from the existing one, or set '
-                               f'"overwrite" to True.')
+            raise RuntimeError(
+                f'Trying to write coordsystem.json, but it already '
+                f'exists at {fname} and the contents do not match. '
+                f'You must differentiate this coordsystem.json file '
+                f'from the existing one, or set "overwrite" to True.')
     _write_json(fname, fid_json, overwrite=True, verbose=verbose)
 
 

--- a/mne_bids/dig.py
+++ b/mne_bids/dig.py
@@ -207,7 +207,7 @@ def _electrodes_tsv(raw, fname, datatype, overwrite=False, verbose=True):
     if hasattr(raw, 'impedances'):
         data['impedance'] = _get_impedances(raw, names)
 
-    _write_tsv(fname, data, overwrite=overwrite, verbose=verbose)
+    _write_tsv(fname, data, overwrite=True, verbose=verbose)
 
 
 def _coordsystem_json(*, raw, unit, hpi_coord_system, sensor_coord_system,

--- a/mne_bids/dig.py
+++ b/mne_bids/dig.py
@@ -207,7 +207,7 @@ def _electrodes_tsv(raw, fname, datatype, overwrite=False, verbose=True):
     if hasattr(raw, 'impedances'):
         data['impedance'] = _get_impedances(raw, names)
 
-    _write_tsv(fname, data, overwrite=True, verbose=verbose)
+    _write_tsv(fname, data, overwrite=overwrite, verbose=verbose)
 
 
 def _coordsystem_json(*, raw, unit, hpi_coord_system, sensor_coord_system,

--- a/mne_bids/dig.py
+++ b/mne_bids/dig.py
@@ -296,7 +296,7 @@ def _coordsystem_json(*, raw, unit, hpi_coord_system, sensor_coord_system,
     # overwrite is set to True always
     # XXX: improve later when BIDS is updated
     # check that there already exists a coordsystem.json
-    if datatype == 'meg' and Path(fname).exists():
+    if datatype == 'meg' and Path(fname).exists() and not overwrite:
         with open(fname, 'r') as fin:
             coordsystem_dict = json.load(fin)
         if fid_json != coordsystem_dict:

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -2162,7 +2162,6 @@ def test_coordsystem_json(dir_name, fname, reader, datatype, coord_frame):
     raw = reader(raw_fname)
 
     # clean all events for this test
-    raw.set_annotations(None)
     kwargs = dict(raw=raw, bids_path=bids_path, overwrite=True,
                   verbose=False)
 

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -2196,13 +2196,21 @@ def test_coordsystem_json(dir_name, fname, reader, datatype, coord_frame):
     # if datatype is MEG and there is a change in the underlying
     # coordsystem.json file, then an error will occur
     if datatype == 'meg':
+        # writing twice should work as long as the coordsystem
+        # contents have not changed
+        write_raw_bids(raw=raw, bids_path=bids_path.copy().update(run='02'),
+                       overwrite=False, verbose=False)
+
+        # upon changing coordsystem contents, and overwrite not True
+        # this will fail
         new_coordsystem_json = coordsystem_json.copy()
         new_coordsystem_json['MEGCoordinateSystem'] = 'Other'
         _write_json(coordsystem_fname, new_coordsystem_json, overwrite=True)
         with pytest.raises(RuntimeError,
                            match='Trying to write coordsystem.json, '
                                  'but it already exists'):
-            write_raw_bids(**kwargs)
+            write_raw_bids(raw=raw, bids_path=bids_path, overwrite=False,
+                           verbose=False)
 
     # perform checks on the coordsystem.json file itself
     if datatype == 'eeg' and coord_frame == 'head':

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -2160,6 +2160,9 @@ def test_coordsystem_json(dir_name, fname, reader, datatype, coord_frame):
                                          datatype=datatype)
 
     raw = reader(raw_fname)
+
+    # clean all events for this test
+    raw.set_annotations(None)
     kwargs = dict(raw=raw, bids_path=bids_path, overwrite=True,
                   verbose=False)
 
@@ -2204,13 +2207,13 @@ def test_coordsystem_json(dir_name, fname, reader, datatype, coord_frame):
     # upon changing coordsystem contents, and overwrite not True
     # this will fail
     new_coordsystem_json = coordsystem_json.copy()
-    new_coordsystem_json[f'{datatype_}CoordinateSystem'] = 'Other'
+    new_coordsystem_json[f'{datatype_}CoordinateSystem'] = 'blah'
     _write_json(coordsystem_fname, new_coordsystem_json, overwrite=True)
     with pytest.raises(RuntimeError,
                        match='Trying to write coordsystem.json, '
                              'but it already exists'):
-        write_raw_bids(raw=raw, bids_path=bids_path, overwrite=False,
-                       verbose=False)
+        write_raw_bids(raw=raw, bids_path=bids_path.copy().update(run='03'),
+                       overwrite=False, verbose=False)
 
     # perform checks on the coordsystem.json file itself
     if datatype == 'eeg' and coord_frame == 'head':

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -2193,24 +2193,24 @@ def test_coordsystem_json(dir_name, fname, reader, datatype, coord_frame):
     with open(coordsystem_fname, 'r', encoding='utf-8') as fin:
         coordsystem_json = json.load(fin)
 
-    # if datatype is MEG and there is a change in the underlying
+    # if there is a change in the underlying
     # coordsystem.json file, then an error will occur
-    if datatype == 'meg':
-        # writing twice should work as long as the coordsystem
-        # contents have not changed
-        write_raw_bids(raw=raw, bids_path=bids_path.copy().update(run='02'),
-                       overwrite=False, verbose=False)
+    # writing twice should work as long as the coordsystem
+    # contents have not changed
+    write_raw_bids(raw=raw, bids_path=bids_path.copy().update(run='02'),
+                   overwrite=False, verbose=False)
 
-        # upon changing coordsystem contents, and overwrite not True
-        # this will fail
-        new_coordsystem_json = coordsystem_json.copy()
-        new_coordsystem_json['MEGCoordinateSystem'] = 'Other'
-        _write_json(coordsystem_fname, new_coordsystem_json, overwrite=True)
-        with pytest.raises(RuntimeError,
-                           match='Trying to write coordsystem.json, '
-                                 'but it already exists'):
-            write_raw_bids(raw=raw, bids_path=bids_path, overwrite=False,
-                           verbose=False)
+    datatype_ = {'meg': 'MEG', 'eeg': 'EEG', 'ieeg': 'iEEG'}[datatype]
+    # upon changing coordsystem contents, and overwrite not True
+    # this will fail
+    new_coordsystem_json = coordsystem_json.copy()
+    new_coordsystem_json[f'{datatype_}CoordinateSystem'] = 'Other'
+    _write_json(coordsystem_fname, new_coordsystem_json, overwrite=True)
+    with pytest.raises(RuntimeError,
+                       match='Trying to write coordsystem.json, '
+                             'but it already exists'):
+        write_raw_bids(raw=raw, bids_path=bids_path, overwrite=False,
+                       verbose=False)
 
     # perform checks on the coordsystem.json file itself
     if datatype == 'eeg' and coord_frame == 'head':

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -933,14 +933,15 @@ def write_raw_bids(raw, bids_path, events_data=None,
         Example::
 
             bids_path = BIDSPath(subject='01', session='01', task='testing',
-                                 acquisition='01', run='01', root='/data/BIDS')
+                                 acquisition='01', run='01', datatype='meg',
+                                 root='/data/BIDS')
 
         This will write the following files in the correct subfolder ``root``::
 
             sub-01_ses-01_task-testing_acq-01_run-01_meg.fif
             sub-01_ses-01_task-testing_acq-01_run-01_meg.json
             sub-01_ses-01_task-testing_acq-01_run-01_channels.tsv
-            sub-01_ses-01_task-testing_acq-01_run-01_coordsystem.json
+            sub-01_ses-01_acq-01_coordsystem.json
 
         and the following one if ``events_data`` is not ``None``::
 
@@ -1215,11 +1216,15 @@ def write_raw_bids(raw, bids_path, events_data=None,
 
     # for MEG, we only write coordinate system
     if bids_path.datatype == 'meg' and not emptyroom:
+        # note that any coordsystem.json file shared within sessions
+        # will be the same across all runs (currently). So
+        # overwrite is set to True always
+        # XXX: improve later when BIDS is updated
         _coordsystem_json(raw=raw, unit=unit, hpi_coord_system=orient,
                           sensor_coord_system=orient,
                           fname=coordsystem_path.fpath,
                           datatype=bids_path.datatype,
-                          overwrite=overwrite, verbose=verbose)
+                          overwrite=True, verbose=verbose)
     elif bids_path.datatype in ['eeg', 'ieeg']:
         # We only write electrodes.tsv and accompanying coordsystem.json
         # if we have an available DigMontage

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1216,15 +1216,11 @@ def write_raw_bids(raw, bids_path, events_data=None,
 
     # for MEG, we only write coordinate system
     if bids_path.datatype == 'meg' and not emptyroom:
-        # note that any coordsystem.json file shared within sessions
-        # will be the same across all runs (currently). So
-        # overwrite is set to True always
-        # XXX: improve later when BIDS is updated
         _coordsystem_json(raw=raw, unit=unit, hpi_coord_system=orient,
                           sensor_coord_system=orient,
                           fname=coordsystem_path.fpath,
                           datatype=bids_path.datatype,
-                          overwrite=True, verbose=verbose)
+                          overwrite=overwrite, verbose=verbose)
     elif bids_path.datatype in ['eeg', 'ieeg']:
         # We only write electrodes.tsv and accompanying coordsystem.json
         # if we have an available DigMontage


### PR DESCRIPTION
PR Description
--------------

Closes: #663 
Closes: #662 
Closes: #656 

Currently to my knowledge, MEG data coordsystem.json file is only supported as one per session. There might be say multiple coordsystem.json files, but there is no right way to read those in currently. This addresses the main doc errors and FileExistsError.

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
