### PR TITLE
Fix bug if no event descriptions are present; support stim_type column in events.tsv

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -31,7 +31,7 @@ Detailed list of changes
 Enhancements
 ^^^^^^^^^^^^
 
-- xxx
+- Some datasets out in the real world have a non-standard ``stim_type`` instead of a ``trial_type`` column in ``*_events.tsv``. :func:`mne_bids.read_raw_bids` now makes use of this column, and emits a warning, encouraging users to rename it, by `Richard Höchenberger`_ (:gh:`680`)
 
 API changes
 ^^^^^^^^^^^
@@ -49,6 +49,7 @@ Bug fixes
 - Fix writing MEGIN Triux files, by `Alexandre Gramfort`_ (:gh:`674`)
 - Anonymization of EDF files in :func:`write_raw_bids` will now convert recording date to ``01-01-1985 00:00:00`` if anonymization takes place, while setting the recording date in the ``scans.tsv`` file to the anonymized date, thus making the file EDF/EDFBrowser compliant, by `Adam Li`_ (:gh:`669`)
 - :func:`mne_bids.write_raw_bids` will not overwrite an existing ``coordsystem.json`` anymore, unless explicitly requested, by `Adam Li`_ (:gh:`675`)
+- :func:`mne_bids.read_raw_bids` now properly handles datasets without event descriptions, by `Richard Höchenberger`_ (:gh:`680`) 
 
 :doc:`Find out what was new in previous releases <whats_new_previous_releases>`
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -24,6 +24,7 @@ Authors
 ~~~~~~~
 
 * `Adam Li`_
+* `Richard Höchenberger`_
 
 Detailed list of changes
 ~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
If no event descriptions could be generated, we'd crash as we'd try
to access descriptions like an array, while our placeholder would only
be a string. This is fixed now.

The other part of this PR is related to the naming of the column in the
events.tsv file that contains the event description. According to
BIDS, this column is optional and shall be named `trial_type`. Now
I've come across multiple (older?) datasets where the column is
called `stim_type` instead. I've now added support for reading this
column if `trial_type` is not present. A warning will be issued in
this case, informing the user that the column name should be changed.

This was necessary to read the ds000117 datset from
https://openneuro.org/datasets/ds000117


Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
