### PR TITLE
MRG: Fix scans.tsv reading

### DIFF
--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -529,8 +529,8 @@ def read_raw_bids(bids_path, extra_params=None, verbose=True):
         subject=bids_path.subject, session=bids_path.session,
         suffix='scans', extension='.tsv',
         root=bids_path.root
-    )
-    if scans_fname.fpath.exists():
+    ).fpath
+    if scans_fname.exists():
         raw = _handle_scans_reading(scans_fname, raw, bids_path,
                                     verbose=verbose)
 


### PR DESCRIPTION
I cannot fully reproduce this, but @dnacombo was experiencing issues
when trying to read a raw file, as reading of `scans.tsv` failed. Reason
was that NumPy's `loadtxt` couldn't cope with the `BIDSPath`. Passing
a `pathlib.Path` instead fixed the problem.

Like I said, I could not reproduce this problem locally, but passing a
`Path` instead of a `BIDSPath` is probably a good idea anyway.


Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
