### PR TITLE
RFC, WIP: Add eeg_reference kwarg to write_raw_bids()

### DIFF
--- a/examples/convert_eeg_to_bids.py
+++ b/examples/convert_eeg_to_bids.py
@@ -228,8 +228,8 @@ print(text)
 ###############################################################################
 # Now it's time to manually check the BIDS directory and the meta files to add
 # all the information that MNE-BIDS could not infer. For instance, you must
-# describe EEGReference and EEGGround yourself. It's easy to find these by
-# searching for "n/a" in the sidecar files.
+# describe EEGGround yourself. It's easy to find these by searching for "n/a"
+# in the sidecar files.
 #
 # Remember that there is a convenient javascript tool to validate all your BIDS
 # directories called the "BIDS-validator", available as a web version and a

--- a/examples/convert_ieeg_to_bids.py
+++ b/examples/convert_ieeg_to_bids.py
@@ -204,8 +204,8 @@ print(text)
 #
 # Now it's time to manually check the BIDS directory and the meta files to add
 # all the information that MNE-BIDS could not infer. For instance, you must
-# describe iEEGReference and iEEGGround yourself. It's easy to find these by
-# searching for "n/a" in the sidecar files.
+# describe iEEGGround yourself. It's easy to find these by searching for "n/a"
+# in the sidecar files.
 #
 # `$ grep -i 'n/a' <bids_root>`
 #


### PR DESCRIPTION
PR Description
--------------

This PR adds an `eeg_reference` kwarg to `write_raw_bids()`, allowing users to set `EEGReference` (EEG) and `iEEGReference` (iEEG).

Con:
- growing API
- where do we stop? there's like a million optional params for different recording types; we cannot add all of them as kwargs

Pro:
- an EEG reference is such a fundamental property of a recording, it must be extremely convenient to add it to the data in a single go without having to manually fiddle with the JSON sidecars, as is currently suggested in the docs:

    ```
    # Now it's time to manually check the BIDS directory and the meta files to add
    # all the information that MNE-BIDS could not infer. For instance, you must
    # describe EEGReference and EEGGround yourself. It's easy to find these by
    # searching for "n/a" in the sidecar files.
    ```

We need a general discussion about this at one point; however I am deeply convinced that for now, having an `eeg_reference` param in `write_raw_bids()` is the best option. But you're free to try and change my mind ;)

😅


Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
