### PR TITLE
ENH: Don't enforce BIDS & Raw channel name equivalence in read_raw_bids()

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -34,6 +34,7 @@ Enhancements
 
 - Some datasets out in the real world have a non-standard ``stim_type`` instead of a ``trial_type`` column in ``*_events.tsv``. :func:`mne_bids.read_raw_bids` now makes use of this column, and emits a warning, encouraging users to rename it, by `Richard Höchenberger`_ (:gh:`680`)
 - When reading data where the same event name or trial type refers to different event or trigger values, we will now create a hierarchical event name in the form of ``trial_type/value``, e.g. ``stimulus/110``  by `Richard Höchenberger`_ (:gh:`688`)
+- When reading data via :func:`mne_bids.read_raw_bids`, the channel names specified in the BIDS ``*_channels.tsv`` files now always take precedence (and to not need to match) the channel names stored in the raw files anymore, by `Richard Höchenberger`_ (:gh:`691`)
 
 API changes
 ^^^^^^^^^^^

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -34,7 +34,7 @@ Enhancements
 
 - Some datasets out in the real world have a non-standard ``stim_type`` instead of a ``trial_type`` column in ``*_events.tsv``. :func:`mne_bids.read_raw_bids` now makes use of this column, and emits a warning, encouraging users to rename it, by `Richard Höchenberger`_ (:gh:`680`)
 - When reading data where the same event name or trial type refers to different event or trigger values, we will now create a hierarchical event name in the form of ``trial_type/value``, e.g. ``stimulus/110``  by `Richard Höchenberger`_ (:gh:`688`)
-- When reading data via :func:`mne_bids.read_raw_bids`, the channel names specified in the BIDS ``*_channels.tsv`` files now always take precedence (and to not need to match) the channel names stored in the raw files anymore, by `Richard Höchenberger`_ (:gh:`691`)
+- When reading data via :func:`mne_bids.read_raw_bids`, the channel names specified in the BIDS ``*_channels.tsv`` files now always take precedence (and do not need to match) the channel names stored in the raw files anymore, by `Richard Höchenberger`_ (:gh:`691`)
 
 API changes
 ^^^^^^^^^^^

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -354,7 +354,7 @@ def _handle_channels_reading(channels_fname, raw):
     logger.info('Reading channel info from {}.'.format(channels_fname))
     channels_dict = _from_tsv(channels_fname)
     ch_names_tsv = channels_dict['name']
- 
+
     # Now we can do some work.
     # The "type" column is mandatory in BIDS. We can use it to set channel
     # types in the raw data using a mapping between channel types
@@ -383,7 +383,6 @@ def _handle_channels_reading(channels_fname, raw):
 
         if updated_ch_type is not None:
             channel_type_dict[ch_name] = updated_ch_type
-
 
     # Rename channels in loaded Raw to match those read from the BIDS sidecar
     for bids_ch_name, raw_ch_name in zip(ch_names_tsv, raw.ch_names.copy()):

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -1000,9 +1000,9 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate):
     del raw2, events2
 
     # alter some channels manually
-    raw.rename_channels({raw.info['ch_names'][0]: 'EOGtest'})
+    raw.rename_channels({raw.ch_names[0]: 'EOGtest'})
     raw.info['chs'][0]['coil_type'] = FIFF.FIFFV_COIL_EEG_BIPOLAR
-    raw.rename_channels({raw.info['ch_names'][1]: 'EMG'})
+    raw.rename_channels({raw.ch_names[1]: 'EMG'})
     raw.set_channel_types({'EMG': 'emg'})
 
     # Test we can overwrite dataset_description.json
@@ -1045,15 +1045,12 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate):
             ["Please cite MNE-BIDS in your publication before removing this "
              "(citations in README)"]
 
-    # Reading the file back should raise an error, because we renamed channels
-    # in `raw` and used that information to write a channels.tsv. Yet, we
-    # saved the unchanged `raw` in the BIDS folder, so channels in the TSV and
-    # in raw clash
-    # Note: only needed for data files that store channel names
-    # alongside the data
-    if dir_name == 'EDF':
-        with pytest.raises(RuntimeError, match='Channels do not correspond'):
-            read_raw_bids(bids_path=bids_path)
+    # Reading the file back should still work, even though we've renamed
+    # some channels (there's now a mismatch between BIDS and Raw channel
+    # names, and BIDS should take precedence)
+    raw_read = read_raw_bids(bids_path=bids_path)
+    assert raw_read.ch_names[0] == 'EOGtest'
+    assert raw_read.ch_names[1] == 'EMG'
 
     with pytest.raises(TypeError, match="unexpected keyword argument 'foo'"):
         read_raw_bids(bids_path=bids_path, extra_params=dict(foo='bar'))


### PR DESCRIPTION
Fixes #697

Please note that the same issue still exists for iEEG data in `dig._handle_electrodes_reading()`, but I don't fully understand the code and therefore currently don't dare to touch it. @adam2392 might want to give this one a shot 😇

cc @MaelysSolal 

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
