### PR TITLE
list split files separately in scans.tsv

### DIFF
--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -9,6 +9,7 @@
 import os.path as op
 import glob
 import json
+import re
 from datetime import datetime, timezone
 
 import numpy as np
@@ -203,6 +204,21 @@ def _handle_scans_reading(scans_fname, raw, bids_path, verbose=False):
     fnames = scans_tsv['filename']
     acq_times = scans_tsv['acq_time']
     row_ind = fnames.index(data_fname)
+
+    # check whether all split files have the same acq_time
+    # and throw an error if they don't
+    if '_split-' in fname:
+        split_idx = fname.find('split-')
+        pattern = re.compile(bids_path.datatype + '/' +
+                             bids_path.basename[:split_idx] +
+                             r'split-\d+_' + bids_path.basename[split_idx:] +
+                             bids_path.fpath.suffix)
+        split_fnames = list(filter(pattern.match, fnames))
+        split_acq_times = []
+        for split_f in split_fnames:
+            split_acq_times.append(acq_times[fnames.index(split_f)])
+        if len(set(split_acq_times)) != 1:
+            raise ValueError("Split files must have the same acq_time.")
 
     # extract the acquisition time from scans file
     acq_time = acq_times[row_ind]
@@ -537,6 +553,7 @@ def read_raw_bids(bids_path, extra_params=None, verbose=True):
         suffix='scans', extension='.tsv',
         root=bids_path.root
     ).fpath
+
     if scans_fname.exists():
         raw = _handle_scans_reading(scans_fname, raw, bids_path,
                                     verbose=verbose)

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -211,7 +211,7 @@ def _handle_scans_reading(scans_fname, raw, bids_path, verbose=False):
         split_idx = fname.find('split-')
         pattern = re.compile(bids_path.datatype + '/' +
                              bids_path.basename[:split_idx] +
-                             r'split-\d+_' + bids_path.basename[split_idx:] +
+                             r'split-\d+_' + bids_path.datatype +
                              bids_path.fpath.suffix)
         split_fnames = list(filter(pattern.match, fnames))
         split_acq_times = []

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -192,12 +192,7 @@ def _handle_scans_reading(scans_fname, raw, bids_path, verbose=False):
     scans_tsv = _from_tsv(scans_fname)
     fname = bids_path.fpath.name
 
-    if '_split-' in fname:
-        # for split files, scans only stores the filename without ``split``
-        extension = bids_path.fpath.suffix
-        bids_path.update(split=None, extension=extension)
-        fname = bids_path.basename
-    elif fname.endswith('.pdf'):
+    if fname.endswith('.pdf'):
         # for BTI files, the scan is an entire directory
         fname = fname.split('.')[0]
 

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -787,11 +787,54 @@ def test_write_read_fif_split_file():
 
     bids_path.update(split='01')
     raw2 = read_raw_bids(bids_path=bids_path)
+
     bids_path.update(split='02')
     raw3 = read_raw_bids(bids_path=bids_path)
     assert len(raw) == len(raw1)
     assert len(raw) == len(raw2)
     assert len(raw) > len(raw3)
+
+    # check that the scans list contains two scans
+    scans_tsv = BIDSPath(
+        subject=subject_id, session=session_id,
+        suffix='scans', extension='.tsv',
+        root=bids_root)
+    scan_data = _from_tsv(scans_tsv)
+
+    scan_fnames = scan_data['filename']
+    scan_acqtime = scan_data['acq_time']
+    assert len(scan_fnames) == 2
+    assert 'split-01' in scan_fnames[0] and 'split-02' in scan_fnames[1]
+    # check that the acq_times in scans.tsv are the same
+    assert scan_acqtime[0] == scan_acqtime[1]
+    # check the recordings are in the correct order
+    assert raw2.first_time < raw3.first_time
+
+    # find sidecar scans.tsv file and alter the
+    # acquisition time to not have the optional microseconds
+    acq_time_str = scan_acqtime[0]
+    acq_time = datetime.strptime(acq_time_str, '%Y-%m-%dT%H:%M:%S.%fZ')
+    acq_time = acq_time.replace(tzinfo=timezone.utc)
+    new_acq_time = acq_time_str.split('.')[0]
+    assert acq_time == raw1.info['meas_date']
+    scan_data['acq_time'][0] = new_acq_time
+    _to_tsv(scan_data, scans_tsv)
+
+    """
+    # now re-load the data and it should be different
+    # from the original date and the same as the newly altered date
+    # but as read.py throws a ValueError when acq_time won't match,
+    # the ValueError need to be dealt with here.
+    bids_path.update(split='01')
+    raw4 = read_raw_bids(bids_path)
+    new_acq_time += '.0Z'
+    new_acq_time = datetime.strptime(new_acq_time,
+                                     '%Y-%m-%dT%H:%M:%S.%fZ')
+    new_acq_time = new_acq_time.replace(tzinfo=timezone.utc)
+    assert scan_acqtime[0] != scan_acqtime[1]
+    assert raw4.info['meas_date'] == new_acq_time
+    assert new_acq_time != raw1.info['meas_date']
+    """
 
 
 @pytest.mark.filterwarnings(warning_str['channel_unit_changed'])

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -774,6 +774,9 @@ def test_write_read_fif_split_file():
     tmp_dir = _TempDir()
     bids_path = _bids_path.copy().update(root=bids_root, datatype='meg')
     raw = _read_raw_fif(raw_fname, verbose=False)
+    bids_path.update(acquisition=None)
+    write_raw_bids(raw, bids_path, verbose=False)
+    bids_path.update(acquisition='01')
     n_channels = len(raw.ch_names)
     n_times = int(2.2e9 / (n_channels * 4))  # enough to produce a split
     data = np.empty((n_channels, n_times), dtype=np.float32)
@@ -803,7 +806,7 @@ def test_write_read_fif_split_file():
     scan_fnames = scan_data['filename']
     scan_acqtime = scan_data['acq_time']
 
-    assert len(scan_fnames) == 2
+    assert len(scan_fnames) == 3
     assert 'split-01' in scan_fnames[0] and 'split-02' in scan_fnames[1]
     # check that the acq_times in scans.tsv are the same
     assert scan_acqtime[0] == scan_acqtime[1]

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -2570,33 +2570,3 @@ def test_write_fif_triux():
         subject="01", session="01", run="01", datatype="meg", root=bids_root
     )
     write_raw_bids(raw, bids_path=bids_path, overwrite=True)
-
-
-@pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
-def test_write_fif_split_scan_file():
-    """Test scans.tsv is written correctly for split fif files."""
-    data_path = testing.data_path()
-    bids_root = _TempDir()
-    tmp_dir = _TempDir()
-    bids_path = _bids_path.copy().update(root=bids_root, datatype='meg')
-    raw_fname = op.join(data_path, 'MEG', 'sample',
-                        'sample_audvis_trunc_raw.fif')
-    raw = _read_raw_fif(raw_fname, verbose=False)
-    n_channels = len(raw.ch_names)
-    n_times = int(2.2e9 / (n_channels * 4))  # enough to produce a split
-    data = np.empty((n_channels, n_times), dtype=np.float32)
-    raw = mne.io.RawArray(data, raw.info)
-    big_fif_fname = op.join(tmp_dir, 'test_raw.fif')
-    raw.save(big_fif_fname)
-    raw = _read_raw_fif(big_fif_fname, verbose=False)
-    write_raw_bids(raw, bids_path, verbose=False)
-
-    # check that the scans list contains two scans
-    scans_tsv = BIDSPath(
-        subject=subject_id, session=session_id,
-        suffix='scans', extension='.tsv',
-        root=bids_root)
-    data = _from_tsv(scans_tsv)
-    assert len(list(data.values())[0]) == 2
-    # check that the acq_times of the split recording is identical
-    assert list(data.values())[1][0] == list(data.values())[1][1]

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -414,17 +414,19 @@ def _scans_tsv(raw, raw_fname, fname, overwrite=False, verbose=True):
         acq_time = meas_date.strftime('%Y-%m-%dT%H:%M:%S.%fZ')
 
     # check whether raw file is likely to be split
-    if len(raw.filenames)>1:
+    if len(raw.filenames) > 1:
         raw_parts = raw_fname.split('_')
-        raw_fnames= []
-        for f_idx in range(1,len(raw.filenames)+1):
-            raw_fnames.append('_'.join(raw_parts[:-1]+[f'split-{f_idx:02d}']+raw_parts[-1:]))
+        raw_fnames = []
+        for f_idx in range(1, len(raw.filenames) + 1):
+            raw_fnames.append('_'.join(raw_parts[:-1] +
+                              [f'split-{f_idx:02d}'] + raw_parts[-1:]))
     else:
         raw_fnames = [raw_fname]
 
-    data = OrderedDict([('filename', 
-        ['{:s}'.format(raw_f.replace(os.sep, '/')) for raw_f in raw_fnames]),
-                        ('acq_time', [acq_time] * len(raw_fnames))])
+    data = OrderedDict(
+        [('filename', ['{:s}'.format(raw_f.replace(os.sep, '/'))
+          for raw_f in raw_fnames]),
+            ('acq_time', [acq_time] * len(raw_fnames))])
 
     if os.path.exists(fname):
         orig_data = _from_tsv(fname)

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -413,8 +413,18 @@ def _scans_tsv(raw, raw_fname, fname, overwrite=False, verbose=True):
         # for MNE >= v0.20
         acq_time = meas_date.strftime('%Y-%m-%dT%H:%M:%S.%fZ')
 
-    data = OrderedDict([('filename', ['%s' % raw_fname.replace(os.sep, '/')]),
-                        ('acq_time', [acq_time])])
+    # check whether raw file is likely to be split
+    if len(raw.filenames)>1:
+        raw_parts = raw_fname.split('_')
+        raw_fnames= []
+        for f_idx in range(1,len(raw.filenames)+1):
+            raw_fnames.append('_'.join(raw_parts[:-1]+[f'split-{f_idx:02d}']+raw_parts[-1:]))
+    else:
+        raw_fnames = [raw_fname]
+
+    data = OrderedDict([('filename', 
+        ['{:s}'.format(raw_f.replace(os.sep, '/')) for raw_f in raw_fnames]),
+                        ('acq_time', [acq_time] * len(raw_fnames))])
 
     if os.path.exists(fname):
         orig_data = _from_tsv(fname)

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -419,7 +419,7 @@ def _scans_tsv(raw, raw_fname, fname, overwrite=False, verbose=True):
         # check whether fif files were split when saved
         # use the files in the target directory what should be written
         # to scans.tsv
-        datatype, basename = raw_fname.split('/')
+        datatype, basename = raw_fname.split(os.sep)
         raw_dir = op.join(op.dirname(fname), datatype)
         raw_files = [f for f in os.listdir(raw_dir) if f.endswith('.fif')]
         if basename not in raw_files:

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -424,9 +424,11 @@ def _scans_tsv(raw, raw_fname, fname, overwrite=False, verbose=True):
         raw_files = [f for f in os.listdir(raw_dir) if f.endswith('.fif')]
         if basename not in raw_files:
             raw_fnames = []
+            split_basename = basename.replace('_meg.fif', '_split{}')
             for raw_f in raw_files:
-                if basename.split('_meg.fif')[0] in raw_f:
-                    raw_fnames.append(op.join(datatype, raw_f))
+                if len(raw_f.split('split')) == 2:
+                    if split_basename.format(raw_f.split('split')[1]) == raw_f:
+                        raw_fnames.append(op.join(datatype, raw_f))
             raw_fnames.sort()
 
     data = OrderedDict(

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -424,10 +424,10 @@ def _scans_tsv(raw, raw_fname, fname, overwrite=False, verbose=True):
         raw_files = [f for f in os.listdir(raw_dir) if f.endswith('.fif')]
         if basename not in raw_files:
             raw_fnames = []
-            split_basename = basename.replace('_meg.fif', '_split{}')
+            split_base = basename.replace('_meg.fif', '_split-{}')
             for raw_f in raw_files:
-                if len(raw_f.split('split')) == 2:
-                    if split_basename.format(raw_f.split('split')[1]) == raw_f:
+                if len(raw_f.split('_split-')) == 2:
+                    if split_base.format(raw_f.split('_split-')[1]) == raw_f:
                         raw_fnames.append(op.join(datatype, raw_f))
             raw_fnames.sort()
 


### PR DESCRIPTION
closes #692 

The changes in `read.py` should be clear. In `write.py` it is somewhat more complicated. I didn't know how to infer whether there are split files based on the bids_path, because the splitting is done in mne during saving. What I did now is using the number of files in the `raw.filenames` attribute of the `raw`object, which contains the names of all files that were loaded into this raw instance. That is not ideal, because if for some reason someone wants to combine two files that won't exceed the single-file-size limit, the method would split write split files into `scans.tsv`. I don't think this scenario is very likely though. 

Alternatively, one could try to infer based on the files that have been written, whether a filename is to be split or not. What do you think? 

Aside of that, I couldn't run all tests, because there were missing files for some tests in `test_write.py`: 
- `test_kit()`
- `test_bci()`
- `test_vhdr()`

However, those tests also failed even before I added my changes, so I don't think it has to do with this commit. All other tests passed. 

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
