### PR TITLE
MRG: More detailed error message when trying to write modified data

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -115,7 +115,7 @@ jobs:
     - name: Install MNE (stable)
       if: "matrix.os != 'ubuntu-latest'"
       run: |
-        git clone --depth 1 https://github.com/mne-tools/mne-python.git -b maint/0.21
+        git clone --depth 1 https://github.com/mne-tools/mne-python.git -b maint/0.22
         pip install --no-deps -e ./mne-python
     - name: Install MNE (main)
       if: "matrix.os == 'ubuntu-latest'"

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -33,8 +33,9 @@ Enhancements
 ^^^^^^^^^^^^
 
 - Some datasets out in the real world have a non-standard ``stim_type`` instead of a ``trial_type`` column in ``*_events.tsv``. :func:`mne_bids.read_raw_bids` now makes use of this column, and emits a warning, encouraging users to rename it, by `Richard Höchenberger`_ (:gh:`680`)
-- When reading data where the same event name or trial type refers to different event or trigger values, we will now create a hierarchical event name in the form of ``trial_type/value``, e.g. ``stimulus/110``  by `Richard Höchenberger`_ (:gh:`688`)
+- When reading data where the same event name or trial type refers to different event or trigger values, we will now create a hierarchical event name in the form of ``trial_type/value``, e.g. ``stimulus/110``, by `Richard Höchenberger`_ (:gh:`688`)
 - When reading data via :func:`mne_bids.read_raw_bids`, the channel names specified in the BIDS ``*_channels.tsv`` and ``*_electrodes.tsv`` files now always take precedence (and do not need to match) the channel names stored in the raw files anymore, by `Adam Li`_ and `Richard Höchenberger`_ (:gh:`691`, :gh:`704`)
+- More detailed error messages when trying to write modified data via :func:`mne_bids.write_raw_bids`, by `Richard Höchenberger`_ (:gh:`719`)
 
 API changes
 ^^^^^^^^^^^

--- a/examples/write_modified_files.py
+++ b/examples/write_modified_files.py
@@ -32,7 +32,8 @@ to store such data, despite it being modified before writing.
 # License: BSD (3-clause)
 
 ###############################################################################
-# Load the ``sample`` dataset, and create a concatenated raw data object
+# Load the ``sample`` dataset, and create a concatenated raw data object.
+
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 
@@ -52,7 +53,7 @@ raw.info['line_freq'] = 60
 raw_concat = mne.concatenate_raws([raw.copy(), raw])
 
 ###############################################################################
-# Trying to write these data will fail
+# Trying to write these data will fail.
 
 try:
     write_raw_bids(raw=raw_concat, bids_path=bids_path, overwrite=True)
@@ -61,7 +62,7 @@ except ValueError as e:
 
 ###############################################################################
 # We can work around this limitation by first writing the modified data to
-# a temporary file, and then writing this new file
+# a temporary file, and then writing this new file.
 
 with NamedTemporaryFile(suffix='_raw.fif') as f:
     fname = f.name

--- a/examples/write_modified_files.py
+++ b/examples/write_modified_files.py
@@ -1,0 +1,76 @@
+"""
+========================================
+13. Writing modified files with MNE-BIDS
+========================================
+
+MNE-BIDS is designed such that it enforces good practices when working with
+BIDS data. One of the principles of creating BIDS datasets from raw data is
+that the raw data should ideally be written unmodified, as-is. To enforce
+this, :func:`mne_bids.write_raw_bids` performs some basic checks and will
+throw an exception if it believes you're doing something that you really
+shouldn't be doing (i.e., trying to store modified "raw" data as a BIDS
+raw data set.)
+
+There might be some – rare! – situations, however, when working around this
+intentional limitation in MNE-BIDS can be warranted. For example, you might
+encounter data that has manually been split across multiple files during
+recording, even though it belongs to a single experimental run. In this case,
+you might want to concatenate the data before storing them in BIDS. This
+tutorial will give you an example on how to use :func:`mne_bids.write_raw_bids`
+to store such data, despite it being modified before writing.
+
+.. warning:: Please be aware that the situations in which you would need
+             to apply the following solution are **extremely** rare. If you
+             ever find yourself wanting to apply this solution, please take a
+             step back, take a deep breath and re-consider whether this is
+             **absolutely** necessary. If even a slight doubt remains,
+             reach out to the MNE-BIDS developers.
+
+"""
+
+# Authors: Richard Höchenberger <richard.hoechenberger@gmail.com>
+# License: BSD (3-clause)
+
+###############################################################################
+# Load the ``sample`` dataset, and create a concatenated raw data object
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+import mne
+from mne.datasets import sample
+
+from mne_bids import write_raw_bids, BIDSPath
+
+
+data_path = Path(sample.data_path())
+raw_fname = data_path / 'MEG' / 'sample' / 'sample_audvis_raw.fif'
+output_path = data_path / '..' / 'MNE-sample-data-bids'
+bids_path = BIDSPath(subject='01', task='audiovisual', root=output_path)
+
+raw = mne.io.read_raw_fif(raw_fname)
+raw.info['line_freq'] = 60
+raw_concat = mne.concatenate_raws([raw.copy(), raw])
+
+###############################################################################
+# Trying to write these data will fail
+
+try:
+    write_raw_bids(raw=raw_concat, bids_path=bids_path, overwrite=True)
+except ValueError as e:
+    print(f'Data cannot be written. Exception message was: {e}')
+
+###############################################################################
+# We can work around this limitation by first writing the modified data to
+# a temporary file, and then writing this new file
+
+with NamedTemporaryFile(suffix='_raw.fif') as f:
+    fname = f.name
+    raw_concat.save(fname, overwrite=True)
+    raw_concat = mne.io.read_raw_fif(fname, preload=False)
+    write_raw_bids(raw=raw_concat, bids_path=bids_path, overwrite=True)
+
+###############################################################################
+# That's it!
+#
+# .. warning:: **Remmeber, this should only ever be a last resort!**
+#

--- a/examples/write_modified_files.py
+++ b/examples/write_modified_files.py
@@ -62,7 +62,7 @@ except ValueError as e:
 
 ###############################################################################
 # We can work around this limitation by first writing the modified data to
-# a temporary file, and then writing this new file.
+# a temporary file, reading it back in, and then writing it via MNE-BIDS.
 
 with NamedTemporaryFile(suffix='_raw.fif') as f:
     fname = f.name

--- a/examples/write_modified_files.py
+++ b/examples/write_modified_files.py
@@ -73,5 +73,5 @@ with NamedTemporaryFile(suffix='_raw.fif') as f:
 ###############################################################################
 # That's it!
 #
-# .. warning:: **Remmeber, this should only ever be a last resort!**
+# .. warning:: **Remember, this should only ever be a last resort!**
 #

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -15,7 +15,6 @@ import shutil
 from collections import defaultdict, OrderedDict
 
 import numpy as np
-from numpy.testing import assert_array_equal
 from scipy import linalg
 import mne
 from mne.transforms import (_get_trans, apply_trans, rotation, translation)
@@ -1146,28 +1145,25 @@ def write_raw_bids(raw, bids_path, events_data=None,
         raise ValueError(f'Unrecognized file format {ext}')
 
     raw_orig = reader[ext](**raw._init_kwargs)
-    if (len(raw.times) == len(raw_orig.times) and
-            not np.array_equal(raw.times, raw_orig.times)):
-        raise ValueError(
-            "raw.times should has changed since reading from the file, but "
-            "write_raw_bids() doesn't allow writing modified files.")
-    elif len(raw.times) < len(raw_orig.times):
-        raise ValueError(
-            "The raw data you want to write contains fewer time points than "
-            "the raw data on disk. It is possible that you cropped your data, "
-            "which write_raw_bids() won't accept.")
-    elif len(raw.times) > len(raw_orig.times):
-        if np.array_equal(raw.times[:len(raw_orig.times)], raw_orig.times):
-            logger.info('Raw object contains more time points than the '
-                        'original file on disk; assuming concatenated data.')
+    if not np.array_equal(raw.times, raw_orig.times):
+        if len(raw.times) == len(raw_orig.times):
+            msg = ("raw.times has changed since reading from disk, but "
+                   "write_raw_bids() doesn't allow writing modified data.")
         else:
-            raise ValueError(
-                "Raw object contains more time points than the original file "
-                "on disk; but the first time points don't match.")
+            msg = ("The raw data you want to write contains {comp} time "
+                   "points than the raw data on disk. It is possible that you "
+                   "{guess} your data, which write_raw_bids() won't accept.")
+            if len(raw.times) < len(raw_orig.times):
+                msg = msg.format(comp='fewer', guess='cropped')
+            elif len(raw.times) > len(raw_orig.times):
+                msg = msg.format(comp='more', guess='concatenated')
 
+        msg += (' If you believe you have a valid use case that should be '
+                'supported, please reach out to the developers at '
+                'https://github.com/mne-tools/mne-bids/issues')
+        raise ValueError(msg)
 
     datatype = _handle_datatype(raw)
-
     bids_path = bids_path.copy()
     bids_path = bids_path.update(
         datatype=datatype, suffix=datatype, extension=ext)


### PR DESCRIPTION
This fails on `master`, but works with this PR:

```python
from pathlib import Path
from tempfile import NamedTemporaryFile

import mne
from mne.datasets import sample

from mne_bids import write_raw_bids,  BIDSPath

data_path = Path(sample.data_path())
raw_fname = data_path / 'MEG' /  'sample' / 'sample_audvis_raw.fif'
output_path = data_path / '..' /'MNE-sample-data-bids'
bids_path = BIDSPath(subject='01',  task='audiovisual', root=output_path)

raw = mne.io.read_raw_fif(raw_fname)
raw.info['line_freq'] = 60
raw_concat = mne.concatenate_raws([raw.copy(), raw])

write_raw_bids(raw=raw_concat, bids_path=bids_path, overwrite=True)
```

Addresses part of #718

What do you think?

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
