### PR TITLE
[MRG] ENH: BIDSPath now automatically expands ~ in BIDSPath.root

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -42,6 +42,7 @@ Enhancements
 - Improve the ``Convert iEEG data to BIDS`` tutorial to include a note on how BIDS and MNE-Python coordinate frames are handled, by `Adam Li`_ (:gh:`717`)
 - More detailed error messages when trying to write modified data via :func:`mne_bids.write_raw_bids`, by `Richard Höchenberger`_ (:gh:`719`)
 - If ``check=True``, :class:`mne_bids.BIDSPath` now checks the ``space`` entity to be valid according to BIDS specification Appendix VIII, by `Stefan Appelhoff`_ (:gh:`724`)
+- ``BIDSPath.root`` now automatically expands ``~`` to the user's home directory, by `Richard Höchenberger`_ (:gh:`725`)
 
 API changes
 ^^^^^^^^^^^

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -577,7 +577,7 @@ class BIDSPath(object):
 
             # set entity value, ensuring `root` is a Path
             if val is not None and key == 'root':
-                val = Path(val)
+                val = Path(val).expanduser()
             setattr(self, key, val)
 
         # infer datatype if suffix is uniquely the datatype

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -559,6 +559,13 @@ def test_bids_path(return_bids_test_dir):
     bids_path.update(split=1)
     assert bids_path.basename == 'sub-01_ses-02_task-03_split-01_ieeg.mat'
 
+    # test home dir expansion
+    bids_path = BIDSPath(root='~/foo')
+    assert '~/foo' not in str(bids_path.root)
+    # explicitly test update() method too
+    bids_path.update(root='~/foo')
+    assert '~/foo' not in str(bids_path.root)
+
 
 def test_make_filenames():
     """Test that we create filenames according to the BIDS spec."""


### PR DESCRIPTION
PR Description
--------------

`~` in `BIDSPath.root` is now being expanded to the user's home directory automatically.

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
