### PR TITLE
MRG, ENH: Treat MEG channel type EXCI as 'MEGOTHER'

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -29,6 +29,7 @@ Authors
 * `Diego Lozano-Soldevilla`_
 * `Eduard Ort`_
 * `Alexandre Gramfort`_
+* `Maximilien Chaumon`_
 
 Detailed list of changes
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -43,6 +44,7 @@ Enhancements
 - More detailed error messages when trying to write modified data via :func:`mne_bids.write_raw_bids`, by `Richard Höchenberger`_ (:gh:`719`)
 - If ``check=True``, :class:`mne_bids.BIDSPath` now checks the ``space`` entity to be valid according to BIDS specification Appendix VIII, by `Stefan Appelhoff`_ (:gh:`724`)
 - ``BIDSPath.root`` now automatically expands ``~`` to the user's home directory, by `Richard Höchenberger`_ (:gh:`725`)
+- Add support for MNE's flux excitation channel (``exci``), by `Maximilien Chaumon`_ (:gh:`728`)
 
 API changes
 ^^^^^^^^^^^

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -698,6 +698,7 @@ def test_fif_ias(tmpdir):
     raw = read_raw_bids(data_path)
     assert raw.info['chs'][0]['kind'] == FIFF.FIFFV_IAS_CH
 
+
 def test_fif_exci(tmpdir):
     """Test writing FIF files with excitation channel."""
     data_path = testing.data_path()

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -707,9 +707,7 @@ def test_fif_exci(tmpdir):
                         'sample_audvis_trunc_raw.fif')
     raw = _read_raw_fif(raw_fname)
 
-    match = r'The unit for channel\(s\) MEG 0113 has changed'
-    with pytest.warns(RuntimeWarning, match=match):
-        raw.set_channel_types({raw.ch_names[0]: 'exci'})
+    raw.set_channel_types({raw.ch_names[0]: 'exci'})
     data_path = BIDSPath(subject='sample', root=tmpdir)
 
     write_raw_bids(raw, data_path)

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -699,6 +699,7 @@ def test_fif_ias(tmpdir):
     assert raw.info['chs'][0]['kind'] == FIFF.FIFFV_IAS_CH
 
 
+@pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
 def test_fif_exci(tmpdir):
     """Test writing FIF files with excitation channel."""
     data_path = testing.data_path()

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -706,8 +706,9 @@ def test_fif_exci(tmpdir):
                         'sample_audvis_trunc_raw.fif')
     raw = _read_raw_fif(raw_fname)
 
-    raw.set_channel_types({raw.ch_names[0]: 'exci'})
-
+    match = r'The unit for channel\(s\) MEG 0113 has changed'
+    with pytest.warns(RuntimeError, match=match):
+        raw.set_channel_types({raw.ch_names[0]: 'exci'})
     data_path = BIDSPath(subject='sample', root=tmpdir)
 
     write_raw_bids(raw, data_path)

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -698,6 +698,21 @@ def test_fif_ias(tmpdir):
     raw = read_raw_bids(data_path)
     assert raw.info['chs'][0]['kind'] == FIFF.FIFFV_IAS_CH
 
+def test_fif_exci(tmpdir):
+    """Test writing FIF files with excitation channel."""
+    data_path = testing.data_path()
+    raw_fname = op.join(data_path, 'MEG', 'sample',
+                        'sample_audvis_trunc_raw.fif')
+    raw = _read_raw_fif(raw_fname)
+
+    raw.set_channel_types({raw.ch_names[0]: 'exci'})
+
+    data_path = BIDSPath(subject='sample', root=tmpdir)
+
+    write_raw_bids(raw, data_path)
+    raw = read_raw_bids(data_path)
+    assert raw.info['chs'][0]['kind'] == FIFF.FIFFV_EXCI_CH
+
 
 def test_kit(_bids_validate, tmpdir):
     """Test functionality of the write_raw_bids conversion for KIT data."""

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -707,7 +707,7 @@ def test_fif_exci(tmpdir):
     raw = _read_raw_fif(raw_fname)
 
     match = r'The unit for channel\(s\) MEG 0113 has changed'
-    with pytest.warns(RuntimeError, match=match):
+    with pytest.warns(RuntimeWarning, match=match):
         raw.set_channel_types({raw.ch_names[0]: 'exci'})
     data_path = BIDSPath(subject='sample', root=tmpdir)
 

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -72,7 +72,7 @@ def _get_ch_type_mapping(fro='mne', to='bids'):
                        meggradaxial='MEGGRADAXIAL', megmag='MEGMAG',
                        megrefgradaxial='MEGREFGRADAXIAL',
                        meggradplanar='MEGGRADPLANAR', megrefmag='MEGREFMAG',
-                       ias='MEGOTHER', syst='MEGOTHER')
+                       ias='MEGOTHER', syst='MEGOTHER', exci='MEGOTHER')
 
     elif fro == 'bids' and to == 'mne':
         mapping = dict(EEG='eeg', MISC='misc', TRIG='stim', EMG='emg',


### PR DESCRIPTION
PR Description
--------------

Fixing issue in utils.py/_get_ch_type_mapping.
Channel type EXCI (from neuromag system) does not have a mapping.
Adding it to "MEGOTHER" (?)

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [x] All comments resolved
- [x] This is not your own PR
- [ ] All CIs are happy
- [x] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
