### PR TITLE
[MRG] Separate entity checks from suffix to allow BIDSpath to represent dataset_description.json file

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -43,7 +43,7 @@ Enhancements
 - More detailed error messages when trying to write modified data via :func:`mne_bids.write_raw_bids`, by `Richard Höchenberger`_ (:gh:`719`)
 - If ``check=True``, :class:`mne_bids.BIDSPath` now checks the ``space`` entity to be valid according to BIDS specification Appendix VIII, by `Stefan Appelhoff`_ (:gh:`724`)
 - ``BIDSPath.root`` now automatically expands ``~`` to the user's home directory, by `Richard Höchenberger`_ (:gh:`725`)
-- ``dataset_description.json`` file is now able to be represented as a ``BIDSPath``, by passing in ``check=False`` and ``suffix='dataset_description'``, by `Adam Li`_ (:gh:`729`)
+- Arbitrary file names can now be represented as a `BIDSPath`` by passing the entire name as ``suffix`` and setting ``check=False``, by `Adam Li`_ (:gh:`729`)
 
 API changes
 ^^^^^^^^^^^

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -43,6 +43,7 @@ Enhancements
 - More detailed error messages when trying to write modified data via :func:`mne_bids.write_raw_bids`, by `Richard Höchenberger`_ (:gh:`719`)
 - If ``check=True``, :class:`mne_bids.BIDSPath` now checks the ``space`` entity to be valid according to BIDS specification Appendix VIII, by `Stefan Appelhoff`_ (:gh:`724`)
 - ``BIDSPath.root`` now automatically expands ``~`` to the user's home directory, by `Richard Höchenberger`_ (:gh:`725`)
+- ``dataset_description.json`` file is now able to be represented as a ``BIDSPath``, by passing in ``check=False`` and ``suffix='dataset_description'``, by `Adam Li`_ (:gh:`729`)
 
 API changes
 ^^^^^^^^^^^

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -271,9 +271,9 @@ class BIDSPath(object):
     to make sure that there are no ``'-'``, ``'_'``, or ``'/'`` characters
     associated with any of these entities.
 
-    To represent a file such as the ``dataset_description.json`` file,
-    one can set ``check=False``, and pass in ``suffix='dataset_description'``
-    and ``extension='.json'`` to the BIDSPath.
+    To represent a filename such as ``dataset_description.json``,
+    one can set ``check=False``, and pass ``suffix='dataset_description'``
+    and ``extension='.json'``.
     """
 
     def __init__(self, subject=None, session=None,
@@ -583,16 +583,13 @@ class BIDSPath(object):
 
         # error check entities
         for key, val in kwargs.items():
-            # XXX: suffix can be overridden with non-BIDS characters
-            # which allows `dataset_description.json` to be represented
-            if key != 'suffix':
-                # check if there are any characters not allowed
-                if val is not None and key != 'root':
-                    _check_key_val(key, val)
-            elif self.check:
-                # check if there are any characters not allowed
-                if val is not None and key != 'root':
-                    _check_key_val(key, val)
+            # suffix may skip a check if check=False to allow things like
+            # dataset_description.json
+            if key == 'suffix' and not self.check:
+                continue
+            # check if there are any characters not allowed
+            if val is not None and key != 'root':
+                _check_key_val(key, val)
 
             # set entity value, ensuring `root` is a Path
             if val is not None and key == 'root':

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -583,13 +583,15 @@ class BIDSPath(object):
 
         # error check entities
         for key, val in kwargs.items():
-            # suffix may skip a check if check=False to allow things like
-            # dataset_description.json
-            if key == 'suffix' and not self.check:
-                continue
+
             # check if there are any characters not allowed
             if val is not None and key != 'root':
-                _check_key_val(key, val)
+                if key == 'suffix' and not self.check:
+                    # suffix may skip a check if check=False to allow
+                    # things like "dataset_description.json"
+                    pass
+                else:
+                    _check_key_val(key, val)
 
             # set entity value, ensuring `root` is a Path
             if val is not None and key == 'root':

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -268,12 +268,12 @@ class BIDSPath(object):
     BIDS entities are separated generally with a ``"_"`` character, while
     entity key/value pairs are separated with a ``"-"`` character (e.g.
     ``subject``, ``session``, ``task``, etc.). There are checks performed
-    to make sure that there are no ``'-', '_', '/'`` characters associated
-    with any of these entities.
+    to make sure that there are no ``'-'``, ``'_'``, or ``'/'`` characters
+    associated with any of these entities.
 
     To represent a file such as the ``dataset_description.json`` file,
-    one can set ``check=False``, and pass in ``suffix='dataset_description'`
-    and `extension='.json'` to the BIDSPath.
+    one can set ``check=False``, and pass in ``suffix='dataset_description'``
+    and ``extension='.json'`` to the BIDSPath.
     """
 
     def __init__(self, subject=None, session=None,

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -262,6 +262,18 @@ class BIDSPath(object):
     /bids_dataset/sub-test2/ses-one/ieeg/sub-test2_ses-one_task-mytask_ieeg.edf
     >>> print(new_bids_path.directory)
     /bids_dataset/sub-test2/ses-one/ieeg/
+
+    Notes
+    -----
+    BIDS entities are separated generally with a ``"_"`` character, while
+    entity key/value pairs are separated with a ``"-"`` character (e.g.
+    ``subject``, ``session``, ``task``, etc.). There are checks performed
+    to make sure that there are no ``'-', '_', '/'`` characters associated
+    with any of these entities.
+
+    To represent a file such as the ``dataset_description.json`` file,
+    one can set ``check=False``, and pass in ``suffix='dataset_description'`
+    and `extension='.json'` to the BIDSPath.
     """
 
     def __init__(self, subject=None, session=None,
@@ -571,9 +583,16 @@ class BIDSPath(object):
 
         # error check entities
         for key, val in kwargs.items():
-            # check if there are any characters not allowed
-            if val is not None and key != 'root':
-                _check_key_val(key, val)
+            # XXX: suffix can be overridden with non-BIDS characters
+            # which allows `dataset_description.json` to be represented
+            if key != 'suffix':
+                # check if there are any characters not allowed
+                if val is not None and key != 'root':
+                    _check_key_val(key, val)
+            elif self.check:
+                # check if there are any characters not allowed
+                if val is not None and key != 'root':
+                    _check_key_val(key, val)
 
             # set entity value, ensuring `root` is a Path
             if val is not None and key == 'root':

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -954,4 +954,4 @@ def test_datasetdescription_with_bidspath(return_bids_test_dir):
         root=return_bids_test_dir, suffix='dataset_description',
         extension='.json', check=False)
     assert bids_path.fpath.as_posix() == \
-           f'{return_bids_test_dir}/dataset_description.json'
+           Path(f'{return_bids_test_dir}/dataset_description.json').as_posix()

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -942,3 +942,16 @@ def test_meg_crosstalk_fpath(return_bids_test_dir):
     bids_path_ = bids_path.copy().update(subject='01', root=bids_root)
     Path(bids_path_.meg_crosstalk_fpath).unlink()
     assert bids_path_.meg_crosstalk_fpath is None
+
+
+def test_datasetdescription_with_bidspath(return_bids_test_dir):
+    with pytest.raises(ValueError, match='Unallowed'):
+        bids_path = BIDSPath(
+            root=return_bids_test_dir, suffix='dataset_description',
+            extension='.json')
+
+    bids_path = BIDSPath(
+        root=return_bids_test_dir, suffix='dataset_description',
+        extension='.json', check=False)
+    assert bids_path.fpath.as_posix() == \
+           f'{return_bids_test_dir}/dataset_description.json'


### PR DESCRIPTION
PR Description
--------------

Closes: #727 

I think those checks still should be applied to BIDs entities, but the suffix is allowed to be "overwritten".

It should be noted that a consequence is the ability to represent arbitrary suffixes again if one really is "hacking". E.g. `suffix=desc-derivative_ieeg, check=False` will work, but isn't obviously a documented or intended usage rn.

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
