### PR TITLE
[MRG] MAINT: migrate setup.py to setup.cfg

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 jobs:
   docs-build:
     docker:
-      - image: circleci/python:3.8.1-buster
+      - image: cimg/python:3.8
     steps:
         - checkout
 
@@ -24,7 +24,7 @@ jobs:
               python -m pip install --user --upgrade --progress-bar off pip
               python -m pip install --user --upgrade --progress-bar off -r test_requirements.txt
               python -m pip install --user --upgrade --progress-bar off -r doc/requirements.txt
-              pip install --upgrade --no-deps https://api.github.com/repos/mne-tools/mne-python/zipball/main
+              python -m pip install --upgrade --no-deps https://api.github.com/repos/mne-tools/mne-python/zipball/main
               python -m pip install --user -e .
 
         - run:
@@ -61,7 +61,7 @@ jobs:
   docs-deploy:
     # will only be run on master branch
     docker:
-      - image: node:8.10.0
+      - image: cimg/node:lts
     steps:
       - checkout
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -60,6 +60,8 @@ jobs:
       run: rm -rf ./*
     - name: Try importing mne_bids
       run: python -c 'import mne_bids; print(mne_bids.__version__)'
+    - name: Try cli mne_bids
+      run: mne_bids --version
     - name: Remove sdist install
       run: pip uninstall -y mne-bids
 
@@ -72,9 +74,11 @@ jobs:
       run: rm -rf ./*
     - name: Try importing mne_bids
       run: python -c 'import mne_bids; print(mne_bids.__version__)'
+    - name: Try cli mne_bids
+      run: mne_bids --version
     - name: Remove wheel install
       run: pip uninstall -y mne-bids
-    
+
     - uses: actions/checkout@v2
     - name: Test extras install
       run: |

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -7,13 +7,12 @@ Dependencies
 ------------
 
 * ``mne`` (>=0.21.2)
-* ``numpy`` (>=1.14)
-* ``scipy`` (>=0.18.1, or >=1.5.0 for certain operations with EEGLAB data)
+* ``numpy`` (>=1.15.4)
+* ``scipy`` (>=1.1.0, or >=1.5.0 for certain operations with EEGLAB data)
 * ``nibabel`` (>=2.2, optional, for processing MRI data)
 * ``pybv`` (>=0.5, optional, for writing BrainVision data)
 * ``pandas`` (>=0.23.4, optional, for generating event statistics)
 * ``matplotlib`` (optional, for using the interactive data inspector)
-
 
 We recommend the `Anaconda <https://www.anaconda.com/download/>`_ Python
 distribution. We require that you use Python 3.6 or higher.

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,8 +36,8 @@ project_urls =
 python_requires = ~= 3.6
 install_requires =
   mne >= 0.21.2
-  numpy >= 1.14
-  scipy >= 0.18.1
+  numpy>=1.15.4
+  scipy>=1.1.0
 packages = find:
 include_package_data = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,60 @@
+[metadata]
+name = mne-bids
+url = https://github.com/mne-tools/mne-bids
+author = mne-bids developers
+maintainer = Mainak Jas
+maintainer_email = mainakjas@gmail.com
+description = MNE-BIDS: Organizing MEG, EEG, and iEEG data according to the BIDS specification and facilitating their analysis with MNE-Python
+keywords = meg, eeg, ieeg, bids, brain imaging data structure, neuroscience, neuroimaging
+long-description = file: README.md
+long-description-content-type = text/markdown; charset=UTF-8
+license = BSD (3-clause)
+license_files = LICENSE
+platforms = any
+classifiers =
+  Topic :: Scientific/Engineering
+  Intended Audience :: Science/Research
+  Intended Audience :: Developers
+  License :: OSI Approved
+  Topic :: Software Development
+  Topic :: Scientific/Engineering
+  Operating System :: Microsoft :: Windows
+  Operating System :: POSIX
+  Operating System :: Unix
+  Operating System :: MacOS
+  Programming Language :: Python
+  Programming Language :: Python :: 3.6
+  Programming Language :: Python :: 3.7
+  Programming Language :: Python :: 3.8
+  Programming Language :: Python :: 3.9
+project_urls =
+  Documentation = https://mne.tools/mne-bids
+  Bug Reports = https://github.com/mne-tools/mne-bids/issues
+  Source = https://github.com/mne-tools/mne-bids
+
+[options]
+python_requires = ~= 3.6
+install_requires =
+  mne >= 0.21.2
+  numpy >= 1.14
+  scipy >= 0.18.1
+packages = find:
+include_package_data = True
+
+[options.extras_require]
+full =
+  nibabel >= 2.2
+  pybv >= 0.5
+  matplotlib
+  pandas >= 0.23.4
+
+[options.entry_points]
+console_scripts =
+    mne_bids = mne_bids.commands.run:main
+
+[bdist_wheel]
+universal = true
+
 [flake8]
 exclude = __init__.py
 ignore = W504,I101,I100,I201

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
-#! /usr/bin/env python
 """Setup MNE-BIDS."""
 import os
-from setuptools import setup, find_packages
+from setuptools import setup
 
 # get the version
 version = None
@@ -11,70 +10,7 @@ with open(os.path.join('mne_bids', '__init__.py'), 'r') as fid:
             version = line.split('=')[1].strip().strip('\'')
             break
 if version is None:
-    raise RuntimeError('Could not determine version')
-
-
-descr = ('MNE-BIDS: Organizing MEG, EEG, and iEEG data according to the BIDS '
-         'specification and facilitating their analysis with MNE-Python')
-
-DISTNAME = 'mne-bids'
-DESCRIPTION = descr
-MAINTAINER = 'Mainak Jas'
-MAINTAINER_EMAIL = 'mainakjas@gmail.com'
-URL = 'https://mne.tools/mne-bids/'
-LICENSE = 'BSD (3-clause)'
-DOWNLOAD_URL = 'https://github.com/mne-tools/mne-bids.git'
-VERSION = version
+    raise RuntimeError('Could not determine version.')
 
 if __name__ == "__main__":
-    setup(name=DISTNAME,
-          maintainer=MAINTAINER,
-          maintainer_email=MAINTAINER_EMAIL,
-          description=DESCRIPTION,
-          license=LICENSE,
-          url=URL,
-          version=VERSION,
-          download_url=DOWNLOAD_URL,
-          long_description=open('README.md').read(),
-          long_description_content_type='text/markdown',
-          python_requires='~=3.6',
-          install_requires=[
-              'mne >=0.21.2',
-              'numpy >=1.14',
-              'scipy >=0.18.1',
-          ],
-          extras_require={
-              'full': [
-                  'nibabel >=2.2',
-                  'pybv >=0.5',
-                  'matplotlib',
-                  'pandas >=0.23.4'
-              ]
-          },
-          classifiers=[
-              'Intended Audience :: Science/Research',
-              'Intended Audience :: Developers',
-              'License :: OSI Approved',
-              'Programming Language :: Python',
-              'Topic :: Software Development',
-              'Topic :: Scientific/Engineering',
-              'Operating System :: Microsoft :: Windows',
-              'Operating System :: POSIX',
-              'Operating System :: Unix',
-              'Operating System :: MacOS',
-              'Programming Language :: Python :: 3.6',
-              'Programming Language :: Python :: 3.7',
-              'Programming Language :: Python :: 3.8',
-              'Programming Language :: Python :: 3.9',
-          ],
-          platforms='any',
-          packages=find_packages(),
-          entry_points={'console_scripts': [
-              'mne_bids = mne_bids.commands.run:main',
-          ]},
-          project_urls={
-              'Documentation': 'https://mne.tools/mne-bids',
-              'Bug Reports': 'https://github.com/mne-tools/mne-bids/issues',
-              'Source': 'https://github.com/mne-tools/mne-bids',
-          },
-          )
+    setup(version=version)


### PR DESCRIPTION
using just setup.cfg as proposed in this PR should be equivalent to our previous setup.py+setup.cfg

It seems like many people have moved towards using the cfg file (which is just parsed) to declare their data instead of the py file (which needs to be executed).

I added:
- author = mne-bids developers
- keywords = meg, eeg, ieeg, bids, brain imaging data structure, neuroscience, neuroimaging

I removed
- download_url (because it was just pointing to GitHub, not to a download page)

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [x] All comments resolved
- [x] This is not your own PR
- [ ] All CIs are happy
- [x] PR title starts with [MRG]
- ~[whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated~
- ~PR description includes phrase "closes <#issue-number>"~
