### PR TITLE
[DOC] - Fix list rendering issue on ieeg example

### DIFF
--- a/examples/convert_ieeg_to_bids.py
+++ b/examples/convert_ieeg_to_bids.py
@@ -23,11 +23,11 @@ data. Specifically, we will follow these steps:
 The iEEG data will be written by :func:`write_raw_bids` with
 the addition of extra metadata elements in the following files:
 
-    * the sidecar file ``ieeg.json``
-    * ``electrodes.tsv``
-    * ``coordsystem.json``
-    * ``events.tsv``
-    * ``channels.tsv``
+- the sidecar file ``ieeg.json``
+- ``electrodes.tsv``
+- ``coordsystem.json``
+- ``events.tsv``
+- ``channels.tsv``
 
 Compared to EEG data, the main differences are within the
 ``coordsystem.json`` and ``electrodes.tsv`` files.

--- a/examples/convert_ieeg_to_bids.py
+++ b/examples/convert_ieeg_to_bids.py
@@ -138,8 +138,8 @@ pprint([x for x in zip(ch_names, pos)])
 #
 # MNE-Python has a few tutorials on this topic:
 #
-#   - `background on FreeSurfer`_
-#   - `MNE-Python coordinate frames`_
+# - `background on FreeSurfer`_
+# - `MNE-Python coordinate frames`_
 #
 # Currently, MNE-Python supports the ``mni_tal`` coordinate frame, which
 # corresponds to the ``fsaverage`` BIDS coordinate system. All other coordinate
@@ -160,9 +160,9 @@ pprint([x for x in zip(ch_names, pos)])
 # compatible way. :func:`write_raw_bids` takes a bunch of inputs, most of
 # which are however optional. The required inputs are:
 #
-# * :code:`raw`
-# * :code:`bids_basename`
-# * :code:`bids_root`
+# - :code:`raw`
+# - :code:`bids_basename`
+# - :code:`bids_root`
 #
 # ... as you can see in the docstring:
 print(write_raw_bids.__doc__)


### PR DESCRIPTION
PR Description
--------------

As I was browsing the documentation, I noticed a rendering issue on a list on example # 8:

<img width="780" alt="Screen Shot 2021-03-17 at 12 30 25 AM" src="https://user-images.githubusercontent.com/7727566/111415345-10ddae00-86b8-11eb-909e-09a85aa12f0e.png">

This stems from a small formatting thing writing out this list on the underlying page, which this PR fixes. 

I copied this section of the file out, and re-generated it locally with sphinx, and this update does seem to fix the rendering of this list on the resultant file, for me at least. 

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
