### PR TITLE
fix link to publication

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Citing
 [![JOSS publication](https://joss.theoj.org/papers/5b9024503f7bea324d5e738a12b0a108/status.svg)](https://joss.theoj.org/papers/5b9024503f7bea324d5e738a12b0a108)
 
 If you use MNE-BIDS in your work, please cite our
-[publication in JOSS](https://doi.org/10.21105/joss.01896>):
+[publication in JOSS](https://doi.org/10.21105/joss.01896):
 
 
 Appelhoff, S., Sanderson, M., Brooks, T., Vliet, M., Quentin, R., Holdgraf, C.,


### PR DESCRIPTION
PR Description
--------------

The link to the publication didn't work. It seems there was an extra `>`

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
