### PR TITLE
WIP: Use event_id to assign event IDs to Annotations

### DIFF
--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -101,10 +101,10 @@ def _read_events(events_data, event_id, raw, verbose=None):
         events = read_events(events_data, verbose=verbose).astype(int)
     elif isinstance(events_data, np.ndarray):
         if events_data.ndim != 2:
-            raise ValueError('Events must have two dimensions, '
+            raise ValueError(f'Events must have two dimensions, '
                              f'found {events_data.ndim}')
         if events_data.shape[1] != 3:
-            raise ValueError('Events must have second dimension of length 3, '
+            raise ValueError(f'Events must have second dimension of length 3, '
                              f'found {events_data.shape[1]}')
         events = events_data
     else:
@@ -143,6 +143,8 @@ def _read_events(events_data, event_id, raw, verbose=None):
         del id_to_desc_map, annotations, new_annotations
 
     # Now convert the Annotations to events.
+    if event_id is None:
+        event_id = 'auto'
     all_events, all_desc = events_from_annotations(
         raw,
         event_id=event_id,

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1007,11 +1007,15 @@ def write_raw_bids(raw, bids_path, events_data=None,
            parameter.
 
     event_id : dict | None
-        Descriptions of all event IDs, if you passed ``events_data``.
-        The descriptions will be written to the ``trial_type`` column in
-        ``*_events.tsv``. The dictionary keys correspond to the event
-        descriptions and the values to the event IDs. You must specify a
-        description for all event IDs in ``events_data``.
+        The mappings from event descriptions (keys) to IDs (values). This is
+        required if you passed ``events_data``, and optional if
+        ``raw.annotations`` are present. The descriptions will be written to
+        the ``trial_type`` column in ``*_events.tsv``.
+        This parameter must specify mappings between **all** descriptions and
+        event IDs in your data, without any omissions.
+
+        .. versionchanged:: 0.7
+           Allow mappings for :class:`mne.Annotations` too.
     anonymize : dict | None
         If `None` (default), no anonymization is performed.
         If a dictionary, data will be anonymized depending on the dictionary
@@ -1126,9 +1130,13 @@ def write_raw_bids(raw, bids_path, events_data=None,
         raise RuntimeError('You passed events_data, but no event_id '
                            'dictionary. You need to pass both, or neither.')
 
-    if event_id is not None and events_data is None:
+    if (event_id is not None and events_data is None and
+            raw.annotations is None):
         raise RuntimeError('You passed event_id, but no events_data NumPy '
-                           'array. You need to pass both, or neither.')
+                           'array, and raw.annotations is empty too. '
+                           'If you pass event_id, either need to pass '
+                           'events_data, raw.annotations, or both in '
+                           'addition.')
 
     raw = raw.copy()
 


### PR DESCRIPTION
PR Description
--------------

When writing raw data with Annotations, passing `event_id` can be used to control which event IDs will be generated for each respective event type.

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
