### PR TITLE
BIDS's participant_id should map to MNE's his_id

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -47,10 +47,11 @@ Enhancements
 - Arbitrary file names can now be represented as a `BIDSPath`` by passing the entire name as ``suffix`` and setting ``check=False``, by `Adam Li`_ (:gh:`729`)
 - Add support for MNE's flux excitation channel (``exci``), by `Maximilien Chaumon`_ (:gh:`728`)
 
-API changes
-^^^^^^^^^^^
+API and behavior changes
+^^^^^^^^^^^^^^^^^^^^^^^^
 
 - Add ``format`` kwarg to :func:`write_raw_bids` that allows users to specify if they want to force conversion to ``BrainVision`` or ``FIF`` file format, by `Adam Li`_ (:gh:`672`)
+- :func:`mne_bids.read_raw_bids` now stores the ``participant_id`` value from ``participants.tsv`` in ``raw.info['subject_info']['his_id']``, not in ``raw.info['subject_info']['participant_id']`` anymore, by `Richard Höchenberger`_ (:gh:`745`)
 
 Requirements
 ^^^^^^^^^^^^

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -166,24 +166,25 @@ def _handle_participants_reading(participants_fname, raw,
     row_ind = subjects.index(subject)
 
     # set data from participants tsv into subject_info
-    for infokey, infovalue in participants_tsv.items():
-        if infokey == 'sex' or infokey == 'hand':
-            value = _map_options(what=infokey, key=infovalue[row_ind],
+    for col_name, value in participants_tsv.items():
+        if col_name == 'sex' or col_name == 'hand':
+            value = _map_options(what=col_name, key=value[row_ind],
                                  fro='bids', to='mne')
             # We don't know how to translate to MNE, so skip.
             if value is None:
-                if infokey == 'sex':
+                if col_name == 'sex':
                     info_str = 'subject sex'
                 else:
                     info_str = 'subject handedness'
-                warn(f'Unable to map `{infokey}` value to MNE. '
+                warn(f'Unable to map `{col_name}` value to MNE. '
                      f'Not setting {info_str}.')
         else:
-            value = infovalue[row_ind]
+            value = value[row_ind]
         # add data into raw.Info
         if raw.info['subject_info'] is None:
             raw.info['subject_info'] = dict()
-        raw.info['subject_info'][infokey] = value
+        key = 'his_id' if col_name == 'participant_id' else col_name
+        raw.info['subject_info'][key] = value
 
     return raw
 

--- a/mne_bids/tests/test_inspect.py
+++ b/mne_bids/tests/test_inspect.py
@@ -120,7 +120,7 @@ def test_inspect_multiple_files(tmp_path):
     # Inspection should end with the second subject.
     inspect_dataset(bids_path.copy().update(subject=None))
     raw_fig = mne_bids.inspect._global_vars['raw_fig']
-    assert raw_fig.mne.info['subject_info']['participant_id'] == 'sub-02'
+    assert raw_fig.mne.info['subject_info']['his_id'] == 'sub-02'
     raw_fig.canvas.key_press_event(raw_fig.mne.close_key)
 
 

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -130,6 +130,8 @@ def test_read_participants_data(tmpdir):
     assert raw.info['subject_info']['hand'] == 1
     assert raw.info['subject_info']['sex'] == 2
     assert raw.info['subject_info'].get('birthday', None) is None
+    assert raw.info['subject_info']['his_id'] == f'sub-{bids_path.subject}'
+    assert 'participant_id' not in raw.info['subject_info']
 
     # if modifying participants tsv, then read_raw_bids reflects that
     participants_tsv_fpath = tmpdir / 'participants.tsv'


### PR DESCRIPTION
The correct place to store a participant identifier in MNE's info
structure is `info['subject_info']['his_id']`, not `...['participant_id']`

Now while this change is not backward-compatible, I don't think it
will affect many (any?) users, so I suggest it's safe to merge this
change without a deprecation cycle.


Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
