### PR TITLE
MRG, FIX: Retain essential annotations created by acquisition system

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -23,7 +23,7 @@ Notable changes
 Authors
 ~~~~~~~
 
-* ...
+* `Richard Höchenberger`_
 
 Detailed list of changes
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -46,7 +46,7 @@ Requirements
 Bug fixes
 ^^^^^^^^^
 
-- ...
+- The :class:`mne.Annotations` ``BAD_ACQ_SKIP`` – added by the acquisition system to ``FIFF`` files – will now be preserved when reading raw data, even if these time periods are **not** explicitly included in ``*_events.tsv``, by `Richard Höchenberger`_ (:gh:`xxx`)
 
 :doc:`Find out what was new in previous releases <whats_new_previous_releases>`
 

--- a/mne_bids/config.py
+++ b/mne_bids/config.py
@@ -144,6 +144,9 @@ ALLOWED_PATH_ENTITIES_SHORT = {'sub': 'subject', 'ses': 'session',
                                'space': 'space', 'rec': 'recording',
                                'split': 'split', 'suffix': 'suffix'}
 
+# Annotations to never remove during reading or writing
+ANNOTATIONS_TO_KEEP = ('BAD_ACQ_SKIP',)
+
 coordsys_standard_template = [
     'ICBM452AirSpace',
     'ICBM452Warp5Space',

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -344,11 +344,13 @@ def _handle_events_reading(events_fname, raw):
     # Add events as Annotations, but keep essential Annotations present in
     # raw file
     # Ensure Annotations share the same orig_time
+    orig_time = None
     annot_from_raw = raw.annotations.copy()
+    annot_from_raw._orig_time = orig_time
     annot_from_events = mne.Annotations(onset=onsets,
                                         duration=durations,
                                         description=descriptions,
-                                        orig_time=annot_from_raw.orig_time)
+                                        orig_time=orig_time)
 
     annot_idx_to_keep = [idx for idx, annot in enumerate(annot_from_raw)
                          if annot['description'] in ANNOTATIONS_TO_KEEP]

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -343,7 +343,7 @@ def _handle_events_reading(events_fname, raw):
 
     # Add events as Annotations, but keep essential Annotations present in
     # raw file
-    # Ensusure Annotations share the same orig_time
+    # Ensure Annotations share the same orig_time
     annot_from_raw = raw.annotations.copy()
     annot_from_events = mne.Annotations(onset=onsets,
                                         duration=durations,


### PR DESCRIPTION
MNE exposes certain markers added by the acquisition system as Annotations,
for example `BAD_ACQ_SKIP` but possibly others. Typically, these markers are
not transferred to `events.tsv` by BIDS users.

Now, when reading raw files, we moved to superseding Annotations in raw data
with information from `events.tsv`: we first read the sidecar, create Annotations
from those events, and call `raw.set_annotations()`. However, this removes
all existing Annotations – including the special ones like `BAD_ACQ_SKIP`,
leading to problems in downstream processing.

This PR ensures that `BAD_ACQ_SKIP` is retained; the list of Annotations
to retain can be easily expanded.

(The problem does not seem to exist when writing raw data; it only occured
when reading)


cc @agramfort 


Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [x] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [x] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/master/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
