### PR TITLE
[MRG, BUG] Fix consistency cast to upper for sex

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -23,7 +23,7 @@ Notable changes
 Authors
 ~~~~~~~
 
-* ...
+* `Alex Rockhill`_
 
 Detailed list of changes
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -46,7 +46,7 @@ Requirements
 Bug fixes
 ^^^^^^^^^
 
-- ...
+- Fix m/f for male/female and l/r for left/right instead of only accpeting caps, by `Alex Rockhill`_ (:gh:`755`)
 
 :doc:`Find out what was new in previous releases <whats_new_previous_releases>`
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -46,7 +46,7 @@ Requirements
 Bug fixes
 ^^^^^^^^^
 
-- Fix m/f for male/female and l/r for left/right instead of only accpeting caps, by `Alex Rockhill`_ (:gh:`755`)
+- :func:`mne_bids.make_report` now (1) detects male/female sex and left/right handedness irrespective of letter case, (2) will parse a ``gender`` column if no ``sex`` column is found in ``participants.tsv``, and (3) reports sex as male/female instead of man/woman, by `Alex Rockhill`_ (:gh:`755`)
 
 :doc:`Find out what was new in previous releases <whats_new_previous_releases>`
 

--- a/mne_bids/report.py
+++ b/mne_bids/report.py
@@ -201,10 +201,13 @@ def _summarize_participants_tsv(root, verbose=True):
     # summarize sex count statistics
     keys = ['M', 'F', 'n/a']
     p_sex = participants_tsv.get('sex')
+    # phrasing works for both sex and gender
+    p_gender = participants_tsv.get('gender')
     sexs = ['n/a']
-    if p_sex:
+    if p_sex or p_gender:
         # only summarize sex if it conforms to
         # mne-bids handedness
+        p_sex = p_gender if p_sex is None else p_sex
         if all([sex.upper() in keys
                 for sex in p_sex if sex != 'n/a']):
             sexs = p_sex

--- a/mne_bids/report.py
+++ b/mne_bids/report.py
@@ -44,9 +44,9 @@ def _summarize_participant_hand(hands):
 
     if n_unknown == len(hands):
         return f'handedness were all unknown'
-    n_rhand = len([hand for hand in hands if hand == 'R'])
-    n_lhand = len([hand for hand in hands if hand == 'L'])
-    n_ambidex = len([hand for hand in hands if hand == 'A'])
+    n_rhand = len([hand for hand in hands if hand.upper() == 'R'])
+    n_lhand = len([hand for hand in hands if hand.upper() == 'L'])
+    n_ambidex = len([hand for hand in hands if hand.upper() == 'A'])
 
     return f'comprised of {n_rhand} right hand, {n_lhand} left hand ' \
            f'and {n_ambidex} ambidextrous'
@@ -56,10 +56,10 @@ def _summarize_participant_sex(sexs):
 
     if n_unknown == len(sexs):
         return f'sex were all unknown'
-    n_males = len([sex for sex in sexs if sex == 'M'])
-    n_females = len([sex for sex in sexs if sex == 'F'])
+    n_males = len([sex for sex in sexs if sex.upper() == 'M'])
+    n_females = len([sex for sex in sexs if sex.upper() == 'F'])
 
-    return f'comprised of {n_males} men and {n_females} women'
+    return f'comprised of {n_males} male and {n_females} female participants'
 
 def _length_recording_str(length_recordings):
     import numpy as np

--- a/mne_bids/report.py
+++ b/mne_bids/report.py
@@ -205,8 +205,7 @@ def _summarize_participants_tsv(root, verbose=True):
     p_gender = participants_tsv.get('gender')
     sexs = ['n/a']
     if p_sex or p_gender:
-        # only summarize sex if it conforms to
-        # mne-bids handedness
+        # only summarize sex if it conforms to `keys` referenced above
         p_sex = p_gender if p_sex is None else p_sex
         if all([sex.upper() in keys
                 for sex in p_sex if sex != 'n/a']):


### PR DESCRIPTION
PR Description
--------------

'm' and 'f' aren't currently recognized only 'M' and 'F', so fix by casting to upper.

Also report said `n` men and `n` women and these are gendered terms whereas male and female denote sex so probably best to use male/female.

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [x] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
