### PR TITLE
ENH: Add t1_bids_path parameter to get_head_mri_trans()

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -35,6 +35,7 @@ Enhancements
 
 - Updated the "Read BIDS datasets" example to use data from `OpenNeuro <https://openneuro.org>`_, by `Alex Rockhill`_ (:gh:`753`)
 - :func:`mne_bids.get_head_mri_trans` is now more lenient when looking for the fiducial points (LPA, RPA, and nasion) in the MRI JSON sidecar file, and accepts a larger variety of landmark names (upper- and lowercase letters; ``'nasion'`` instead of only ``'NAS'``), by `Richard Höchenberger`_ (:gh:`769`)
+- :func:`mne_bids.get_head_mri_trans` gained a new keyword argument ``t1_bids_path``, allowing for the MR scan to be stored in a different session or even in a different BIDS dataset than the electrophysiological recording, by `Richard Höchenberger`_ (:gh:`xxx`)
 
 API and behavior changes
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -35,7 +35,7 @@ Enhancements
 
 - Updated the "Read BIDS datasets" example to use data from `OpenNeuro <https://openneuro.org>`_, by `Alex Rockhill`_ (:gh:`753`)
 - :func:`mne_bids.get_head_mri_trans` is now more lenient when looking for the fiducial points (LPA, RPA, and nasion) in the MRI JSON sidecar file, and accepts a larger variety of landmark names (upper- and lowercase letters; ``'nasion'`` instead of only ``'NAS'``), by `Richard Höchenberger`_ (:gh:`769`)
-- :func:`mne_bids.get_head_mri_trans` gained a new keyword argument ``t1_bids_path``, allowing for the MR scan to be stored in a different session or even in a different BIDS dataset than the electrophysiological recording, by `Richard Höchenberger`_ (:gh:`xxx`)
+- :func:`mne_bids.get_head_mri_trans` gained a new keyword argument ``t1_bids_path``, allowing for the MR scan to be stored in a different session or even in a different BIDS dataset than the electrophysiological recording, by `Richard Höchenberger`_ (:gh:`771`)
 
 API and behavior changes
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -605,11 +605,14 @@ def get_head_mri_trans(bids_path, extra_params=None, t1_bids_path=None):
         Extra parameters to be passed to :func:`mne.io.read_raw` when reading
         the MEG file.
     t1_bids_path : mne_bids.BIDSPath | None
-        You may optionally specify a :class:`mne_bids.BIDSPath` pointing to the
-        T1-weighted MRI scan that shall be used for extraction of MRI
-        landmarks. Use this parameter if the T1 scan was recorded during a
-        different session than the MEG. It is even possible to point to a
-        T1 image stored in a different **BIDS dataset** than the MEG data.
+        If ``None`` (default), will try to discover the T1-weighted MRI file
+        based on the name and location of the MEG recording specified via the
+        ``bids_path`` parameter. Alternatively, you explicitly specify which
+        T1-weighted MRI scan to use for extraction of MRI landmarks. To do
+        that, pass a :class:`mne_bids.BIDSPath` pointing to the scan.
+        Use this parameter e.g. if the T1 scan was recorded during a different
+        session than the MEG. It is even possible to point to a T1 image stored
+        in an entirely different BIDS dataset than the MEG data.
 
         .. versionadded:: 0.8
 

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -270,6 +270,31 @@ def test_get_head_mri_trans(tmpdir):
                                                     .update(root=tmpdir)))
     assert_almost_equal(trans['trans'], estimated_trans['trans'])
 
+    # Test t1_bids_path parameter
+    #
+    # Case 1: different BIDS roots
+    meg_bids_path = _bids_path.copy().update(root=tmpdir / 'meg_root')
+    t1_bids_path = _bids_path.copy().update(root=tmpdir / 'mri_root')
+    raw = _read_raw_fif(raw_fname)
+
+    write_raw_bids(raw, bids_path=meg_bids_path)
+    write_anat(t1w_mgh, bids_path=t1_bids_path, raw=raw, trans=trans)
+    read_trans = get_head_mri_trans(bids_path=meg_bids_path,
+                                    t1_bids_path=t1_bids_path)
+    assert np.allclose(trans['trans'], read_trans['trans'])
+
+    # Case 2: different sessions
+    raw = _read_raw_fif(raw_fname)
+    meg_bids_path = _bids_path.copy().update(root=tmpdir / 'session_test',
+                                             session='01')
+    t1_bids_path = meg_bids_path.copy().update(session='02')
+
+    write_raw_bids(raw, bids_path=meg_bids_path)
+    write_anat(t1w_mgh, bids_path=t1_bids_path, raw=raw, trans=trans)
+    read_trans = get_head_mri_trans(bids_path=meg_bids_path,
+                                    t1_bids_path=t1_bids_path)
+    assert np.allclose(trans['trans'], read_trans['trans'])
+
 
 def test_handle_events_reading(tmpdir):
     """Test reading events from a BIDS events.tsv file."""


### PR DESCRIPTION
The new parameter allows to generate the head <> MRI trans from recordings belonging to different sessions or even separate datasets.

Scenario:

- 1st session: MR
- all following sessions: MEG

In `main`, it wouldn't be possible to use `get_head_mri_trans()` to get the transformation matrix, as MNE-BIDS cannot find the required files.

**RFC**: Should the param maybe be called `t1w_bids_path` instead? (t1w instead of t1)

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
