### PR TITLE
[MRG] write digitized landmarks + digitized head points

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -32,7 +32,7 @@ Detailed list of changes
 
 Enhancements
 ^^^^^^^^^^^^
-
+- For Neuromag data, the fields "DigitizedLandmarks" and "DigitizedHeadPoints" in the json sidecar are now set depending on whether any landmarks (NAS, RPA, LPA) or extra points are found in raw.info['dig'], by `Eduard Ort`_ (:gh:`772`)
 - Updated the "Read BIDS datasets" example to use data from `OpenNeuro <https://openneuro.org>`_, by `Alex Rockhill`_ (:gh:`753`)
 - :func:`mne_bids.get_head_mri_trans` is now more lenient when looking for the fiducial points (LPA, RPA, and nasion) in the MRI JSON sidecar file, and accepts a larger variety of landmark names (upper- and lowercase letters; ``'nasion'`` instead of only ``'NAS'``), by `Richard Höchenberger`_ (:gh:`769`)
 - :func:`mne_bids.get_head_mri_trans` gained a new keyword argument ``t1_bids_path``, allowing for the MR scan to be stored in a different session or even in a different BIDS dataset than the electrophysiological recording, by `Richard Höchenberger`_ (:gh:`771`)

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -32,7 +32,7 @@ Detailed list of changes
 
 Enhancements
 ^^^^^^^^^^^^
-- For Neuromag data, the fields "DigitizedLandmarks" and "DigitizedHeadPoints" in the json sidecar are now set depending on whether any landmarks (NAS, RPA, LPA) or extra points are found in raw.info['dig'], by `Eduard Ort`_ (:gh:`772`)
+- The fields "DigitizedLandmarks" and "DigitizedHeadPoints" in the json sidecar of Neuromag data are now set to True/False depending on whether any landmarks (NAS, RPA, LPA) or extra points are found in raw.info['dig'], by `Eduard Ort`_ (:gh:`772`)
 - Updated the "Read BIDS datasets" example to use data from `OpenNeuro <https://openneuro.org>`_, by `Alex Rockhill`_ (:gh:`753`)
 - :func:`mne_bids.get_head_mri_trans` is now more lenient when looking for the fiducial points (LPA, RPA, and nasion) in the MRI JSON sidecar file, and accepts a larger variety of landmark names (upper- and lowercase letters; ``'nasion'`` instead of only ``'NAS'``), by `Richard Höchenberger`_ (:gh:`769`)
 - :func:`mne_bids.get_head_mri_trans` gained a new keyword argument ``t1_bids_path``, allowing for the MR scan to be stored in a different session or even in a different BIDS dataset than the electrophysiological recording, by `Richard Höchenberger`_ (:gh:`771`)

--- a/mne_bids/dig.py
+++ b/mne_bids/dig.py
@@ -228,10 +228,6 @@ def _write_coordsystem_json(*, raw, unit, hpi_coord_system,
     if dig is None:
         dig = []
     coords = _extract_landmarks(dig)
-    hpi = {d['ident']: d for d in dig if d['kind'] == FIFF.FIFFV_POINT_HPI}
-    if hpi:
-        for ident in hpi.keys():
-            coords['coil%d' % ident] = hpi[ident]['r'].tolist()
 
     coord_frame = set([dig[ii]['coord_frame'] for ii in range(len(dig))])
     if len(coord_frame) > 1:  # noqa E501
@@ -258,6 +254,7 @@ def _write_coordsystem_json(*, raw, unit, hpi_coord_system,
 
     # create the coordinate json data structure based on 'datatype'
     if datatype == 'meg':
+        landmarks = dict(coords)
         hpi = {d['ident']: d for d in dig if d['kind'] == FIFF.FIFFV_POINT_HPI}
         if hpi:
             for ident in hpi.keys():
@@ -269,7 +266,10 @@ def _write_coordsystem_json(*, raw, unit, hpi_coord_system,
             'MEGCoordinateSystemDescription': sensor_coord_system_descr,
             'HeadCoilCoordinates': coords,
             'HeadCoilCoordinateSystem': hpi_coord_system,
-            'HeadCoilCoordinateUnits': unit  # XXX validate this
+            'HeadCoilCoordinateUnits': unit,  # XXX validate this
+            'AnatomicalLandmarkCoordinates': landmarks,
+            'AnatomicalLandmarkCoordinateSystem': sensor_coord_system,
+            'AnatomicalLandmarkCoordinateUnits': unit
         }
     elif datatype == 'eeg':
         fid_json = {

--- a/mne_bids/dig.py
+++ b/mne_bids/dig.py
@@ -227,7 +227,6 @@ def _write_coordsystem_json(*, raw, unit, hpi_coord_system,
     dig = raw.info['dig']
     if dig is None:
         dig = []
-    coords = _extract_landmarks(dig)
 
     coord_frame = set([dig[ii]['coord_frame'] for ii in range(len(dig))])
     if len(coord_frame) > 1:  # noqa E501
@@ -251,7 +250,7 @@ def _write_coordsystem_json(*, raw, unit, hpi_coord_system,
         sensor_coord_system_descr = (BIDS_COORD_FRAME_DESCRIPTIONS
                                      .get(sensor_coord_system_mne.lower(),
                                           "n/a"))
-
+    coords = _extract_landmarks(dig)
     # create the coordinate json data structure based on 'datatype'
     if datatype == 'meg':
         landmarks = dict(coords)

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -462,10 +462,23 @@ def test_handle_info_reading(tmpdir):
     for dig_point in raw.info['dig']:
         if dig_point['kind'] == FIFF.FIFFV_POINT_EXTRA:
             n_dig_points += 1
-    if sidecar_json['DigitizedLandmarks']:
+    if sidecar_json['DigitizedHeadPoints']:
         assert n_dig_points > 0
     else:
         assert n_dig_points == 0
+
+    # check whether if there any of NAS/LPA/RPA are present in raw.info['dig']
+    # DigitizedLandmark is set to True, and False otherwise
+    landmark_present = False
+    for dig_point in raw.info['dig']:
+        if dig_point['kind'] in [FIFF.FIFFV_POINT_LPA, FIFF.FIFFV_POINT_RPA,
+                                 FIFF.FIFFV_POINT_NASION]:
+            landmark_present = True
+            break
+    if landmark_present:
+        assert sidecar_json['DigitizedLandmarks'] is True
+    else:
+        assert sidecar_json['DigitizedLandmarks'] is False
 
     # make a copy of the sidecar in "derivatives/"
     # to check that we make sure we always get the right sidecar

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -462,7 +462,10 @@ def test_handle_info_reading(tmpdir):
     for dig_point in raw.info['dig']:
         if dig_point['kind'] == FIFF.FIFFV_POINT_EXTRA:
             n_dig_points += 1
-    assert n_dig_points > 0
+    if sidecar_json['DigitizedLandmarks']:
+        assert n_dig_points > 0
+    else:
+        assert n_dig_points == 0
 
     # make a copy of the sidecar in "derivatives/"
     # to check that we make sure we always get the right sidecar

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -21,7 +21,7 @@ with warnings.catch_warnings():
                             message="can't resolve package",
                             category=ImportWarning)
     import mne
-
+from mne.io.constants import FIFF
 from mne.utils import requires_nibabel, object_diff
 from mne.utils import assert_dig_allclose
 from mne.datasets import testing, somato
@@ -455,6 +455,14 @@ def test_handle_info_reading(tmpdir):
     del raw.info['line_freq']
     with pytest.raises(ValueError, match="PowerLineFrequency .* required"):
         write_raw_bids(raw, bids_path, overwrite=True)
+
+    # check whether there are "Extra points" in raw.info['dig'] if
+    # DigitizedHeadPoints is set to True and not otherwise
+    n_dig_points = 0
+    for dig_point in raw.info['dig']:
+        if dig_point['kind'] == FIFF.FIFFV_POINT_EXTRA:
+            n_dig_points += 1
+    assert n_dig_points > 0
 
     # make a copy of the sidecar in "derivatives/"
     # to check that we make sure we always get the right sidecar

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -637,9 +637,9 @@ def _sidecar_json(raw, task, manufacturer, fname, datatype, overwrite=False,
     n_stimchan = len([ch for ch in raw.info['chs']
                       if ch['kind'] == FIFF.FIFFV_STIM_CH]) - n_ignored
 
-    # for Neuromag MEG files, check whether Extra points are present
-    # and set DigitizedHeadPoints accordingly, and whether RPA/LPA/
-    # NAS is present, and set DigitizedLandmarks accordingly
+    # Set DigitizedLandmarks to True if any of LPA, RPA, NAS are found
+    # Set DigitizedHeadPoints to True if any "Extra" points are found
+    # (DigitizedHeadPoints done for Neuromag MEG files only)
     digitized_head_points = False
     digitized_landmark = False
     if datatype == 'meg':

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -648,7 +648,7 @@ def _sidecar_json(raw, task, manufacturer, fname, datatype, overwrite=False,
         ('RecordingType', rec_type)]
     ch_info_json_meg = [
         ('DewarPosition', 'n/a'),
-        ('DigitizedLandmarks', False),
+        ('DigitizedLandmarks', True),
         ('DigitizedHeadPoints', False),
         ('MEGChannelCount', n_megchan),
         ('MEGREFChannelCount', n_megrefchan)]

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -642,9 +642,7 @@ def _sidecar_json(raw, task, manufacturer, fname, datatype, overwrite=False,
     # (DigitizedHeadPoints done for Neuromag MEG files only)
     digitized_head_points = False
     digitized_landmark = False
-    if datatype == 'meg':
-        if raw.info['dig'] is None:
-            raw.info['dig'] = []
+    if datatype == 'meg' and raw.info['dig'] is not None:
         for dig_point in raw.info['dig']:
             if dig_point['kind'] in [FIFF.FIFFV_POINT_NASION,
                                      FIFF.FIFFV_POINT_RPA,

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -637,6 +637,15 @@ def _sidecar_json(raw, task, manufacturer, fname, datatype, overwrite=False,
     n_stimchan = len([ch for ch in raw.info['chs']
                       if ch['kind'] == FIFF.FIFFV_STIM_CH]) - n_ignored
 
+    # for Neuromag MEG files, check whether Extra points are present
+    # and set DigitizedHeadPoints accordingly
+    digitized_head_points = False
+    if datatype == 'meg' and raw.filenames[0].endswith('.fif'):
+        for dig_point in raw.info['dig']:
+            if dig_point['kind'] == FIFF.FIFFV_POINT_EXTRA:
+                digitized_head_points = True
+                break
+
     # Define datatype-specific JSON dictionaries
     ch_info_json_common = [
         ('TaskName', task),
@@ -649,7 +658,7 @@ def _sidecar_json(raw, task, manufacturer, fname, datatype, overwrite=False,
     ch_info_json_meg = [
         ('DewarPosition', 'n/a'),
         ('DigitizedLandmarks', True),
-        ('DigitizedHeadPoints', False),
+        ('DigitizedHeadPoints', digitized_head_points),
         ('MEGChannelCount', n_megchan),
         ('MEGREFChannelCount', n_megrefchan)]
     ch_info_json_eeg = [


### PR DESCRIPTION
PR Description
--------------
closes #705 
closes #48

###### digitized landmarks
Extracts the coordinates of the landmarks (NAS, RPA, LPA) from MEG data and writes them to `coordsystem.json` as `AnatomicalLandmarkCoordinates` (like it is done for EEG data). Once set, `DigitizedLandmarks` in the meg json sidecar is changed to `true`, instead of the default `false`. 

###### digitized head points

For Neuromag MEG data the raw.info['dig'] is checked for the presence of `Extra` points (which should be digitized headshape points). If at least one of those points is found, `DigitizedHeadPoints` is set to `True` and `False` otherwise. 
I added tests for reading and writing.

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [x] All comments resolved
- [x] This is not your own PR
- [x] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [x] PR description includes phrase "closes <#issue-number>"
