### PR TITLE
Update BIDS_VERSION to 1.6.0

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -44,7 +44,7 @@ API and behavior changes
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 - Writing datasets via :func:`write_raw_bids`, will now never overwrite ``dataset_description.json`` file, by `Adam Li`_ (:gh:`765`)
-- When writing BIDS datasets, MNE-BIDS now tags them as BIDS 1.6.0 (we previously tagged them as BIDS 1.4.0), `Richard Höchenberger`_ (:gh:`xxx`)
+- When writing BIDS datasets, MNE-BIDS now tags them as BIDS 1.6.0 (we previously tagged them as BIDS 1.4.0), `Richard Höchenberger`_ (:gh:`782`)
 
 Requirements
 ^^^^^^^^^^^^

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -44,6 +44,7 @@ API and behavior changes
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 - Writing datasets via :func:`write_raw_bids`, will now never overwrite ``dataset_description.json`` file, by `Adam Li`_ (:gh:`765`)
+- When writing BIDS datasets, MNE-BIDS now tags them as BIDS 1.6.0 (we previously tagged them as BIDS 1.4.0), `Richard Höchenberger`_ (:gh:`xxx`)
 
 Requirements
 ^^^^^^^^^^^^

--- a/mne_bids/commands/tests/test_cli.py
+++ b/mne_bids/commands/tests/test_cli.py
@@ -18,8 +18,7 @@ with warnings.catch_warnings():
     import mne
 
 from mne.datasets import testing
-from mne.utils import (run_tests_if_main, ArgvSetter, requires_pandas,
-                       requires_version)
+from mne.utils import ArgvSetter, requires_pandas, requires_version
 from mne.utils._testing import requires_module
 
 from mne_bids.commands import (mne_bids_raw_to_bids,
@@ -306,6 +305,3 @@ def test_inspect(tmpdir):
         with ArgvSetter(args):
             with pytest.warns(RuntimeWarning, match='The unit for chann*'):
                 mne_bids_inspect.run()
-
-
-run_tests_if_main()

--- a/mne_bids/config.py
+++ b/mne_bids/config.py
@@ -3,7 +3,7 @@ from mne import io
 from mne.io.constants import FIFF
 
 
-BIDS_VERSION = "1.4.0"
+BIDS_VERSION = "1.6.0"
 
 DOI = """https://doi.org/10.21105/joss.01896"""
 

--- a/mne_bids/report.py
+++ b/mne_bids/report.py
@@ -99,8 +99,8 @@ def _summarize_software_filters(software_filters):
 
 BIDS_DATASET_TEMPLATE = \
     """{{if name == 'n/a'}}This{{else}}The {{name}}{{endif}}
-dataset was created with BIDS version {{bids_version}}
-by {{_pretty_str(authors)}}. This report was generated with
+dataset was created by {{_pretty_str(authors)}} and conforms to BIDS version
+{{bids_version}}. This report was generated with
 MNE-BIDS ({{mne_bids_doi}}). """
 BIDS_DATASET_TEMPLATE += \
     """The dataset consists of

--- a/mne_bids/tests/test_report.py
+++ b/mne_bids/tests/test_report.py
@@ -45,7 +45,8 @@ def test_report(tmpdir):
     print(report)
 
     expected_report = \
-    """This dataset was created with BIDS version 1.6.0 by Please cite MNE-BIDS in your
+    """This dataset was created with BIDS version 1.6.0 by MNE-BIDS.
+Please cite MNE-BIDS in your
 publication before removing this (citations in README). This report was
 generated with MNE-BIDS (https://doi.org/10.21105/joss.01896). The dataset
 consists of 1 participants (sex were all unknown; handedness were all unknown;

--- a/mne_bids/tests/test_report.py
+++ b/mne_bids/tests/test_report.py
@@ -59,4 +59,3 @@ analysis (2.0 +/- 0.0 were removed from analysis)."""  # noqa
 
     print(report)
     assert report == expected_report
-    

--- a/mne_bids/tests/test_report.py
+++ b/mne_bids/tests/test_report.py
@@ -11,6 +11,8 @@ from mne.datasets import testing
 from mne_bids import (BIDSPath,
                       make_report)
 from mne_bids.write import write_raw_bids
+from mne_bids.config import BIDS_VERSION
+
 
 subject_id = '01'
 session_id = '01'
@@ -42,19 +44,19 @@ def test_report(tmpdir):
     write_raw_bids(raw, bids_path, overwrite=True, verbose=False)
 
     report = make_report(bids_root)
-    print(report)
 
     expected_report = \
-    """This dataset was created with BIDS version 1.6.0 by MNE-BIDS.
-Please cite MNE-BIDS in your
-publication before removing this (citations in README). This report was
-generated with MNE-BIDS (https://doi.org/10.21105/joss.01896). The dataset
-consists of 1 participants (sex were all unknown; handedness were all unknown;
-ages all unknown) and 1 recording sessions: 01. Data was recorded using a MEG
-system (Elekta manufacturer) sampled at 300.31 Hz with line noise at 60 Hz.
-There was 1 scan in total. Recording durations ranged from 20.0 to 20.0 seconds
-(mean = 20.0, std = 0.0), for a total of 20.0 seconds of data recorded over all
-scans. For each dataset, there were on average 376.0 (std = 0.0) recording
-channels per scan, out of which 374.0 (std = 0.0) were used in analysis (2.0 +/-
-0.0 were removed from analysis)."""  # noqa
+    f"""This dataset was created by [Unspecified] and conforms to BIDS version {BIDS_VERSION}.
+This report was generated with MNE-BIDS (https://doi.org/10.21105/joss.01896).
+The dataset consists of 1 participants (sex were all unknown; handedness were
+all unknown; ages all unknown) and 1 recording sessions: 01. Data was recorded
+using a MEG system (Elekta manufacturer) sampled at 300.31 Hz with line noise at
+60 Hz. There was 1 scan in total. Recording durations ranged from 20.0 to 20.0
+seconds (mean = 20.0, std = 0.0), for a total of 20.0 seconds of data recorded
+over all scans. For each dataset, there were on average 376.0 (std = 0.0)
+recording channels per scan, out of which 374.0 (std = 0.0) were used in
+analysis (2.0 +/- 0.0 were removed from analysis)."""  # noqa
+
+    print(report)
     assert report == expected_report
+    

--- a/mne_bids/tests/test_report.py
+++ b/mne_bids/tests/test_report.py
@@ -45,7 +45,7 @@ def test_report(tmpdir):
     print(report)
 
     expected_report = \
-    """This dataset was created with BIDS version 1.4.0 by Please cite MNE-BIDS in your
+    """This dataset was created with BIDS version 1.6.0 by Please cite MNE-BIDS in your
 publication before removing this (citations in README). This report was
 generated with MNE-BIDS (https://doi.org/10.21105/joss.01896). The dataset
 consists of 1 participants (sex were all unknown; handedness were all unknown;

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -252,9 +252,7 @@ def test_make_dataset_description(tmpdir):
     with open(op.join(tmpdir, 'dataset_description.json'), 'r',
               encoding='utf-8') as fid:
         dataset_description_json = json.load(fid)
-        assert dataset_description_json["Authors"] == \
-            ["Please cite MNE-BIDS in your publication before removing this "
-             "(citations in README)"]
+        assert dataset_description_json["Authors"] == ["[Unspecified]"]
 
     make_dataset_description(
         path=tmpdir, name='tst', authors='MNE B., MNE P.',
@@ -266,9 +264,7 @@ def test_make_dataset_description(tmpdir):
     with open(op.join(tmpdir, 'dataset_description.json'), 'r',
               encoding='utf-8') as fid:
         dataset_description_json = json.load(fid)
-        assert dataset_description_json["Authors"] == \
-            ["Please cite MNE-BIDS in your publication before removing this "
-             "(citations in README)"]
+        assert dataset_description_json["Authors"] == ["[Unspecified]"]
 
     make_dataset_description(
         path=tmpdir, name='tst2', authors='MNE B., MNE P.',

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -935,8 +935,7 @@ def make_dataset_description(path, name, data_license=None,
     # if the user passed an author don't overwrite,
     # if there was an author there, only overwrite if `overwrite=True`
     if authors is None and (description['Authors'] is None or overwrite):
-        description['Authors'] = ["Please cite MNE-BIDS in your publication "
-                                  "before removing this (citations in README)"]
+        description['Authors'] = ["[Unspecified]"]
 
     pop_keys = [key for key, val in description.items() if val is None]
     for key in pop_keys:


### PR DESCRIPTION
When writing BIDS datasets, MNE-BIDS now tags them as BIDS 1.6.0 (we previously tagged them as BIDS 1.4.0), since we're always relying on the latest specs anyway.

PR Description
--------------

Describe your PR here

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
