### PR TITLE
CI: run linkcheck only on main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,10 +41,17 @@ jobs:
             destination: dev
 
         - run:
-            name: Check links
+            name: Check links (if on main)
             command: |
-              make -C doc clean
-              make -C doc linkcheck
+              current_branch=$(git rev-parse --abbrev-ref HEAD)
+              if (echo $current_branch | grep main) ; then
+                echo $current_branch
+                make -C doc clean
+                make -C doc linkcheck
+              else
+                echo $current_branch
+                echo "Skip running linkcheck."
+              fi
 
         # Store the data cache
         - save_cache:


### PR DESCRIPTION
closes #780 

running linkcheck only on `main`.

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
