### PR TITLE
When reading FIFF files, "allow Maxshield" by default

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -45,7 +45,9 @@ API and behavior changes
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 - Writing datasets via :func:`write_raw_bids`, will now never overwrite ``dataset_description.json`` file, by `Adam Li`_ (:gh:`765`)
-- When writing BIDS datasets, MNE-BIDS now tags them as BIDS 1.6.0 (we previously tagged them as BIDS 1.4.0), `Richard Höchenberger`_ (:gh:`782`)
+- When writing BIDS datasets, MNE-BIDS now tags them as BIDS 1.6.0 (we previously tagged them as BIDS 1.4.0), by `Richard Höchenberger`_ (:gh:`782`)
+- :func:`mne_bids.read_raw_bids` now passes ``allow_maxshield=True`` to the MNE-Python reader function by default when reading FIFF files. Previously, ``extra_params=dict(allow_maxshield=True)`` had to be passed explicitly, by `Richard Höchenberger`_ (:gh:`#787`)
+- The ``raw_to_bids`` command has lost its ``--allow_maxshield`` parameter. If writing a FIFF file, we will now always assume that writing data before applying a Maxwell filter is fine, by `Richard Höchenberger`_ (:gh:`#787`)
 
 Requirements
 ^^^^^^^^^^^^

--- a/mne_bids/commands/mne_bids_raw_to_bids.py
+++ b/mne_bids/commands/mne_bids_raw_to_bids.py
@@ -50,9 +50,6 @@ def run():
                       help='path to the configuration file')
     parser.add_option('--overwrite', dest='overwrite',
                       help="whether to overwrite existing data (BOOLEAN)")
-    parser.add_option('--allow_maxshield', dest='allow_maxshield',
-                      help="whether to allow non maxfiltered data (BOOLEAN)",
-                      action='store_true')
     parser.add_option('--line_freq', dest='line_freq',
                       help="The frequency of the line noise in Hz "
                            "(e.g. 50 or 60). If unknown, pass None")
@@ -72,9 +69,14 @@ def run():
     bids_path = BIDSPath(
         subject=opt.subject_id, session=opt.session_id, run=opt.run,
         acquisition=opt.acq, task=opt.task, root=opt.bids_root)
+
+    allow_maxshield = False
+    if opt.raw_fname.endswith('.fif'):
+        allow_maxshield = True
+        
     raw = _read_raw(opt.raw_fname, hpi=opt.hpi, electrode=opt.electrode,
                     hsp=opt.hsp, config=opt.config,
-                    allow_maxshield=opt.allow_maxshield)
+                    allow_maxshield=allow_maxshield)
     if opt.line_freq is not None:
         line_freq = None if opt.line_freq == "None" else opt.line_freq
         raw.info['line_freq'] = line_freq

--- a/mne_bids/commands/mne_bids_raw_to_bids.py
+++ b/mne_bids/commands/mne_bids_raw_to_bids.py
@@ -73,7 +73,7 @@ def run():
     allow_maxshield = False
     if opt.raw_fname.endswith('.fif'):
         allow_maxshield = True
-        
+
     raw = _read_raw(opt.raw_fname, hpi=opt.hpi, electrode=opt.electrode,
                     hsp=opt.hsp, config=opt.config,
                     allow_maxshield=allow_maxshield)

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -447,7 +447,6 @@ def read_raw_bids(bids_path, extra_params=None, verbose=True):
 
     extra_params : None | dict
         Extra parameters to be passed to MNE read_raw_* functions.
-        If a dict, for example: ``extra_params=dict(allow_maxshield=True)``.
         Note that the ``exclude`` parameter, which is supported by some
         MNE-Python readers, is not supported; instead, you need to subset
         your channels **after** reading.
@@ -522,6 +521,9 @@ def read_raw_bids(bids_path, extra_params=None, verbose=True):
     elif 'exclude' in extra_params:
         del extra_params['exclude']
         logger.info('"exclude" parameter is not supported by read_raw_bids')
+
+    if bids_fname.endswith('.fif') and 'allow_maxshield' not in extra_params:
+        extra_params['allow_maxshield'] = True
 
     raw = _read_raw(bids_fpath, electrode=None, hsp=None, hpi=None,
                     config=config, verbose=None, **extra_params)

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -408,8 +408,7 @@ def test_fif(_bids_validate, tmpdir):
     with pytest.raises(TypeError, match="unexpected keyword argument 'foo'"):
         read_raw_bids(bids_path=bids_path, extra_params=dict(foo='bar'))
 
-    raw2 = read_raw_bids(bids_path=bids_path,
-                         extra_params=dict(allow_maxshield=True))
+    raw2 = read_raw_bids(bids_path=bids_path)
     assert set(raw.info['bads']) == set(raw2.info['bads'])
     events, _ = mne.events_from_annotations(raw2)
     events2 = mne.read_events(events_fname)


### PR DESCRIPTION
In `main`, when trying to read a FIFF file that was recorded with activated Maxshield and hasn't been Maxwell-filtered yet, one needed to explicitly pass `extra_params=dict(allow_maxshield=True)` to `read_raw_bids()`.

However, since we currently only support reading and writing "raw" data properly (i.e., no derivatives), this unncessarily complicates things: raw data is often not Maxwell-filtered, and Maxwell-filtering is one of the very first processing steps after loading the data. In contrast, IF the data was already Maxwell-filtered on the device, this would be clearly recognizable by its `proc` entity, which should indicate such processing, making any further complications just for the sake of "making users aware they need to Maxwell-filter" a bit pointless.

So this commit makes it such that FIFF files will be read with `allow_maxshield=True` by default, unless explicitly disabled via e.g. `extra_params=dict(allow_maxshield=False)`.

I also removed the `--allow_maxshield` switch from the `raw_to_bids` command, as this seems similarly superfluous and is not in line with how `write_raw_bids()` handles things (auto-sets `allow_maxshield=True`)

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
