### PR TITLE
MRG: Make use of AssociatedEmptyRoom field in *_meg.json

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -61,6 +61,7 @@ Bug fixes
 - The :class:`mne.Annotations` ``BAD_ACQ_SKIP`` – added by the acquisition system to ``FIFF`` files – will now be preserved when reading raw data, even if these time periods are **not** explicitly included in ``*_events.tsv``, by `Richard Höchenberger`_ and `Alexandre Gramfort`_ (:gh:`754` and :gh:`762`)
 - :func:`mne_bids.write_raw_bids` will handle different cased extensions for EDF files, such as `.edf` and `.EDF` by `Adam Li`_ (:gh: `765`)
 - :func:`mne_bids.inspect_dataset` didn't handle certain filenames correctly on some systems, by `Richard Höchenberger`_ (:gh:`769`)
+- :func:`mne_bids.write_raw_bids` now works across data types with ``overwrite=True``, by `Alexandre Gramfort`_ (:gh:`791`)
 
 :doc:`Find out what was new in previous releases <whats_new_previous_releases>`
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -41,6 +41,7 @@ Enhancements
 - :func:`mne_bids.write_raw_bids` gained a new keyword argument ``symlink``, which allows to create symbolic links to the original data files instead of copying them over. Currently works for ``FIFF`` files on macOS and Linux, by `Richard Höchenberger`_ (:gh:`778`)
 - :class:`mne_bids.BIDSPath` now has property getter and setter methods for all BIDS entities, i.e., you can now do things like ``bids_path.subject = 'foo'`` and don't have to resort to ``bids_path.update()``. This also ensures you'll get proper completion suggestions from your favorite Python IDE, by `Richard Höchenberger`_ (:gh:`786`)
 - :func:`mne_bids.write_raw_bids` now stores information about continuous head localization measurements (e.g., Elekta/Neuromag cHPI) in the MEG sidecar file, by `Richard Höchenberger`_ (:gh:`794`)
+- :func:`mne_bids.write_raw_bids` gained a new parameter `empty_room` that allows to specify an associated empty-room recording when writing an MEG data file. This information will be stored in the ``AssociatedEmptyRoom`` field of the MEG JSON sidecar file, by `Richard Höchenberger`_ (:gh:`795`)
 
 API and behavior changes
 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -49,6 +50,7 @@ API and behavior changes
 - When writing BIDS datasets, MNE-BIDS now tags them as BIDS 1.6.0 (we previously tagged them as BIDS 1.4.0), by `Richard Höchenberger`_ (:gh:`782`)
 - :func:`mne_bids.read_raw_bids` now passes ``allow_maxshield=True`` to the MNE-Python reader function by default when reading FIFF files. Previously, ``extra_params=dict(allow_maxshield=True)`` had to be passed explicitly, by `Richard Höchenberger`_ (:gh:`#787`)
 - The ``raw_to_bids`` command has lost its ``--allow_maxshield`` parameter. If writing a FIFF file, we will now always assume that writing data before applying a Maxwell filter is fine, by `Richard Höchenberger`_ (:gh:`#787`)
+- :meth:`mne_bids.BIDSPath.find_empty_room` now first looks for an ``AssociatedEmptyRoom`` field in the MEG JSON sidecar file to retrieve the empty-room recording; only if this information is missing, it will proceed to try and find the best-matching empty-room recording based on measurement date (i.e., fall back to the previous behavior), by `Richard Höchenberger`_ (:gh:`#795`)
 
 Requirements
 ^^^^^^^^^^^^

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -871,7 +871,7 @@ class BIDSPath(object):
             The path corresponding to the best-matching empty-room measurement.
             Returns ``None`` if none was found.
         """
-        if self.datatype not in('meg', None):
+        if self.datatype not in ('meg', None):
             raise ValueError('Empty-room data is only supported for MEG '
                              'datasets')
 

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -864,7 +864,7 @@ class BIDSPath(object):
                   entry, the empty-room recording specified there will be used.
                   Otherwise, this method will try to find the best-matching
                   empty-room recording based on measurement date.
-           
+
         Returns
         -------
         BIDSPath | None
@@ -873,7 +873,7 @@ class BIDSPath(object):
         """
         if self.datatype != 'meg':
             raise ValueError('Empty-room data is only supported for MEG '
-                             'datasets') 
+                             'datasets')
 
         if self.root is None:
             raise ValueError('The root of the "bids_path" must be set. '

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -871,7 +871,7 @@ class BIDSPath(object):
             The path corresponding to the best-matching empty-room measurement.
             Returns ``None`` if none was found.
         """
-        if self.datatype != 'meg':
+        if self.datatype not in('meg', None):
             raise ValueError('Empty-room data is only supported for MEG '
                              'datasets')
 

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -950,7 +950,7 @@ def test_find_emptyroom_no_meas_date(tmpdir):
 
     with pytest.warns(RuntimeWarning, match='Could not retrieve .* date'):
         bids_path.find_empty_room()
- 
+
 
 def test_bids_path_label_vs_index_entity():
     match = "subject must be an instance of None or str"

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -493,7 +493,7 @@ def test_fif(_bids_validate, tmpdir):
     # test that an incorrect date raises an error.
     er_bids_basename_bad = BIDSPath(subject='emptyroom', session='19000101',
                                     task='noise', root=bids_root)
-    with pytest.raises(ValueError, match='Date provided'):
+    with pytest.raises(ValueError, match='The date provided'):
         write_raw_bids(raw, er_bids_basename_bad, overwrite=False)
 
     # test that the acquisition time was written properly

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -2767,6 +2767,7 @@ def test_write_associated_emptyroom(_bids_validate, tmpdir):
         meg_json_data = json.load(fin)
 
     assert 'AssociatedEmptyRoom' in meg_json_data
-    assert (bids_path_er.fpath.as_posix()  # make test work on Windows, too
+    assert (bids_path_er.fpath
+            .as_posix()  # make test work on Windows, too
             .endswith(meg_json_data['AssociatedEmptyRoom']))
     assert meg_json_data['AssociatedEmptyRoom'].startswith('/')

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -2767,6 +2767,6 @@ def test_write_associated_emptyroom(_bids_validate, tmpdir):
         meg_json_data = json.load(fin)
 
     assert 'AssociatedEmptyRoom' in meg_json_data
-    assert (str(bids_path_er.fpath)
+    assert (bids_path_er.fpath.as_posix()  # make test work on Windows, too
             .endswith(meg_json_data['AssociatedEmptyRoom']))
     assert meg_json_data['AssociatedEmptyRoom'].startswith('/')

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -851,6 +851,7 @@ def test_ctf(_bids_validate, tmpdir):
     raw = _read_raw_ctf(raw_fname)
     raw.info['line_freq'] = 60
     write_raw_bids(raw, bids_path)
+    write_raw_bids(raw, bids_path, overwrite=True)  # test overwrite
 
     _bids_validate(tmpdir)
     with pytest.warns(RuntimeWarning, match='Did not find any events'):

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1344,10 +1344,16 @@ def write_raw_bids(raw, bids_path, events_data=None,
     # create parent directories if needed
     _mkdir_p(os.path.dirname(data_path))
 
-    if os.path.exists(bids_path.fpath) and not overwrite:
-        raise FileExistsError(
-            f'"{bids_path.fpath}" already exists. '  # noqa: F821
-            'Please set overwrite to True.')
+    if os.path.exists(bids_path.fpath):
+        if overwrite:
+            if bids_path.fpath.is_dir():
+                shutil.rmtree(bids_path.fpath)
+            else:
+                bids_path.fpath.unlink()
+        else:
+            raise FileExistsError(
+                f'"{bids_path.fpath}" already exists. '  # noqa: F821
+                'Please set overwrite to True.')
 
     # If not already converting for anonymization, we may still need to do it
     # if current format not BIDS compliant

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1293,8 +1293,16 @@ def write_raw_bids(raw, bids_path, events_data=None,
                                     f'{associated_er_path}')
 
         # Turn it into a path relative to the BIDS root
+        # We want forward slashes as directory separators on Windows too
+        if sys.platform in ('win32', 'cygwin'):
+            from pathlib import PureWindowsPath
+            associated_er_path = PureWindowsPath(associated_er_path)
+            root = PureWindowsPath(empty_room.root)
+        else:
+            root = empty_room.root
+
         associated_er_path = Path(str(associated_er_path)
-                                  .replace(str(empty_room.root), ''))
+                                  .replace(str(root), ''))
 
     data_path = bids_path.mkdir().directory
 

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1293,16 +1293,10 @@ def write_raw_bids(raw, bids_path, events_data=None,
                                     f'{associated_er_path}')
 
         # Turn it into a path relative to the BIDS root
-        # We want forward slashes as directory separators on Windows too
-        if sys.platform in ('win32', 'cygwin'):
-            from pathlib import PureWindowsPath
-            associated_er_path = PureWindowsPath(associated_er_path)
-            root = PureWindowsPath(empty_room.root)
-        else:
-            root = empty_room.root
-
         associated_er_path = Path(str(associated_er_path)
-                                  .replace(str(root), ''))
+                                  .replace(str(empty_room.root), ''))
+        # Ensure it works on Windows too
+        associated_er_path = associated_er_path.as_posix()
 
     data_path = bids_path.mkdir().directory
 

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1188,7 +1188,7 @@ def write_raw_bids(raw, bids_path, events_data=None,
                            'array. You need to pass both, or neither.')
 
     _validate_type(item=empty_room, item_name='empty_room',
-                   types=(BIDSPath, None))        
+                   types=(BIDSPath, None))
 
     raw = raw.copy()
 


### PR DESCRIPTION
Fixes #493.

`write_raw_bids` gains a new parameter, `empty_room`, which allows users to specify an empty-room recording that belongs to the experimental MEG data. This information is stored in the `AssociatedEmptyRoom` field in the `*_meg.json` sidecar file.

`BIDSPath` gained an `empty_room` property that parses the sidecar and returns a `BIDSPath` to the empty-room recording. If no `AssociatedEmptyRoom` key is found in the sidecar, an error message is emitted, suggesting users may wish to use `BIDSPath.find_empty_room()` instead, which will try to find the "best-matching" empty-room recording based on session date.

Would like to hear your thought on the API.


cc @agramfort @sappelhof

x-ref https://github.com/bids-standard/bids-specification/issues/790 -> the BIDS specs are unclear, and I'm now just going ahead here with an implementation, also with the idea to provide something that "works in real-life" before trying to push the BIDS discussion forward again.

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
