### PR TITLE
MRG: Relax restriction when reading cHPI for CTF, KIT; add support for writing basic cHPI info for CTF, KIT

### DIFF
--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -297,14 +297,22 @@ def _handle_info_reading(sidecar_fname, raw, verbose=None):
                         'data for KIT files.')
         else:
             hpi_freqs_json = sidecar_json['HeadCoilFrequency']
-            hpi_freqs_raw, _, _ = mne.chpi.get_chpi_info(raw.info)
-            if not np.allclose(hpi_freqs_json, hpi_freqs_raw):
-                raise ValueError(
-                    f'The cHPI coil frequencies in the sidecar file '
-                    f'{sidecar_fname}:\n    {hpi_freqs_json}\ndiffer from'
-                    f' what is stored in the raw data:\n    {hpi_freqs_raw}\n'
-                    f'Cannot proceed.'
+            try:
+                hpi_freqs_raw, _, _ = mne.chpi.get_chpi_info(raw.info)
+            except ValueError:
+                logger.info(
+                    'Cannot verify that the cHPI frequencies provided in '
+                    'the MEG JSON sidecar file correspond to those in the '
+                    'raw data. (Was it converted from another format?)'
                 )
+            else:
+                if not np.allclose(hpi_freqs_json, hpi_freqs_raw):
+                    raise ValueError(
+                        f'The cHPI coil frequencies in the sidecar file '
+                        f'{sidecar_fname}:\n    {hpi_freqs_json}\ndiffer from'
+                        f' what is stored in the raw data:\n'
+                        f'    {hpi_freqs_raw}\nCannot proceed.'
+                    )
     else:
         if raw.info['hpi_subsystem']:
             logger.info('Dropping cHPI information stored in raw data, '

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -15,6 +15,7 @@ from datetime import datetime, timezone
 import numpy as np
 import mne
 from mne import io, read_events, events_from_annotations
+from mne.io.pick import pick_channels_regexp
 from mne.utils import has_nibabel, logger, warn
 from mne.coreg import fit_matched_points
 from mne.transforms import apply_trans
@@ -275,15 +276,35 @@ def _handle_info_reading(sidecar_fname, raw, verbose=None):
         # no cHPI info in the sidecar – leave raw.info unchanged
         pass
     elif chpi is True:
-        hpi_freqs = sidecar_json['HeadCoilFrequency']
-        hpi_freqs_data, _, _ = mne.chpi.get_chpi_info(raw.info)
-        if not np.allclose(hpi_freqs, hpi_freqs_data):
-            raise ValueError(
-                f'The cHPI coil frequencies in the sidecar file '
-                f'{sidecar_fname}:\n    {hpi_freqs}\ndiffer from what is '
-                f'stored in the raw data:\n    {hpi_freqs_data}\n'
-                f'Cannot proceed.'
-            )
+        from mne.io.ctf import RawCTF
+        from mne.io.kit.kit import RawKIT
+
+        if isinstance(raw, RawCTF):
+            # Pick channels corresponding to the cHPI positions
+            hpi_picks = pick_channels_regexp(raw.info['ch_names'],
+                                             'HLC00[123][123].*')
+            if len(hpi_picks) != 9:
+                raise ValueError(
+                    f'Could not find all cHPI channels that we expected for '
+                    f'CTF data. Expected: 9, found: {len(hpi_picks)}'
+                )
+            logger.info('Cannot verify that the cHPI frequencies provided in '
+                        'the MEG JSON sidecar file correspond to the raw data '
+                        'for CTF files.')
+        elif isinstance(raw, RawKIT):
+            logger.info('Cannot verify that the cHPI information provided in '
+                        'the MEG JSON sidecar file corresponds to the raw '
+                        'data for KIT files.')
+        else:
+            hpi_freqs_json = sidecar_json['HeadCoilFrequency']
+            hpi_freqs_raw, _, _ = mne.chpi.get_chpi_info(raw.info)
+            if not np.allclose(hpi_freqs_json, hpi_freqs_raw):
+                raise ValueError(
+                    f'The cHPI coil frequencies in the sidecar file '
+                    f'{sidecar_fname}:\n    {hpi_freqs_json}\ndiffer from'
+                    f' what is stored in the raw data:\n    {hpi_freqs_raw}\n'
+                    f'Cannot proceed.'
+                )
     else:
         if raw.info['hpi_subsystem']:
             logger.info('Dropping cHPI information stored in raw data, '

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -675,7 +675,7 @@ def test_chpi(_bids_validate, tmpdir, format):
     if parse_version(mne.__version__) <= parse_version('0.23'):
         assert 'ContinuousHeadLocalization' not in meg_json_data
         assert 'HeadCoilFrequency' not in meg_json_data
-    elif format == 'fif_no_chpi':
+    elif format in ['fif_no_chpi', 'kit']:
         # no cHPI info is contained in the sample data
         assert meg_json_data['ContinuousHeadLocalization'] is False
         assert meg_json_data['HeadCoilFrequency'] == []
@@ -683,7 +683,7 @@ def test_chpi(_bids_validate, tmpdir, format):
         assert meg_json_data['ContinuousHeadLocalization'] is True
         assert_array_almost_equal(meg_json_data['HeadCoilFrequency'],
                                   [83., 143., 203., 263., 323.])
-    elif format in ('ctf', 'kit'):
+    elif format == 'ctf':
         assert meg_json_data['ContinuousHeadLocalization'] is True
         assert_array_equal(meg_json_data['HeadCoilFrequency'],
                            np.array([]))

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -604,29 +604,20 @@ def test_fif(_bids_validate, tmpdir):
     with pytest.raises(ValueError, match='Unrecognized file format'):
         write_raw_bids(raw, bids_path)
 
-    raw = _read_raw_fif(raw_fname)
-    bids_path = bids_path.copy().update(datatype='meg')
-    write_raw_bids(raw, bids_path, events_data=events, event_id=event_id,
-                   overwrite=True)
-
+    # test whether extra points in raw.info['dig'] are correctly used
+    # to set DigitizedHeadShape in the json sidecar
+    # unchanged sample data includes Extra points
     meg_json = _find_matching_sidecar(
         bids_path.copy().update(root=bids_root),
         suffix='meg', extension='.json')
 
-    with open(meg_json, 'r') as fin:
-        meg_json_data = json.load(fin)
+    with open(meg_json, 'r') as f:
+        meg_json_data = json.load(f)
 
-    # no cHPI info is contained in the sample data
-    assert meg_json_data['ContinuousHeadLocalization'] is False
-    assert meg_json_data['HeadCoilFrequency'] == []
-
-    # test whether extra points in raw.info['dig'] are correctly used
-    # to set DigitizedHeadShape in the json sidecar
-    # unchanged sample data includes Extra points
     assert meg_json_data['DigitizedHeadPoints'] is True
 
     # drop extra points from raw.info['dig'] and write again
-    raw_no_extra_points = raw.copy()
+    raw_no_extra_points = _read_raw_fif(raw_fname)
     new_dig = []
     for dig_point in raw_no_extra_points.info['dig']:
         if dig_point['kind'] != FIFF.FIFFV_POINT_EXTRA:
@@ -645,27 +636,57 @@ def test_fif(_bids_validate, tmpdir):
         # DigitizedHeadPoints should be false
         assert meg_json_data['DigitizedHeadPoints'] is False
 
-    # test data with cHPI info
-    data_path = testing.data_path()
-    raw_fname = op.join(data_path, 'SSS', 'test_move_anon_raw.fif')
-    raw = _read_raw_fif(raw_fname, allow_maxshield=True)
 
-    root = tmpdir.mkdir('chpi')
-    bids_path = bids_path.copy().update(root=root, datatype='meg')
-    bids_path = write_raw_bids(raw, bids_path)
+@pytest.mark.parametrize('format', ('fif_no_chpi', 'fif', 'ctf', 'kit'))
+@pytest.mark.filterwarnings(warning_str['maxshield'])
+def test_chpi(_bids_validate, tmpdir, format):
+    """Test writing of cHPI information."""
+    data_path = testing.data_path()
+    kit_data_path = op.join(base_path, 'kit', 'tests', 'data')
+
+    if format == 'fif_no_chpi':
+        fif_raw_fname = op.join(data_path, 'MEG', 'sample',
+                                'sample_audvis_trunc_raw.fif')
+        raw = _read_raw_fif(fif_raw_fname)
+    elif format == 'fif':
+        fif_raw_fname = op.join(data_path, 'SSS', 'test_move_anon_raw.fif')
+        raw = _read_raw_fif(fif_raw_fname, allow_maxshield=True)
+    elif format == 'ctf':
+        ctf_raw_fname = op.join(data_path, 'CTF', 'testdata_ctf.ds')
+        raw = _read_raw_ctf(ctf_raw_fname)
+    elif format == 'kit':
+        kit_raw_fname = op.join(kit_data_path, 'test.sqd')
+        kit_hpi_fname = op.join(kit_data_path, 'test_mrk.sqd')
+        kit_electrode_fname = op.join(kit_data_path, 'test.elp')
+        kit_headshape_fname = op.join(kit_data_path, 'test.hsp')
+        raw = _read_raw_kit(kit_raw_fname, mrk=kit_hpi_fname,
+                            elp=kit_electrode_fname, hsp=kit_headshape_fname)
+
+    bids_root = tmpdir.mkdir('bids')
+    bids_path = _bids_path.copy().update(root=bids_root, datatype='meg')
+
+    write_raw_bids(raw, bids_path)
     _bids_validate(bids_path.root)
 
     meg_json = bids_path.copy().update(suffix='meg', extension='.json')
-    with open(meg_json, 'r') as fin:
-        meg_json_data = json.load(fin)
+    with open(meg_json, 'r') as f:
+        meg_json_data = json.load(f)
 
-    if parse_version(mne.__version__) > parse_version('0.23'):
+    if parse_version(mne.__version__) <= parse_version('0.23'):
+        assert 'ContinuousHeadLocalization' not in meg_json_data
+        assert 'HeadCoilFrequency' not in meg_json_data
+    elif format == 'fif_no_chpi':
+        # no cHPI info is contained in the sample data
+        assert meg_json_data['ContinuousHeadLocalization'] is False
+        assert meg_json_data['HeadCoilFrequency'] == []
+    elif format == 'fif':
         assert meg_json_data['ContinuousHeadLocalization'] is True
         assert_array_almost_equal(meg_json_data['HeadCoilFrequency'],
                                   [83., 143., 203., 263., 323.])
-    else:
-        assert meg_json_data['ContinuousHeadLocalization'] is False
-        assert meg_json_data['HeadCoilFrequency'] == []
+    elif format in ('ctf', 'kit'):
+        assert meg_json_data['ContinuousHeadLocalization'] is True
+        assert_array_equal(meg_json_data['HeadCoilFrequency'],
+                           np.array([]))
 
 
 @pytest.mark.filterwarnings(warning_str['channel_unit_changed'])

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -681,7 +681,7 @@ def _sidecar_json(raw, task, manufacturer, fname, datatype,
                 pass
         elif parse_version(mne.__version__) > parse_version('0.23'):
             hpi_freqs, _, _ = mne.chpi.get_chpi_info(info=raw.info,
-                                                    on_missing='ignore')
+                                                     on_missing='ignore')
             if hpi_freqs.size > 0:
                 chpi = True
 

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -665,7 +665,8 @@ def _sidecar_json(raw, task, manufacturer, fname, datatype,
 
     chpi = False
     hpi_freqs = np.array([])
-    if datatype == 'meg':
+    if (datatype == 'meg' and
+            parse_version(mne.__version__) > parse_version('0.23')):
         # We need to handle different data formats differently
         if isinstance(raw, RawCTF):
             try:
@@ -679,11 +680,14 @@ def _sidecar_json(raw, task, manufacturer, fname, datatype,
                 chpi = True
             except RuntimeError:
                 pass
-        elif parse_version(mne.__version__) > parse_version('0.23'):
+        else:
             hpi_freqs, _, _ = mne.chpi.get_chpi_info(info=raw.info,
                                                      on_missing='ignore')
             if hpi_freqs.size > 0:
                 chpi = True
+    elif datatype == 'meg':
+        logger.info('Cannot check for & write continuous head localization '
+                    'information: requires MNE-Python >= 0.24')
 
     # Define datatype-specific JSON dictionaries
     ch_info_json_common = [

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1009,10 +1009,6 @@ def write_raw_bids(raw, bids_path, events_data=None,
                    for the manufacturer, please update the manufacturer field
                    in the sidecars manually.
 
-    .. note:: Information about continuous head localization (cHPI) will
-              currently only be included in the MEG sidecar files for
-              Elekta/Neuromag data (i.e., ``.fif`` files).
-
     Parameters
     ----------
     raw : mne.io.Raw

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -668,11 +668,10 @@ def _sidecar_json(raw, task, manufacturer, fname, datatype,
     if (datatype == 'meg' and
             parse_version(mne.__version__) > parse_version('0.23')):
         # We need to handle different data formats differently
-        if isinstance(raw, (RawCTF, RawKIT)) and 'hpi_results' in raw.info:
-            chpi = True
-        elif isinstance(raw, RawCTF):
+        if isinstance(raw, RawCTF):
             try:
                 mne.chpi.extract_chpi_locs_ctf(raw)
+                chpi = True
             except RuntimeError:
                 logger.info('Could not find cHPI information in raw data.')
         elif isinstance(raw, RawKIT):


### PR DESCRIPTION
The existing tests in the reader would not allow us to read CTF and KIT data with cHPI info proclaimed in the MEG sidecar. This PR tries to salvage the situation.

<strike>Not sure how to test, as we're currently not supporting writing that info for CTF / KIT files either. We'd probably need to extent the `write_raw_bids` API for this…</strike>


Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
