### PR TITLE
[MRG] Do not preload data in _infer_eeg_placement_scheme

### DIFF
--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -270,7 +270,6 @@ def _infer_eeg_placement_scheme(raw):
         return placement_scheme
 
     # How many of the channels in raw are based on the extended 10/20 system
-    raw.load_data()
     sel = pick_types(raw.info, meg=False, eeg=True)
     ch_names = [raw.ch_names[i] for i in sel]
     channel_names = [ch.lower() for ch in ch_names]

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -825,6 +825,9 @@ def _write_raw_fif(raw, bids_fname):
         should be saved.
 
     """
+    if (not raw.preload) and (bids_fname in raw._filenames):
+        raw.load_data()
+
     raw.save(bids_fname, fmt=raw.orig_format, split_naming='bids',
              overwrite=True)
 

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -825,9 +825,6 @@ def _write_raw_fif(raw, bids_fname):
         should be saved.
 
     """
-    if (not raw.preload) and (bids_fname in raw._filenames):
-        raw.load_data()
-
     raw.save(bids_fname, fmt=raw.orig_format, split_naming='bids',
              overwrite=True)
 
@@ -1437,6 +1434,8 @@ def write_raw_bids(raw, bids_path, events_data=None,
 
     if os.path.exists(bids_path.fpath):
         if overwrite:
+            # Need to load data before removing its source
+            raw.load_data()
             if bids_path.fpath.is_dir():
                 shutil.rmtree(bids_path.fpath)
             else:


### PR DESCRIPTION
related to #809 ... ~could potentially be a fix for #809~, but I think there is something else going on there (potentially not mne-bids related).

Anyhow, since https://github.com/mne-tools/mne-python/pull/7507 I don't think we need to preload data anymore. But let's see what the CI says, local tests had two weird issues that I suspect are unrelated.

Update: We need to preload data. But not from within `_infer_eeg_placement_scheme`.



Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [x] All comments resolved
- [x] This is not your own PR
- [x] All CIs are happy
- [x] PR title starts with [MRG]
- ~[whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated~
- ~PR description includes phrase "closes <#issue-number>"~
