### PR TITLE
MRG: Wipe out all measurement date info when reading scans.tsv

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -67,6 +67,7 @@ Bug fixes
 - :func:`mne_bids.write_raw_bids` will handle different cased extensions for EDF files, such as `.edf` and `.EDF` by `Adam Li`_ (:gh: `765`)
 - :func:`mne_bids.inspect_dataset` didn't handle certain filenames correctly on some systems, by `Richard Höchenberger`_ (:gh:`769`)
 - :func:`mne_bids.write_raw_bids` now works across data types with ``overwrite=True``, by `Alexandre Gramfort`_ (:gh:`791`)
+- :func:`mne_bids.read_raw_bids` didn't always replace all traces of the measurement date stored in the raw data with the date found in `*_scans.tsv`, by `Richard Höchenberger`_ (:gh:`812`)
 
 :doc:`Find out what was new in previous releases <whats_new_previous_releases>`
 

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -237,6 +237,11 @@ def _handle_scans_reading(scans_fname, raw, bids_path, verbose=False):
         if verbose:
             logger.debug(f'Loaded {scans_fname} scans file to set '
                          f'acq_time as {acq_time}.')
+        # First set meas_date to None and call anonymize_info to remove any
+        # traces of the measurement date we wish to replace – it might lurk out
+        # in more places than just raw.info['meas_date']!
+        raw.set_meas_date(None)
+        mne.io.anonymize_info(info=raw.info, keep_his=True)
         raw.set_meas_date(acq_time)
     return raw
 

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -237,11 +237,11 @@ def _handle_scans_reading(scans_fname, raw, bids_path, verbose=False):
         if verbose:
             logger.debug(f'Loaded {scans_fname} scans file to set '
                          f'acq_time as {acq_time}.')
-        # First set meas_date to None and call anonymize_info to remove any
-        # traces of the measurement date we wish to replace – it might lurk out
-        # in more places than just raw.info['meas_date']!
-        raw.set_meas_date(None)
-        mne.io.anonymize_info(info=raw.info, keep_his=True)
+        # Call anonymize() to remove any traces of the measurement date we wish
+        # to replace – it might lurk out in more places than just
+        # raw.info['meas_date'], e.g. in info['meas_id]['secs'] and in
+        # info['file_id'], which are not affected by set_meas_date().
+        raw.anonymize(daysback=None, keep_his=True)
         raw.set_meas_date(acq_time)
     return raw
 


### PR DESCRIPTION
If we find the acquisition date in `scans.tsv`, we use it to replace `raw.info['meas_date']` in `main`.

However, the acquisition time might be stored in a few other places too, which can lead to issues when trying to write the file again. For example, I updated `scans.tsv` of one of my datasets so MNE could load it properly. But when trying to write the data again, MNE raised an exception, because `raw.info['meas_id']['secs']` was out of range.

This PR ensures that these problems are a thing of the past 💪

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [x] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
