### PR TITLE
Update docstring of get_entity_vals() "root" param

### DIFF
--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -1357,7 +1357,7 @@ def get_entity_vals(root, entity_key, *, ignore_subjects='emptyroom',
                   may take a **considerable** amount of time (seconds up to
                   several minutes). If you find yourself running into such
                   performance issues, consider limiting the search to only a
-                  subdirectory in the dataset, e.g., for a single subject or
+                  subdirectory in the dataset, e.g., to a single subject or
                   session only.
 
     entity_key : str

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -1346,7 +1346,20 @@ def get_entity_vals(root, entity_key, *, ignore_subjects='emptyroom',
     Parameters
     ----------
     root : str | pathlib.Path
-        Path to the root of the BIDS directory.
+        Path to the "root" directory from which to start traversing to gather
+        BIDS entities from file- and folder names. This will commonly be the
+        BIDS root, but it may also be a subdirectory inside of a BIDS dataset,
+        e.g., the ``sub-X`` directory of a hypothetical subject ``X``.
+
+        .. note:: This function searches the names of all files and directories
+                  nested within ``root``. Depending on the size of your
+                  dataset and storage system, searching the entire BIDS dataset
+                  may take a **considerable** amount of time (seconds up to
+                  several minutes). If you find yourself running into such
+                  performance issues, consider limiting the search to only a
+                  subdirectory in the dataset, e.g., for a single subject or
+                  session only.
+
     entity_key : str
         The name of the entity key to search for.
     ignore_subjects : str | iterable | None


### PR DESCRIPTION
We found that `get_entity_vals()` can be a horrible performance bottleneck on large datasets stored on a network-attached storage system. Luckily for us, we figured that, instead of passing the BIDS root as the `root` parameter, it was totally valid and functional to pass a sub-directory (in this specific case, `sub-X` for individual subjects) instead, leading to a speedup by one order of magnitude. However, this behavior was so far undocumented. This commit changes the docstring to "officially" expose this functionality.

cc @agramfort @dengemann

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
