### PR TITLE
[BUG] fix orientations if not LIA

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -69,6 +69,7 @@ Bug fixes
 - :func:`mne_bids.write_raw_bids` now works across data types with ``overwrite=True``, by `Alexandre Gramfort`_ (:gh:`791`)
 - :func:`mne_bids.read_raw_bids` didn't always replace all traces of the measurement date and time stored in the raw data with the date found in `*_scans.tsv`, by `Richard Höchenberger`_ (:gh:`812`, :gh:`815`)
 - :func:`mne_bids.read_raw_bids` crashed when the (optional) ``acq_time`` column was missing in ``*_scans.tsv``, by `Alexandre Gramfort`_ (:gh:`814`)
+- :func:`mne_bids.get_head_mri_trans` gave incorrect results when the T1 image was not in LIA format, now all formats function properly, by `Alex Rockhill`_ (:gh:`826`)
 
 :doc:`Find out what was new in previous releases <whats_new_previous_releases>`
 

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -782,8 +782,21 @@ def get_head_mri_trans(bids_path, extra_params=None, t1_bids_path=None):
                            'with "{}". Tried: "{}" but it does not exist.'
                            .format(t1w_json_path, t1w_path))
     t1_nifti = nib.load(t1w_path)
+    # Convert T1 to LIA (freesurfer stores scanner RAS in LIA)
+    ori_trans = nib.orientations.ornt_transform(
+        nib.orientations.axcodes2ornt(
+            nib.orientations.aff2axcodes(t1_nifti.affine)),
+        nib.orientations.axcodes2ornt('LIA'))
+    t1_lia = t1_nifti.as_reoriented(ori_trans)
+
     # Convert to MGH format to access vox2ras method
-    t1_mgh = nib.MGHImage(t1_nifti.dataobj, t1_nifti.affine)
+    t1_mgh = nib.MGHImage(t1_lia.dataobj, t1_lia.affine)
+
+    # Convert the landmarks to LIA as well
+    # Original orientation -> real world coordinates
+    mri_landmarks = apply_trans(t1_nifti.affine, mri_landmarks)
+    # Real world coordinates -> LIA
+    mri_landmarks = apply_trans(np.linalg.inv(t1_lia.affine), mri_landmarks)
 
     # now extract transformation matrix and put back to RAS coordinates of MRI
     vox2ras_tkr = t1_mgh.header.get_vox2ras_tkr()


### PR DESCRIPTION
This fixes non-LIA orientation image determining of `trans` since freesurfer stores images internally in LIA.

Fixes https://github.com/mne-tools/mne-bids/issues/822, adds on https://github.com/mne-tools/mne-bids/pull/825

<img width="673" alt="Screen Shot 2021-07-04 at 10 57 35 AM" src="https://user-images.githubusercontent.com/13473576/124395046-d4f64500-dcb6-11eb-9361-47529d7f9f15.png">


Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [x] PR description includes phrase "closes <#issue-number>"
