### PR TITLE
[MRG] Style: sphinx gallery, go from ### to # %%

### DIFF
--- a/examples/bidspath.py
+++ b/examples/bidspath.py
@@ -11,12 +11,12 @@ operations. Learn here how to use it.
 # Author: Richard Höchenberger <richard.hoechenberger@gmail.com>
 # License: BSD (3-clause)
 
-###############################################################################
+# %%
 # Obviously, to start exploring BIDSPath, we first need to import it.
 
 from mne_bids import BIDSPath
 
-###############################################################################
+# %%
 # Now let's discuss a little bit of background on the BIDS file and folder
 # naming scheme. The first term we are going to introduce is the **BIDS root**.
 # The BIDS root is simply the root folder of your BIDS dataset. For
@@ -32,7 +32,7 @@ from mne_bids import BIDSPath
 
 bids_root = './my_bids_root'
 
-###############################################################################
+# %%
 # This refers to a folder named `my_bids_root` in the current working
 # directory. Finally, let is create a ``BIDSPath``, and tell it about our
 # BIDS root. We can then also query the ``BIDSPath`` for its root.
@@ -40,7 +40,7 @@ bids_root = './my_bids_root'
 bids_path = BIDSPath(root=bids_root)
 print(bids_path.root)
 
-###############################################################################
+# %%
 # Great! But not really useful so far. BIDS also asks us to specify **subject
 # identifiers**. We can either create a new ``BIDSPath``, or update our
 # existing one. The value can be retrieved via the ``.subject`` attribute.
@@ -55,7 +55,7 @@ print(bids_path_new.subject)
 bids_path.update(subject=subject)
 print(bids_path.subject)
 
-###############################################################################
+# %%
 # In this example, we are going to update the existing ``BIDSPath`` using its
 # ``update()`` method. But note that all parameters we pass to this method can
 # also be used when creating a ``BIDSPath``.
@@ -70,7 +70,7 @@ session = 'test'
 bids_path.update(session=session)
 print(bids_path.session)
 
-###############################################################################
+# %%
 # Now that was easy! We're almost there! We also need to specify a
 # **data type**, i.e., ``meg`` for MEG data, ``eeg`` and ``ieeg`` for EEG and
 # iEEG data, or ``anat`` for anatomical MRI scans. Typically, MNE-BIDS will
@@ -82,11 +82,11 @@ datatype = 'meg'
 bids_path.update(datatype=datatype)
 print(bids_path.datatype)
 
-###############################################################################
+# %%
 # Excellent! Let's have a look at the path we have constructed!
 print(bids_path)
 
-###############################################################################
+# %%
 # As you can see, ``BIDSPath`` automatically arranged all the information we
 # provided such that it creates a valid BIDS folder structure. You can also
 # retrieve a `pathlib.Path` object of this path:
@@ -94,12 +94,12 @@ print(bids_path)
 pathlib_path = bids_path.fpath
 pathlib_path
 
-###############################################################################
+# %%
 # Let's have a closer look at the components of our ``BIDSPath`` again.
 
 bids_path
 
-###############################################################################
+# %%
 # The most interesting thing here is probably the **basename**. It's what
 # MNE-BIDS uses to name individual files. The basename consists of a set of
 # so-called **entities**, which are concatenated using underscores. You can
@@ -107,7 +107,7 @@ bids_path
 
 bids_path.basename
 
-###############################################################################
+# %%
 # The two entities you can see here are the ``subject`` entity (``sub``) and
 # the ``session`` entity (``ses``). Each entity name also has a value; for
 # ``sub``, this is ``123``, and for ``ses``, it is ``test`` in our example.
@@ -117,7 +117,7 @@ bids_path.basename
 
 bids_path.entities
 
-###############################################################################
+# %%
 # As you can see, most entity keys are set to ``None``, which is the default
 # and implies that no value has been set. Let us add a ``run`` entity, and
 # remove the ``session``:
@@ -127,14 +127,14 @@ session = None
 bids_path.update(run=run, session=session)
 bids_path
 
-###############################################################################
+# %%
 # As you can see, the ``basename`` has been updated. In fact, the entire
 # **path** has been updated, and the ``ses-test`` folder has been dropped from
 # the path:
 
 print(bids_path.fpath)
 
-###############################################################################
+# %%
 # Awesome! We're almost done! Two important things are still missing, though:
 # the so-called **suffix** and the filename **extension**. Sometimes these
 # terms are used interchangably, but in BIDS, they have a very specific
@@ -155,7 +155,7 @@ bids_path.update(suffix='meg', extension='fif')
 print(bids_path.fpath)
 bids_path
 
-###############################################################################
+# %%
 # By default, most MNE-BIDS functions will try to infer to correct
 # suffix and extension for your data, and you don't need to specify them
 # manually.

--- a/examples/convert_eeg_to_bids.py
+++ b/examples/convert_eeg_to_bids.py
@@ -26,7 +26,7 @@ data. Specifically, we will follow these steps:
 #
 # License: BSD (3-clause)
 
-###############################################################################
+# %%
 # We are importing everything we need for this example:
 import os.path as op
 import shutil
@@ -37,7 +37,7 @@ from mne.datasets import eegbci
 from mne_bids import write_raw_bids, BIDSPath, print_dir_tree
 from mne_bids.stats import count_events
 
-###############################################################################
+# %%
 # Download the data
 # -----------------
 #
@@ -63,7 +63,7 @@ subject = 1
 run = 2
 eegbci.load_data(subject=subject, runs=run, update_path=True)
 
-###############################################################################
+# %%
 # Let's see whether the data has been downloaded using a quick visualization
 # of the directory tree.
 
@@ -73,7 +73,7 @@ data_dir = op.join(mne_data_dir, 'MNE-eegbci-data')
 
 print_dir_tree(data_dir)
 
-###############################################################################
+# %%
 # The data are in the `European Data Format <https://www.edfplus.info/>`_ with
 # the ``.edf`` extension, which is good for us because next to the
 # `BrainVision format`_, EDF is one of the recommended file formats for EEG
@@ -84,7 +84,7 @@ print_dir_tree(data_dir)
 #
 # We will do exactly that in the next step.
 
-###############################################################################
+# %%
 # Convert to BIDS
 # ---------------
 #
@@ -100,7 +100,7 @@ edf_path = eegbci.load_data(subject=subject, runs=run)[0]
 raw = mne.io.read_raw_edf(edf_path, preload=False)
 raw.info['line_freq'] = 50  # specify power line frequency as required by BIDS
 
-###############################################################################
+# %%
 # For the sake of the example we will also pretend that we have the electrode
 # coordinates for the data recordings.
 # We will use a coordinates file from the MNE testing data in `CapTrak`_
@@ -131,7 +131,7 @@ raw.set_montage(montage)
 # show the electrode positions
 raw.plot_sensors()
 
-###############################################################################
+# %%
 # With these steps, we have everything to start a new BIDS directory using
 # our data.
 #
@@ -149,7 +149,7 @@ raw.plot_sensors()
 # ... as you can see in the docstring:
 print(write_raw_bids.__doc__)
 
-###############################################################################
+# %%
 # We loaded ``S001R02.edf``, which corresponds to subject 1 in the second run.
 # In the second run of the experiment, the task was to rest with closed eyes.
 
@@ -160,7 +160,7 @@ subject_id = '001'
 task = 'RestEyesClosed'
 bids_root = op.join(mne_data_dir, 'eegmmidb_bids_eeg_example')
 
-###############################################################################
+# %%
 # To ensure the output path doesn't contain any leftover files from previous
 # tests and example runs, we simply delete it.
 #
@@ -170,29 +170,29 @@ bids_root = op.join(mne_data_dir, 'eegmmidb_bids_eeg_example')
 if op.exists(bids_root):
     shutil.rmtree(bids_root)
 
-###############################################################################
+# %%
 # The data contains annotations; which will be converted to events
 # automatically by MNE-BIDS when writing the BIDS data:
 
 print(raw.annotations)
 
-###############################################################################
+# %%
 # Finally, let's write the BIDS data!
 
 bids_path = BIDSPath(subject=subject_id, task=task, root=bids_root)
 write_raw_bids(raw, bids_path, overwrite=True)
 
-###############################################################################
+# %%
 # What does our fresh BIDS directory look like?
 print_dir_tree(bids_root)
 
-###############################################################################
+# %%
 # Finally let's get an overview of the events on the whole dataset
 
 counts = count_events(bids_root)
 counts
 
-###############################################################################
+# %%
 # We can see that MNE-BIDS wrote several important files related to subject 1
 # for us:
 #
@@ -226,7 +226,7 @@ with open(readme, 'r', encoding='utf-8-sig') as fid:
 print(text)
 
 
-###############################################################################
+# %%
 # Now it's time to manually check the BIDS directory and the meta files to add
 # all the information that MNE-BIDS could not infer. For instance, you must
 # describe EEGReference and EEGGround yourself. It's easy to find these by

--- a/examples/convert_empty_room.py
+++ b/examples/convert_empty_room.py
@@ -13,7 +13,7 @@ and how to retrieve them.
 #
 # License: BSD (3-clause)
 
-###############################################################################
+# %%
 # We are dealing with MEG data, which is often accompanied by so-called
 # "empty room" recordings for noise modeling. Below we show that we can use
 # MNE-BIDS to also save such a recording with the just converted data.
@@ -31,7 +31,7 @@ from mne.datasets import sample
 from mne_bids import (write_raw_bids, read_raw_bids,
                       BIDSPath, print_dir_tree)
 
-###############################################################################
+# %%
 # And define the paths and event_id dictionary.
 
 data_path = sample.data_path()
@@ -39,7 +39,7 @@ raw_fname = op.join(data_path, 'MEG', 'sample', 'sample_audvis_raw.fif')
 
 bids_root = op.join(data_path, '..', 'MNE-sample-data-bids')
 
-###############################################################################
+# %%
 # To ensure the output path doesn't contain any leftover files from previous
 # tests and example runs, we simply delete it.
 #
@@ -49,7 +49,7 @@ bids_root = op.join(data_path, '..', 'MNE-sample-data-bids')
 if op.exists(bids_root):
     shutil.rmtree(bids_root)
 
-###############################################################################
+# %%
 # Specify the raw_file and events_data and run the BIDS conversion, and write
 # the BIDS data.
 
@@ -60,7 +60,7 @@ bids_path = BIDSPath(subject='01', session='01',
                      task='audiovisual', run='01', root=bids_root)
 write_raw_bids(raw, bids_path, overwrite=True)
 
-###############################################################################
+# %%
 # Specify some empty room data and run BIDS conversion on it.
 er_raw_fname = op.join(data_path, 'MEG', 'sample', 'ernoise_raw.fif')
 er_raw = mne.io.read_raw_fif(er_raw_fname)
@@ -71,19 +71,19 @@ er_raw.info['line_freq'] = 60  # specify power line frequency as req. by BIDS
 er_date = er_raw.info['meas_date'].strftime('%Y%m%d')
 print(er_date)
 
-###############################################################################
+# %%
 # The measurement date is
 raw_date = raw.info['meas_date'].strftime('%Y%m%d')
 print(raw_date)
 
-###############################################################################
+# %%
 # We also need to specify that the subject ID is 'emptyroom', and that the
 # task is 'noise' (these are BIDS rules).
 er_bids_path = BIDSPath(subject='emptyroom', session=er_date,
                         task='noise', root=bids_root)
 write_raw_bids(er_raw, er_bids_path, overwrite=True)
 
-###############################################################################
+# %%
 # Just to illustrate, we can save more than one empty room file for different
 # dates. Here, they will all contain the same data but in your study, they
 # will be different on different days.
@@ -95,12 +95,12 @@ for date in dates:
     er_raw.set_meas_date(er_meas_date.replace(tzinfo=timezone.utc))
     write_raw_bids(er_raw, er_bids_path, overwrite=True)
 
-###############################################################################
+# %%
 # Let us look at the directory structure
 
 print_dir_tree(bids_root)
 
-###############################################################################
+# %%
 # To get an accurate estimate of the noise, it is important that the empty
 # room recording be as close in date as the raw data.
 # We can retrieve the basename corresponding to the empty room
@@ -109,7 +109,7 @@ print_dir_tree(bids_root)
 er_bids_path = bids_path.find_empty_room()
 print(er_bids_path)
 
-###############################################################################
+# %%
 # Finally, we can read the empty room file using
 raw = read_raw_bids(bids_path=er_bids_path)
 print(raw)

--- a/examples/convert_group_studies.py
+++ b/examples/convert_group_studies.py
@@ -16,7 +16,7 @@ checking out this group conversion example: :ref:`ex-convert-mne-sample`
 #
 # License: BSD (3-clause)
 
-###############################################################################
+# %%
 # Let us import ``mne_bids``
 
 import os.path as op
@@ -30,7 +30,7 @@ from mne_bids import (write_raw_bids, BIDSPath,
                       print_dir_tree)
 from mne_bids.stats import count_events
 
-###############################################################################
+# %%
 # And fetch the data for several subjects and runs of a single task.
 
 subject_ids = [1, 2]
@@ -54,13 +54,13 @@ for subject_id in subject_ids:
 mne_data_dir = mne.get_config('MNE_DATASETS_EEGBCI_PATH')
 data_dir = op.join(mne_data_dir, 'MNE-eegbci-data')
 
-###############################################################################
+# %%
 # Let us loop over the subjects and create BIDS-compatible folder
 
 # Make a path where we can save the data to
 bids_root = op.join(mne_data_dir, 'eegmmidb_bids_group_conversion')
 
-###############################################################################
+# %%
 # To ensure the output path doesn't contain any leftover files from previous
 # tests and example runs, we simply delete it.
 #
@@ -70,7 +70,7 @@ bids_root = op.join(mne_data_dir, 'eegmmidb_bids_group_conversion')
 if op.exists(bids_root):
     shutil.rmtree(bids_root)
 
-###############################################################################
+# %%
 # Get a list of the raw objects for this dataset to use their dates
 # to determine the number of daysback to use to anonymize.
 # While we're looping through the files, also generate the
@@ -105,18 +105,18 @@ for raw, bids_path in zip(raw_list, bids_list):
                    anonymize=dict(daysback=daysback_min + 2117),
                    overwrite=True)
 
-###############################################################################
+# %%
 # Now let's see the structure of the BIDS folder we created.
 
 print_dir_tree(bids_root)
 
-###############################################################################
+# %%
 # Now let's get an overview of the events on the whole dataset
 
 counts = count_events(bids_root)
 counts
 
-###############################################################################
+# %%
 # Now let's generate a report on the dataset.
 dataset_report = make_report(root=bids_root)
 print(dataset_report)

--- a/examples/convert_ieeg_to_bids.py
+++ b/examples/convert_ieeg_to_bids.py
@@ -57,7 +57,7 @@ from mne_bids import (write_raw_bids, BIDSPath,
                       read_raw_bids, print_dir_tree)
 
 
-###############################################################################
+# %%
 # Step 1: Download the data
 # -------------------------
 #
@@ -85,7 +85,7 @@ elec = np.empty(shape=(len(ch_names), 3))
 for ind, axis in enumerate(['x', 'y', 'z']):
     elec[:, ind] = list(map(float, electrode_tsv[axis]))
 
-###############################################################################
+# %%
 # Now we make a montage stating that the iEEG contacts are in the MNI
 # coordinate system, which corresponds to the `fsaverage` subject in
 # FreeSurfer. For example, one can look at how MNE-Python deals with iEEG data
@@ -96,7 +96,7 @@ montage = mne.channels.make_dig_montage(ch_pos=dict(zip(ch_names, elec)),
 print(f'Created {len(ch_names)} channel positions')
 print(dict(zip(ch_names, elec)))
 
-###############################################################################
+# %%
 # We will load a :class:`mne.io.Raw` object and
 # use the montage we created.
 info = mne.create_info(ch_names, 1000., 'ecog')
@@ -113,7 +113,7 @@ raw.info['bads'].extend(['BTM1', 'BTM2', 'BTM3', 'BTM4', 'BTM5', 'BTM6',
 # (note that this only works for some channel types: EEG/sEEG/ECoG/DBS/fNIRS)
 raw.set_montage(montage, on_missing='warn')
 
-###############################################################################
+# %%
 # Let us confirm what our channel coordinates look like.
 
 # make a plot of the sensors in 2D plane
@@ -128,7 +128,7 @@ ch_names = np.array([ch['ch_name'] for ch in chs[:5]])
 print("The channel coordinates before writing into BIDS: ")
 pprint([x for x in zip(ch_names, pos)])
 
-###############################################################################
+# %%
 # BIDS vs MNE-Python Coordinate Systems
 # -------------------------------------
 #
@@ -168,7 +168,7 @@ pprint([x for x in zip(ch_names, pos)])
 # ... as you can see in the docstring:
 print(write_raw_bids.__doc__)
 
-###############################################################################
+# %%
 # Let us initialize some of the necessary data for the subject.
 
 # There is a subject, and specific task for the dataset.
@@ -181,7 +181,7 @@ mne_data_dir = mne.get_config('MNE_DATASETS_MISC_PATH')
 # There is the root directory for where we will write our data.
 bids_root = op.join(mne_data_dir, 'ieegmmidb_bids')
 
-###############################################################################
+# %%
 # To ensure the output path doesn't contain any leftover files from previous
 # tests and example runs, we simply delete it.
 #
@@ -191,7 +191,7 @@ bids_root = op.join(mne_data_dir, 'ieegmmidb_bids')
 if op.exists(bids_root):
     shutil.rmtree(bids_root)
 
-###############################################################################
+# %%
 # Now we just need to specify a few iEEG details to make things work:
 # We need the basename of the dataset. In addition, :func:`write_raw_bids`
 # requires the ``.filenames`` attribute of the Raw object to be non-empty,
@@ -207,14 +207,14 @@ bids_path = BIDSPath(subject=subject_id,
 write_raw_bids(raw, bids_path, anonymize=dict(daysback=30000),
                overwrite=True)
 
-###############################################################################
+# %%
 # Step 3: Check and compare with standard
 # ---------------------------------------
 
 # Now we have written our BIDS directory.
 print_dir_tree(bids_root)
 
-###############################################################################
+# %%
 # Step 4: Cite mne-bids
 # ---------------------
 # We can see that the appropriate citations are already written in the README.
@@ -225,7 +225,7 @@ with open(readme, 'r', encoding='utf-8-sig') as fid:
     text = fid.read()
 print(text)
 
-###############################################################################
+# %%
 # MNE-BIDS has created a suitable directory structure for us, and among other
 # meta data files, it started an ``events.tsv``` and ``channels.tsv`` file,
 # and created an initial ``dataset_description.json`` file on top!
@@ -245,7 +245,7 @@ print(text)
 #
 # Command line tool: https://www.npmjs.com/package/bids-validator
 
-###############################################################################
+# %%
 # Step 5: Plot output channels and check that they match!
 # -------------------------------------------------------
 #

--- a/examples/convert_mne_sample.py
+++ b/examples/convert_mne_sample.py
@@ -21,7 +21,7 @@ In a second step we will read the organized dataset using MNE-BIDS.
 #
 # License: BSD (3-clause)
 
-###############################################################################
+# %%
 # First we import some basic Python libraries, followed by MNE-Python and its
 # sample data, and then finally the MNE-BIDS functions we need for this example
 
@@ -35,7 +35,7 @@ from mne_bids import (write_raw_bids, read_raw_bids, write_meg_calibration,
                       write_meg_crosstalk, BIDSPath, print_dir_tree)
 from mne_bids.stats import count_events
 
-###############################################################################
+# %%
 # Now we can read the MNE sample data. We define an `event_id` based on our
 # knowledge of the data, to give meaning to events in the data.
 #
@@ -50,7 +50,7 @@ raw_fname = op.join(data_path, 'MEG', 'sample', 'sample_audvis_raw.fif')
 events_data = op.join(data_path, 'MEG', 'sample', 'sample_audvis_raw-eve.fif')
 output_path = op.join(data_path, '..', 'MNE-sample-data-bids')
 
-###############################################################################
+# %%
 # To ensure the output path doesn't contain any leftover files from previous
 # tests and example runs, we simply delete it.
 #
@@ -60,7 +60,7 @@ output_path = op.join(data_path, '..', 'MNE-sample-data-bids')
 if op.exists(output_path):
     shutil.rmtree(output_path)
 
-###############################################################################
+# %%
 #
 # .. note::
 #
@@ -82,7 +82,7 @@ bids_path = BIDSPath(subject='01', session='01',
 write_raw_bids(raw, bids_path, events_data=events_data,
                event_id=event_id, overwrite=True)
 
-###############################################################################
+# %%
 # The sample MEG dataset comes with fine-calibration and crosstalk files that
 # are required when processing Elekta/Neuromag/MEGIN data using MaxFilter®.
 # Let's store these data in appropriate places, too.
@@ -93,25 +93,25 @@ ct_fname = op.join(data_path, 'SSS', 'ct_sparse_mgh.fif')
 write_meg_calibration(cal_fname, bids_path)
 write_meg_crosstalk(ct_fname, bids_path)
 
-###############################################################################
+# %%
 # Now let's see the structure of the BIDS folder we created.
 
 print_dir_tree(output_path)
 
-###############################################################################
+# %%
 # Now let's get an overview of the events on the whole dataset
 
 counts = count_events(output_path)
 counts
 
-###############################################################################
+# %%
 # A big advantage of having data organized according to BIDS is that software
 # packages can automate your workflow. For example, reading the data back
 # into MNE-Python can easily be done using :func:`read_raw_bids`.
 
 raw = read_raw_bids(bids_path=bids_path)
 
-###############################################################################
+# %%
 # The resulting data is already in a convenient form to create epochs and
 # evoked data.
 
@@ -119,14 +119,14 @@ events, event_id = mne.events_from_annotations(raw)
 epochs = mne.Epochs(raw, events, event_id)
 epochs['Auditory'].average().plot()
 
-###############################################################################
+# %%
 # It is trivial to retrieve the path of the fine-calibration and crosstalk
 # files, too.
 
 print(bids_path.meg_calibration_fpath)
 print(bids_path.meg_crosstalk_fpath)
 
-###############################################################################
+# %%
 # The README created by :func:`write_raw_bids` also takes care of the citation
 # for mne-bids. If you are preparing a manuscript, please make sure to also
 # cite MNE-BIDS there.

--- a/examples/convert_mri_and_trans.py
+++ b/examples/convert_mri_and_trans.py
@@ -33,7 +33,7 @@ See the documentation pages in the MNE docs for more information on
 #          Alex Gramfort <alexandre.gramfort@inria.fr>
 # License: BSD (3-clause)
 
-###############################################################################
+# %%
 # We are importing everything we need for this example:
 
 import os.path as op
@@ -52,7 +52,7 @@ from mne.source_space import head_to_mri
 from mne_bids import (write_raw_bids, BIDSPath, write_anat,
                       get_head_mri_trans, print_dir_tree)
 
-###############################################################################
+# %%
 # We will be using the `MNE sample data <mne_sample_data_>`_ and write a basic
 # BIDS dataset. For more information, you can checkout the respective
 # :ref:`example <ex-convert-mne-sample>`.
@@ -64,7 +64,7 @@ raw_fname = op.join(data_path, 'MEG', 'sample', 'sample_audvis_raw.fif')
 events_data = op.join(data_path, 'MEG', 'sample', 'sample_audvis_raw-eve.fif')
 output_path = op.abspath(op.join(data_path, '..', 'MNE-sample-data-bids'))
 
-###############################################################################
+# %%
 # To ensure the output path doesn't contain any leftover files from previous
 # tests and example runs, we simply delete it.
 #
@@ -74,7 +74,7 @@ output_path = op.abspath(op.join(data_path, '..', 'MNE-sample-data-bids'))
 if op.exists(output_path):
     shutil.rmtree(output_path)
 
-###############################################################################
+# %%
 # Read the input data and store it as BIDS data.
 
 raw = mne.io.read_raw_fif(raw_fname)
@@ -89,11 +89,11 @@ bids_path = BIDSPath(subject=sub, session=ses, task=task,
 write_raw_bids(raw, bids_path, events_data=events_data,
                event_id=event_id, overwrite=True)
 
-###############################################################################
+# %%
 # Print the directory tree
 print_dir_tree(output_path)
 
-###############################################################################
+# %%
 # Writing T1 image
 # ----------------
 #
@@ -111,7 +111,7 @@ trans_fname = op.join(data_path, 'MEG', 'sample',
 trans = mne.read_trans(trans_fname)
 print(trans)
 
-###############################################################################
+# %%
 # We can save the MRI to our existing BIDS directory and at the same time
 # create a JSON sidecar file that contains metadata, we will later use to
 # retrieve our transformation matrix :code:`trans`. The metadata will here
@@ -133,16 +133,16 @@ t1w_bids_path = write_anat(
 )
 anat_dir = t1w_bids_path.directory
 
-###############################################################################
+# %%
 # Let's have another look at our BIDS directory
 print_dir_tree(output_path)
 
-###############################################################################
+# %%
 # Our BIDS dataset is now ready to be shared. We can easily estimate the
 # transformation matrix using ``MNE-BIDS`` and the BIDS dataset.
 estim_trans = get_head_mri_trans(bids_path=bids_path)
 
-###############################################################################
+# %%
 # Finally, let's use the T1 weighted MRI image and plot the anatomical
 # landmarks Nasion, LPA, and RPA onto the brain image. For that, we can
 # extract the location of Nasion, LPA, and RPA from the MEG file, apply our
@@ -176,7 +176,7 @@ for point_idx, label in enumerate(('LPA', 'NAS', 'RPA')):
               title=label, vmax=160)
 plt.show()
 
-###############################################################################
+# %%
 # Writing FLASH MRI image
 # -----------------------
 #
@@ -194,7 +194,7 @@ write_anat(
     verbose=True
 )
 
-###############################################################################
+# %%
 # Writing defaced and anonymized T1 image
 # ---------------------------------------
 #
@@ -218,7 +218,7 @@ fig, ax = plt.subplots()
 plot_anat(t1_nii_fname, axes=ax, title='Defaced', vmax=160)
 plt.show()
 
-###############################################################################
+# %%
 # Writing defaced and anonymized FLASH MRI image
 # ----------------------------------------------
 #
@@ -232,7 +232,7 @@ plt.show()
 # fiducial coordinates from the `raw` and apply the `trans` yourself.
 # Let's explore the different options to do this.
 
-###############################################################################
+# %%
 # Option 1 : Pass `t1w` with `raw` and `trans`
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 flash_bids_path = write_anat(
@@ -254,7 +254,7 @@ fig, ax = plt.subplots()
 plot_anat(flash_nii_fname, axes=ax, title='Defaced', vmax=700)
 plt.show()
 
-###############################################################################
+# %%
 # Option 2 : Use manual landmarks coordinates in scanner RAS for FLASH image
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 #
@@ -286,7 +286,7 @@ fig, ax = plt.subplots()
 plot_anat(flash_nii_fname, axes=ax, title='Defaced', vmax=700)
 plt.show()
 
-###############################################################################
+# %%
 # Option 3 : Compute the landmarks in scanner RAS or mri voxel space from trans
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 #
@@ -328,7 +328,7 @@ fig, ax = plt.subplots()
 plot_anat(flash_nii_fname, axes=ax, title='Defaced', vmax=700)
 plt.show()
 
-##############################################################################
+# %%
 # Let's now pass it in voxel coordinates
 flash_mri_hdr = nib.load(flash_mgh_fname).header
 flash_vox_pos = mne.transforms.apply_trans(
@@ -356,7 +356,7 @@ fig, ax = plt.subplots()
 plot_anat(flash_nii_fname, axes=ax, title='Defaced', vmax=700)
 plt.show()
 
-###############################################################################
+# %%
 # .. LINKS
 #
 # .. _coregistration GUI:

--- a/examples/create_bids_folder.py
+++ b/examples/create_bids_folder.py
@@ -16,12 +16,12 @@ wish to create these files/folders on your own.
 # Authors: Chris Holdgraf <choldgraf@berkeley.edu>
 # License: BSD (3-clause)
 
-###############################################################################
+# %%
 # First we will import the relevant functions
 
 from mne_bids import BIDSPath
 
-###############################################################################
+# %%
 # Creating file names for BIDS
 # ----------------------------
 #
@@ -34,14 +34,14 @@ bids_path = BIDSPath(subject='test', session='two', task='mytask',
                      suffix='events', extension='.tsv')
 print(bids_path)
 
-###############################################################################
+# %%
 # You may also omit the suffix, which will result in *only* a prefix for a
 # file name. This could then prepended to many more files.
 
 bids_path = BIDSPath(subject='test', task='mytask')
 print(bids_path)
 
-###############################################################################
+# %%
 # Creating folders
 # ----------------
 #

--- a/examples/mark_bad_channels.py
+++ b/examples/mark_bad_channels.py
@@ -18,7 +18,7 @@ segments as "bad".
 # Authors: Richard Höchenberger <richard.hoechenberger@gmail.com>
 # License: BSD (3-clause)
 
-###############################################################################
+# %%
 # We will demonstrate how to mark individual channels as bad on the MNE
 # "sample" dataset. After that, we will mark channels as good again.
 #
@@ -41,7 +41,7 @@ bids_root = op.join(data_path, '..', 'MNE-sample-data-bids')
 bids_path = BIDSPath(subject='01', session='01', task='audiovisual', run='01',
                      root=bids_root)
 
-###############################################################################
+# %%
 # To ensure the output path doesn't contain any leftover files from previous
 # tests and example runs, we simply delete it.
 #
@@ -51,7 +51,7 @@ bids_path = BIDSPath(subject='01', session='01', task='audiovisual', run='01',
 if op.exists(bids_root):
     shutil.rmtree(bids_root)
 
-###############################################################################
+# %%
 # Now write the raw data to BIDS.
 
 raw = mne.io.read_raw_fif(raw_fname, verbose=False)
@@ -59,7 +59,7 @@ raw.info['line_freq'] = 60  # Specify power line frequency as required by BIDS.
 write_raw_bids(raw, bids_path=bids_path, events_data=events_fname,
                event_id=event_id, overwrite=True, verbose=False)
 
-###############################################################################
+# %%
 # Interactive use
 # ---------------
 #
@@ -74,7 +74,7 @@ write_raw_bids(raw, bids_path=bids_path, events_data=events_fname,
 
 inspect_dataset(bids_path)
 
-###############################################################################
+# %%
 # You can even apply frequency filters when viewing the data: A high-pass
 # filter can remove slow drifts, while a low-pass filter will get rid of
 # high-frequency artifacts. This can make visual inspection easier. Let's
@@ -82,7 +82,7 @@ inspect_dataset(bids_path)
 
 inspect_dataset(bids_path, l_freq=1., h_freq=30.)
 
-###############################################################################
+# %%
 # By pressing the ``A`` key, you can toggle annotation mode to add, edit, or
 # remove experimental events, or to mark entire time periods as bad. Please see
 # the `MNE-Python Annotations tutorial`_ for an introduction to the interactive
@@ -100,7 +100,7 @@ raw = read_raw_bids(bids_path=bids_path, verbose=False)
 print(f'The following channels are currently marked as bad:\n'
       f'    {", ".join(raw.info["bads"])}\n')
 
-###############################################################################
+# %%
 # So currently, two channels are maked as bad: ``EEG 053`` and ``MEG 2443``.
 # Let's assume that through visual data inspection, we found that two more
 # MEG channels are problematic, and we would like to mark them as bad as well.
@@ -110,14 +110,14 @@ print(f'The following channels are currently marked as bad:\n'
 bads = ['MEG 0112', 'MEG 0131']
 mark_bad_channels(ch_names=bads, bids_path=bids_path, verbose=False)
 
-###############################################################################
+# %%
 # That's it! Let's verify the result.
 
 raw = read_raw_bids(bids_path=bids_path, verbose=False)
 print(f'After marking MEG 0112 and MEG 0131 as bad, the following channels '
       f'are now marked as bad:\n    {", ".join(raw.info["bads"])}\n')
 
-###############################################################################
+# %%
 # As you can see, now a total of **four** channels is marked as bad: the ones
 # that were already bad when we started – ``EEG 053`` and ``MEG 2443`` – and
 # the two channels we passed to :func:`mne_bids.mark_bad_channels` –
@@ -138,7 +138,7 @@ print(f'After marking MEG 0112 and MEG 0131 as bad and passing '
       f'`overwrite=True`, the following channels '
       f'are now marked as bad:\n    {", ".join(raw.info["bads"])}\n')
 
-###############################################################################
+# %%
 # Lastly, if you're looking for a way to mark all channels as good, simply
 # pass an empty list as ``ch_names``, combined with ``overwrite=True``:
 

--- a/examples/read_bids_datasets.py
+++ b/examples/read_bids_datasets.py
@@ -30,7 +30,7 @@ inspect BIDS-formatted data.
 #
 # License: BSD (3-clause)
 
-###############################################################################
+# %%
 # Imports
 # -------
 # We are importing everything we need for this example:
@@ -41,7 +41,7 @@ import openneuro
 from mne.datasets import sample
 from mne_bids import BIDSPath, read_raw_bids, print_dir_tree, make_report
 
-###############################################################################
+# %%
 # Download a subject's data from an OpenNeuro BIDS dataset
 # --------------------------------------------------------
 #
@@ -67,7 +67,7 @@ if not op.isdir(bids_root):
 openneuro.download(dataset=dataset, target_dir=bids_root,
                    include=[f'sub-{subject}'])
 
-###############################################################################
+# %%
 # Explore the dataset contents
 # ----------------------------
 #
@@ -78,13 +78,13 @@ openneuro.download(dataset=dataset, target_dir=bids_root,
 
 print_dir_tree(bids_root, max_depth=4)
 
-###############################################################################
+# %%
 # We can even ask MNE-BIDS to produce a human-readbale summary report
 # on the dataset contents.
 
 print(make_report(bids_root))
 
-###############################################################################
+# %%
 # Now it's time to get ready for reading some of the data! First, we need to
 # create an :class:`mne_bids.BIDSPath`, which is the workhorse object of
 # MNE-BIDS when it comes to file and folder operations.
@@ -99,12 +99,12 @@ datatype = 'eeg'
 session = 'off'
 bids_path = BIDSPath(root=bids_root, session=session, datatype=datatype)
 
-###############################################################################
+# %%
 # We can now retrieve a list of all MEG-related files in the dataset:
 
 print(bids_path.match())
 
-###############################################################################
+# %%
 # The returned list contains ``BIDSpaths`` of 3 files:
 # ``sub-pd6_ses-off_task-rest_channels.tsv``,
 # ``sub-pd6_ses-off_task-rest_events.tsv``, and
@@ -130,12 +130,12 @@ suffix = 'eeg'
 bids_path = BIDSPath(subject=subject, session=session, task=task,
                      suffix=suffix, datatype=datatype, root=bids_root)
 
-###############################################################################
+# %%
 # Now let's print the contents of ``bids_path``.
 
 print(bids_path)
 
-###############################################################################
+# %%
 # You probably noticed two things: Firstly, this looks like an ordinary string
 # now, not like the more-or-less neatly formatted output we saw before. And
 # secondly, that there's suddenly a filename extension which we never specified
@@ -149,7 +149,7 @@ print(bids_path)
 
 bids_path
 
-###############################################################################
+# %%
 # The ``root`` here is – you guessed it – the directory we passed via the
 # ``root`` parameter: the "home" of our BIDS dataset. The ``datatype``, again,
 # is self-explanatory. The ``basename``, on the other hand, is created
@@ -169,7 +169,7 @@ bids_path
 # more portable. Note that, however, you **can** explicitly specify an
 # extension too, by passing e.g. ``extension='.bdf'`` to ``BIDSPath``.
 
-###############################################################################
+# %%
 # Read the data
 # -------------
 #
@@ -177,7 +177,7 @@ bids_path
 
 raw = read_raw_bids(bids_path=bids_path, verbose=False)
 
-###############################################################################
+# %%
 # Now we can inspect the ``raw`` object to check that it contains to correct
 # metadata.
 #
@@ -185,26 +185,26 @@ raw = read_raw_bids(bids_path=bids_path, verbose=False)
 
 print(raw.info['subject_info'])
 
-###############################################################################
+# %%
 # Power line frequency is here.
 
 print(raw.info['line_freq'])
 
-###############################################################################
+# %%
 # Sampling frequency is here.
 
 print(raw.info['sfreq'])
 
-###############################################################################
+# %%
 # Events are now Annotations
 print(raw.annotations)
 
-###############################################################################
+# %%
 # Plot the raw data.
 
 raw.plot()
 
-###############################################################################
+# %%
 # .. LINKS
 #
 # .. _parkinsons_eeg_dataset:

--- a/examples/rename_brainvision_files.py
+++ b/examples/rename_brainvision_files.py
@@ -39,7 +39,7 @@ References
 #
 # License: BSD (3-clause)
 
-###############################################################################
+# %%
 # We are importing everything we need for this example:
 import os.path as op
 
@@ -47,7 +47,7 @@ import mne
 
 from mne_bids.copyfiles import copyfile_brainvision
 
-###############################################################################
+# %%
 # Download some example data
 # --------------------------
 # To demonstrate the MNE-BIDS functions, we need some testing data. Here, we
@@ -59,7 +59,7 @@ from mne_bids.copyfiles import copyfile_brainvision
 data_path = mne.datasets.testing.data_path()
 examples_dir = op.join(data_path, 'Brainvision')
 
-###############################################################################
+# %%
 # Rename the recording
 # --------------------
 # Above, at the top of the example, we imported
@@ -88,7 +88,7 @@ copyfile_brainvision(vhdr_file, vhdr_file_renamed, verbose=True)
 raw = mne.io.read_raw_brainvision(vhdr_file)
 raw_renamed = mne.io.read_raw_brainvision(vhdr_file_renamed)
 
-###############################################################################
+# %%
 # Further information
 # -------------------
 #

--- a/examples/update_bids_datasets.py
+++ b/examples/update_bids_datasets.py
@@ -15,7 +15,7 @@ modify BIDS-formatted data.
 #
 # License: BSD (3-clause)
 
-###############################################################################
+# %%
 # Imports
 # -------
 # We are importing everything we need for this example:
@@ -24,7 +24,7 @@ from mne.datasets import somato
 from mne_bids import (BIDSPath, read_raw_bids,
                       print_dir_tree, make_report, update_sidecar_json)
 
-###############################################################################
+# %%
 # We will be using the `MNE somato data <mne_somato_data_>`_, which
 # is already stored in BIDS format.
 # For more information, you can check out the
@@ -38,7 +38,7 @@ from mne_bids import (BIDSPath, read_raw_bids,
 # BIDS dataset.
 bids_root = somato.data_path()
 
-###############################################################################
+# %%
 # Explore the dataset contents
 # ----------------------------
 #
@@ -52,7 +52,7 @@ print_dir_tree(bids_root, max_depth=3)
 # We can generate a report of the existing dataset
 print(make_report(bids_root))
 
-###############################################################################
+# %%
 # Update the sidecar JSON dataset contents
 # ----------------------------------------
 #
@@ -92,7 +92,7 @@ entries = {
 # Now update all sidecar fields according to our updating dictionary
 update_sidecar_json(bids_path=sidecar_path, entries=entries)
 
-###############################################################################
+# %%
 # Read the updated dataset
 # ------------------------
 
@@ -100,13 +100,13 @@ update_sidecar_json(bids_path=sidecar_path, entries=entries)
 raw = read_raw_bids(bids_path=bids_path)
 print(raw.info['line_freq'])
 
-###############################################################################
+# %%
 # Generate a new report based on the updated metadata.
 
 # The manufacturer was changed to ``MEGIN``
 print(make_report(bids_root))
 
-###############################################################################
+# %%
 # We can revert the changes by updating the sidecar again.
 
 # update the sidecar data to have a new PowerLineFrequency
@@ -114,7 +114,7 @@ entries['Manufacturer'] = "Elekta"
 entries['PowerLineFrequency'] = 50
 update_sidecar_json(bids_path=sidecar_path, entries=entries)
 
-###############################################################################
+# %%
 # Now let us inspect the dataset again by generating the report again. Now that
 # ``update_sidecar_json`` was called, the metadata will be updated.
 
@@ -125,7 +125,7 @@ print(raw.info['line_freq'])
 # Generate the report with updated fields
 print(make_report(bids_root))
 
-###############################################################################
+# %%
 # .. LINKS
 #
 # .. _mne_somato_data:

--- a/examples/write_modified_files.py
+++ b/examples/write_modified_files.py
@@ -31,7 +31,7 @@ to store such data, despite it being modified before writing.
 # Authors: Richard Höchenberger <richard.hoechenberger@gmail.com>
 # License: BSD (3-clause)
 
-###############################################################################
+# %%
 # Load the ``sample`` dataset, and create a concatenated raw data object.
 
 from pathlib import Path
@@ -52,7 +52,7 @@ raw = mne.io.read_raw_fif(raw_fname)
 raw.info['line_freq'] = 60
 raw_concat = mne.concatenate_raws([raw.copy(), raw])
 
-###############################################################################
+# %%
 # Trying to write these data will fail.
 
 try:
@@ -60,7 +60,7 @@ try:
 except ValueError as e:
     print(f'Data cannot be written. Exception message was: {e}')
 
-###############################################################################
+# %%
 # We can work around this limitation by first writing the modified data to
 # a temporary file, reading it back in, and then writing it via MNE-BIDS.
 
@@ -70,7 +70,7 @@ with NamedTemporaryFile(suffix='_raw.fif') as f:
     raw_concat = mne.io.read_raw_fif(fname, preload=False)
     write_raw_bids(raw=raw_concat, bids_path=bids_path, overwrite=True)
 
-###############################################################################
+# %%
 # That's it!
 #
 # .. warning:: **Remember, this should only ever be a last resort!**


### PR DESCRIPTION
This is a developer and user quality of life PR. I want to replace the block of `#` characters with the more standard `# %%`.

The functionality for rendering the docs is equal, see: https://sphinx-gallery.github.io/stable/syntax.html#embed-rst-in-your-example-python-files

The advantage of this PR is that many code editors recognize and parse `# %%` as "code blocks" so that you can execute an example similar to a notebook from your editor. This is good for playing around and debugging (using IPython).

> The #%% and # %% syntax is consistent with the ‘code block’ (or ‘code cell’) separator syntax in Visual Studio Code Python extension, Visual Studio Python Tools, Jupytext, Pycharm Professional, Hydrogen plugin (for Atom) and Spyder. 

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [x] All comments resolved
- [x] This is not your own PR
- [x] All CIs are happy
- [x] PR title starts with [MRG]
- ~[whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated~
- ~PR description includes phrase "closes <#issue-number>"~
