### PR TITLE
Add KIT/Yokogawa/Ricoh marker coil extension: ".mrk" to allowed extensions

### DIFF
--- a/doc/authors.rst
+++ b/doc/authors.rst
@@ -24,3 +24,4 @@
 .. _Tom Donoghue: https://github.com/TomDonoghue
 .. _Richard Köhler: https://github.com/richardkoehler
 .. _Sin Kim: https://github.com/AKSoo
+.. _Jean-Rémi King: https://kingjr.github.io/

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -45,7 +45,7 @@ Enhancements
 - :func:`mne_bids.write_raw_bids` gained a new parameter ``empty_room`` that allows to specify an associated empty-room recording when writing an MEG data file. This information will be stored in the ``AssociatedEmptyRoom`` field of the MEG JSON sidecar file, by `Richard Höchenberger`_ (:gh:`795`)
 - Added support for the new channel type ``'dbs'`` (Deep Brain Stimulation), which was introduced in MNE-Python 0.23, by `Richard Köhler`_ (:gh:`800`)
 - :func:`mne_bids.read_raw_bids` now warns in many situations when it encounters a mismatch between the channels in ``*_channels.tsv`` and the raw data, by `Richard Höchenberger`_ (:gh:`823`)
-- accepts ".mrk" head digitization files used in the KIT MEG system, by `Jean-Rémi King`_ (:gh:`842`)
+- MNE BIDS now accepts ".mrk" head digitization files used in the KIT/Yokogawa/Ricoh MEG system, by `Jean-Rémi King`_ and `Stefan Appelhoff`_ (:gh:`842`)
 
 API and behavior changes
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -27,6 +27,7 @@ Authors
 * `Richard Höchenberger`_
 * `Adam Li`_
 * `Richard Köhler`_ (new contributor)
+* `Jean-Rémi King`_ (new contributor)
 
 Detailed list of changes
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -44,6 +45,7 @@ Enhancements
 - :func:`mne_bids.write_raw_bids` gained a new parameter ``empty_room`` that allows to specify an associated empty-room recording when writing an MEG data file. This information will be stored in the ``AssociatedEmptyRoom`` field of the MEG JSON sidecar file, by `Richard Höchenberger`_ (:gh:`795`)
 - Added support for the new channel type ``'dbs'`` (Deep Brain Stimulation), which was introduced in MNE-Python 0.23, by `Richard Köhler`_ (:gh:`800`)
 - :func:`mne_bids.read_raw_bids` now warns in many situations when it encounters a mismatch between the channels in ``*_channels.tsv`` and the raw data, by `Richard Höchenberger`_ (:gh:`823`)
+- accepts ".mrk" head digitization files used in the KIT MEG system, by `Jean-Rémi King`_ (:gh:`842`)
 
 API and behavior changes
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/examples/convert_mri_and_trans.py
+++ b/examples/convert_mri_and_trans.py
@@ -46,7 +46,7 @@ from nilearn.plotting import plot_anat
 
 import mne
 from mne.datasets import sample
-from mne.source_space import head_to_mri
+from mne import head_to_mri
 
 from mne_bids import (write_raw_bids, BIDSPath, write_anat, get_anat_landmarks,
                       get_head_mri_trans, print_dir_tree)

--- a/mne_bids/config.py
+++ b/mne_bids/config.py
@@ -131,7 +131,7 @@ ALLOWED_FILENAME_EXTENSIONS = (
     ALLOWED_INPUT_EXTENSIONS +
     ['.json', '.tsv', '.tsv.gz', '.nii', '.nii.gz'] +
     ['.pos', '.eeg', '.vmrk'] +  # extra datatype-specific metadata files.
-    ['.dat', '.EEG']  # extra eeg extensions
+    ['.mrk', '.dat', '.EEG']  # extra eeg extensions
 )
 
 # allowed BIDS path entities

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -886,6 +886,25 @@ def test_kit(_bids_validate, tmpdir):
                        events_data=events_fname, event_id=event_id,
                        overwrite=True)
 
+    # check that everything works with MRK markers, and CON files
+    data_path = op.join(testing.data_path(download=False), 'KIT')
+    raw_fname = op.join(data_path, 'data_berlin.con')
+    hpi_fname = op.join(data_path, 'MQKIT_125.mrk')
+    electrode_fname = op.join(data_path, 'MQKIT_125.elp')
+    headshape_fname = op.join(data_path, 'MQKIT_125.hsp')
+    bids_root = tmpdir.mkdir("bids_kit_mrk")
+    kit_bids_path = _bids_path.copy().update(acquisition=None,
+                                             root=bids_root,
+                                             suffix='meg')
+    raw = _read_raw_kit(
+        raw_fname, mrk=hpi_fname, elp=electrode_fname,
+        hsp=headshape_fname)
+    write_raw_bids(raw, kit_bids_path)
+
+    _bids_validate(bids_root)
+    assert op.exists(bids_root / 'participants.tsv')
+    read_raw_bids(bids_path=kit_bids_path)
+
 
 @pytest.mark.filterwarnings(warning_str['meas_date_set_to_none'])
 def test_ctf(_bids_validate, tmpdir):


### PR DESCRIPTION
KIT files have ['mrk' files](https://bids-specification.readthedocs.io/en/stable/99-appendices/06-meg-file-formats.html#kityokogawaricoh), which is currently missing in the config

this fixes it
