### PR TITLE
try remove matplotlib pin, add openneuro-py pin

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ full =
   pybv >= 0.5
   matplotlib >= 3.1.0
   pandas >= 0.24.0
-  openneuro-py
+  openneuro-py >=2021.8
 
 [options.entry_points]
 console_scripts =

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,11 +1,11 @@
 numpy>=1.16.0
 scipy>=1.5.0
 mne>=0.21.2
-matplotlib<3.4
+matplotlib>=3.1
 pandas>=0.24.0
 nibabel>=2.5
 pybv>=0.5
-openneuro-py
+openneuro-py>=2021.8
 pytest
 pytest-cov
 pytest-sugar


### PR DESCRIPTION
I think the issue why matplotlib was pinned might have been resolved in the meantime.

Also adding a minimum openneuro-py version in accordance with https://github.com/conda-forge/mne-bids-feedstock/pull/13

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
