### PR TITLE
MRG: copyfile_kit() didn't handle acq, mrk is None

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -22,7 +22,7 @@ Notable changes
 Authors
 ~~~~~~~
 
-* ...
+* `Richard Höchenberger`_
 
 Detailed list of changes
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -45,7 +45,7 @@ Requirements
 Bug fixes
 ^^^^^^^^^
 
-- ...
+- Fix writing Ricoh/KIT data that comes without an associated ``.mrk``, ``.elp``, or ``.hsp`` file using :func:`mne_bids.write_raw_bids`, by `Richard Höchenberger`_ (:gh:`850`)
 
 :doc:`Find out what was new in previous releases <whats_new_previous_releases>`
 

--- a/mne_bids/copyfiles.py
+++ b/mne_bids/copyfiles.py
@@ -203,7 +203,8 @@ def copyfile_kit(src, dest, subject_id, session_id,
     sh.copyfile(src, dest)
     data_path = op.split(dest)[0]
     datatype = 'meg'
-    if 'mrk' in _init_kwargs:
+
+    if 'mrk' in _init_kwargs and _init_kwargs['mrk'] is not None:
         hpi = _init_kwargs['mrk']
         acq_map = dict()
         if isinstance(hpi, list):
@@ -220,8 +221,9 @@ def copyfile_kit(src, dest, subject_id, session_id,
                 acquisition=key, suffix='markers', extension=marker_ext,
                 datatype=datatype)
             sh.copyfile(value, op.join(data_path, marker_path.basename))
+
     for acq in ['elp', 'hsp']:
-        if acq in _init_kwargs:
+        if acq in _init_kwargs and _init_kwargs[acq] is not None:
             position_file = _init_kwargs[acq]
             task, run, acq = None, None, acq.upper()
             position_ext = '.pos'

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -909,7 +909,7 @@ def test_kit(_bids_validate, tmpdir):
     # supplied
     raw = _read_raw_kit(raw_fname)
     bids_root = tmpdir.mkdir('no_elp_hsp_mrk')
-    kit_bids_path = kit_bids_path.update(root=bids_root)
+    kit_bids_path = kit_bids_path.copy().update(root=bids_root)
     write_raw_bids(raw=raw, bids_path=kit_bids_path)
     _bids_validate(bids_root)
 

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -905,6 +905,14 @@ def test_kit(_bids_validate, tmpdir):
     assert op.exists(bids_root / 'participants.tsv')
     read_raw_bids(bids_path=kit_bids_path)
 
+    # Check that we can successfully write even when elp, hsp, and mrk are not
+    # supplied
+    raw = _read_raw_kit(raw_fname)
+    bids_root = tmpdir.mkdir('no_elp_hsp_mrk')
+    kit_bids_path = kit_bids_path.update(root=bids_root)
+    write_raw_bids(raw=raw, bids_path=kit_bids_path)
+    _bids_validate(bids_root)
+
 
 @pytest.mark.filterwarnings(warning_str['meas_date_set_to_none'])
 def test_ctf(_bids_validate, tmpdir):


### PR DESCRIPTION
This fixes an issue reported on the forum at https://mne.discourse.group/t/problem-with-bids-emptyroom/3449

The user kindly sent me the problematic file and with the changes here, the problem is fixed for me.

WIP:
- [x] Add tests

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [x] All comments resolved
- [ ] This is not your own PR
- [x] All CIs are happy
- [x] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
