### PR TITLE
Making the entry of 'headcoilfrequency' in the sidecar_json file for ELEKTA data optional

### DIFF
--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -327,23 +327,24 @@ def _handle_info_reading(sidecar_fname, raw, verbose=None):
                         'the MEG JSON sidecar file corresponds to the raw '
                         'data for KIT files.')
         else:
-            hpi_freqs_json = sidecar_json['HeadCoilFrequency']
-            try:
-                hpi_freqs_raw, _, _ = mne.chpi.get_chpi_info(raw.info)
-            except ValueError:
-                logger.info(
-                    'Cannot verify that the cHPI frequencies provided in '
-                    'the MEG JSON sidecar file correspond to those in the '
-                    'raw data. (Was it converted from another format?)'
-                )
-            else:
-                if not np.allclose(hpi_freqs_json, hpi_freqs_raw):
-                    raise ValueError(
-                        f'The cHPI coil frequencies in the sidecar file '
-                        f'{sidecar_fname}:\n    {hpi_freqs_json}\ndiffer from'
-                        f' what is stored in the raw data:\n'
-                        f'    {hpi_freqs_raw}\nCannot proceed.'
+            if 'HeadCoilFrequency' in hpi_freqs_json:
+                hpi_freqs_json = sidecar_json['HeadCoilFrequency']
+                try:
+                    hpi_freqs_raw, _, _ = mne.chpi.get_chpi_info(raw.info)
+                except ValueError:
+                    logger.info(
+                        'Cannot verify that the cHPI frequencies provided in '
+                        'the MEG JSON sidecar file correspond to those in the '
+                        'raw data. (Was it converted from another format?)'
                     )
+                else:
+                    if not np.allclose(hpi_freqs_json, hpi_freqs_raw):
+                        raise ValueError(
+                            f'The cHPI coil frequencies in the sidecar file '
+                            f'{sidecar_fname}:\n    {hpi_freqs_json}\ndiffer from'
+                            f' what is stored in the raw data:\n'
+                            f'    {hpi_freqs_raw}\nCannot proceed.'
+                        )
     else:
         if raw.info['hpi_subsystem']:
             logger.info('Dropping cHPI information stored in raw data, '


### PR DESCRIPTION
This is my first PR ever, so please let me know if I am not following proper github etiquette :). I am also somewhat new to coding, so please let me know if my fix doesn't do what it is supposed to do. 

Please see [my post to the MNE forum](https://mne.discourse.group/t/mne-bids-read-raw-bids-keyerror-headcoilfrequency/3516) for a thorough description of the issue. 

TL;DR: While using `mne_bids.read_raw_bids` I noticed that if you have MEG data recorded on an ELEKTA system, and your JSON sidecar has the value `ContinuousHeadLocalization` set to `True,` but does **not** specify the value for `HeadCoilFrequency`, it will throw you an error. Please note that according to the [BIDS documentation](https://bids-specification.readthedocs.io/en/stable/04-modality-specific-files/02-magnetoencephalography.html), specifiying `HeadCoilFrequency` is only recommended but **not required**. Thus, it should also work if it is not specified. 