### PR TITLE
Maint: Update devdocs

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -114,14 +114,17 @@ jobs:
       FORCE_COLOR: true
     steps:
     - uses: actions/checkout@v2
+
     - name: Set up Node.js
       uses: actions/setup-node@v2
       with:
         node-version: 12
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+
     - name: Restore cache
       # Restoring cache on Ubuntu 20.04 seems buggy
       # only do it on other operating systems
@@ -131,6 +134,7 @@ jobs:
       with:
         path: ${{ env.pythonLocation }}
         key: test-${{ env.pythonLocation }}-${{ hashFiles('setup.cfg') }}-${{ hashFiles('test_requirements.txt') }}
+
     - name: Install Python dependencies using pip
       run: |
         python -m pip install --upgrade pip wheel
@@ -141,6 +145,7 @@ jobs:
       run: |
         git clone --depth 1 https://github.com/mne-tools/mne-python.git -b maint/0.23
         pip install --no-deps -e ./mne-python
+
     - name: Install MNE (main)
       if: "matrix.os == 'ubuntu-latest'"
       run: |
@@ -167,26 +172,19 @@ jobs:
         echo "npm"; npm --version
         echo "node"; node --version
         echo "bids-validator"; bids-validator --version
-        python --version
+        echo "python"; python --version
         which python
         mne sys_info
+
     - name: Install MNE-BIDS
-      run: pip install --no-deps .
+      run: pip install --no-deps -e .
+
     - name: Run pytest
-      run: |
-        export BIDS_VALIDATOR_VERSION=`bids-validator --version`
-        echo Using bids-validator $BIDS_VALIDATOR_VERSION
-        python -m pytest . \
-        --doctest-modules \
-        --cov=mne_bids mne_bids/tests/ mne_bids/commands/tests/ \
-        --cov-report=xml \
-        --cov-config=setup.cfg \
-        --verbose \
-        --ignore mne-python \
-        --ignore examples
+      run: make test
       shell: bash
+
     - name: Upload coverage stats to codecov
       if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9' && matrix.bids-validator == 'main' }}
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v2
       with:
-        file: ./coverage.xml
+        files: ./coverage.xml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,9 +20,11 @@ for review.
 
 ## Setting up a development environment
 
-To start with, you should have installed `mne-bids` in its own, isolated Python environment,
-for example using `conda`, as recommended in our
+To start with, you should install `mne-bids` as described in our
 [installation documentation](https://mne.tools/mne-bids/dev/install.html).
+For a development environment we recommend that you perform the installation in
+a dedicated Python environment,
+for example using `conda`.
 Afterwards a few additional steps need to be performed.
 For all of the steps below we assume that you work in your dedicated `mne-bids`
 Python environment.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,7 +96,12 @@ bids-validator --version
 We use [GNU Make](https://www.gnu.org/software/make/) for developing `mne-bids`.
 We recommend that you install GNU Make and make use of our `Makefile` at the root
 of the repository.
-If you can't install GNU Make, it might suffice to inspect the `Makefile` and to
+For most Linux and OSX operating systems, GNU Make will be already installed by default.
+Windows users can download the [Chocolatey package manager](https://chocolatey.org/)
+and install [GNU Make from their repository](https://community.chocolatey.org/packages/make).
+
+If for some reason you can't install GNU Make,
+it might suffice to inspect the `Makefile` and to
 figure out how to run the commands without invoking `make`.
 
 ## Making style checks

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,7 @@
 # Contributions
 
-Contributions are welcome in the form of pull requests.
+Contributions are welcome in the form of feedback and discussion in issues,
+or pull requests for changes to the code.
 
 Once the implementation of a piece of functionality is considered to be bug
 free and properly documented (both API docs and an example script),
@@ -9,94 +10,143 @@ it can be incorporated into the `main` branch.
 To help developing `mne-bids`, you will need a few adjustments to your
 installation as shown below.
 
-## Running tests
+Before submitting a pull request, we recommend that you run all style checks
+and the test suite, and build the documentation **locally** on your machine.
+Like that, you can fix errors with your changes before submitting something
+for review.
 
-### (Optional) Install development version of MNE-Python
+**All contributions are expected to follow the**
+[**Code of Conduct of the mne-tools GitHub organization.**](https://github.com/mne-tools/.github/blob/master/CODE_OF_CONDUCT.md)
 
-If you want to run the tests with a development version of MNE-Python,
-you can install it by running
+## Setting up a development environment
 
-    $ pip install -U https://github.com/mne-tools/mne-python/archive/main.zip
+To start with, you should have installed `mne-bids` in its own, isolated Python environment,
+for example using `conda`, as recommended in our
+[installation documentation](https://mne.tools/mne-bids/dev/install.html).
+Afterwards a few additional steps need to be performed.
+For all of the steps below we assume that you work in your dedicated `mne-bids`
+Python environment.
 
-### Install development version of MNE-BIDS
+### Clone MNE-Python and install it from the git repository
 
-First, you should [fork](https://help.github.com/en/github/getting-started-with-github/fork-a-repo) the `mne-bids` repository. Then, clone the fork and install it in
-"editable" mode.
+Use `git clone` to obtain the MNE-Python repository from https://github.com/mne-tools/mne-python/,
+then navigate to the cloned repository using the `cd` command.
 
-    $ git clone https://github.com/<your-GitHub-username>/mne-bids
-    $ pip install -e ./mne-bids
+Then from the `mne-python` root directory call:
 
+```Shell
+pip uninstall mne
+pip install -e .
+```
 
-### Install Python packages required to run tests
+This will uninstall the current MNE-Python installation and instead install the MNE-Python
+development version, including access to several internal test files that are needed
+for `mne-bids` as well.
 
-You can install the testing requirements using the `test_requirements.txt` file
-from the root of the mne-bids repository.
+### Install the development version of MNE-BIDS
 
-    $ pip install -r test_requirements.txt
+Now [fork](https://help.github.com/en/github/getting-started-with-github/fork-a-repo) the `mne-bids` repository.
+Then, `git clone` your fork and install it in "editable" mode.
+
+```Shell
+git clone https://github.com/<your-GitHub-username>/mne-bids
+pip install -e ./mne-bids
+```
+
+You should now have both the `mne` and `mne-bids` development versions available in your Python environment.
+
+### Install additional Python packages required for development
+
+Navigate to the root of the `mne-bids` repository and call:
+
+```Shell
+pip install -r test_requirements.txt
+pip install -r doc/requirements.txt
+```
+
+This will install several packages to run tests, and build the documentation for `mne-bids`.
 
 ### Install the BIDS validator
 
-Finally, it is necessary to install the
-[BIDS validator](https://github.com/bids-standard/bids-validator). The outputs
-of MNE-BIDS are run through the BIDS validator to check if the conversion
-worked properly and produced datasets that conforms to the BIDS specifications.
+For a complete development setup of `mne-bids`, it is necessary to install the
+[BIDS validator](https://github.com/bids-standard/bids-validator).
+The outputs of `mne-bids` are run through the BIDS validator to check if the conversion
+worked properly and produced datasets conform to the
+[BIDS specification](https://bids-specification.readthedocs.io/en/stable/).
 
-You will need the `command line version` of the validator.
+To install the **stable** version of `bids-validator`, please follow the instructions
+in the [bids-validator README](https://github.com/bids-standard/bids-validator#quickstart).
+You will need the "command line version" of the bids-validator.
 
-#### Global (system-wide) installation
+To install the **development** version of `bids-validator`, see the
+[contributor documentation of bids-validator](https://github.com/bids-standard/bids-validator/blob/master/CONTRIBUTING.md#using-the-development-version-of-bids-validator).
 
-- First, install [Node.js](https://nodejs.org/en/).
-- For installing the **stable** version of `bids-validator`, please follow the
-instructions as detailed in the README of the bids-validator repository.
-- For installing the **development** version of `bids-validator`, see [here](https://github.com/bids-standard/bids-validator/blob/master/CONTRIBUTING.md#using-the-development-version-of-bids-validator).
+We recommend that to get started, you install the **stable** `bids-validator`.
 
-Test your installation by running:
+Check your installation by running:
 
-    $ bids-validator --version
+```Shell
+bids-validator --version
+```
 
-#### Local (per-user) development installation
+### Install GNU Make
 
-Install [Node.js](https://nodejs.org/en/). If you're use `conda`, you can
-install the `nodejs` package from `conda-forge` by running
-`conda install -c conda-forge nodejs`.
+We use [GNU Make](https://www.gnu.org/software/make/) for developing `mne-bids`.
+We recommend that you install GNU Make and make use of our `Makefile` at the root
+of the repository.
+If you can't install GNU Make, it might suffice to inspect the `Makefile` and to
+figure out how to run the commands without invoking `make`.
 
-Then, retrieve the validator and install all its dependencies via `npm`.
+## Making style checks
 
-    $ git clone git@github.com:bids-standard bids-validator.git
-    $ cd bids-validator/bids-validator
-    $ npm install
+We run several style checks on `mne-bids`.
+If you have accurately followed the steps to setup your `mne-bids` development version,
+you can simply call from the root of the `mne-bids` repository:
 
-Test your installation by running:
+```Shell
+make pep
+```
 
-    $ ./bin/bids-validator --version
+## Running tests
 
+We run tests using `pytest`.
+If you have accurately followed the steps to setup your `mne-bids` development version,
+you can simply call from the root of the `mne-bids` repository:
 
-### Invoke pytest
+```Shell
+make test
+```
 
-Now you can finally run the tests by running `pytest` in the
-`mne-bids` directory.
+If you have installed the `bids-validator` on a per-user basis (that is, *not* globally),
+set the environment variable `VALIDATOR_EXECUTABLE` to point to the path of the `bids-validator` before invoking `pytest`:
 
-    $ pytest
-
-If you have installed the `bids-validator`
-on a per-user basis, set the environment variable `VALIDATOR_EXECUTABLE` to point to the path of the `bids-validator` before invoking `pytest`:
-
-    $ VALIDATOR_EXECUTABLE=../bids-validator/bids-validator/bin/bids-validator pytest
+```Shell
+VALIDATOR_EXECUTABLE=../bids-validator/bids-validator/bin/bids-validator pytest
+```
 
 ## Building the documentation
 
-The documentation can be built using sphinx.
-You can install the documentation requirements using the `requirements.txt` file
-in the `doc/` directory of the mne-bids repository.
+The documentation can be built using [Sphinx](https://www.sphinx-doc.org).
+If you have accurately followed the steps to setup your `mne-bids` development version,
+you can simply call from the root of the `mne-bids` repository:
 
-    $ pip install -r doc/requirements.txt
-
-To build the documentation locally, one can run:
-
-    $ make build-doc
+```Shell
+make build-doc
+```
 
 or, if you don't want to run the examples to build the documentation:
 
-    $ make -C doc/ html-noplot
+```Shell
+make -C doc/ html-noplot
+```
 
 The latter command will result in a faster build but produce no plots in the examples.
+
+More information on our documentation setup can be found in our
+[mne-bids WIKI](https://github.com/mne-tools/mne-bids/wiki).
+
+## Making a release
+
+Usually only core developers make a release after consensus has been reached.
+There is dedicated documentation for this in our
+[mne-bids WIKI](https://github.com/mne-tools/mne-bids/wiki).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,17 @@ You will need the "command line version" of the bids-validator.
 To install the **development** version of `bids-validator`, see the
 [contributor documentation of bids-validator](https://github.com/bids-standard/bids-validator/blob/master/CONTRIBUTING.md#using-the-development-version-of-bids-validator).
 
-We recommend that to get started, you install the **stable** `bids-validator`.
+In brief, the most convenient installation can be done using `conda`.
+In your `conda` development environment for `mne-bids` simply call:
+
+```Shell
+conda install -c conda-forge nodejs
+npm install --global npm@^7
+npm install --global bids-validator
+```
+
+This would install the **stable** `bids-validator` and make it globally available
+on your system.
 
 Check your installation by running:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ installation as shown below.
 
 Before submitting a pull request, we recommend that you run all style checks
 and the test suite, and build the documentation **locally** on your machine.
-Like that, you can fix errors with your changes before submitting something
+That way, you can fix errors with your changes before submitting something
 for review.
 
 **All contributions are expected to follow the**
@@ -25,7 +25,7 @@ To start with, you should install `mne-bids` as described in our
 For a development environment we recommend that you perform the installation in
 a dedicated Python environment,
 for example using `conda`.
-Afterwards a few additional steps need to be performed.
+Afterwards, a few additional steps need to be performed.
 For all of the steps below we assume that you work in your dedicated `mne-bids`
 Python environment.
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -14,8 +14,7 @@ Dependencies
 * ``pandas`` (>=0.24.0, optional, for generating event statistics)
 * ``matplotlib`` (>=3.1.0, optional, for using the interactive data inspector)
 
-We recommend the `Anaconda <https://www.anaconda.com/download/>`_ Python distribution,
-and that you install ``mne_bids`` in a dedicated Python environment.
+We recommend the `Anaconda <https://www.anaconda.com/download/>`_ Python distribution.
 We require that you use Python 3.7 or higher.
 You may choose to install ``mne-bids``
 `via pip <#Installation via pip>`_ or
@@ -35,7 +34,7 @@ This ``pip`` command will also work if you want to upgrade if a newer version
 of ``mne-bids`` is available.
 
 If you don't require advanced features like interactive visual data inspection,
-you may also install a basic version of MNE-BIDS via
+you may also install a basic version of ``mne-bids`` via
 
 .. code-block:: bash
 
@@ -47,15 +46,15 @@ If you want to install a snapshot of the current development version, run:
 
    pip install --user -U https://api.github.com/repos/mne-tools/mne-bids/zipball/main
 
-To check if everything worked fine, the following command should not give any
-error messages:
+To check if everything worked fine, the following command should
+print a version number and not give any error messages:
 
 .. code-block:: bash
 
-   python -c 'import mne_bids'
+   python -c 'import mne_bids; print(mne_bids.__version__)'
 
-MNE-BIDS works best with the latest stable release of MNE-Python. To ensure
-MNE-Python is up-to-date, run:
+MNE-BIDS works best with the latest stable release of MNE-Python (the ``mne`` package).
+To ensure MNE-Python is up-to-date, run:
 
 .. code-block:: bash
 
@@ -67,7 +66,7 @@ Installation via conda
 If you have followed the
 `MNE-Python installation instructions <https://mne.tools/stable/install/mne_python.html#installing-mne-python>`_,
 all that's left to do is to install ``mne-bids`` without its dependencies, as
-they've already been installed during the ``MNE`` installation process.
+they've already been installed during the MNE-Python installation process.
 
 Activate the correct ``conda`` environment and install ``mne-bids``:
 
@@ -94,4 +93,4 @@ After activating the environment, you should be ready to use ``mne-bids``:
 .. code-block:: bash
 
    conda activate mne
-   python -c 'import mne_bids'
+   python -c 'import mne_bids; print(mne_bids.__version__)'

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -14,8 +14,9 @@ Dependencies
 * ``pandas`` (>=0.24.0, optional, for generating event statistics)
 * ``matplotlib`` (>=3.1.0, optional, for using the interactive data inspector)
 
-We recommend the `Anaconda <https://www.anaconda.com/download/>`_ Python
-distribution. We require that you use Python 3.7 or higher.
+We recommend the `Anaconda <https://www.anaconda.com/download/>`_ Python distribution,
+and that you install ``mne_bids`` in a dedicated Python environment.
+We require that you use Python 3.7 or higher.
 You may choose to install ``mne-bids``
 `via pip <#Installation via pip>`_ or
 `via conda <#Installation via conda>`_.


### PR DESCRIPTION
I wanted to point @fravona2211 in #855 to our [CONTRIBUTING.md](https://github.com/mne-tools/mne-bids/blob/main/CONTRIBUTING.md) file for developer documentation and noticed once more that it is a bit out of date.

This is an update, also note that I pruned some not-needed commands from the `Makefile`.