### PR TITLE
[MRG] FIX: add support for 2nd order gradient compensation

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -23,6 +23,7 @@ Authors
 ~~~~~~~
 
 * `Richard Höchenberger`_
+* `Mainak Jas`_
 
 Detailed list of changes
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -46,6 +47,8 @@ Bug fixes
 ^^^^^^^^^
 
 - Fix writing Ricoh/KIT data that comes without an associated ``.mrk``, ``.elp``, or ``.hsp`` file using :func:`mne_bids.write_raw_bids`, by `Richard Höchenberger`_ (:gh:`850`)
+
+- Properly support CTF MEG data with 2nd-order gradient compensation, by `Mainak Jas`_ (:gh:`858`)
 
 :doc:`Find out what was new in previous releases <whats_new_previous_releases>`
 

--- a/mne_bids/pick.py
+++ b/mne_bids/pick.py
@@ -19,6 +19,7 @@ def get_coil_types():
                               FIFF.FIFFV_COIL_CTF_GRAD,
                               # Support for gradient-compensated data:
                               int(FIFF.FIFFV_COIL_CTF_GRAD | (3 << 16)),
+                              int(FIFF.FIFFV_COIL_CTF_GRAD | (2 << 16)),
                               FIFF.FIFFV_COIL_AXIAL_GRAD_5CM,
                               FIFF.FIFFV_COIL_BABY_GRAD),
                 megrefgradaxial=(FIFF.FIFFV_COIL_CTF_REF_GRAD,


### PR DESCRIPTION
PR Description
--------------

Hey guys, a colleague from Karim Jerbi's lab reached out to me who was having trouble with converting to BIDS with 2nd order gradient compensation. I followed the fix of @agramfort in #549 

If you want to reproduce the data and script was shared here:

https://drive.google.com/file/d/1mfEsDg6wVH6MjUPSCrFSOTRhtHdbFB0L/view?usp=sharing

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
