### PR TITLE
[MAINT] Require MNE-Python `main` until `0.23.1` release

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -143,7 +143,7 @@ jobs:
     - name: Install MNE (stable)
       if: "matrix.os != 'ubuntu-latest'"
       run: |
-        git clone --depth 1 https://github.com/mne-tools/mne-python.git -b maint/0.23
+        git clone --depth 1 https://github.com/mne-tools/mne-python.git -b main  # XXX: move to maint/0.24 after release
         pip install --no-deps -e ./mne-python
 
     - name: Install MNE (main)

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ project_urls =
 [options]
 python_requires = ~= 3.7
 install_requires =
-  git+https://github.com/mne-tools/mne-python.git
+  mne @ git+https://github.com/mne-tools/mne-python.git
   numpy >= 1.16.0
   scipy >= 1.2.0
   setuptools

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ project_urls =
 [options]
 python_requires = ~= 3.7
 install_requires =
-  mne == git+https://github.com/mne-tools/mne-python.git
+  https://github.com/mne-tools/mne-python.git
   numpy >= 1.16.0
   scipy >= 1.2.0
   setuptools

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ project_urls =
 [options]
 python_requires = ~= 3.7
 install_requires =
-  https://github.com/mne-tools/mne-python.git
+  git+https://github.com/mne-tools/mne-python.git
   numpy >= 1.16.0
   scipy >= 1.2.0
   setuptools

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ project_urls =
 [options]
 python_requires = ~= 3.7
 install_requires =
-  mne >= 0.21.2
+  mne == git+https://github.com/mne-tools/mne-python.git
   numpy >= 1.16.0
   scipy >= 1.2.0
   setuptools


### PR DESCRIPTION
I have no idea what's causing the CIs to fail here https://github.com/mne-tools/mne-bids/pull/859 and I assume it's not something to do with the PR but I have failed to replicate the issue locally so I'm just pushing an empty commit just to make sure.