### PR TITLE
[WIP] Enable write_raw_bids to format as EDF files

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -24,6 +24,7 @@ Authors
 
 * `Richard Höchenberger`_
 * `Mainak Jas`_
+* `Adam Li`_
 
 Detailed list of changes
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -32,6 +33,7 @@ Enhancements
 ^^^^^^^^^^^^
 
 - :func:`mne_bids.get_anat_landmarks` now accepts a :class:`mne_bids.BIDSPath` as ``image`` parameter, by `Alex Rockhill`_ (:gh:`852`)
+- :func:`mne_bids.write_raw_bids` now accepts 'EDF' as a 'format' key word to force conversion to EDF files, by `Adam Li`_ (:gh:``)
 
 API and behavior changes
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,6 +49,8 @@ full =
   matplotlib >= 3.1.0
   pandas >= 0.24.0
   openneuro-py >=2021.8
+  EDFlib-Python >= 1.0.2
+
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
PR Description
--------------

Closes: #863
Closes: #864

- Refactors one unit test into two existing unit tests to improve readability
- Refactors current unit test of "converting to BrainVision" to just "converting EEG data in general"
- Adds EDF export support

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
