### PR TITLE
[MRG] Fix bug in writing EDF files with upper-case extension

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -56,6 +56,8 @@ Bug fixes
 
 - Properly support CTF MEG data with 2nd-order gradient compensation, by `Mainak Jas`_ (:gh:`858`)
 
+- Fix writing and reading EDF files with upper-case extension (``.EDF``), by `Adam Li`_ (:gh:`868`)
+
 :doc:`Find out what was new in previous releases <whats_new_previous_releases>`
 
 .. include:: authors.rst

--- a/mne_bids/copyfiles.py
+++ b/mne_bids/copyfiles.py
@@ -436,7 +436,7 @@ def copyfile_edf(src, dest, anonymize=None):
     if anonymize is not None:
         if ext_src == '.bdf':
             raw = read_raw_bdf(dest, preload=False, verbose=0)
-        elif ext_src == '.edf':
+        elif ext_src in ['.edf', '.EDF']:
             raw = read_raw_edf(dest, preload=False, verbose=0)
         else:
             raise ValueError('Unsupported file type ({0})'.format(ext_src))

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -52,7 +52,7 @@ def _read_raw(raw_fpath, electrode=None, hsp=None, hpi=None,
     elif ext == '.fif':
         raw = reader[ext](raw_fpath, allow_maxshield, **kwargs)
 
-    elif ext in ['.ds', '.vhdr', '.set', '.edf', '.bdf']:
+    elif ext in ['.ds', '.vhdr', '.set', '.edf', '.bdf', '.EDF']:
         raw = reader[ext](raw_fpath, **kwargs)
 
     # MEF and NWB are allowed, but not yet implemented

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -2519,7 +2519,8 @@ def test_anonymize(subject, dir_name, fname, reader, tmp_path):
 
     # capitalize the EDF extension file
     if subject == 'cap':
-        new_raw_fname = tmp_path / (op.basename(raw_fname).split('.edf')[0] + '.EDF')
+        new_basename = (op.basename(raw_fname).split('.edf')[0] + '.EDF')
+        new_raw_fname = tmp_path / new_basename
         sh.copyfile(raw_fname, new_raw_fname)
         raw_fname = new_raw_fname.as_posix()
 

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -2511,7 +2511,7 @@ def test_coordsystem_json_compliance(
     warning_str['edf_warning'],
     warning_str['brainvision_unit']
 )
-def test_anonymize(subject, dir_name, fname, reader, tmpdir):
+def test_anonymize(subject, dir_name, fname, reader, tmp_path):
     """Test writing anonymized EDF data."""
     data_path = testing.data_path()
 
@@ -2519,11 +2519,12 @@ def test_anonymize(subject, dir_name, fname, reader, tmpdir):
 
     # capitalize the EDF extension file
     if subject == 'cap':
-        new_raw_fname = raw_fname.split('.edf')[0] + '.EDF'
-        os.rename(raw_fname, new_raw_fname)
-        raw_fname = new_raw_fname
+        new_raw_fname = tmp_path / (op.basename(raw_fname).split('.edf')[0] + '.EDF')
+        sh.copyfile(raw_fname, new_raw_fname)
+        raw_fname = new_raw_fname.as_posix()
 
-    bids_root = tmpdir.mkdir('bids1')
+    bids_root = tmp_path / 'bids1'
+    bids_root.mkdir(parents=True)
     raw = reader(raw_fname)
     raw_date = raw.info['meas_date'].strftime('%Y%m%d')
 

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1462,7 +1462,7 @@ def write_raw_bids(raw, bids_path, events_data=None, event_id=None,
             convert = True
             bids_path.update(extension='.fif')
         elif bids_path.datatype in ['eeg', 'ieeg']:
-            if ext not in ['.vhdr', '.edf', '.bdf']:
+            if ext not in ['.vhdr', '.edf', '.bdf', '.EDF']:
                 if verbose:
                     warn('Converting data files to BrainVision format '
                          'for anonymization')
@@ -1617,7 +1617,7 @@ def write_raw_bids(raw, bids_path, events_data=None, event_id=None,
     # BrainVision is multifile, copy over all of them and fix pointers
     elif ext == '.vhdr':
         copyfile_brainvision(raw_fname, bids_path, anonymize=anonymize)
-    elif ext in ['.edf', '.bdf']:
+    elif ext in ['.edf', '.EDF', '.bdf']:
         if anonymize is not None:
             warn("EDF/EDF+/BDF files contain two fields for recording dates."
                  "Due to file format limitations, one of these fields only "


### PR DESCRIPTION
PR Description
--------------

Fixes a bug in writing and reading EDF files with upper-case extension (`.EDF`).

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
