### PR TITLE
Make "mne" dependency URL point to zipball

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ project_urls =
 [options]
 python_requires = ~= 3.7
 install_requires =
-  mne @ git+https://github.com/mne-tools/mne-python.git
+  mne @ https://api.github.com/repos/mne-tools/mne-python/zipball/main
   numpy >= 1.16.0
   scipy >= 1.2.0
   setuptools


### PR DESCRIPTION
We're running into problems downstream at https://github.com/mne-tools/mne-bids-pipeline/pull/449 because the BIDS Pipeline depends on both MNE and MNE-BIDS devel versions, so we install them both from their `main` zipball URL.

Now, MNE-BIDS itself depends on MNE-Python again, but specifies a different source (git URL). This confuses pip and everything blows up. Since usage of the zipball URL seems to be rather common, this PR switches from the git to the zipball URL, hopefully fixing our issues downstream.

cc @agramfort


Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
