### PR TITLE
MRG: Fix sidecar discovery when multiple data types are present

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -91,9 +91,11 @@ Bug fixes
 
 - Fix erroneous measurement date check in :func:`mne_bids.write_raw_bids` when requesting to anonymize empty-room data, by `Richard Höchenberger`_ (:gh:`893`)
 
-- More robust handling of situations where :func:`mne_bids.read_raw_bids` tries to read a file that does not exist, by `Richard Höchenberger`_ (:gh:`904`)
-
 - :func:`mne_bids.write_raw_bids` now raises an exception if the provided :class:`mne_bids.BIDSPath` doesn't contain ``subject`` and ``task`` entities, which are required for neurophysiological data, by `Richard Höchenberger`_ (:gh:`903`)
+
+- :func:`mne_bids.read_raw_bids` now handles datasets with multiple electrophysiological data types correctly, by `Richard Höchenberger`_ (:gh:`910`)
+
+- More robust handling of situations where :func:`mne_bids.read_raw_bids` tries to read a file that does not exist, by `Richard Höchenberger`_ (:gh:`904`)
 
 :doc:`Find out what was new in previous releases <whats_new_previous_releases>`
 

--- a/examples/convert_mri_and_trans.py
+++ b/examples/convert_mri_and_trans.py
@@ -121,7 +121,7 @@ print(trans)
 # w.r.t. the T1 image.
 
 # First create the BIDSPath object.
-t1w_bids_path = BIDSPath(subject=sub, session=ses, root=output_path,
+t1w_bids_path = BIDSPath(subject=sub, session=ses, root=output_path, run=None,
                          suffix='T1w')
 
 # use ``trans`` to transform landmarks from the ``raw`` file to
@@ -159,8 +159,10 @@ print_dir_tree(output_path)
 # .. note:: If this dataset were shared with you, you would first have to use
 #           the T1 image as input for the FreeSurfer recon-all, see
 #           :ref:`tut-freesurfer-mne`.
-estim_trans = get_head_mri_trans(bids_path=bids_path, fs_subject='sample',
-                                 fs_subjects_dir=fs_subjects_dir)
+estim_trans = get_head_mri_trans(
+    bids_path=bids_path, t1_bids_path=t1w_bids_path, fs_subject='sample',
+    fs_subjects_dir=fs_subjects_dir
+)
 
 # %%
 # Finally, let's use the T1 weighted MRI image and plot the anatomical

--- a/examples/convert_mri_and_trans.py
+++ b/examples/convert_mri_and_trans.py
@@ -160,7 +160,7 @@ print_dir_tree(output_path)
 #           the T1 image as input for the FreeSurfer recon-all, see
 #           :ref:`tut-freesurfer-mne`.
 estim_trans = get_head_mri_trans(
-    bids_path=bids_path, t1_bids_path=t1w_bids_path, fs_subject='sample',
+    bids_path=bids_path,fs_subject='sample',
     fs_subjects_dir=fs_subjects_dir
 )
 

--- a/examples/convert_mri_and_trans.py
+++ b/examples/convert_mri_and_trans.py
@@ -121,7 +121,7 @@ print(trans)
 # w.r.t. the T1 image.
 
 # First create the BIDSPath object.
-t1w_bids_path = BIDSPath(subject=sub, session=ses, root=output_path, run=None,
+t1w_bids_path = BIDSPath(subject=sub, session=ses, root=output_path,
                          suffix='T1w')
 
 # use ``trans`` to transform landmarks from the ``raw`` file to
@@ -159,10 +159,8 @@ print_dir_tree(output_path)
 # .. note:: If this dataset were shared with you, you would first have to use
 #           the T1 image as input for the FreeSurfer recon-all, see
 #           :ref:`tut-freesurfer-mne`.
-estim_trans = get_head_mri_trans(
-    bids_path=bids_path,fs_subject='sample',
-    fs_subjects_dir=fs_subjects_dir
-)
+estim_trans = get_head_mri_trans(bids_path=bids_path, fs_subject='sample',
+                                 fs_subjects_dir=fs_subjects_dir)
 
 # %%
 # Finally, let's use the T1 weighted MRI image and plot the anatomical

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -1410,7 +1410,7 @@ def _find_matching_sidecar(bids_path, suffix=None,
     # search suffix is BIDS-suffix and extension
     search_suffix = ''
     if suffix is not None:
-        search_suffix = search_suffix + suffix
+        search_suffix = suffix
 
         # do not search for suffix if suffix is explicitly passed
         bids_path = bids_path.copy()
@@ -1432,7 +1432,7 @@ def _find_matching_sidecar(bids_path, suffix=None,
         search_str_filename += f'_ses-{bids_path.session}'
 
     # Find all potential sidecar files, doing a recursive glob
-    # from bids_root/sub_id, potentially taking into account the data type
+    # from bids_root/sub-*, potentially taking into account the data type
     search_dir = Path(bids_root) / f'sub-{bids_path.subject}'
     # ** -> don't forget about potentially present session directories
     if bids_path.datatype is None:
@@ -1443,7 +1443,7 @@ def _find_matching_sidecar(bids_path, suffix=None,
     search_str_complete = str(
         search_dir / f'{search_str_filename}*{search_suffix}'
     )
-    
+
     candidate_list = glob.glob(search_str_complete, recursive=True)
     best_candidates = _find_best_candidates(bids_path.entities,
                                             candidate_list)

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -833,14 +833,26 @@ def get_head_mri_trans(bids_path, extra_params=None, t1_bids_path=None,
     t1w_bids_path = (
         (meg_bids_path if t1_bids_path is None else t1_bids_path)
         .copy()
-        .update(datatype='anat', suffix='T1w', extension='.nii.gz')
+        .update(
+            datatype='anat',
+            suffix='T1w',
+            task=None
+        )
     )
-    if t1_bids_path is None:
-        # Eliminate electrophysiological task and run entities
-        t1w_bids_path.task = None
-        t1w_bids_path.run = None
+    t1_paths = t1w_bids_path.match()
+    if any([p.suffix == '.nii' for p in t1_paths]):
+        t1w_bids_path.extension = '.nii'
+    elif any([p.suffix == '.nii.gz' for p in t1_paths]):
+        t1w_bids_path.extension = '.nii.gz'
+    else:
+        raise FileNotFoundError(
+            f'Could not find T1w MRI scan in the following locations: '
+            f'{t1w_bids_path.fpath}[.nii,.nii.gz]'
+        )
 
-    t1w_json_bids_path = t1w_bids_path.copy().update(extension='.json')
+    t1w_json_bids_path = _find_matching_sidecar(
+        bids_path=t1w_bids_path, extension='.json'
+    )
     del t1_bids_path
 
     if not t1w_json_bids_path.fpath.exists():

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -830,15 +830,28 @@ def get_head_mri_trans(bids_path, extra_params=None, t1_bids_path=None,
     meg_bids_path.update(datatype='meg', suffix='meg')
 
     # Get the sidecar file for MRI landmarks
-    match_bids_path = meg_bids_path if t1_bids_path is None else t1_bids_path
-    t1w_path = _find_matching_sidecar(
-        match_bids_path, suffix='T1w', extension='.nii.gz')
-    t1w_json_path = _find_matching_sidecar(
-        match_bids_path, suffix='T1w', extension='.json')
+    t1w_bids_path = (
+        (meg_bids_path if t1_bids_path is None else t1_bids_path)
+        .copy()
+        .update(datatype='anat', suffix='T1w', extension='.nii.gz')
+    )
+    t1w_path = _find_matching_sidecar(t1_bids_path)
 
+    t1w_json_bids_path = t1w_bids_path.copy().update(extension='.json')
+    t1w_json_path = _find_matching_sidecar(t1_bids_path)
+
+    if not t1w_json_bids_path.fpath.exists():
+        raise FileNotFoundError(
+            f'Did not find T1w JSON sidecar file, tried location: '
+            f'{t1w_bids_path.fpath}'
+        )
+
+    del t1_bids_path
+    
     # Get MRI landmarks from the JSON sidecar
-    with open(t1w_json_path, 'r', encoding='utf-8') as f:
-        t1w_json = json.load(f)
+    t1w_json = json.loads(
+        t1w_json_bids_path.fpath.read_text(encoding='utf-8')
+    )
     mri_coords_dict = t1w_json.get('AnatomicalLandmarkCoordinates', dict())
 
     # landmarks array: rows: [LPA, NAS, RPA]; columns: [x, y, z]
@@ -857,7 +870,7 @@ def get_head_mri_trans(bids_path, extra_params=None, t1_bids_path=None,
     if np.isnan(mri_landmarks).any():
         raise RuntimeError(
             f'Could not extract fiducial points from T1w sidecar file: '
-            f'{t1w_json_path}\n\n'
+            f'{t1w_json_bids_path}\n\n'
             f'The sidecar file SHOULD contain a key '
             f'"AnatomicalLandmarkCoordinates" pointing to an '
             f'object with the keys "LPA", "NAS", and "RPA". '
@@ -877,7 +890,7 @@ def get_head_mri_trans(bids_path, extra_params=None, t1_bids_path=None,
             f"Could not find {fs_t1_fname}. Consider running FreeSurfer's "
             f"'recon-all` for subject {fs_subject}.")
     fs_t1_mgh = nib.load(str(fs_t1_fname))
-    t1_nifti = nib.load(str(t1w_path))
+    t1_nifti = nib.load(str(t1w_bids_path.fpath))
 
     # Convert to MGH format to access vox2ras method
     t1_mgh = nib.MGHImage(t1_nifti.dataobj, t1_nifti.affine)

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -835,19 +835,20 @@ def get_head_mri_trans(bids_path, extra_params=None, t1_bids_path=None,
         .copy()
         .update(datatype='anat', suffix='T1w', extension='.nii.gz')
     )
-    t1w_path = _find_matching_sidecar(t1_bids_path)
+    if t1_bids_path is None:
+        # Eliminate electrophysiological task and run entities
+        t1w_bids_path.task = None
+        t1w_bids_path.run = None
 
     t1w_json_bids_path = t1w_bids_path.copy().update(extension='.json')
-    t1w_json_path = _find_matching_sidecar(t1_bids_path)
+    del t1_bids_path
 
     if not t1w_json_bids_path.fpath.exists():
         raise FileNotFoundError(
             f'Did not find T1w JSON sidecar file, tried location: '
-            f'{t1w_bids_path.fpath}'
+            f'{t1w_json_bids_path.fpath}'
         )
 
-    del t1_bids_path
-    
     # Get MRI landmarks from the JSON sidecar
     t1w_json = json.loads(
         t1w_json_bids_path.fpath.read_text(encoding='utf-8')

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -861,7 +861,7 @@ def get_head_mri_trans(bids_path, extra_params=None, t1_bids_path=None,
     if not t1w_bids_path.fpath.exists():
         raise FileNotFoundError(
             f'Did not find T1w recording file, tried location: '
-            f'{t1w_bids_path}'
+            f'{t1w_path_candidate.name.replace(".nii.gz", "")}[.nii, .nii.gz]'
         )
 
     # Get MRI landmarks from the JSON sidecar

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -281,7 +281,9 @@ def test_get_head_mri_trans(tmp_path):
     #
     # Case 1: different BIDS roots
     meg_bids_path = _bids_path.copy().update(root=tmp_path / 'meg_root')
-    t1_bids_path = _bids_path.copy().update(root=tmp_path / 'mri_root')
+    t1_bids_path = _bids_path.copy().update(
+        root=tmp_path / 'mri_root', task=None, run=None
+    )
     raw = _read_raw_fif(raw_fname)
 
     write_raw_bids(raw, bids_path=meg_bids_path)
@@ -298,7 +300,9 @@ def test_get_head_mri_trans(tmp_path):
     raw = _read_raw_fif(raw_fname)
     meg_bids_path = _bids_path.copy().update(root=tmp_path / 'session_test',
                                              session='01')
-    t1_bids_path = meg_bids_path.copy().update(session='02')
+    t1_bids_path = meg_bids_path.copy().update(
+        session='02', task=None, run=None
+    )
 
     write_raw_bids(raw, bids_path=meg_bids_path)
     write_anat(t1w_mgh, bids_path=t1_bids_path, landmarks=landmarks)

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -213,7 +213,7 @@ def test_get_head_mri_trans(tmp_path):
                    overwrite=False)
 
     # We cannot recover trans if no MRI has yet been written
-    with pytest.raises(RuntimeError, match='Did not find any T1w'):
+    with pytest.raises(FileNotFoundError, match='Did not find'):
         estimated_trans = get_head_mri_trans(
             bids_path=bids_path, fs_subject='sample',
             fs_subjects_dir=subjects_dir)

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -626,9 +626,15 @@ def test_fif(_bids_validate, tmp_path):
     # test whether extra points in raw.info['dig'] are correctly used
     # to set DigitizedHeadShape in the JSON sidecar
     # unchanged sample data includes extra points
-    meg_json_path = bids_path.copy().update(
-        root=bids_root, datatype='meg', suffix='meg', extension='.json'
-    ).fpath
+    meg_json_path = Path(
+        _find_matching_sidecar(
+            bids_path=bids_path.copy().update(
+                root=bids_root, datatype='meg'
+            ),
+            suffix='meg',
+            extension='.json'
+        )
+    )
 
     meg_json = json.loads(meg_json_path.read_text(encoding='utf-8'))
     assert meg_json['DigitizedHeadPoints'] is True
@@ -646,9 +652,15 @@ def test_fif(_bids_validate, tmp_path):
     write_raw_bids(raw_no_extra_points, bids_path, events_data=events,
                    event_id=event_id, overwrite=True)
 
-    meg_json_path = bids_path.copy().update(
-        root=bids_root, datatype='meg', suffix='meg', extension='.json'
-    ).fpath
+    meg_json_path = Path(
+        _find_matching_sidecar(
+            bids_path=bids_path.copy().update(
+                root=bids_root, datatype='meg'
+            ),
+            suffix='meg',
+            extension='.json'
+        )
+    )
     meg_json = json.loads(meg_json_path.read_text(encoding='utf-8'))
 
     assert meg_json['DigitizedHeadPoints'] is False
@@ -1411,6 +1423,16 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate, tmp_path):
     assert electrodes_path.exists()
     assert coordsystem_path.exists()
 
+    # Test we get the correct sidecar via _find_matching_sidecar()
+    electrodes_fname = _find_matching_sidecar(bids_path,
+                                              suffix='electrodes',
+                                              extension='.tsv')
+    coordsystem_fname = _find_matching_sidecar(bids_path,
+                                               suffix='coordsystem',
+                                               extension='.json')
+    electrodes_fname == str(electrodes_fpath)
+    coordsystem_fname == str(coordsystem_path)
+
     coordsystem_json = json.loads(
         coordsystem_path.read_text(encoding='utf-8')
     )
@@ -1448,6 +1470,16 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate, tmp_path):
 
     assert electrodes_path.exists()
     assert coordsystem_path.exists()
+
+    # Test we get the correct sidecar via _find_matching_sidecar()
+    electrodes_fname = _find_matching_sidecar(bids_path,
+                                              suffix='electrodes',
+                                              extension='.tsv')
+    coordsystem_fname = _find_matching_sidecar(bids_path,
+                                               suffix='coordsystem',
+                                               extension='.json')
+    electrodes_fname == str(electrodes_fpath)
+    coordsystem_fname == str(coordsystem_path)
 
     coordsystem_json = json.loads(
         coordsystem_path.read_text(encoding='utf-8')

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -1433,9 +1433,7 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate, tmp_path):
     electrodes_fname == str(electrodes_fpath)
     coordsystem_fname == str(coordsystem_path)
 
-    coordsystem_json = json.loads(
-        coordsystem_path.read_text(encoding='utf-8')
-    )
+    coordsystem_json = json.loads(coordsystem_path.read_text(encoding='utf-8'))
     assert coordsystem_json['iEEGCoordinateSystem'] == 'fsaverage'
 
     # test writing to ACPC
@@ -1481,9 +1479,7 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate, tmp_path):
     electrodes_fname == str(electrodes_fpath)
     coordsystem_fname == str(coordsystem_path)
 
-    coordsystem_json = json.loads(
-        coordsystem_path.read_text(encoding='utf-8')
-    )
+    coordsystem_json = json.loads(coordsystem_path.read_text(encoding='utf-8'))
     assert coordsystem_json['iEEGCoordinateSystem'] == 'ACPC'
 
     kwargs.update(acpc_aligned=False)


### PR DESCRIPTION
Scenario:

A user has a dataset that contains both EEG and iEEG data. They want to read the iEEG data. The BIDS path does specify the data type correctly:

```python
    bids_path = BIDSPath(
        root=(
            Path('~/Development/Support/mne-python/BIDS_EEG_and_iEEG/bids')
            .expanduser()
        ),
        subject=subject,
        session="V1",
        datatype='ieeg',
        task="TEST"
    )
```

But `read_raw_bids()` produces the following warning:


> RuntimeWarning: Expected to find a single events file associated with sub-SAMPLE1_ses-V1_task-TEST, but found 2: "['/Users/hoechenberger/Development/Support/mne-python/BIDS_EEG_and_iEEG/bids/sub-SAMPLE1/ses-V1/ieeg/sub-SAMPLE1_ses-V1_task-TEST_events.tsv', '/Users/hoechenberger/Development/Support/mne-python/BIDS_EEG_and_iEEG/bids/sub-SAMPLE1/ses-V1/eeg/sub-SAMPLE1_ses-V1_task-TEST_events.tsv']".


This is because our sidecar discovery doesn't take into account the data type.

This PR makes it such that we respect `BIDSPath.datatype` if it's present.

This problem was reported on the forum, https://mne.discourse.group/t/mne-bids-read-raw-doesnt-set-channel-types-when-several-data-types-in-session/3724

To me it's another argument that we need to remove our heuristics and ask users to be more explicit instead of trying to do the right thing automatically, since we're sometimes just not good at it.

WIP Because there are no tests so far …

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
