### PR TITLE
[MRG] adjust code for pybv 0.6

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -10,7 +10,7 @@ Dependencies
 * ``numpy`` (>=1.16.0)
 * ``scipy`` (>=1.2.0, or >=1.5.0 for certain operations with EEGLAB data)
 * ``nibabel`` (>=2.2, optional, for processing MRI data)
-* ``pybv`` (>=0.5, optional, for writing BrainVision data)
+* ``pybv`` (>=0.6, optional, for writing BrainVision data)
 * ``pandas`` (>=0.24.0, optional, for generating event statistics)
 * ``matplotlib`` (>=3.1.0, optional, for using the interactive data inspector)
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -26,6 +26,7 @@ Authors
 * `Richard Höchenberger`_
 * `Mainak Jas`_
 * `Adam Li`_
+* `Stefan Appelhoff`_
 
 Detailed list of changes
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -49,7 +50,8 @@ API and behavior changes
 Requirements
 ^^^^^^^^^^^^
 
-- ...
+- Writing BrainVision files now requires ``pybv`` version 0.6, by `Stefan Appelhoff`_ (:gh:`868`)
+
 
 Bug fixes
 ^^^^^^^^^

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -50,7 +50,7 @@ API and behavior changes
 Requirements
 ^^^^^^^^^^^^
 
-- Writing BrainVision files now requires ``pybv`` version 0.6, by `Stefan Appelhoff`_ (:gh:`868`)
+- Writing BrainVision files now requires ``pybv`` version 0.6, by `Stefan Appelhoff`_ (:gh:`880`)
 
 
 Bug fixes

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -387,7 +387,7 @@ def test_line_freq(line_freq, _bids_validate, tmpdir):
         assert eeg_json['PowerLineFrequency'] == 'n/a'
 
 
-@requires_version('pybv', '0.4')
+@requires_version('pybv', '0.6')
 @pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
 @pytest.mark.filterwarnings(warning_str['maxshield'])
 def test_fif(_bids_validate, tmpdir):
@@ -1052,7 +1052,7 @@ def test_vhdr(_bids_validate, tmpdir):
     assert len([f for f in os.listdir(data_path) if op.isfile(f)]) == 0
 
     # test anonymize and convert
-    if check_version('pybv', '0.4'):
+    if check_version('pybv', '0.6'):
         raw = _read_raw_brainvision(raw_fname)
         output_path = _test_anonymize(tmpdir.mkdir('tmp'), raw, bids_path)
         _bids_validate(output_path)
@@ -1295,7 +1295,7 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate, tmpdir):
     assert len(list(data.values())[0]) == 2
 
     # check that scans list is properly converted to brainvision
-    if check_version('pybv', '0.4') or dir_name == 'EDF':
+    if check_version('pybv', '0.6') or dir_name == 'EDF':
         daysback_min, daysback_max = _get_anonymization_daysback(raw)
         daysback = (daysback_min + daysback_max) // 2
 
@@ -1438,7 +1438,7 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate, tmpdir):
         write_raw_bids(**kwargs)
 
     # test anonymize and convert
-    if check_version('pybv', '0.4') or dir_name == 'EDF':
+    if check_version('pybv', '0.6') or dir_name == 'EDF':
         raw = reader(raw_fname)
         bids_path.update(root=bids_root, datatype='eeg')
         kwargs = dict(raw=raw, bids_path=bids_path, overwrite=True)
@@ -1572,7 +1572,7 @@ def test_set(_bids_validate, tmpdir):
     _bids_validate(bids_root)
 
     # test anonymize and convert
-    if check_version('pybv', '0.4'):
+    if check_version('pybv', '0.6'):
         with pytest.warns(RuntimeWarning,
                           match='Encountered data in "double" format'):
             output_path = _test_anonymize(tmpdir.mkdir('tmp'), raw, bids_path)
@@ -2612,17 +2612,13 @@ def test_sidecar_encoding(_bids_validate, tmpdir):
 
 
 @requires_version('mne', '0.24.dev0')
-@requires_version('pybv', '0.5')
+@requires_version('pybv', '0.6')
 @pytest.mark.parametrize(
     'dir_name, format, fname, reader', test_converteeg_data)
 @pytest.mark.filterwarnings(
     warning_str['channel_unit_changed'], warning_str['edfblocks'])
 def test_convert_eeg_formats(dir_name, format, fname, reader, tmp_path):
-    """Test conversion of EEG/iEEG manufacturer format to BrainVision and EDF.
-
-    BrainVision should correctly store data from pybv>=0.5 that
-    has different non-voltage units.
-    """
+    """Test conversion of EEG/iEEG manufacturer fmt to BrainVision/EDF."""
     bids_root = tmp_path / format
     bids_root.mkdir(exist_ok=True, parents=True)
     data_path = op.join(testing.data_path(), dir_name)

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -860,7 +860,7 @@ def _write_raw_fif(raw, bids_fname):
              overwrite=True)
 
 
-def _write_raw_brainvision(raw, bids_fname, events):
+def _write_raw_brainvision(raw, bids_fname, events, overwrite):
     """Save out the raw file in BrainVision format.
 
     Parameters
@@ -872,10 +872,11 @@ def _write_raw_brainvision(raw, bids_fname, events):
         should be saved.
     events : ndarray
         The events as MNE-Python format ndaray.
-
+    overwrite : bool
+        Whether or not to overwrite existing files.
     """
-    if not check_version('pybv', '0.4'):  # pragma: no cover
-        raise ImportError('pybv >=0.4 is required for converting '
+    if not check_version('pybv', '0.6'):  # pragma: no cover
+        raise ImportError('pybv >=0.6 is required for converting '
                           'file to BrainVision format')
     from pybv import write_brainvision
     # Subtract raw.first_samp because brainvision marks events starting from
@@ -913,8 +914,10 @@ def _write_raw_brainvision(raw, bids_fname, events):
     write_brainvision(data=raw.get_data(),
                       sfreq=raw.info['sfreq'],
                       ch_names=raw.ch_names,
+                      ref_ch_names=None,
                       fname_base=op.splitext(op.basename(bids_fname))[0],
                       folder_out=op.dirname(bids_fname),
+                      overwrite=overwrite,
                       events=events,
                       resolution=resolution,
                       unit=unit,
@@ -1581,7 +1584,8 @@ def write_raw_bids(raw, bids_path, events_data=None, event_id=None,
             warn('Converting data files to BrainVision format')
             bids_path.update(suffix=bids_path.datatype, extension='.vhdr')
             # XXX Should we write durations here too?
-            _write_raw_brainvision(raw, bids_path.fpath, events=events_array)
+            _write_raw_brainvision(raw, bids_path.fpath, events=events_array,
+                                   overwrite=overwrite)
     elif ext == '.fif':
         if symlink:
             link_target = Path(raw.filenames[0])

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ include_package_data = True
 [options.extras_require]
 full =
   nibabel >= 2.2
-  pybv >= 0.5
+  pybv >= 0.6
   matplotlib >= 3.1.0
   pandas >= 0.24.0
   openneuro-py >= 2021.8

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -4,7 +4,7 @@ mne>=0.21.2
 matplotlib>=3.1
 pandas>=0.24.0
 nibabel>=2.5
-pybv>=0.5
+pybv>=0.6
 openneuro-py>=2021.8
 EDFlib-Python>=1.0.2
 pytest


### PR DESCRIPTION
PR Description
--------------

CIs were failing due to the recent pybv release: https://github.com/mne-tools/mne-bids/runs/3780102400?check_suite_focus=true

Mainly, pybv now has an `overwrite` parameter that defaults to `False`. Previously, pybv always overwrote everything without asking. That's now adjusted in this PR, and pybv 0.6 is now required (also contains a fix for big endian archs)

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [x] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- ~~PR description includes phrase "closes <#issue-number>"~~
