### PR TITLE
Add `SpatialCompensation` parameter in meg.json sidecar file

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -39,6 +39,8 @@ Enhancements
 
 - :func:`mne_bids.write_raw_bids` now accepts ``'EDF'`` as a ``'format'`` value to force conversion to EDF files, by `Adam Li`_ (:gh:`866`)
 
+- :func:`mne_bids.write_raw_bids` now adds ``SpatialCompensation`` information to the JSON sidecar for MEG data, by `Julia Guiomar Niso Galán`_ (:gh:`885`)
+
 - Modify iEEG tutorial to use MNE ``raw`` object, by `Alex Rockhill`_ (:gh:`859`)
 
 - Add :func:`mne_bids.search_folder_for_text` to find specific metadata entries (e.g. all ``"n/a"`` sidecar data fields, or to check that "60 Hz" was written properly as the power line frequency), by `Alex Rockhill`_ (:gh: `870`)

--- a/mne_bids/report.py
+++ b/mne_bids/report.py
@@ -114,10 +114,16 @@ DATATYPE_AGNOSTIC_TEMPLATE = \
     """Data was recorded using a {{_pretty_str(system)}} system
 {{if manufacturer}}({{_pretty_str(manufacturer)}} manufacturer){{endif}}
 sampled at {{_pretty_str(sfreq)}} Hz
-with line noise at {{_pretty_str(powerlinefreq)}} Hz{{if _summarize_software_filters(software_filters)}} using
-{{_summarize_software_filters(software_filters)}}.{{else}}.{{endif}}
-{{if n_scans > 1}}There were {{n_scans}} scans in total.
-{{else}}There was {{n_scans}} scan in total.{{endif}}{{_length_recording_str(length_recordings)}}
+with line noise at {{_pretty_str(powerlinefreq)}} Hz.
+{{if _summarize_software_filters(software_filters)}}
+The following software filters were applied during recording: 
+{{_summarize_software_filters(software_filters)}}.
+{{endif}}
+{{if n_scans > 1}}
+There were {{n_scans}} scans in total.
+{{else}}There was {{n_scans}} scan in total.
+{{endif}}
+{{_length_recording_str(length_recordings)}}
 For each dataset, there were on average {{mean_chs}} (std = {{std_chs}}) recording channels per scan,
 out of which {{mean_good_chs}} (std = {{std_good_chs}}) were used in analysis
 ({{mean_bad_chs}} +/- {{std_bad_chs}} were removed from analysis). """  # noqa

--- a/mne_bids/tests/test_report.py
+++ b/mne_bids/tests/test_report.py
@@ -51,10 +51,11 @@ This report was generated with MNE-BIDS (https://doi.org/10.21105/joss.01896).
 The dataset consists of 1 participants (sex were all unknown; handedness were
 all unknown; ages all unknown) and 1 recording sessions: 01. Data was recorded
 using a MEG system (Elekta manufacturer) sampled at 300.31 Hz with line noise at
-60.0 Hz. There was 1 scan in total. Recording durations ranged from 20.0 to 20.0
-seconds (mean = 20.0, std = 0.0), for a total of 20.0 seconds of data recorded
-over all scans. For each dataset, there were on average 376.0 (std = 0.0)
-recording channels per scan, out of which 374.0 (std = 0.0) were used in
+60.0 Hz. The following software filters were applied during recording:
+SpatialCompensation. There was 1 scan in total. Recording durations ranged from
+20.0 to 20.0 seconds (mean = 20.0, std = 0.0), for a total of 20.0 seconds of
+data recorded over all scans. For each dataset, there were on average 376.0 (std
+= 0.0) recording channels per scan, out of which 374.0 (std = 0.0) were used in
 analysis (2.0 +/- 0.0 were removed from analysis)."""  # noqa
 
     assert report == expected_report

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -640,13 +640,14 @@ def test_fif(_bids_validate, tmpdir):
         # sample data does not have Extra points, so it should
         # DigitizedHeadPoints should be false
         assert meg_json_data['DigitizedHeadPoints'] is False
-   
+
     assert 'SoftwareFilters' in meg_json_data
     software_filters = meg_json_data['SoftwareFilters']
     assert 'SpatialCompensation' in software_filters
     assert 'GradientOrder' in software_filters['SpatialCompensation']
-    assert software_filters['SpatialCompensation']['GradientOrder'] == raw.compensation_grade
-    
+    assert (software_filters['SpatialCompensation']['GradientOrder'] ==
+            raw.compensation_grade)
+
 
 @pytest.mark.parametrize('format', ('fif_no_chpi', 'fif', 'ctf', 'kit'))
 @pytest.mark.filterwarnings(warning_str['maxshield'])

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -640,7 +640,13 @@ def test_fif(_bids_validate, tmpdir):
         # sample data does not have Extra points, so it should
         # DigitizedHeadPoints should be false
         assert meg_json_data['DigitizedHeadPoints'] is False
-
+   
+    assert 'SoftwareFilters' in meg_json_data
+    software_filters = meg_json_data['SoftwareFilters']
+    assert 'SpatialCompensation' in software_filters
+    assert 'GradientOrder' in software_filters['SpatialCompensation']
+    assert software_filters['SpatialCompensation']['GradientOrder'] == raw.compensation_grade
+    
 
 @pytest.mark.parametrize('format', ('fif_no_chpi', 'fif', 'ctf', 'kit'))
 @pytest.mark.filterwarnings(warning_str['maxshield'])

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -692,7 +692,8 @@ def _sidecar_json(raw, task, manufacturer, fname, datatype,
             elif dig_point['kind'] == FIFF.FIFFV_POINT_EXTRA and \
                     raw.filenames[0].endswith('.fif'):
                 digitized_head_points = True
-
+    comp_grade = raw.compensation_grade
+    
     # Compile cHPI information, if any.
     from mne.io.ctf import RawCTF
     from mne.io.kit.kit import RawKIT
@@ -739,7 +740,8 @@ def _sidecar_json(raw, task, manufacturer, fname, datatype,
         ('DigitizedLandmarks', digitized_landmark),
         ('DigitizedHeadPoints', digitized_head_points),
         ('MEGChannelCount', n_megchan),
-        ('MEGREFChannelCount', n_megrefchan)]
+        ('MEGREFChannelCount', n_megrefchan),
+        ('SoftwareFilters','{"SpatialCompensation": { "GradientOrder" : %d}' % comp_grade)]
 
     if chpi is not None:
         ch_info_json_meg.append(('ContinuousHeadLocalization', chpi))

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -693,13 +693,12 @@ def _sidecar_json(raw, task, manufacturer, fname, datatype,
             elif dig_point['kind'] == FIFF.FIFFV_POINT_EXTRA and \
                     raw.filenames[0].endswith('.fif'):
                 digitized_head_points = True
-    comp_grade = raw.compensation_grade   
     software_filters = {
         'SpatialCompensation': {
             'GradientOrder': raw.compensation_grade
         }
     }
-    
+
     # Compile cHPI information, if any.
     from mne.io.ctf import RawCTF
     from mne.io.kit.kit import RawKIT

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -692,7 +692,12 @@ def _sidecar_json(raw, task, manufacturer, fname, datatype,
             elif dig_point['kind'] == FIFF.FIFFV_POINT_EXTRA and \
                     raw.filenames[0].endswith('.fif'):
                 digitized_head_points = True
-    comp_grade = raw.compensation_grade
+    comp_grade = raw.compensation_grade   
+    software_filters = {
+        'SpatialCompensation': {
+            'GradientOrder': raw.compensation_grade
+        }
+    }
     
     # Compile cHPI information, if any.
     from mne.io.ctf import RawCTF
@@ -741,7 +746,7 @@ def _sidecar_json(raw, task, manufacturer, fname, datatype,
         ('DigitizedHeadPoints', digitized_head_points),
         ('MEGChannelCount', n_megchan),
         ('MEGREFChannelCount', n_megrefchan),
-        ('SoftwareFilters','{"SpatialCompensation": { "GradientOrder" : %d}' % comp_grade)]
+        ('SoftwareFilters', software_filters)]
 
     if chpi is not None:
         ch_info_json_meg.append(('ContinuousHeadLocalization', chpi))


### PR DESCRIPTION
Thanks for contributing. If this is your first time,
make sure to read [contributing.md](https://github.com/mne-tools/mne-bids/blob/main/CONTRIBUTING.md)

PR Description
--------------

I tried to add the `SpatialCompensation`parameter in the **sidecar meg.json** file, inside the `SoftwareFilters` field.
I saw this field was missing, but not sure this works properly (please review), because I don't know how to use my local version instead of the official release, so every time I tried to run it, it went through the other one :)
Thanks for the awesome tool!


Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [x] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
