### PR TITLE
[MRG] Fixes for upstream MNE-Python changes & fix tests

### DIFF
--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -369,8 +369,9 @@ def _handle_info_reading(sidecar_fname, raw):
         if raw.info['hpi_subsystem']:
             logger.info('Dropping cHPI information stored in raw data, '
                         'following specification in sidecar file')
-        raw.info['hpi_subsystem'] = None
-        raw.info['hpi_meas'] = []
+        with raw.info._unlock():
+            raw.info['hpi_subsystem'] = None
+            raw.info['hpi_meas'] = []
 
     return raw
 

--- a/mne_bids/tests/test_report.py
+++ b/mne_bids/tests/test_report.py
@@ -51,11 +51,10 @@ This report was generated with MNE-BIDS (https://doi.org/10.21105/joss.01896).
 The dataset consists of 1 participants (sex were all unknown; handedness were
 all unknown; ages all unknown) and 1 recording sessions: 01. Data was recorded
 using a MEG system (Elekta manufacturer) sampled at 300.31 Hz with line noise at
-60 Hz. There was 1 scan in total. Recording durations ranged from 20.0 to 20.0
+60.0 Hz. There was 1 scan in total. Recording durations ranged from 20.0 to 20.0
 seconds (mean = 20.0, std = 0.0), for a total of 20.0 seconds of data recorded
 over all scans. For each dataset, there were on average 376.0 (std = 0.0)
 recording channels per scan, out of which 374.0 (std = 0.0) were used in
 analysis (2.0 +/- 0.0 were removed from analysis)."""  # noqa
 
-    print(report)
     assert report == expected_report


### PR DESCRIPTION
The implementations here break some tests and read_raw_bids() for MNE-Python <0.24 (which will be released in a few days).

Is this really an issue?

We're relying on other MNE-Python 0.24 functionality already, and I'd vote for dropping support for earlier versions with the next release (0.9)

cc @agramfort

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
