### PR TITLE
MRG: Replace tmpdir with tmp_path fixture

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,5 @@
 nilearn
+sphinx <4.3
 sphinx_gallery
 sphinx-copybutton
 pydata-sphinx-theme

--- a/mne_bids/commands/tests/test_cli.py
+++ b/mne_bids/commands/tests/test_cli.py
@@ -52,9 +52,9 @@ def check_usage(module, force_help=False):
         assert 'Usage: ' in out.stdout.getvalue()
 
 
-def test_raw_to_bids(tmpdir):
+def test_raw_to_bids(tmp_path):
     """Test mne_bids raw_to_bids."""
-    output_path = str(tmpdir)
+    output_path = str(tmp_path)
     data_path = testing.data_path()
     raw_fname = op.join(data_path, 'MEG', 'sample',
                         'sample_audvis_trunc_raw.fif')
@@ -87,9 +87,9 @@ def test_raw_to_bids(tmpdir):
             mne_bids_cp.run()
 
 
-def test_cp(tmpdir):
+def test_cp(tmp_path):
     """Test mne_bids cp."""
-    output_path = str(tmpdir)
+    output_path = str(tmp_path)
     data_path = op.join(base_path, 'brainvision', 'tests', 'data')
     raw_fname = op.join(data_path, 'test.vhdr')
     outname = op.join(output_path, 'test2.vhdr')
@@ -107,14 +107,14 @@ def test_cp(tmpdir):
             mne_bids_cp.run()
 
 
-def test_mark_bad_chanels_single_file(tmpdir):
+def test_mark_bad_chanels_single_file(tmp_path):
     """Test mne_bids mark_channels."""
 
     # Check that help is printed
     check_usage(mne_bids_mark_channels)
 
     # Create test dataset.
-    output_path = str(tmpdir)
+    output_path = str(tmp_path)
     data_path = testing.data_path()
     raw_fname = op.join(data_path, 'MEG', 'sample',
                         'sample_audvis_trunc_raw.fif')
@@ -160,14 +160,14 @@ def test_mark_bad_chanels_single_file(tmpdir):
     assert raw.info['bads'] == []
 
 
-def test_mark_bad_chanels_multiple_files(tmpdir):
+def test_mark_bad_chanels_multiple_files(tmp_path):
     """Test mne_bids mark_channels."""
 
     # Check that help is printed
     check_usage(mne_bids_mark_channels)
 
     # Create test dataset.
-    output_path = str(tmpdir)
+    output_path = str(tmp_path)
     data_path = testing.data_path()
     raw_fname = op.join(data_path, 'MEG', 'sample',
                         'sample_audvis_trunc_raw.fif')
@@ -202,13 +202,13 @@ def test_mark_bad_chanels_multiple_files(tmpdir):
         assert set(old_bads + ch_names) == set(raw.info['bads'])
 
 
-def test_calibration_to_bids(tmpdir):
+def test_calibration_to_bids(tmp_path):
     """Test mne_bids calibration_to_bids."""
 
     # Check that help is printed
     check_usage(mne_bids_calibration_to_bids)
 
-    output_path = str(tmpdir)
+    output_path = str(tmp_path)
     data_path = Path(testing.data_path())
     fine_cal_fname = data_path / 'SSS' / 'sss_cal_mgh.dat'
     bids_path = BIDSPath(subject=subject_id, root=output_path)
@@ -222,13 +222,13 @@ def test_calibration_to_bids(tmpdir):
     assert bids_path.meg_calibration_fpath.exists()
 
 
-def test_crosstalk_to_bids(tmpdir):
+def test_crosstalk_to_bids(tmp_path):
     """Test mne_bids crosstalk_to_bids."""
 
     # Check that help is printed
     check_usage(mne_bids_crosstalk_to_bids)
 
-    output_path = str(tmpdir)
+    output_path = str(tmp_path)
     data_path = Path(testing.data_path())
     crosstalk_fname = data_path / 'SSS' / 'ct_sparse.fif'
     bids_path = BIDSPath(subject=subject_id, root=output_path)
@@ -243,14 +243,14 @@ def test_crosstalk_to_bids(tmpdir):
 
 
 @requires_pandas
-def test_count_events(tmpdir):
+def test_count_events(tmp_path):
     """Test mne_bids count_events."""
 
     # Check that help is printed
     check_usage(mne_bids_count_events)
 
     # Create test dataset.
-    output_path = str(tmpdir)
+    output_path = str(tmp_path)
     data_path = testing.data_path()
     raw_fname = op.join(data_path, 'MEG', 'sample',
                         'sample_audvis_trunc_raw.fif')
@@ -288,14 +288,14 @@ def test_count_events(tmpdir):
 
 @requires_matplotlib
 @requires_version('mne', '0.22')
-def test_inspect(tmpdir):
+def test_inspect(tmp_path):
     """Test mne_bids inspect."""
 
     # Check that help is printed
     check_usage(mne_bids_inspect)
 
     # Create test dataset.
-    bids_root = str(tmpdir)
+    bids_root = str(tmp_path)
     data_path = testing.data_path()
     subject = '01'
     task = 'test'

--- a/mne_bids/tests/test_copyfiles.py
+++ b/mne_bids/tests/test_copyfiles.py
@@ -114,7 +114,8 @@ def test_copyfile_brainvision(tmp_path):
 
 def test_copyfile_edf(tmp_path):
     """Test the anonymization of EDF/BDF files."""
-    bids_root = str(tmp_path.mkdir("bids1"))
+    bids_root = tmp_path / "bids1"
+    bids_root.mkdir()
     data_path = op.join(base_path, 'edf', 'tests', 'data')
 
     # Test regular copying

--- a/mne_bids/tests/test_copyfiles.py
+++ b/mne_bids/tests/test_copyfiles.py
@@ -141,7 +141,8 @@ def test_copyfile_edf(tmp_path):
         startdate = rec_info.split(' ')[1]
         return datetime.datetime.strptime(startdate, "%d-%b-%Y")
 
-    bids_root2 = tmp_path.mkdir("bids2")
+    bids_root2 = tmp_path / 'bids2'
+    bids_root2.mkdir()
     infile = op.join(bids_root, 'test_copy.edf')
     outfile = op.join(bids_root2, 'test_copy_anon.edf')
     anonymize = {'daysback': 33459, 'keep_his': False}

--- a/mne_bids/tests/test_copyfiles.py
+++ b/mne_bids/tests/test_copyfiles.py
@@ -47,7 +47,7 @@ def test_get_brainvision_encoding():
         f.readlines()
 
 
-def test_get_brainvision_paths(tmpdir):
+def test_get_brainvision_paths(tmp_path):
     """Test getting the file links from a BrainVision header."""
     data_path = op.join(base_path, 'brainvision', 'tests', 'data')
     raw_fname = op.join(data_path, 'test.vhdr')
@@ -56,17 +56,17 @@ def test_get_brainvision_paths(tmpdir):
         _get_brainvision_paths(op.join(data_path, 'test.eeg'))
 
     # Write some temporary test files
-    with open(tmpdir / 'test1.vhdr', 'w') as f:
+    with open(tmp_path / 'test1.vhdr', 'w') as f:
         f.write('DataFile=testing.eeg')
 
-    with open(tmpdir / 'test2.vhdr', 'w') as f:
+    with open(tmp_path / 'test2.vhdr', 'w') as f:
         f.write('MarkerFile=testing.vmrk')
 
     with pytest.raises(ValueError):
-        _get_brainvision_paths(tmpdir / 'test1.vhdr')
+        _get_brainvision_paths(tmp_path / 'test1.vhdr')
 
     with pytest.raises(ValueError):
-        _get_brainvision_paths(tmpdir / 'test2.vhdr')
+        _get_brainvision_paths(tmp_path / 'test2.vhdr')
 
     # This should work
     eeg_file_path, vmrk_file_path = _get_brainvision_paths(raw_fname)
@@ -78,9 +78,9 @@ def test_get_brainvision_paths(tmpdir):
 
 @pytest.mark.filterwarnings('ignore:.*Exception ignored.*:'
                             'pytest.PytestUnraisableExceptionWarning')
-def test_copyfile_brainvision(tmpdir):
+def test_copyfile_brainvision(tmp_path):
     """Test the copying of BrainVision vhdr, vmrk and eeg files."""
-    bids_root = str(tmpdir)
+    bids_root = str(tmp_path)
     data_path = op.join(base_path, 'brainvision', 'tests', 'data')
     raw_fname = op.join(data_path, 'test.vhdr')
     new_name = op.join(bids_root, 'tested_conversion.vhdr')
@@ -112,9 +112,9 @@ def test_copyfile_brainvision(tmpdir):
     assert new_date == (prev_date - datetime.timedelta(days=32459))
 
 
-def test_copyfile_edf(tmpdir):
+def test_copyfile_edf(tmp_path):
     """Test the anonymization of EDF/BDF files."""
-    bids_root = str(tmpdir.mkdir("bids1"))
+    bids_root = str(tmp_path.mkdir("bids1"))
     data_path = op.join(base_path, 'edf', 'tests', 'data')
 
     # Test regular copying
@@ -148,7 +148,7 @@ def test_copyfile_edf(tmpdir):
         startdate = rec_info.split(' ')[1]
         return datetime.datetime.strptime(startdate, "%d-%b-%Y")
 
-    bids_root2 = tmpdir.mkdir("bids2")
+    bids_root2 = tmp_path.mkdir("bids2")
     infile = op.join(bids_root, 'test_copy.edf')
     outfile = op.join(bids_root2, 'test_copy_anon.edf')
     anonymize = {'daysback': 33459, 'keep_his': False}
@@ -185,13 +185,13 @@ def test_copyfile_edf(tmpdir):
 @pytest.mark.parametrize('fname',
                          ('test_raw.set', 'test_raw_chanloc.set',
                           'test_raw_2021.set'))
-def test_copyfile_eeglab(tmpdir, fname):
+def test_copyfile_eeglab(tmp_path, fname):
     """Test the copying of EEGlab set and fdt files."""
     if (fname == 'test_raw_chanloc.set' and
             LooseVersion(testing.get_version()) < LooseVersion('0.112')):
         return
 
-    bids_root = str(tmpdir)
+    bids_root = str(tmp_path)
     data_path = op.join(testing.data_path(), 'EEGLAB')
     raw_fname = op.join(data_path, fname)
     new_name = op.join(bids_root, 'tested_conversion.set')
@@ -213,9 +213,9 @@ def test_copyfile_eeglab(tmpdir, fname):
     assert isinstance(raw, mne.io.BaseRaw)
 
 
-def test_copyfile_kit(tmpdir):
+def test_copyfile_kit(tmp_path):
     """Test copying and renaming KIT files to a new location."""
-    output_path = str(tmpdir)
+    output_path = str(tmp_path)
     data_path = op.join(base_path, 'kit', 'tests', 'data')
     raw_fname = op.join(data_path, 'test.sqd')
     hpi_fname = op.join(data_path, 'test_mrk.sqd')

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -217,7 +217,8 @@ def test_make_folders(tmp_path):
     assert op.isdir(tmp_path / 'sub-03' / 'ses-foo' / 'eeg')
 
     # Check if bids_root=None creates folders in the current working directory
-    bids_root = tmp_path.mkdir("tmp")
+    bids_root = tmp_path / "tmp"
+    bids_root.mkdir()
     curr_dir = os.getcwd()
     os.chdir(bids_root)
     bids_path = BIDSPath(subject='04', session='foo',
@@ -811,8 +812,10 @@ def test_find_empty_room(return_bids_test_dir, tmp_path):
     data_path = testing.data_path()
     raw_fname = op.join(data_path, 'MEG', 'sample',
                         'sample_audvis_trunc_raw.fif')
-    bids_root = tmp_path.mkdir("bids")
-    tmp_dir = tmp_path.mkdir("tmp")
+    bids_root = tmp_path / "bids"
+    bids_root.mkdir()
+    tmp_dir = tmp_path / "tmp"
+    tmp_dir.mkdir()
 
     raw = _read_raw_fif(raw_fname)
     bids_path = BIDSPath(subject='01', session='01',
@@ -875,7 +878,8 @@ def test_find_empty_room(return_bids_test_dir, tmp_path):
 
     # test that the `AssociatedEmptyRoom` key in MEG sidecar is respected
 
-    bids_root = tmp_path.mkdir('associated-empty-room')
+    bids_root = tmp_path / 'associated-empty-room'
+    bids_root.mkdir()
     raw = _read_raw_fif(raw_fname)
     meas_date = datetime(year=2020, month=1, day=10, tzinfo=timezone.utc)
     er_date = datetime(year=2010, month=1, day=1, tzinfo=timezone.utc)

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -214,7 +214,7 @@ def test_make_folders(tmp_path):
 
     # Check if a pathlib.Path bids_root works.
     bids_path = BIDSPath(subject='03', session='foo',
-                         datatype='eeg', root=Path(tmp_path))
+                         datatype='eeg', root=tmp_path)
     bids_path.mkdir().directory
     assert op.isdir(tmp_path / 'sub-03' / 'ses-foo' / 'eeg')
 

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -47,9 +47,9 @@ bids_path = BIDSPath(
 
 
 @pytest.fixture(scope='session')
-def return_bids_test_dir(tmpdir_factory):
+def return_bids_test_dir(tmp_path_factory):
     """Return path to a written test BIDS dir."""
-    bids_root = str(tmpdir_factory.mktemp('mnebids_utils_test_bids_ds'))
+    bids_root = str(tmp_path_factory.mktemp('mnebids_utils_test_bids_ds'))
     data_path = testing.data_path()
     raw_fname = op.join(data_path, 'MEG', 'sample',
                         'sample_audvis_trunc_raw.fif')
@@ -196,28 +196,28 @@ def test_print_dir_tree(capsys):
     assert '.pyc' not in out
 
 
-def test_make_folders(tmpdir):
+def test_make_folders(tmp_path):
     """Test that folders are created and named properly."""
     # Make sure folders are created properly
     bids_path = BIDSPath(subject='01', session='foo',
-                         datatype='eeg', root=str(tmpdir))
+                         datatype='eeg', root=str(tmp_path))
     bids_path.mkdir().directory
-    assert op.isdir(tmpdir / 'sub-01' / 'ses-foo' / 'eeg')
+    assert op.isdir(tmp_path / 'sub-01' / 'ses-foo' / 'eeg')
 
     # If we remove a kwarg the folder shouldn't be created
     bids_path = BIDSPath(subject='02', datatype='eeg',
-                         root=tmpdir)
+                         root=tmp_path)
     bids_path.mkdir().directory
-    assert op.isdir(tmpdir / 'sub-02' / 'eeg')
+    assert op.isdir(tmp_path / 'sub-02' / 'eeg')
 
     # Check if a pathlib.Path bids_root works.
     bids_path = BIDSPath(subject='03', session='foo',
-                         datatype='eeg', root=Path(tmpdir))
+                         datatype='eeg', root=Path(tmp_path))
     bids_path.mkdir().directory
-    assert op.isdir(tmpdir / 'sub-03' / 'ses-foo' / 'eeg')
+    assert op.isdir(tmp_path / 'sub-03' / 'ses-foo' / 'eeg')
 
     # Check if bids_root=None creates folders in the current working directory
-    bids_root = tmpdir.mkdir("tmp")
+    bids_root = tmp_path.mkdir("tmp")
     curr_dir = os.getcwd()
     os.chdir(bids_root)
     bids_path = BIDSPath(subject='04', session='foo',
@@ -806,13 +806,13 @@ def test_match(return_bids_test_dir):
 
 @pytest.mark.filterwarnings(warning_str['meas_date_set_to_none'])
 @pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
-def test_find_empty_room(return_bids_test_dir, tmpdir):
+def test_find_empty_room(return_bids_test_dir, tmp_path):
     """Test reading of empty room data."""
     data_path = testing.data_path()
     raw_fname = op.join(data_path, 'MEG', 'sample',
                         'sample_audvis_trunc_raw.fif')
-    bids_root = tmpdir.mkdir("bids")
-    tmp_dir = tmpdir.mkdir("tmp")
+    bids_root = tmp_path.mkdir("bids")
+    tmp_dir = tmp_path.mkdir("tmp")
 
     raw = _read_raw_fif(raw_fname)
     bids_path = BIDSPath(subject='01', session='01',
@@ -875,7 +875,7 @@ def test_find_empty_room(return_bids_test_dir, tmpdir):
 
     # test that the `AssociatedEmptyRoom` key in MEG sidecar is respected
 
-    bids_root = tmpdir.mkdir('associated-empty-room')
+    bids_root = tmp_path.mkdir('associated-empty-room')
     raw = _read_raw_fif(raw_fname)
     meas_date = datetime(year=2020, month=1, day=10, tzinfo=timezone.utc)
     er_date = datetime(year=2010, month=1, day=1, tzinfo=timezone.utc)
@@ -920,13 +920,13 @@ def test_find_empty_room(return_bids_test_dir, tmpdir):
 
 
 @pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
-def test_find_emptyroom_ties(tmpdir):
+def test_find_emptyroom_ties(tmp_path):
     """Test that we receive a warning on a date tie."""
     data_path = testing.data_path()
     raw_fname = op.join(data_path, 'MEG', 'sample',
                         'sample_audvis_trunc_raw.fif')
 
-    bids_root = str(tmpdir)
+    bids_root = str(tmp_path)
     bids_path.update(root=bids_root)
     session = '20010101'
     er_dir_path = BIDSPath(subject='emptyroom', session=session,
@@ -958,13 +958,13 @@ def test_find_emptyroom_ties(tmpdir):
 
 
 @pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
-def test_find_emptyroom_no_meas_date(tmpdir):
+def test_find_emptyroom_no_meas_date(tmp_path):
     """Test that we warn if measurement date can be read or inferred."""
     data_path = testing.data_path()
     raw_fname = op.join(data_path, 'MEG', 'sample',
                         'sample_audvis_trunc_raw.fif')
 
-    bids_root = str(tmpdir)
+    bids_root = str(tmp_path)
     bids_path.update(root=bids_root)
     er_session = 'mysession'
     er_meas_date = None

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -92,10 +92,10 @@ def test_read_raw():
         _read_raw(f)
 
 
-def test_not_implemented(tmpdir):
+def test_not_implemented(tmp_path):
     """Test the not yet implemented data formats raise an adequate error."""
     for not_implemented_ext in ['.mef', '.nwb']:
-        raw_fname = tmpdir / 'test' + not_implemented_ext
+        raw_fname = tmp_path / 'test' + not_implemented_ext
         with open(raw_fname, 'w', encoding='utf-8'):
             pass
         with pytest.raises(ValueError, match=('there is no IO support for '
@@ -116,9 +116,9 @@ def test_read_correct_inputs():
 
 
 @pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
-def test_read_participants_data(tmpdir):
+def test_read_participants_data(tmp_path):
     """Test reading information from a BIDS sidecar.json file."""
-    bids_path = _bids_path.copy().update(root=tmpdir, datatype='meg')
+    bids_path = _bids_path.copy().update(root=tmp_path, datatype='meg')
     raw = _read_raw_fif(raw_fname, verbose=False)
 
     # if subject info was set, we don't roundtrip birthday
@@ -138,7 +138,7 @@ def test_read_participants_data(tmpdir):
     assert 'participant_id' not in raw.info['subject_info']
 
     # if modifying participants tsv, then read_raw_bids reflects that
-    participants_tsv_fpath = tmpdir / 'participants.tsv'
+    participants_tsv_fpath = tmp_path / 'participants.tsv'
     participants_tsv = _from_tsv(participants_tsv_fpath)
     participants_tsv['hand'][0] = 'n/a'
     _to_tsv(participants_tsv, participants_tsv_fpath)
@@ -177,10 +177,10 @@ def test_read_participants_data(tmpdir):
 @pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
 def test_read_participants_handedness_and_sex_mapping(hand_bids, hand_mne,
                                                       sex_bids, sex_mne,
-                                                      tmpdir):
+                                                      tmp_path):
     """Test we're correctly mapping handedness and sex between BIDS and MNE."""
-    bids_path = _bids_path.copy().update(root=tmpdir, datatype='meg')
-    participants_tsv_fpath = tmpdir / 'participants.tsv'
+    bids_path = _bids_path.copy().update(root=tmp_path, datatype='meg')
+    participants_tsv_fpath = tmp_path / 'participants.tsv'
     raw = _read_raw_fif(raw_fname, verbose=False)
 
     # Avoid that we end up with subject information stored in the raw data.
@@ -199,7 +199,7 @@ def test_read_participants_handedness_and_sex_mapping(hand_bids, hand_mne,
 
 @requires_nibabel()
 @pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
-def test_get_head_mri_trans(tmpdir):
+def test_get_head_mri_trans(tmp_path):
     """Test getting a trans object from BIDS data."""
     import nibabel as nib
 
@@ -215,7 +215,7 @@ def test_get_head_mri_trans(tmpdir):
 
     # Write it to BIDS
     raw = _read_raw_fif(raw_fname)
-    bids_path = _bids_path.copy().update(root=tmpdir)
+    bids_path = _bids_path.copy().update(root=tmp_path)
     write_raw_bids(raw, bids_path, events_data=events, event_id=event_id,
                    overwrite=False)
 
@@ -287,8 +287,8 @@ def test_get_head_mri_trans(tmpdir):
     # Test t1_bids_path parameter
     #
     # Case 1: different BIDS roots
-    meg_bids_path = _bids_path.copy().update(root=tmpdir / 'meg_root')
-    t1_bids_path = _bids_path.copy().update(root=tmpdir / 'mri_root')
+    meg_bids_path = _bids_path.copy().update(root=tmp_path / 'meg_root')
+    t1_bids_path = _bids_path.copy().update(root=tmp_path / 'mri_root')
     raw = _read_raw_fif(raw_fname)
 
     write_raw_bids(raw, bids_path=meg_bids_path)
@@ -303,7 +303,7 @@ def test_get_head_mri_trans(tmpdir):
 
     # Case 2: different sessions
     raw = _read_raw_fif(raw_fname)
-    meg_bids_path = _bids_path.copy().update(root=tmpdir / 'session_test',
+    meg_bids_path = _bids_path.copy().update(root=tmp_path / 'session_test',
                                              session='01')
     t1_bids_path = meg_bids_path.copy().update(session='02')
 
@@ -321,7 +321,7 @@ def test_get_head_mri_trans(tmpdir):
             fs_subjects_dir=subjects_dir)
 
 
-def test_handle_events_reading(tmpdir):
+def test_handle_events_reading(tmp_path):
     """Test reading events from a BIDS events.tsv file."""
     # We can use any `raw` for this
     raw = _read_raw_fif(raw_fname)
@@ -331,7 +331,7 @@ def test_handle_events_reading(tmpdir):
     events = {'onset': [11, 12, 'n/a'],
               'duration': ['n/a', 'n/a', 'n/a'],
               'trial_type': ["rec start", "trial #1", "trial #2!"]}
-    events_fname = tmpdir.mkdir('bids1') / 'sub-01_task-test_events.json'
+    events_fname = tmp_path.mkdir('bids1') / 'sub-01_task-test_events.json'
     _to_tsv(events, events_fname)
 
     raw = _handle_events_reading(events_fname, raw)
@@ -341,7 +341,7 @@ def test_handle_events_reading(tmpdir):
     events = {'onset': [11, 12, 'n/a'],
               'duration': ['n/a', 'n/a', 'n/a'],
               'stim_type': ["rec start", "trial #1", "trial #2!"]}
-    events_fname = tmpdir.mkdir('bids2') / 'sub-01_task-test_events.json'
+    events_fname = tmp_path.mkdir('bids2') / 'sub-01_task-test_events.json'
     _to_tsv(events, events_fname)
 
     with pytest.warns(RuntimeWarning, match='This column should be renamed'):
@@ -353,7 +353,7 @@ def test_handle_events_reading(tmpdir):
               'duration': ['n/a', 'n/a', 'n/a'],
               'trial_type': ["event1", "event1", "event2"],
               'value': [1, 2, 3]}
-    events_fname = tmpdir.mkdir('bids3') / 'sub-01_task-test_events.json'
+    events_fname = tmp_path.mkdir('bids3') / 'sub-01_task-test_events.json'
     _to_tsv(events, events_fname)
 
     raw = _handle_events_reading(events_fname, raw)
@@ -368,7 +368,7 @@ def test_handle_events_reading(tmpdir):
     # Test without any kind of event description.
     events = {'onset': [11, 12, 'n/a'],
               'duration': ['n/a', 'n/a', 'n/a']}
-    events_fname = tmpdir.mkdir('bids4') / 'sub-01_task-test_events.json'
+    events_fname = tmp_path.mkdir('bids4') / 'sub-01_task-test_events.json'
     _to_tsv(events, events_fname)
 
     raw = _handle_events_reading(events_fname, raw)
@@ -379,7 +379,7 @@ def test_handle_events_reading(tmpdir):
 
 
 @pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
-def test_keep_essential_annotations(tmpdir):
+def test_keep_essential_annotations(tmp_path):
     """Test that essential Annotations are not omitted during I/O roundtrip."""
     raw = _read_raw_fif(raw_fname)
     annotations = mne.Annotations(onset=[raw.times[0]], duration=[1],
@@ -388,7 +388,7 @@ def test_keep_essential_annotations(tmpdir):
 
     # Write data, remove events.tsv, then try to read again
     bids_path = BIDSPath(subject='01', task='task', datatype='meg',
-                         root=tmpdir)
+                         root=tmp_path)
     with pytest.warns(RuntimeWarning, match='Acquisition skips detected'):
         write_raw_bids(raw, bids_path, overwrite=True)
 
@@ -401,7 +401,7 @@ def test_keep_essential_annotations(tmpdir):
 
 
 @pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
-def test_handle_scans_reading(tmpdir):
+def test_handle_scans_reading(tmp_path):
     """Test reading data from a BIDS scans.tsv file."""
     raw = _read_raw_fif(raw_fname)
     suffix = "meg"
@@ -411,7 +411,7 @@ def test_handle_scans_reading(tmpdir):
     bids_path = BIDSPath(subject='01', session='01',
                          task='audiovisual', run='01',
                          datatype=suffix,
-                         root=tmpdir)
+                         root=tmp_path)
     bids_path = write_raw_bids(raw, bids_path, overwrite=True)
     raw_01 = read_raw_bids(bids_path)
 
@@ -419,7 +419,7 @@ def test_handle_scans_reading(tmpdir):
     # acquisition time to not have the optional microseconds
     scans_path = BIDSPath(subject=bids_path.subject,
                           session=bids_path.session,
-                          root=tmpdir,
+                          root=tmp_path,
                           suffix='scans', extension='.tsv')
     scans_tsv = _from_tsv(scans_path)
     acq_time_str = scans_tsv['acq_time'][0]
@@ -442,7 +442,7 @@ def test_handle_scans_reading(tmpdir):
 
 
 @pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
-def test_handle_info_reading(tmpdir):
+def test_handle_info_reading(tmp_path):
     """Test reading information from a BIDS sidecar JSON file."""
     # read in USA dataset, so it should find 50 Hz
     raw = _read_raw_fif(raw_fname)
@@ -451,7 +451,7 @@ def test_handle_info_reading(tmpdir):
     # bids basename and fname
     bids_path = BIDSPath(subject='01', session='01',
                          task='audiovisual', run='01',
-                         root=tmpdir)
+                         root=tmp_path)
     suffix = "meg"
     bids_fname = bids_path.copy().update(suffix=suffix,
                                          extension='.fif')
@@ -511,7 +511,7 @@ def test_handle_info_reading(tmpdir):
     # in `read_raw_bids`
     raw.info['line_freq'] = 60
     write_raw_bids(raw, bids_path, overwrite=True)
-    deriv_dir = tmpdir.mkdir("derivatives")
+    deriv_dir = tmp_path.mkdir("derivatives")
     sidecar_copy = deriv_dir / op.basename(sidecar_fname)
     with open(sidecar_fname, "r", encoding='utf-8') as fin:
         sidecar_json = json.load(fin)
@@ -530,10 +530,10 @@ def test_handle_info_reading(tmpdir):
 @requires_version('mne', '0.24.dev0')
 @pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
 @pytest.mark.filterwarnings(warning_str['maxshield'])
-def test_handle_chpi_reading(tmpdir):
+def test_handle_chpi_reading(tmp_path):
     """Test reading of cHPI information."""
     raw = _read_raw_fif(raw_fname_chpi, allow_maxshield=True)
-    root = tmpdir.mkdir('chpi')
+    root = tmp_path.mkdir('chpi')
     bids_path = BIDSPath(subject='01', session='01',
                          task='audiovisual', run='01',
                          root=root, datatype='meg')
@@ -567,11 +567,11 @@ def test_handle_chpi_reading(tmpdir):
 
 @pytest.mark.filterwarnings(warning_str['nasion_not_found'])
 @pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
-def test_handle_eeg_coords_reading(tmpdir):
+def test_handle_eeg_coords_reading(tmp_path):
     """Test reading iEEG coordinates from BIDS files."""
     bids_path = BIDSPath(
         subject=subject_id, session=session_id, run=run, acquisition=acq,
-        task=task, root=tmpdir)
+        task=task, root=tmp_path)
 
     data_path = op.join(testing.data_path(), 'EDF')
     raw_fname = op.join(data_path, 'test_reduced.edf')
@@ -594,7 +594,7 @@ def test_handle_eeg_coords_reading(tmpdir):
     with pytest.warns(RuntimeWarning, match="Skipping EEG electrodes.tsv"):
         write_raw_bids(raw, bids_path, overwrite=True)
 
-    bids_path.update(root=tmpdir)
+    bids_path.update(root=tmp_path)
     coordsystem_fname = _find_matching_sidecar(bids_path,
                                                suffix='coordsystem',
                                                extension='.json',
@@ -642,14 +642,14 @@ def test_handle_eeg_coords_reading(tmpdir):
                          [_bids_path, _bids_path_minimal])
 @pytest.mark.filterwarnings(warning_str['nasion_not_found'])
 @pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
-def test_handle_ieeg_coords_reading(bids_path, tmpdir):
+def test_handle_ieeg_coords_reading(bids_path, tmp_path):
     """Test reading iEEG coordinates from BIDS files."""
     data_path = op.join(testing.data_path(), 'EDF')
     raw_fname = op.join(data_path, 'test_reduced.edf')
     bids_fname = bids_path.copy().update(datatype='ieeg',
                                          suffix='ieeg',
                                          extension='.edf',
-                                         root=tmpdir)
+                                         root=tmp_path)
     raw = _read_raw_edf(raw_fname)
 
     # ensure we are writing 'ecog'/'ieeg' data
@@ -664,7 +664,7 @@ def test_handle_ieeg_coords_reading(bids_path, tmpdir):
     coordinate_frames = ['mni_tal']
     for coord_frame in coordinate_frames:
         # XXX: mne-bids doesn't support multiple electrodes.tsv files
-        sh.rmtree(tmpdir)
+        sh.rmtree(tmp_path)
         montage = mne.channels.make_dig_montage(ch_pos=ch_pos,
                                                 coord_frame=coord_frame)
         raw.set_montage(montage)
@@ -678,7 +678,7 @@ def test_handle_ieeg_coords_reading(bids_path, tmpdir):
             assert digpoint['coord_frame'] == coord_frame_int
 
     # start w/ new bids root
-    sh.rmtree(tmpdir)
+    sh.rmtree(tmp_path)
     write_raw_bids(raw, bids_fname, overwrite=True, verbose=False)
 
     # obtain the sensor positions and assert ch_coords are same
@@ -691,7 +691,7 @@ def test_handle_ieeg_coords_reading(bids_path, tmpdir):
     # read in the data and assert montage is the same
     # regardless of 'm', 'cm', 'mm', or 'pixel'
     scalings = {'m': 1, 'cm': 100, 'mm': 1000}
-    bids_fname.update(root=tmpdir)
+    bids_fname.update(root=tmp_path)
     coordsystem_fname = _find_matching_sidecar(bids_fname,
                                                suffix='coordsystem',
                                                extension='.json')
@@ -775,7 +775,7 @@ def test_handle_ieeg_coords_reading(bids_path, tmpdir):
         raw = read_raw_bids(bids_path=bids_fname, verbose=False)
 
     # test error message if electrodes is not a subset of Raw
-    bids_path.update(root=tmpdir)
+    bids_path.update(root=tmp_path)
     write_raw_bids(raw, bids_path, overwrite=True)
     electrodes_dict = _from_tsv(electrodes_fname)
     # pop off 5 channels
@@ -817,14 +817,14 @@ def test_handle_ieeg_coords_reading(bids_path, tmpdir):
 @requires_nibabel()
 @pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
 @pytest.mark.parametrize('fname', ['testdata_ctf.ds', 'catch-alp-good-f.ds'])
-def test_get_head_mri_trans_ctf(fname, tmpdir):
+def test_get_head_mri_trans_ctf(fname, tmp_path):
     """Test getting a trans object from BIDS data in CTF."""
     import nibabel as nib
 
     ctf_data_path = op.join(testing.data_path(), 'CTF')
     raw_ctf_fname = op.join(ctf_data_path, fname)
     raw_ctf = _read_raw_ctf(raw_ctf_fname, clean_names=True)
-    bids_path = _bids_path.copy().update(root=tmpdir)
+    bids_path = _bids_path.copy().update(root=tmp_path)
     write_raw_bids(raw_ctf, bids_path, overwrite=False)
 
     # Take a fake trans
@@ -836,7 +836,7 @@ def test_get_head_mri_trans_ctf(fname, tmpdir):
     t1w_mgh = nib.load(t1w_mgh)
 
     t1w_bids_path = BIDSPath(subject=subject_id, session=session_id,
-                             acquisition=acq, root=tmpdir)
+                             acquisition=acq, root=tmp_path)
     landmarks = get_anat_landmarks(
         t1w_mgh, raw_ctf.info, trans, fs_subject='sample',
         fs_subjects_dir=op.join(data_path, 'subjects'))
@@ -851,18 +851,18 @@ def test_get_head_mri_trans_ctf(fname, tmpdir):
 
 
 @pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
-def test_read_raw_bids_pathlike(tmpdir):
+def test_read_raw_bids_pathlike(tmp_path):
     """Test that read_raw_bids() can handle a Path-like bids_root."""
-    bids_path = _bids_path.copy().update(root=tmpdir, datatype='meg')
+    bids_path = _bids_path.copy().update(root=tmp_path, datatype='meg')
     raw = _read_raw_fif(raw_fname, verbose=False)
     write_raw_bids(raw, bids_path, overwrite=True, verbose=False)
     raw = read_raw_bids(bids_path=bids_path)
 
 
 @pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
-def test_read_raw_datatype(tmpdir):
+def test_read_raw_datatype(tmp_path):
     """Test that read_raw_bids() can infer the str_suffix if need be."""
-    bids_path = _bids_path.copy().update(root=tmpdir, datatype='meg')
+    bids_path = _bids_path.copy().update(root=tmp_path, datatype='meg')
     raw = _read_raw_fif(raw_fname, verbose=False)
     write_raw_bids(raw, bids_path, overwrite=True, verbose=False)
 
@@ -879,15 +879,15 @@ def test_read_raw_datatype(tmpdir):
     assert raw_1 == raw_3
 
 
-def test_handle_channel_type_casing(tmpdir):
+def test_handle_channel_type_casing(tmp_path):
     """Test that non-uppercase entries in the `type` column are accepted."""
-    bids_path = _bids_path.copy().update(root=tmpdir)
+    bids_path = _bids_path.copy().update(root=tmp_path)
     raw = _read_raw_fif(raw_fname, verbose=False)
 
     write_raw_bids(raw, bids_path, overwrite=True,
                    verbose=False)
 
-    ch_path = bids_path.copy().update(root=tmpdir,
+    ch_path = bids_path.copy().update(root=tmp_path,
                                       datatype='meg',
                                       suffix='channels',
                                       extension='.tsv')
@@ -903,8 +903,8 @@ def test_handle_channel_type_casing(tmpdir):
 
 
 @pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
-def test_bads_reading(tmpdir):
-    bids_path = _bids_path.copy().update(root=tmpdir, datatype='meg')
+def test_bads_reading(tmp_path):
+    bids_path = _bids_path.copy().update(root=tmp_path, datatype='meg')
     bads_raw = ['MEG 0112', 'MEG 0113']
     bads_sidecar = ['EEG 053', 'MEG 2443']
 
@@ -925,11 +925,11 @@ def test_bads_reading(tmpdir):
 
 
 @pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
-def test_write_read_fif_split_file(tmpdir):
+def test_write_read_fif_split_file(tmp_path):
     """Test split files are read correctly."""
     # load raw test file, extend it to be larger than 2gb, and save it
-    bids_root = tmpdir.mkdir('bids')
-    tmp_dir = tmpdir.mkdir('tmp')
+    bids_root = tmp_path.mkdir('bids')
+    tmp_dir = tmp_path.mkdir('tmp')
     bids_path = _bids_path.copy().update(root=bids_root, datatype='meg')
     raw = _read_raw_fif(raw_fname, verbose=False)
     bids_path.update(acquisition=None)
@@ -984,9 +984,9 @@ def test_write_read_fif_split_file(tmpdir):
 
 
 @pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
-def test_ignore_exclude_param(tmpdir):
+def test_ignore_exclude_param(tmp_path):
     """Test that extra_params=dict(exclude=...) is being ignored."""
-    bids_path = _bids_path.copy().update(root=tmpdir)
+    bids_path = _bids_path.copy().update(root=tmp_path)
     ch_name = 'EEG 001'
     raw = _read_raw_fif(raw_fname, verbose=False)
     write_raw_bids(raw, bids_path=bids_path, overwrite=True, verbose=False)
@@ -997,9 +997,9 @@ def test_ignore_exclude_param(tmpdir):
 
 
 @pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
-def test_channels_tsv_raw_mismatch(tmpdir):
+def test_channels_tsv_raw_mismatch(tmp_path):
     """Test behavior when channels.tsv contains channels not found in raw."""
-    bids_path = _bids_path.copy().update(root=tmpdir, datatype='meg',
+    bids_path = _bids_path.copy().update(root=tmp_path, datatype='meg',
                                          task='rest')
 
     # Remove one channel from the raw data without updating channels.tsv

--- a/mne_bids/tests/test_report.py
+++ b/mne_bids/tests/test_report.py
@@ -35,9 +35,9 @@ warning_str = dict(
 
 
 @pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
-def test_report(tmpdir):
+def test_report(tmp_path):
     """Test that report generated works as intended."""
-    bids_root = str(tmpdir)
+    bids_root = str(tmp_path)
     raw = mne.io.read_raw_fif(raw_fname, verbose=False)
     raw.info['line_freq'] = 60
     bids_path.update(root=bids_root)

--- a/mne_bids/tests/test_stats.py
+++ b/mne_bids/tests/test_stats.py
@@ -85,9 +85,9 @@ def _check_counts(counts, events, event_id, subjects,
     ]
 )
 @requires_pandas
-def test_count_events(tmpdir, subjects, tasks, runs, sessions):
+def test_count_events(tmp_path, subjects, tasks, runs, sessions):
     """Test the event counts."""
-    root, events, event_id = _make_dataset(tmpdir, subjects, tasks, runs,
+    root, events, event_id = _make_dataset(tmp_path, subjects, tasks, runs,
                                            sessions)
 
     counts = count_events(root)
@@ -96,10 +96,10 @@ def test_count_events(tmpdir, subjects, tasks, runs, sessions):
 
 
 @requires_pandas
-def test_count_events_bids_path(tmpdir):
+def test_count_events_bids_path(tmp_path):
     """Test the event counts passing a BIDSPath."""
     root, events, event_id = \
-        _make_dataset(tmpdir, subjects=['01', '02'], tasks=['task1'])
+        _make_dataset(tmp_path, subjects=['01', '02'], tasks=['task1'])
 
     with pytest.raises(ValueError, match='datatype .*anat.* is not supported'):
         bids_path = BIDSPath(root=root, subject='01', datatype='anat')
@@ -112,14 +112,14 @@ def test_count_events_bids_path(tmpdir):
 
 
 @requires_pandas
-def test_count_no_events_file(tmpdir):
+def test_count_no_events_file(tmp_path):
     """Test count_events with no event present."""
     data_path = testing.data_path()
     raw_fname = \
         Path(data_path) / 'MEG' / 'sample' / 'sample_audvis_trunc_raw.fif'
     raw = mne.io.read_raw(raw_fname)
     raw.info['line_freq'] = 60.
-    root = str(tmpdir)
+    root = str(tmp_path)
 
     bids_path = BIDSPath(
         subject='01', task='task1', root=root,
@@ -131,10 +131,10 @@ def test_count_no_events_file(tmpdir):
 
 
 @requires_pandas
-def test_count_no_events_column(tmpdir):
+def test_count_no_events_column(tmp_path):
     """Test case where events.tsv doesn't contain [stim,trial]_type column."""
     subject, task, run, session, datatype = '01', 'task1', '01', '01', 'meg'
-    root, events, event_id = _make_dataset(tmpdir, [subject], [task], [run],
+    root, events, event_id = _make_dataset(tmp_path, [subject], [task], [run],
                                            [session])
 
     # Delete the `stim_type` column.

--- a/mne_bids/tests/test_tsv_handler.py
+++ b/mne_bids/tests/test_tsv_handler.py
@@ -19,7 +19,7 @@ from mne_bids.tsv_handler import (_from_tsv, _to_tsv, _combine_rows, _drop,
 import pytest
 
 
-def test_tsv_handler(tmpdir):
+def test_tsv_handler(tmp_path):
     """Test the TSV handling."""
     # create some dummy data
     d = odict(a=[1, 2, 3, 4], b=['five', 'six', 'seven', 'eight'])
@@ -36,7 +36,7 @@ def test_tsv_handler(tmpdir):
     assert 'nine' not in d['b']
     print(_tsv_to_str(d))
 
-    d_path = tmpdir / 'output.tsv'
+    d_path = tmp_path / 'output.tsv'
 
     # write the data to an output tsv file
     _to_tsv(d, d_path)

--- a/mne_bids/tests/test_update.py
+++ b/mne_bids/tests/test_update.py
@@ -33,9 +33,9 @@ bids_path = BIDSPath(
 
 
 @pytest.fixture(scope='session')
-def _get_bids_test_dir(tmpdir_factory):
+def _get_bids_test_dir(tmp_path_factory):
     """Return path to a written test BIDS dir."""
-    bids_root = str(tmpdir_factory.mktemp('mnebids_utils_test_bids_ds'))
+    bids_root = str(tmp_path_factory.mktemp('mnebids_utils_test_bids_ds'))
     data_path = testing.data_path()
     raw_fname = op.join(data_path, 'MEG', 'sample',
                         'sample_audvis_trunc_raw.fif')
@@ -138,7 +138,7 @@ def test_update_sidecar_jsons(_get_bids_test_dir, _bids_validate,
 
 
 @requires_nibabel()
-def test_update_anat_landmarks(tmpdir):
+def test_update_anat_landmarks(tmp_path):
     """Test updating the anatomical landmarks of an MRI scan."""
     data_path = Path(testing.data_path())
     raw_path = data_path / 'MEG' / 'sample' / 'sample_audvis_trunc_raw.fif'
@@ -146,7 +146,7 @@ def test_update_anat_landmarks(tmpdir):
     t1_path = data_path / 'subjects' / 'sample' / 'mri' / 'T1.mgz'
     fs_subject = 'sample'
     fs_subjects_dir = data_path / 'subjects'
-    bids_root = Path(tmpdir)
+    bids_root = Path(tmp_path)
     bids_path_mri = BIDSPath(subject=subject_id, session=session_id,
                              acquisition=acq, root=bids_root, datatype='anat',
                              suffix='T1w')

--- a/mne_bids/tests/test_update.py
+++ b/mne_bids/tests/test_update.py
@@ -146,7 +146,7 @@ def test_update_anat_landmarks(tmp_path):
     t1_path = data_path / 'subjects' / 'sample' / 'mri' / 'T1.mgz'
     fs_subject = 'sample'
     fs_subjects_dir = data_path / 'subjects'
-    bids_root = Path(tmp_path)
+    bids_root = tmp_path
     bids_path_mri = BIDSPath(subject=subject_id, session=session_id,
                              acquisition=acq, root=bids_root, datatype='anat',
                              suffix='T1w')

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -1869,7 +1869,7 @@ def test_write_anat(_bids_validate, tmp_path):
 
 
 def test_write_raw_pathlike(tmp_path):
-    data_path = testing.data_path()
+    data_path = Path(testing.data_path())
     raw_fname = op.join(data_path, 'MEG', 'sample',
                         'sample_audvis_trunc_raw.fif')
     event_id = {'Auditory/Left': 1, 'Auditory/Right': 2, 'Visual/Left': 3,
@@ -1877,9 +1877,9 @@ def test_write_raw_pathlike(tmp_path):
                 'unknown': 0}
     raw = _read_raw_fif(raw_fname)
 
-    bids_root = Path(tmp_path)
-    events_fname = \
-        Path(data_path) / 'MEG' / 'sample' / 'sample_audvis_trunc_raw-eve.fif'
+    bids_root = tmp_path
+    events_fname =  (data_path / 'MEG' / 'sample' /
+                     'sample_audvis_trunc_raw-eve.fif')
     bids_path = _bids_path.copy().update(root=bids_root)
     bids_path_ = write_raw_bids(raw=raw, bids_path=bids_path,
                                 events_data=events_fname,
@@ -1895,7 +1895,7 @@ def test_write_raw_no_dig(tmp_path):
     raw_fname = op.join(data_path, 'MEG', 'sample',
                         'sample_audvis_trunc_raw.fif')
     raw = _read_raw_fif(raw_fname)
-    bids_root = Path(tmp_path)
+    bids_root = tmp_path
     bids_path = _bids_path.copy().update(root=bids_root)
     bids_path_ = write_raw_bids(raw=raw, bids_path=bids_path,
                                 overwrite=True)
@@ -1921,7 +1921,7 @@ def test_write_anat_pathlike(tmp_path):
     raw = _read_raw_fif(raw_fname)
     trans = mne.read_trans(trans_fname)
 
-    bids_root = Path(tmp_path)
+    bids_root = tmp_path
     t1w_mgh_fname = Path(data_path) / 'subjects' / 'sample' / 'mri' / 'T1.mgz'
     bids_path = BIDSPath(subject=subject_id, session=session_id,
                          acquisition=acq, root=bids_root)
@@ -3002,7 +3002,7 @@ def test_write_raw_special_paths(tmp_path, dir_name):
                         'sample_audvis_trunc_raw.fif')
     raw = _read_raw_fif(raw_fname)
 
-    root = Path(tmp_path) / dir_name
+    root = tmp_path / dir_name
     bids_path = _bids_path.copy().update(root=root)
     write_raw_bids(raw=raw, bids_path=bids_path)
 

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -339,8 +339,10 @@ def test_get_anonymization_daysback():
 
 def test_create_fif(_bids_validate, tmp_path):
     """Test functionality for very short raw file created from data."""
-    out_dir = tmp_path.mkdir('out')
-    bids_root = tmp_path.mkdir('bids')
+    out_dir = tmp_path / 'out'
+    bids_root = tmp_path / 'bids'
+    out_dir.mkdir()
+
     bids_path = _bids_path.copy().update(root=bids_root)
     sfreq, n_points = 1024., int(1e6)
     info = mne.create_info(['ch1', 'ch2', 'ch3', 'ch4', 'ch5'], sfreq,
@@ -357,8 +359,9 @@ def test_create_fif(_bids_validate, tmp_path):
 @pytest.mark.parametrize('line_freq', [60, None])
 def test_line_freq(line_freq, _bids_validate, tmp_path):
     """Test the power line frequency is written correctly."""
-    out_dir = tmp_path.mkdir('out')
-    bids_root = tmp_path.mkdir('bids')
+    out_dir = tmp_path / 'out'
+    out_dir.mkdir()
+    bids_root = tmp_path / 'bids'
     bids_path = _bids_path.copy().update(root=bids_root)
     sfreq, n_points = 1024., int(1e6)
     info = mne.create_info(['ch1', 'ch2', 'ch3', 'ch4', 'ch5'], sfreq,
@@ -389,7 +392,7 @@ def test_line_freq(line_freq, _bids_validate, tmp_path):
 @pytest.mark.filterwarnings(warning_str['maxshield'])
 def test_fif(_bids_validate, tmp_path):
     """Test functionality of the write_raw_bids conversion for fif."""
-    bids_root = tmp_path.mkdir('bids1')
+    bids_root = tmp_path / 'bids1'
     bids_path = _bids_path.copy().update(root=bids_root, datatype='meg')
     data_path = testing.data_path()
     raw_fname = op.join(data_path, 'MEG', 'sample',
@@ -424,7 +427,7 @@ def test_fif(_bids_validate, tmp_path):
     raw.set_channel_types({raw.ch_names[i]: 'misc'
                            for i in
                            mne.pick_types(raw.info, stim=True, meg=False)})
-    bids_root = tmp_path.mkdir('bids2')
+    bids_root = tmp_path / 'bids2'
     bids_path.update(root=bids_root)
     with pytest.warns(RuntimeWarning, match='No events found or provided.'):
         write_raw_bids(raw, bids_path, overwrite=False)
@@ -432,12 +435,13 @@ def test_fif(_bids_validate, tmp_path):
     _bids_validate(bids_root)
 
     # try with eeg data only (conversion to bv)
-    bids_root = tmp_path.mkdir('bids3')
+    bids_root = tmp_path / 'bids3'
+    bids_root.mkdir()
     bids_path.update(root=bids_root)
     raw = _read_raw_fif(raw_fname)
     raw.load_data()
     raw2 = raw.pick_types(meg=False, eeg=True, stim=True, eog=True, ecg=True)
-    raw2.save(op.join(bids_root, 'test-raw.fif'), overwrite=True)
+    raw2.save(bids_root / 'test-raw.fif', overwrite=True)
     raw2 = mne.io.Raw(op.join(bids_root, 'test-raw.fif'), preload=False)
     events = mne.find_events(raw2)
     event_id = {'auditory/left': 1, 'auditory/right': 2, 'visual/left': 3,
@@ -525,8 +529,8 @@ def test_fif(_bids_validate, tmp_path):
     raw = _read_raw_fif(raw_fname)
     raw.anonymize()
 
-    data_path2 = tmp_path.mkdir('tmp_anon')
-    raw_fname2 = data_path2 / 'sample_audvis_raw.fif'
+    raw_fname2 = tmp_path / 'tmp_anon' / 'sample_audvis_raw.fif'
+    raw_fname2.parent.mkdir()
     raw.save(raw_fname2)
 
     # add some readme text
@@ -586,8 +590,8 @@ def test_fif(_bids_validate, tmp_path):
 
     # check that split files have split key
     raw = _read_raw_fif(raw_fname)
-    data_path3 = tmp_path.mkdir('test-split-key')
-    raw_fname3 = data_path3 / 'sample_audvis_raw.fif'
+    raw_fname3 = tmp_path / 'test-split-key' / 'sample_audvis_raw.fif'
+    raw_fname3.parent.mkdir()
     raw.save(raw_fname3, buffer_size_sec=1.0, split_size='10MB',
              split_naming='neuromag', overwrite=True)
     raw = _read_raw_fif(raw_fname3)
@@ -673,15 +677,14 @@ def test_chpi(_bids_validate, tmp_path, format):
         raw = _read_raw_kit(kit_raw_fname, mrk=kit_hpi_fname,
                             elp=kit_electrode_fname, hsp=kit_headshape_fname)
 
-    bids_root = tmp_path.mkdir('bids')
+    bids_root = tmp_path / 'bids'
     bids_path = _bids_path.copy().update(root=bids_root, datatype='meg')
 
     write_raw_bids(raw, bids_path)
     _bids_validate(bids_path.root)
 
     meg_json = bids_path.copy().update(suffix='meg', extension='.json')
-    with open(meg_json, 'r') as f:
-        meg_json_data = json.load(f)
+    meg_json_data = json.loads(meg_json.fpath.read_text(encoding='utf-8'))
 
     if parse_version(mne.__version__) <= parse_version('0.23'):
         assert 'ContinuousHeadLocalization' not in meg_json_data
@@ -723,7 +726,7 @@ def test_fif_dtype(_bids_validate, tmp_path):
 
 def test_fif_anonymize(_bids_validate, tmp_path):
     """Test write_raw_bids() with anonymization fif."""
-    bids_root = tmp_path.mkdir('bids1')
+    bids_root = tmp_path / 'bids1'
     bids_path = _bids_path.copy().update(root=bids_root)
     data_path = testing.data_path()
     raw_fname = op.join(data_path, 'MEG', 'sample',
@@ -744,21 +747,21 @@ def test_fif_anonymize(_bids_validate, tmp_path):
         write_raw_bids(raw, bids_path, events_data=events, event_id=event_id,
                        anonymize=dict(), overwrite=True)
 
-    bids_root = tmp_path.mkdir('bids2')
+    bids_root = tmp_path / 'bids2'
     bids_path.update(root=bids_root)
     raw = _read_raw_fif(raw_fname)
     with pytest.warns(RuntimeWarning, match='daysback` is too small'):
         write_raw_bids(raw, bids_path, events_data=events, event_id=event_id,
                        anonymize=dict(daysback=400), overwrite=False)
 
-    bids_root = tmp_path.mkdir('bids3')
+    bids_root = tmp_path / 'bids3'
     bids_path.update(root=bids_root)
     raw = _read_raw_fif(raw_fname)
     with pytest.raises(ValueError, match='`daysback` exceeds maximum value'):
         write_raw_bids(raw, bids_path, events_data=events, event_id=event_id,
                        anonymize=dict(daysback=40000), overwrite=False)
 
-    bids_root = tmp_path.mkdir('bids4')
+    bids_root = tmp_path / 'bids4'
     bids_path.update(root=bids_root)
     raw = _read_raw_fif(raw_fname)
     write_raw_bids(raw, bids_path, events_data=events, event_id=event_id,
@@ -813,7 +816,7 @@ def test_fif_exci(tmp_path):
 
 def test_kit(_bids_validate, tmp_path):
     """Test functionality of the write_raw_bids conversion for KIT data."""
-    bids_root = tmp_path.mkdir("bids")
+    bids_root = tmp_path / 'bids'
     data_path = op.join(base_path, 'kit', 'tests', 'data')
     raw_fname = op.join(data_path, 'test.sqd')
     events_fname = op.join(data_path, 'test-eve.txt')
@@ -847,8 +850,9 @@ def test_kit(_bids_validate, tmp_path):
     assert op.exists(marker_fname)
 
     # test anonymize
-    output_path = _test_anonymize(tmp_path.mkdir('tmp1'), raw, kit_bids_path,
-                                  events_fname, event_id)
+    output_path = _test_anonymize(
+        tmp_path / 'tmp1', raw, kit_bids_path, events_fname, event_id
+    )
     _bids_validate(output_path)
 
     # ensure the channels file has no STI 014 channel:
@@ -865,7 +869,7 @@ def test_kit(_bids_validate, tmp_path):
     event_data = np.loadtxt(events_fname)
     # make the data the wrong number of dimensions
     event_data_3d = np.atleast_3d(event_data)
-    other_output_path = tmp_path.mkdir('tmp2')
+    other_output_path = tmp_path / 'tmp2'
     bids_path = _bids_path.copy().update(root=other_output_path)
     with pytest.raises(ValueError, match='two dimensions'):
         write_raw_bids(raw, bids_path, events_data=event_data_3d,
@@ -909,7 +913,7 @@ def test_kit(_bids_validate, tmp_path):
     hpi_fname = op.join(data_path, 'MQKIT_125.mrk')
     electrode_fname = op.join(data_path, 'MQKIT_125.elp')
     headshape_fname = op.join(data_path, 'MQKIT_125.hsp')
-    bids_root = tmp_path.mkdir("bids_kit_mrk")
+    bids_root = tmp_path / 'bids_kit_mrk'
     kit_bids_path = _bids_path.copy().update(acquisition=None,
                                              root=bids_root,
                                              suffix='meg')
@@ -925,7 +929,7 @@ def test_kit(_bids_validate, tmp_path):
     # Check that we can successfully write even when elp, hsp, and mrk are not
     # supplied
     raw = _read_raw_kit(raw_fname)
-    bids_root = tmp_path.mkdir('no_elp_hsp_mrk')
+    bids_root = tmp_path / 'no_elp_hsp_mrk'
     kit_bids_path = kit_bids_path.copy().update(root=bids_root)
     write_raw_bids(raw=raw, bids_path=kit_bids_path)
     _bids_validate(bids_root)
@@ -958,7 +962,7 @@ def test_ctf(_bids_validate, tmp_path):
     raw = _read_raw_ctf(raw_fname)
     with pytest.warns(RuntimeWarning,
                       match='Converting to FIF for anonymization'):
-        output_path = _test_anonymize(tmp_path.mkdir('tmp'), raw, bids_path)
+        output_path = _test_anonymize(tmp_path / 'tmp', raw, bids_path)
     _bids_validate(output_path)
 
     raw.set_meas_date(None)
@@ -997,7 +1001,7 @@ def test_bti(_bids_validate, tmp_path):
                         head_shape_fname=headshape_fname)
     with pytest.warns(RuntimeWarning,
                       match='Converting to FIF for anonymization'):
-        output_path = _test_anonymize(tmp_path.mkdir('tmp'), raw, bids_path)
+        output_path = _test_anonymize(tmp_path / 'tmp', raw, bids_path)
     _bids_validate(output_path)
 
 
@@ -1005,7 +1009,7 @@ def test_bti(_bids_validate, tmp_path):
                             warning_str['unraisable_exception'])
 def test_vhdr(_bids_validate, tmp_path):
     """Test write_raw_bids conversion for BrainVision data."""
-    bids_root = tmp_path.mkdir('bids1')
+    bids_root = tmp_path / 'bids1'
     data_path = op.join(base_path, 'brainvision', 'tests', 'data')
     raw_fname = op.join(data_path, 'test.vhdr')
 
@@ -1051,16 +1055,10 @@ def test_vhdr(_bids_validate, tmp_path):
     events_tsv_fname = channels_tsv_name.update(suffix='events')
     assert op.exists(events_tsv_fname)
 
-    # create another bids folder with the overwrite command and check
-    # no files are in the folder
-    data_path = BIDSPath(subject=subject_id, datatype='eeg',
-                         root=bids_root).mkdir().directory
-    assert len([f for f in os.listdir(data_path) if op.isfile(f)]) == 0
-
     # test anonymize and convert
     if check_version('pybv', '0.6'):
         raw = _read_raw_brainvision(raw_fname)
-        output_path = _test_anonymize(tmp_path.mkdir('tmp'), raw, bids_path)
+        output_path = _test_anonymize(tmp_path / 'tmp', raw, bids_path)
         _bids_validate(output_path)
 
     # Also cover iEEG
@@ -1068,7 +1066,7 @@ def test_vhdr(_bids_validate, tmp_path):
     raw = _read_raw_brainvision(raw_fname)
     raw.set_channel_types({raw.ch_names[i]: 'ecog'
                            for i in mne.pick_types(raw.info, eeg=True)})
-    bids_root = tmp_path.mkdir('bids2')
+    bids_root = tmp_path / 'bids2'
     bids_path.update(root=bids_root, datatype='ieeg')
     write_raw_bids(raw, bids_path, overwrite=False)
     _bids_validate(bids_root)
@@ -1077,7 +1075,7 @@ def test_vhdr(_bids_validate, tmp_path):
     raw = _read_raw_brainvision(raw_fname)
     raw.set_channel_types({raw.ch_names[i]: 'dbs'
                            for i in mne.pick_types(raw.info, eeg=True)})
-    bids_root = tmp_path.mkdir('bids_dbs')
+    bids_root = tmp_path / 'bids_dbs'
     bids_path.update(root=bids_root)
     write_raw_bids(raw, bids_path, overwrite=False)
     _bids_validate(bids_root)
@@ -1093,7 +1091,7 @@ def test_vhdr(_bids_validate, tmp_path):
     raw.set_montage(montage)
 
     # convert to BIDS
-    bids_root = tmp_path.mkdir('bids3')
+    bids_root = tmp_path / 'bids3'
     bids_path.update(root=bids_root, datatype='eeg')
     write_raw_bids(raw, bids_path)
 
@@ -1131,7 +1129,7 @@ def test_vhdr(_bids_validate, tmp_path):
 )
 def test_eegieeg(dir_name, fname, reader, _bids_validate, tmp_path):
     """Test write_raw_bids conversion for EEG/iEEG data formats."""
-    bids_root = tmp_path.mkdir('bids1')
+    bids_root = tmp_path / 'bids1'
     data_path = op.join(testing.data_path(), dir_name)
     raw_fname = op.join(data_path, fname)
 
@@ -1337,7 +1335,7 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate, tmp_path):
     eeg_picks = mne.pick_types(ieeg_raw.info, eeg=True)
     ieeg_raw.set_channel_types({raw.ch_names[i]: 'ecog'
                                 for i in eeg_picks})
-    bids_root = tmp_path.mkdir('bids2')
+    bids_root = tmp_path / 'bids2'
     bids_path.update(root=bids_root, datatype='ieeg')
     kwargs = dict(raw=ieeg_raw, bids_path=bids_path, overwrite=True)
     if dir_name == 'EDF':
@@ -1374,7 +1372,7 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate, tmp_path):
     ecog_montage = mne.channels.make_dig_montage(ch_pos=ch_pos,
                                                  coord_frame='mni_tal')
     ieeg_raw.set_montage(ecog_montage)
-    bids_root = tmp_path.mkdir('bids3')
+    bids_root = tmp_path / 'bids3'
     bids_path.update(root=bids_root, datatype='ieeg')
     kwargs = dict(raw=ieeg_raw, bids_path=bids_path, overwrite=True)
     if dir_name == 'EDF':
@@ -1408,7 +1406,7 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate, tmp_path):
     # test writing to ACPC
     ecog_montage = mne.channels.make_dig_montage(ch_pos=ch_pos,
                                                  coord_frame='mri')
-    bids_root = tmp_path.mkdir('bids4')
+    bids_root = tmp_path / 'bids4'
     bids_path.update(root=bids_root, datatype='ieeg')
     # test works if ACPC-aligned is specified
     kwargs.update(montage=ecog_montage, acpc_aligned=True)
@@ -1451,20 +1449,17 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate, tmp_path):
             with pytest.warns(RuntimeWarning,
                               match='Encountered data in "short" format'):
                 write_raw_bids(**kwargs)
-                output_path = _test_anonymize(tmp_path.mkdir('a'), raw,
-                                              bids_path)
+                output_path = _test_anonymize(tmp_path / 'a', raw, bids_path)
         elif dir_name == 'EDF':
             match = r"^EDF\/EDF\+\/BDF files contain two fields .*"
             with pytest.warns(RuntimeWarning, match=match):
                 write_raw_bids(**kwargs)  # Just copies.
-                output_path = _test_anonymize(tmp_path.mkdir('b'), raw,
-                                              bids_path)
+                output_path = _test_anonymize(tmp_path / 'b', raw, bids_path)
         else:
             with pytest.warns(RuntimeWarning,
                               match='Encountered data in "double" format'):
                 write_raw_bids(**kwargs)  # Converts.
-                output_path = _test_anonymize(tmp_path.mkdir('c'), raw,
-                                              bids_path)
+                output_path = _test_anonymize(tmp_path / 'c', raw, bids_path)
         _bids_validate(output_path)
 
 
@@ -1537,7 +1532,7 @@ def test_bdf(_bids_validate, tmp_path):
     raw = _read_raw_bdf(raw_fname)
     match = r"^EDF\/EDF\+\/BDF files contain two fields .*"
     with pytest.warns(RuntimeWarning, match=match):
-        output_path = _test_anonymize(tmp_path.mkdir('tmp'), raw, bids_path)
+        output_path = _test_anonymize(tmp_path / 'tmp', raw, bids_path)
     _bids_validate(output_path)
 
 
@@ -1545,7 +1540,7 @@ def test_bdf(_bids_validate, tmp_path):
 def test_set(_bids_validate, tmp_path):
     """Test write_raw_bids conversion for EEGLAB data."""
     # standalone .set file with associated .fdt
-    bids_root = tmp_path.mkdir('bids1')
+    bids_root = tmp_path / 'bids1'
     data_path = op.join(testing.data_path(), 'EEGLAB')
     raw_fname = op.join(data_path, 'test_raw.set')
     raw = _read_raw_eeglab(raw_fname)
@@ -1574,7 +1569,7 @@ def test_set(_bids_validate, tmp_path):
     # We use the same data and pretend that eeg channels are ecog
     raw.set_channel_types({raw.ch_names[i]: 'ecog'
                            for i in mne.pick_types(raw.info, eeg=True)})
-    bids_root = tmp_path.mkdir('bids2')
+    bids_root = tmp_path / 'bids2'
     bids_path.update(root=bids_root, datatype='ieeg')
     write_raw_bids(raw, bids_path)
     _bids_validate(bids_root)
@@ -1583,8 +1578,7 @@ def test_set(_bids_validate, tmp_path):
     if check_version('pybv', '0.6'):
         with pytest.warns(RuntimeWarning,
                           match='Encountered data in "double" format'):
-            output_path = _test_anonymize(tmp_path.mkdir('tmp'), raw,
-                                          bids_path)
+            output_path = _test_anonymize(tmp_path / 'tmp', raw, bids_path)
         _bids_validate(output_path)
 
 
@@ -1702,7 +1696,7 @@ def test_write_anat(_bids_validate, tmp_path):
     """Test writing anatomical data."""
     # Get the MNE testing sample data
     import nibabel as nib
-    bids_root = tmp_path.mkdir('bids1')
+    bids_root = tmp_path / 'bids1'
     data_path = testing.data_path()
 
     # Get the T1 weighted MRI data file
@@ -2004,7 +1998,7 @@ def test_mark_channels(_bids_validate,
                        tmp_path):
     """Test marking channels of an existing BIDS dataset as "bad"."""
     # Setup: Create a fresh BIDS dataset.
-    bids_root = tmp_path.mkdir('bids1')
+    bids_root = tmp_path / 'bids1'
     bids_path = _bids_path.copy().update(root=bids_root, datatype='meg',
                                          suffix='meg')
     data_path = testing.data_path()
@@ -2097,7 +2091,7 @@ def test_mark_channels(_bids_validate,
 def test_mark_channel_roundtrip(tmp_path):
     """Test marking channels fulfills roundtrip."""
     # Setup: Create a fresh BIDS dataset.
-    bids_root = tmp_path.mkdir('bids1')
+    bids_root = tmp_path / 'bids1'
     bids_path = _bids_path.copy().update(root=bids_root, datatype='meg',
                                          suffix='meg')
     data_path = testing.data_path()
@@ -2143,7 +2137,7 @@ def test_mark_channel_roundtrip(tmp_path):
 def test_error_mark_channels(tmp_path):
     """Test errors when marking channels."""
     # Setup: Create a fresh BIDS dataset.
-    bids_root = tmp_path.mkdir('bids1')
+    bids_root = tmp_path / 'bids1'
     bids_path = _bids_path.copy().update(root=bids_root, datatype='meg',
                                          suffix='meg')
     data_path = testing.data_path()
@@ -2173,7 +2167,7 @@ def test_error_mark_channels(tmp_path):
 def test_mark_channels_files(tmp_path):
     """Test validity of bad channel writing."""
     # BV
-    bids_root = tmp_path.mkdir('bids1')
+    bids_root = tmp_path / 'bids1'
     data_path = op.join(testing.data_path(), 'montage')
     raw_fname = op.join(data_path, 'bv_dig_test.vhdr')
 
@@ -2204,7 +2198,7 @@ def test_mark_channels_files(tmp_path):
     # test EDF too
     dir_name = 'EDF'
     fname = 'test_reduced.edf'
-    bids_root = tmp_path.mkdir('bids2')
+    bids_root = tmp_path / 'bids2'
     bids_path = _bids_path.copy().update(root=bids_root)
     data_path = op.join(testing.data_path(), dir_name)
     raw_fname = op.join(data_path, fname)
@@ -2216,7 +2210,7 @@ def test_mark_channels_files(tmp_path):
 
 def test_write_meg_calibration(_bids_validate, tmp_path):
     """Test writing of the Elekta/Neuromag fine-calibration file."""
-    bids_root = tmp_path.mkdir('bids1')
+    bids_root = tmp_path / 'bids1'
     bids_path = _bids_path.copy().update(root=bids_root)
 
     data_path = Path(testing.data_path())
@@ -2265,7 +2259,7 @@ def test_write_meg_calibration(_bids_validate, tmp_path):
 
 def test_write_meg_crosstalk(_bids_validate, tmp_path):
     """Test writing of the Elekta/Neuromag fine-calibration file."""
-    bids_root = tmp_path.mkdir('bids1')
+    bids_root = tmp_path / 'bids1'
     bids_path = _bids_path.copy().update(root=bids_root)
     data_path = Path(testing.data_path())
 
@@ -2303,7 +2297,7 @@ def test_write_meg_crosstalk(_bids_validate, tmp_path):
 @pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
 def test_annotations(_bids_validate, bad_segments, tmp_path):
     """Test that Annotations are stored as events."""
-    bids_root = tmp_path.mkdir('bids1')
+    bids_root = tmp_path / 'bids1'
     bids_path = _bids_path.copy().update(root=bids_root, datatype='meg')
     data_path = testing.data_path()
     raw_fname = op.join(data_path, 'MEG', 'sample',
@@ -2358,7 +2352,7 @@ def test_annotations(_bids_validate, bad_segments, tmp_path):
 @pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
 def test_undescribed_events(_bids_validate, drop_undescribed_events, tmp_path):
     """Test we're behaving correctly if event descriptions are missing."""
-    bids_root = tmp_path.mkdir('bids1')
+    bids_root = tmp_path / 'bids1'
     bids_path = _bids_path.copy().update(root=bids_root, datatype='meg')
     data_path = testing.data_path()
     raw_fname = op.join(data_path, 'MEG', 'sample',
@@ -2401,7 +2395,7 @@ def test_undescribed_events(_bids_validate, drop_undescribed_events, tmp_path):
 @pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
 def test_event_storage(tmp_path):
     """Test we're retaining the original event IDs when storing events."""
-    bids_root = tmp_path.mkdir('bids1')
+    bids_root = tmp_path / 'bids1'
     bids_path = _bids_path.copy().update(root=bids_root, datatype='meg')
     data_path = testing.data_path()
     raw_fname = op.join(data_path, 'MEG', 'sample',
@@ -2448,7 +2442,7 @@ def test_coordsystem_json_compliance(
 
     Tests multiple manufacturer data formats and MEG, EEG, and iEEG.
     """
-    bids_root = tmp_path.mkdir('bids1')
+    bids_root = tmp_path / 'bids1'
     data_path = op.join(testing.data_path(), dir_name)
     raw_fname = op.join(data_path, fname)
 
@@ -2593,7 +2587,6 @@ def test_anonymize(subject, dir_name, fname, reader, tmp_path):
         raw_fname = new_raw_fname.as_posix()
 
     bids_root = tmp_path / 'bids1'
-    bids_root.mkdir(parents=True)
     raw = reader(raw_fname)
     raw_date = raw.info['meas_date'].strftime('%Y%m%d')
 
@@ -2630,7 +2623,7 @@ def test_anonymize(subject, dir_name, fname, reader, tmp_path):
 @pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
 def test_sidecar_encoding(_bids_validate, tmp_path):
     """Test we're properly encoding text as UTF8."""
-    bids_root = tmp_path.mkdir('bids1')
+    bids_root = tmp_path / 'bids1'
     bids_path = _bids_path.copy().update(root=bids_root, datatype='meg')
     data_path = testing.data_path()
     raw_fname = op.join(data_path, 'MEG', 'sample',
@@ -2691,7 +2684,6 @@ def test_sidecar_encoding(_bids_validate, tmp_path):
 def test_convert_eeg_formats(dir_name, format, fname, reader, tmp_path):
     """Test conversion of EEG/iEEG manufacturer fmt to BrainVision/EDF."""
     bids_root = tmp_path / format
-    bids_root.mkdir(exist_ok=True, parents=True)
     data_path = op.join(testing.data_path(), dir_name)
     raw_fname = op.join(data_path, fname)
 
@@ -2755,7 +2747,7 @@ def test_convert_eeg_formats(dir_name, format, fname, reader, tmp_path):
 @pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
 def test_error_write_meg_as_eeg(dir_name, format, fname, reader, tmp_path):
     """Test error writing as BrainVision EEG data for MEG."""
-    bids_root = tmp_path.mkdir('bids1')
+    bids_root = tmp_path / 'bids1'
     data_path = op.join(testing.data_path(), dir_name)
     raw_fname = op.join(data_path, fname)
 
@@ -2778,7 +2770,6 @@ def test_error_write_meg_as_eeg(dir_name, format, fname, reader, tmp_path):
 def test_convert_meg_formats(dir_name, format, fname, reader, tmp_path):
     """Test conversion of MEG manufacturer format to FIF."""
     bids_root = tmp_path / format
-    bids_root.mkdir(exist_ok=True, parents=True)
     data_path = op.join(testing.data_path(), dir_name)
     raw_fname = op.join(data_path, fname)
 
@@ -2812,7 +2803,6 @@ def test_convert_meg_formats(dir_name, format, fname, reader, tmp_path):
 def test_convert_raw_errors(dir_name, fname, reader, tmp_path):
     """Test errors when converting raw file formats."""
     bids_root = tmp_path / 'bids_1'
-    bids_root.mkdir(exist_ok=True, parents=True)
 
     data_path = op.join(testing.data_path(), dir_name)
     raw_fname = op.join(data_path, fname)
@@ -2862,7 +2852,7 @@ def test_write_extension_case_insensitive(_bids_validate, tmp_path, datatype):
     """Test writing files is case insensitive."""
     dir_name, fname, reader = 'EDF', 'test_reduced.edf', _read_raw_edf
 
-    bids_root = tmp_path.mkdir('bids1')
+    bids_root = tmp_path / 'bids1'
     source_path = Path(bids_root) / 'sourcedata'
     data_path = op.join(testing.data_path(), dir_name)
     sh.copytree(data_path, source_path)
@@ -2894,7 +2884,7 @@ def test_symlink(tmp_path):
     raw_trunc_path = (testing_data_path / 'MEG' / 'sample' /
                       'sample_audvis_trunc_raw.fif')
     raw = _read_raw_fif(raw_trunc_path)
-    root = tmp_path.mkdir('symlink')
+    root = tmp_path / 'symlink'
     bids_path = _bids_path.copy().update(root=root, datatype='meg')
     kwargs = dict(raw=raw, bids_path=bids_path, symlink=True)
 
@@ -2927,13 +2917,14 @@ def test_symlink(tmp_path):
     raw_path = sample_data_path / 'MEG' / 'sample' / 'sample_audvis_raw.fif'
     raw = _read_raw_fif(raw_path).crop(0, 10)
 
-    split_raw_path = tmp_path.mkdir('raw') / 'sample_audivis_raw.fif'
+    split_raw_path = tmp_path / 'raw' / 'sample_audivis_raw.fif'
+    split_raw_path.parent.mkdir()
     raw.save(split_raw_path, split_size='10MB', split_naming='neuromag')
     raw = _read_raw_fif(split_raw_path)
     assert len(raw.filenames) == 2
 
     # now actually test the I/O roundtrip
-    root = tmp_path.mkdir('symlink-split')
+    root = tmp_path / 'symlink-split'
     bids_path = _bids_path.copy().update(root=root, datatype='meg')
     p = write_raw_bids(raw=raw, bids_path=bids_path, symlink=True)
     raw = read_raw_bids(p)
@@ -2943,7 +2934,7 @@ def test_symlink(tmp_path):
 @pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
 def test_write_associated_emptyroom(_bids_validate, tmp_path):
     """Test functionality of the write_raw_bids conversion for fif."""
-    bids_root = tmp_path.mkdir('bids1')
+    bids_root = tmp_path / 'bids1'
     data_path = testing.data_path()
     raw_fname = op.join(data_path, 'MEG', 'sample',
                         'sample_audvis_trunc_raw.fif')
@@ -2977,7 +2968,7 @@ def test_write_associated_emptyroom(_bids_validate, tmp_path):
 
 def test_preload(_bids_validate, tmp_path):
     """Test writing custom preloaded raw objects"""
-    bids_root = tmp_path.mkdir('bids')
+    bids_root = tmp_path / 'bids'
     bids_path = _bids_path.copy().update(root=bids_root)
     sfreq, n_points = 1024., int(1e6)
     info = mne.create_info(['ch1', 'ch2', 'ch3', 'ch4', 'ch5'], sfreq,
@@ -3020,7 +3011,7 @@ def test_write_raw_special_paths(tmp_path, dir_name):
 def test_anonymize_dataset(_bids_validate, tmpdir):
     """Test creating an anonymized copy of a dataset."""
     # Create a non-anonymized dataset
-    bids_root = tmpdir.mkdir('bids')
+    bids_root = tmpdir / 'bids'
     bids_path = _bids_path.copy().update(
         root=bids_root, subject='testparticipant', extension='.fif',
         datatype='meg'
@@ -3268,7 +3259,7 @@ def test_anonymize_dataset_daysback(tmpdir):
     # Check progress bar output
     from mne_bids.write import _get_daysback
 
-    bids_root = tmpdir.mkdir('bids')
+    bids_root = tmpdir / 'bids'
     bids_path = _bids_path.copy().update(
         root=bids_root, subject='testparticipant', datatype='meg'
     )
@@ -3294,7 +3285,7 @@ def test_anonymize_dataset_daysback(tmpdir):
     )
 
     # Multiple sessions
-    bids_root = tmpdir.mkdir('bids-multisession')
+    bids_root = tmpdir / 'bids-multisession'
     bids_path = _bids_path.copy().update(
         root=bids_root, subject='testparticipant', datatype='meg'
     )

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -1590,7 +1590,8 @@ def test_set(_bids_validate, tmp_path):
     if check_version('pybv', '0.6'):
         with pytest.warns(RuntimeWarning,
                           match='Encountered data in "double" format'):
-            output_path = _test_anonymize(tmp_path.mkdir('tmp'), raw, bids_path)
+            output_path = _test_anonymize(tmp_path.mkdir('tmp'), raw,
+                                          bids_path)
         _bids_validate(output_path)
 
 

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -1878,8 +1878,8 @@ def test_write_raw_pathlike(tmp_path):
     raw = _read_raw_fif(raw_fname)
 
     bids_root = tmp_path
-    events_fname =  (data_path / 'MEG' / 'sample' /
-                     'sample_audvis_trunc_raw-eve.fif')
+    events_fname = (data_path / 'MEG' / 'sample' /
+                    'sample_audvis_trunc_raw-eve.fif')
     bids_path = _bids_path.copy().update(root=bids_root)
     bids_path_ = write_raw_bids(raw=raw, bids_path=bids_path,
                                 events_data=events_fname,


### PR DESCRIPTION
This PR replaces the deprecated pytest `tmpdir` fixture with `tmp_path`. Because the tests do not run on my local system (mainly because the MNE package doesn't contain any test data), this is a first try (blindly replacing all occurrences).

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
