### PR TITLE
Confine get_entity_vals() to /sub-* directories

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -87,6 +87,8 @@ Bug fixes
 
 - Fix erroneous measurement date check in :func:`mne_bids.write_raw_bids` when requesting to anonymize empty-room data, by `Richard Höchenberger`_ (:gh:`893`)
 
+- Ensure that :func:`mne_bids.get_entity_vals` only includes files found in ``sub-*`` folders in the BIDS root, by `Adam Li`_ and `Richard Höchenberger`_ (:gh:`899`)
+
 :doc:`Find out what was new in previous releases <whats_new_previous_releases>`
 
 .. include:: authors.rst

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -1625,8 +1625,9 @@ def get_entity_vals(root, entity_key, *, ignore_subjects='emptyroom',
     filenames = (Path(root)
                  .rglob(f'*{entity_long_abbr_map[entity_key]}-*_*'))
     for filename in filenames:
-        # Ignore `derivatives` folder.
-        if str(filename).startswith(op.join(root, 'derivatives')):
+        # Ignore `derivatives` and `sourcedata` folder.
+        if str(filename).startswith(op.join(root, 'derivatives')) or \
+                str(filename).startswith(op.join(root, 'sourcedata')):
             continue
 
         if ignore_datatypes and filename.parent.name in ignore_datatypes:

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -106,6 +106,13 @@ def test_get_keys(return_bids_test_dir):
 def test_get_entity_vals(entity, expected_vals, kwargs, return_bids_test_dir):
     """Test getting a list of entities."""
     bids_root = return_bids_test_dir
+    # Add some derivative data that should be ignored by get_entity_vals()
+    deriv_path = Path(bids_root) / 'derivatives'
+    deriv_meg_dir = deriv_path / 'pipeline' / 'sub-deriv' / 'ses-deriv' / 'meg'
+    deriv_meg_dir.mkdir(parents=True)
+    (deriv_meg_dir / 'sub-deriv_ses-deriv_task-deriv_meg.fif').touch()
+    (deriv_meg_dir / 'sub-deriv_ses-deriv_task-deriv_meg.json').touch()
+
     if kwargs is None:
         kwargs = dict()
 
@@ -125,6 +132,9 @@ def test_get_entity_vals(entity, expected_vals, kwargs, return_bids_test_dir):
         }
         assert entities == [f'{entity_long_to_short[entity]}-{val}'
                             for val in expected_vals]
+
+    # Clean up
+    shutil.rmtree(deriv_path)
 
 
 def test_search_folder_for_text(capsys):


### PR DESCRIPTION
PR Description
--------------

`sourcedata/` should not be checked for entity_vals when getting a dataset. Quick 1 liner fix...

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
