### PR TITLE
Clean up some bits

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
         # restore cache from last build. Unless __init__.py has changed since then
         - restore_cache:
             keys:
-              - data-cache-1-{{ checksum "./mne_bids/__init__.py" }}
+              - data-cache-2-{{ checksum "./mne_bids/__init__.py" }}
 
         # Also restore pip cache to speed up installations
         - restore_cache:
@@ -42,7 +42,7 @@ jobs:
 
         # Store the data cache
         - save_cache:
-            key: data-cache-1-{{ checksum "./mne_bids/__init__.py" }}
+            key: data-cache-2-{{ checksum "./mne_bids/__init__.py" }}
             paths:
               - ~/mne_data
 

--- a/mne_bids/tests/test_copyfiles.py
+++ b/mne_bids/tests/test_copyfiles.py
@@ -6,22 +6,14 @@
 # License: BSD-3-Clause
 import os.path as op
 import datetime
-from distutils.version import LooseVersion
 
 import pytest
 
-# This is here to handle mne-python <0.20
-import warnings
-with warnings.catch_warnings():
-    warnings.filterwarnings(action='ignore',
-                            message="can't resolve package",
-                            category=ImportWarning)
-    import mne
-
+import mne
+from mne.fixes import _compare_version
 from mne.datasets import testing
 from mne_bids import BIDSPath
 from mne_bids.path import _parse_ext
-
 from mne_bids.copyfiles import (_get_brainvision_encoding,
                                 _get_brainvision_paths,
                                 copyfile_brainvision,
@@ -187,8 +179,10 @@ def test_copyfile_edf(tmpdir):
                           'test_raw_2021.set'))
 def test_copyfile_eeglab(tmpdir, fname):
     """Test the copying of EEGlab set and fdt files."""
-    if (fname == 'test_raw_chanloc.set' and
-            LooseVersion(testing.get_version()) < LooseVersion('0.112')):
+    if (
+        fname == 'test_raw_chanloc.set' and
+        _compare_version(testing.get_version(), '<', '0.112')
+    ):
         return
 
     bids_root = str(tmpdir)

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -5,21 +5,13 @@
 import os
 import os.path as op
 import shutil as sh
-
-# This is here to handle mne-python <0.20
-import warnings
 from pathlib import Path
 import shutil
 from datetime import datetime, timezone
 
 import pytest
 
-with warnings.catch_warnings():
-    warnings.filterwarnings(action='ignore',
-                            message="can't resolve package",
-                            category=ImportWarning)
-    import mne
-
+import mne
 from mne.datasets import testing
 from mne.io import anonymize_info
 

--- a/mne_bids/tests/test_pick.py
+++ b/mne_bids/tests/test_pick.py
@@ -5,16 +5,9 @@
 
 import os.path as op
 
-# This is here to handle mne-python <0.20
-import warnings
-with warnings.catch_warnings():
-    warnings.filterwarnings(action='ignore',
-                            message="can't resolve package",
-                            category=ImportWarning)
-    import mne  # noqa: F401
-
 from mne.datasets import testing
 from mne.io import read_raw_fif
+
 from mne_bids.pick import coil_type
 
 

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -10,17 +10,10 @@ from datetime import datetime, timezone
 
 import pytest
 import shutil as sh
-
 import numpy as np
 from numpy.testing import assert_almost_equal
 
-# This is here to handle mne-python <0.20
-import warnings
-with warnings.catch_warnings():
-    warnings.filterwarnings(action='ignore',
-                            message="can't resolve package",
-                            category=ImportWarning)
-    import mne
+import mne
 from mne.io.constants import FIFF
 from mne.utils import requires_nibabel, object_diff, requires_version
 from mne.utils import assert_dig_allclose
@@ -527,7 +520,7 @@ def test_handle_info_reading(tmpdir):
         assert raw.info['line_freq'] == 55
 
 
-@requires_version('mne', '0.24.dev0')
+@requires_version('mne', '0.24')
 @pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
 @pytest.mark.filterwarnings(warning_str['maxshield'])
 def test_handle_chpi_reading(tmpdir):

--- a/mne_bids/tests/test_tsv_handler.py
+++ b/mne_bids/tests/test_tsv_handler.py
@@ -6,17 +6,10 @@
 
 from collections import OrderedDict as odict
 
-# This is here to handle mne-python <0.20
-import warnings
-with warnings.catch_warnings():
-    warnings.filterwarnings(action='ignore',
-                            message="can't resolve package",
-                            category=ImportWarning)
-    import mne  # noqa: F401
+import pytest
 
 from mne_bids.tsv_handler import (_from_tsv, _to_tsv, _combine_rows, _drop,
                                   _contains_row, _tsv_to_str)
-import pytest
 
 
 def test_tsv_handler(tmpdir):

--- a/mne_bids/tests/test_utils.py
+++ b/mne_bids/tests/test_utils.py
@@ -5,19 +5,13 @@
 #
 # License: BSD-3-Clause
 import os.path as op
-# This is here to handle mne-python <0.20
-import warnings
 from datetime import datetime
 from pathlib import Path
 
 import pytest
 from numpy.random import random, RandomState
 
-with warnings.catch_warnings():
-    warnings.filterwarnings(action='ignore',
-                            message="can't resolve package",
-                            category=ImportWarning)
-    import mne
+import mne
 
 from mne_bids import BIDSPath
 from mne_bids.utils import (_check_types, _age_on_date, _handle_datatype,

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -27,14 +27,7 @@ import numpy as np
 from numpy.testing import (assert_allclose, assert_array_equal,
                            assert_array_almost_equal)
 
-# This is here to handle mne-python <0.20
-import warnings
-with warnings.catch_warnings():
-    warnings.filterwarnings(action='ignore',
-                            message="can't resolve package",
-                            category=ImportWarning)
-    import mne
-
+import mne
 from mne.datasets import testing
 from mne.utils import check_version, requires_nibabel, requires_version
 from mne.io import anonymize_info
@@ -2688,7 +2681,7 @@ def test_sidecar_encoding(_bids_validate, tmpdir):
                        raw_read.annotations.description)
 
 
-@requires_version('mne', '0.24.dev0')
+@requires_version('mne', '0.24')
 @requires_version('pybv', '0.6')
 @pytest.mark.parametrize(
     'dir_name, format, fname, reader', test_converteeg_data)


### PR DESCRIPTION
Remove some old code blocks used to support MNE < 0.20

Also change version requirements from `0.24.dev0` to `0.24` to work around issues with `LooseVersion` that will be addressed upstream in https://github.com/mne-tools/mne-python/pull/9988

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
