### PR TITLE
MRG: Improve handling of read_raw_bids() if input file cannot be found

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -66,6 +66,8 @@ API and behavior changes
 
 - Reading BIDS data with ``"HeadCoilFrequency"`` and ``"PowerLineFrequency"`` data specified in JSON sidecars will only "warn" in case of mismatches between Raw and JSON data, by `Franziska von Albedyll`_ (:gh:`885`)
 
+- Accessing :attr:`mne_bids.BIDSPath.fpath` emit a warning anymore if the path does not exist. This behavior was unreliable and yielded confusing error messages in certain use cases. Use `mne_bids.BIDSPath.fpath.exists()` to check whether the path exists in the file system, by `Richard Höchenberger`_ (:gh:`904`)
+
 Requirements
 ^^^^^^^^^^^^
 
@@ -88,6 +90,9 @@ Bug fixes
 - Fix erroneous measurement date check in :func:`mne_bids.write_raw_bids` when requesting to anonymize empty-room data, by `Richard Höchenberger`_ (:gh:`893`)
 
 - Ensure that :func:`mne_bids.get_entity_vals` only includes files found in ``sub-*`` folders in the BIDS root, by `Adam Li`_ and `Richard Höchenberger`_ (:gh:`899`)
+
+- More robust handling of situations where :func:`mne_bids.read_raw_bids` tries to read a file that does not exist, by `Richard Höchenberger`_ (:gh:`904`)
+
 
 :doc:`Find out what was new in previous releases <whats_new_previous_releases>`
 

--- a/mne_bids/commands/mne_bids_raw_to_bids.py
+++ b/mne_bids/commands/mne_bids_raw_to_bids.py
@@ -75,7 +75,7 @@ def run():
         allow_maxshield = True
 
     raw = _read_raw(opt.raw_fname, hpi=opt.hpi, electrode=opt.electrode,
-                    hsp=opt.hsp, config=opt.config,
+                    hsp=opt.hsp, config_path=opt.config,
                     allow_maxshield=allow_maxshield)
     if opt.line_freq is not None:
         line_freq = None if opt.line_freq == "None" else opt.line_freq

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -599,14 +599,6 @@ class BIDSPath(object):
 
                 # found no matching paths
                 if not matching_paths:
-                    msg = (f'Could not locate a data file of a supported '
-                           f'format. This is likely a problem with your '
-                           f'BIDS dataset. Please run the BIDS validator '
-                           f'on your data. (root={self.root}, '
-                           f'basename={self.basename}). '
-                           f'{matching_paths}')
-                    warn(msg)
-
                     bids_fpath = op.join(data_path, self.basename)
                 # if paths still cannot be resolved, then there is an error
                 elif len(matching_paths) > 1:

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -56,11 +56,6 @@ def _read_raw(raw_path, electrode=None, hsp=None, hpi=None,
 
     elif ext in ['.ds', '.vhdr', '.set', '.edf', '.bdf', '.EDF']:
         raw_path = Path(raw_path)
-        # handle EDF extension upper/lower casing
-        if ext == '.edf' and not raw_path.exists():
-            raw_path = raw_path.with_suffix('.EDF')
-        elif ext == '.EDF' and not raw_path.exists():
-            raw_path = raw_path.with_suffix('.edf')
         raw = reader[ext](raw_path, **kwargs)
 
     # MEF and NWB are allowed, but not yet implemented
@@ -675,9 +670,8 @@ def read_raw_bids(bids_path, extra_params=None, verbose=None):
 
     # Special-handle EDF filenames: we accept upper- and lower-case extensions
     if raw_path.suffix.lower() == '.edf':
-        stem = raw_path.stem
         for extension in ('.edf', '.EDF'):
-            candidate_path = raw_path.parent / f'{stem}{extension}'
+            candidate_path = raw_path.with_suffix(extension)
             if candidate_path.exists():
                 raw_path = candidate_path
                 break

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -673,6 +673,15 @@ def read_raw_bids(bids_path, extra_params=None, verbose=None):
             raw_path = target_path
         config_path = None
 
+    # Special-handle EDF filenames: we accept upper- and lower-case extensions
+    if raw_path.suffix.lower() == '.edf':
+        stem = raw_path.stem
+        for extension in ('.edf', '.EDF'):
+            candidate_path = raw_path.parent / f'{stem}{extension}'
+            if candidate_path.exists():
+                raw_path = candidate_path
+                break
+
     if not raw_path.exists():
         raise FileNotFoundError(f'File does not exist: {raw_path}')
     if config_path is not None and not config_path.exists():

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -8,7 +8,6 @@
 # License: BSD-3-Clause
 import os.path as op
 from pathlib import Path
-import glob
 import json
 import re
 import warnings
@@ -32,33 +31,37 @@ from mne_bids.path import (BIDSPath, _parse_ext, _find_matching_sidecar,
                            _infer_datatype)
 
 
-def _read_raw(raw_fpath, electrode=None, hsp=None, hpi=None,
-              allow_maxshield=False, config=None, **kwargs):
+def _read_raw(raw_path, electrode=None, hsp=None, hpi=None,
+              allow_maxshield=False, config_path=None, **kwargs):
     """Read a raw file into MNE, making inferences based on extension."""
-    _, ext = _parse_ext(raw_fpath)
+    _, ext = _parse_ext(raw_path)
 
     # KIT systems
     if ext in ['.con', '.sqd']:
-        raw = io.read_raw_kit(raw_fpath, elp=electrode, hsp=hsp,
+        raw = io.read_raw_kit(raw_path, elp=electrode, hsp=hsp,
                               mrk=hpi, preload=False, **kwargs)
 
     # BTi systems
     elif ext == '.pdf':
-        raw = io.read_raw_bti(raw_fpath, config_fname=config,
-                              head_shape_fname=hsp,
-                              preload=False, **kwargs)
+        raw = io.read_raw_bti(
+            pdf_fname=str(raw_path),  # FIXME MNE should accept Path!
+            config_fname=str(config_path),  # FIXME MNE should accept Path!
+            head_shape_fname=hsp,
+            preload=False,
+            **kwargs
+        )
 
     elif ext == '.fif':
-        raw = reader[ext](raw_fpath, allow_maxshield, **kwargs)
+        raw = reader[ext](raw_path, allow_maxshield, **kwargs)
 
     elif ext in ['.ds', '.vhdr', '.set', '.edf', '.bdf', '.EDF']:
-        raw_fpath = Path(raw_fpath)
+        raw_path = Path(raw_path)
         # handle EDF extension upper/lower casing
-        if ext == '.edf' and not raw_fpath.exists():
-            raw_fpath = raw_fpath.with_suffix('.EDF')
-        elif ext == '.EDF' and not raw_fpath.exists():
-            raw_fpath = raw_fpath.with_suffix('.edf')
-        raw = reader[ext](raw_fpath, **kwargs)
+        if ext == '.edf' and not raw_path.exists():
+            raw_path = raw_path.with_suffix('.EDF')
+        elif ext == '.EDF' and not raw_path.exists():
+            raw_path = raw_path.with_suffix('.edf')
+        raw = reader[ext](raw_path, **kwargs)
 
     # MEF and NWB are allowed, but not yet implemented
     elif ext in ['.mef', '.nwb']:
@@ -652,23 +655,28 @@ def read_raw_bids(bids_path, extra_params=None, verbose=None):
     if suffix is None:
         bids_path.update(suffix=datatype)
 
-    data_dir = bids_path.directory
-    bids_fname = bids_path.fpath.name
-
-    if op.splitext(bids_fname)[1] == '.pdf':
-        bids_raw_folder = op.join(data_dir, f'{bids_path.basename}')
-        bids_fpath = glob.glob(op.join(bids_raw_folder, 'c,rf*'))[0]
-        config = op.join(bids_raw_folder, 'config')
+    if bids_path.fpath.suffix == '.pdf':
+        bids_raw_folder = bids_path.directory / f'{bids_path.basename}'
+        raw_path = list(bids_raw_folder.glob('c,rf*'))[0]
+        config_path = bids_raw_folder / 'config'
     else:
-        bids_fpath = op.join(data_dir, bids_fname)
+        raw_path = bids_path.fpath
         # Resolve for FIFF files
-        if (bids_fpath.endswith('.fif') and bids_path.split is None and
-                op.islink(bids_fpath)):
-            target_path = op.realpath(bids_fpath)
+        if (
+            raw_path.suffix == '.fif' and
+            bids_path.split is None and
+            raw_path.is_symlink()
+        ):
+            target_path = raw_path.resolve()
             logger.info(f'Resolving symbolic link: '
-                        f'{bids_fpath} -> {target_path}')
-            bids_fpath = target_path
-        config = None
+                        f'{raw_path} -> {target_path}')
+            raw_path = target_path
+        config_path = None
+
+    if not raw_path.exists():
+        raise FileNotFoundError(f'File does not exist: {raw_path}')
+    if config_path is not None and not config_path.exists():
+        raise FileNotFoundError(f'config directory not found: {config_path}')
 
     if extra_params is None:
         extra_params = dict()
@@ -676,10 +684,10 @@ def read_raw_bids(bids_path, extra_params=None, verbose=None):
         del extra_params['exclude']
         logger.info('"exclude" parameter is not supported by read_raw_bids')
 
-    if bids_fname.endswith('.fif') and 'allow_maxshield' not in extra_params:
+    if raw_path.suffix == '.fif' and 'allow_maxshield' not in extra_params:
         extra_params['allow_maxshield'] = True
-    raw = _read_raw(bids_fpath, electrode=None, hsp=None, hpi=None,
-                    config=config, **extra_params)
+    raw = _read_raw(raw_path, electrode=None, hsp=None, hpi=None,
+                    config_path=config_path, **extra_params)
 
     # Try to find an associated events.tsv to get information about the
     # events in the recorded data
@@ -739,14 +747,16 @@ def read_raw_bids(bids_path, extra_params=None, verbose=None):
         raw = _handle_scans_reading(scans_fname, raw, bids_path)
 
     # read in associated subject info from participants.tsv
-    participants_tsv_fpath = op.join(bids_root, 'participants.tsv')
+    participants_tsv_path = bids_root / 'participants.tsv'
     subject = f"sub-{bids_path.subject}"
-    if op.exists(participants_tsv_fpath):
-        raw = _handle_participants_reading(participants_tsv_fpath, raw,
-                                           subject)
+    if op.exists(participants_tsv_path):
+        raw = _handle_participants_reading(
+            participants_fname=participants_tsv_path,
+            raw=raw,
+            subject=subject
+        )
     else:
-        warn("Participants file not found for {}... Not reading "
-             "in any particpants.tsv data.".format(bids_fname))
+        warn(f"participants.tsv file not found for {raw_path}")
 
     assert raw.annotations.orig_time == raw.info['meas_date']
     return raw

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -410,16 +410,6 @@ def test_bids_path_inference(return_bids_test_dir):
     with pytest.raises(RuntimeError, match='Found more than one'):
         bids_path.fpath
 
-    # can't locate a file, but the basename should work
-    bids_path = BIDSPath(
-        subject=subject_id, session=session_id, acquisition=acq,
-        task=task, run='10', root=bids_root)
-    with pytest.warns(RuntimeWarning, match='Could not locate'):
-        fpath = bids_path.fpath
-        assert str(fpath) == op.join(bids_root, f'sub-{subject_id}',
-                                     f'ses-{session_id}',
-                                     bids_path.basename)
-
     # shouldn't error out when there is no uncertainty
     channels_fname = BIDSPath(subject=subject_id, session=session_id,
                               run=run, acquisition=acq, task=task,

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -154,7 +154,7 @@ def test_read_participants_data(tmp_path):
     raw = _read_raw_fif(raw_fname, verbose=False)
     write_raw_bids(raw, bids_path, overwrite=True, verbose=False)
     os.remove(participants_tsv_fpath)
-    with pytest.warns(RuntimeWarning, match='Participants file not found'):
+    with pytest.warns(RuntimeWarning, match='participants.tsv file not found'):
         raw = read_raw_bids(bids_path=bids_path)
         assert raw.info['subject_info'] is None
 
@@ -1069,3 +1069,20 @@ def test_read_edf_extension_casing(tmp_path):
 
     # obtain the sensor positions and assert ch_coords are same
     read_raw_bids(bids_path, verbose=True)
+
+
+def test_file_not_found(tmp_path):
+    """Check behavior if the requested file cannot be found."""
+    # First a path with a filename extension.
+    bp = BIDSPath(
+        root=tmp_path, subject='foo', task='bar', datatype='eeg', suffix='eeg',
+        extension='.fif'
+    )
+    bp.fpath.parent.mkdir(parents=True)
+    with pytest.raises(FileNotFoundError, match='File does not exist'):
+        read_raw_bids(bids_path=bp)
+
+    # Now without an extension
+    bp.extension = None
+    with pytest.raises(FileNotFoundError, match='File does not exist'):
+        read_raw_bids(bids_path=bp)


### PR DESCRIPTION
This avoids entering the code path that tries to load a BTi dataset (and fails) simply because the specified `BIDSPath.fpath` cannot be found.


Fixes #802

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [x] All comments resolved
- [x] This is not your own PR
- [x] All CIs are happy
- [x] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [x] PR description includes phrase "closes <#issue-number>"
