### PR TITLE
MRG: get_entity_vals() gains new parameter ignore_dirs

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -68,7 +68,7 @@ API and behavior changes
 
 - Accessing :attr:`mne_bids.BIDSPath.fpath` emit a warning anymore if the path does not exist. This behavior was unreliable and yielded confusing error messages in certain use cases. Use `mne_bids.BIDSPath.fpath.exists()` to check whether the path exists in the file system, by `Richard Höchenberger`_ (:gh:`904`)
 
-- :func:`mne_bids.get_entity_vals` gaines a new parameter, ``ignore_dirs``, to exclude directories from the search, by `Adam Li`_ and `Richard Höchenberger`_ (:gh:`899`, :gh:`908`)
+- :func:`mne_bids.get_entity_vals` gained a new parameter, ``ignore_dirs``, to exclude directories from the search, by `Adam Li`_ and `Richard Höchenberger`_ (:gh:`899`, :gh:`908`)
 
 Requirements
 ^^^^^^^^^^^^

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -68,6 +68,8 @@ API and behavior changes
 
 - Accessing :attr:`mne_bids.BIDSPath.fpath` emit a warning anymore if the path does not exist. This behavior was unreliable and yielded confusing error messages in certain use cases. Use `mne_bids.BIDSPath.fpath.exists()` to check whether the path exists in the file system, by `Richard Höchenberger`_ (:gh:`904`)
 
+- :func:`mne_bids.get_entity_vals` gaines a new parameter, ``ignore_dirs``, to exclude directories from the search, by `Adam Li`_ and `Richard Höchenberger`_ (:gh:`899`, :gh:`908`)
+
 Requirements
 ^^^^^^^^^^^^
 
@@ -88,8 +90,6 @@ Bug fixes
 - Fix reading of TSV files with only a single column, by `Marijn van Vliet`_ (:gh:`886`)
 
 - Fix erroneous measurement date check in :func:`mne_bids.write_raw_bids` when requesting to anonymize empty-room data, by `Richard Höchenberger`_ (:gh:`893`)
-
-- Ensure that :func:`mne_bids.get_entity_vals` only includes files found in ``sub-*`` folders in the BIDS root, by `Adam Li`_ and `Richard Höchenberger`_ (:gh:`899`)
 
 - More robust handling of situations where :func:`mne_bids.read_raw_bids` tries to read a file that does not exist, by `Richard Höchenberger`_ (:gh:`904`)
 

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -1539,33 +1539,33 @@ def get_entity_vals(root, entity_key, *, ignore_subjects='emptyroom',
 
     entity_key : str
         The name of the entity key to search for.
-    ignore_subjects : str | collection of str | None
+    ignore_subjects : str | array-like of str | None
         Subject(s) to ignore. By default, entities from the ``emptyroom``
         mock-subject are not returned. If ``None``, include all subjects.
-    ignore_sessions : str | collection of str | None
+    ignore_sessions : str | array-like of str | None
         Session(s) to ignore. If ``None``, include all sessions.
-    ignore_tasks : str | collection of str | None
+    ignore_tasks : str | array-like of str | None
         Task(s) to ignore. If ``None``, include all tasks.
-    ignore_runs : str | collection of str | None
+    ignore_runs : str | array-like of str | None
         Run(s) to ignore. If ``None``, include all runs.
-    ignore_processings : str | collection of str | None
+    ignore_processings : str | array-like of str | None
         Processing(s) to ignore. If ``None``, include all processings.
-    ignore_spaces : str | collection of str | None
+    ignore_spaces : str | array-like of str | None
         Space(s) to ignore. If ``None``, include all spaces.
-    ignore_acquisitions : str | collection of str | None
+    ignore_acquisitions : str | array-like of str | None
         Acquisition(s) to ignore. If ``None``, include all acquisitions.
-    ignore_splits : str | collection of str | None
+    ignore_splits : str | array-like of str | None
         Split(s) to ignore. If ``None``, include all splits.
-    ignore_modalities : str | collection of str | None
+    ignore_modalities : str | array-like of str | None
         Modalities(s) to ignore. If ``None``, include all modalities.
-    ignore_datatypes : str | collection of str | None
+    ignore_datatypes : str | array-like of str | None
         Datatype(s) to ignore. If ``None``, include all datatypes (i.e.
         ``anat``, ``ieeg``, ``eeg``, ``meg``, ``func``, etc.)
-    ignore_dirs : str | collection of str | None
+    ignore_dirs : str | array-like of str | None
         Directories nested directly within ``root`` to ignore. If ``None``,
         include all directories in the search.
 
-        .. versionaded:: 0.9
+        .. versionadded:: 0.9
     with_key : bool
         If ``True``, returns the full entity with the key and the value. This
         will for example look like ``['sub-001', 'sub-002']``.

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -78,23 +78,27 @@ def test_get_keys(return_bids_test_dir):
     assert modalities == ['meg']
 
 
-@pytest.mark.parametrize('entity, expected_vals, kwargs',
-                         [('bogus', None, None),
-                          ('subject', [subject_id], None),
-                          ('session', [session_id], None),
-                          ('run', [run, '02'], None),
-                          ('acquisition', ['calibration', 'crosstalk'], None),
-                          ('task', [task], None),
-                          ('subject', [], dict(ignore_subjects=[subject_id])),
-                          ('subject', [], dict(ignore_subjects=subject_id)),
-                          ('session', [], dict(ignore_sessions=[session_id])),
-                          ('session', [], dict(ignore_sessions=session_id)),
-                          ('run', [run], dict(ignore_runs=['02'])),
-                          ('run', [run], dict(ignore_runs='02')),
-                          ('task', [], dict(ignore_tasks=[task])),
-                          ('task', [], dict(ignore_tasks=task)),
-                          ('run', [run, '02'], dict(ignore_runs=['bogus'])),
-                          ('run', [], dict(ignore_datatypes=['meg']))])
+@pytest.mark.parametrize(
+    'entity, expected_vals, kwargs',
+    [
+        ('bogus', None, None),
+        ('subject', [subject_id], None),
+        ('session', [session_id], None),
+        ('run', [run, '02'], None),
+        ('acquisition', ['calibration', 'crosstalk'], None),
+        ('task', [task], None),
+        ('subject', [], dict(ignore_subjects=[subject_id])),
+        ('subject', [], dict(ignore_subjects=subject_id)),
+        ('session', [], dict(ignore_sessions=[session_id])),
+        ('session', [], dict(ignore_sessions=session_id)),
+        ('run', [run], dict(ignore_runs=['02'])),
+        ('run', [run], dict(ignore_runs='02')),
+        ('task', [], dict(ignore_tasks=[task])),
+        ('task', [], dict(ignore_tasks=task)),
+        ('run', [run, '02'], dict(ignore_runs=['bogus'])),
+        ('run', [], dict(ignore_datatypes=['meg']))
+    ]
+)
 def test_get_entity_vals(entity, expected_vals, kwargs, return_bids_test_dir):
     """Test getting a list of entities."""
     bids_root = return_bids_test_dir
@@ -124,6 +128,13 @@ def test_get_entity_vals(entity, expected_vals, kwargs, return_bids_test_dir):
         }
         assert entities == [f'{entity_long_to_short[entity]}-{val}'
                             for val in expected_vals]
+
+        # Test without ignoring the derivatives dir
+        entities = get_entity_vals(
+            root=bids_root, entity_key=entity, **kwargs, ignore_dirs=None
+        )
+        if entity not in ('acquisition', 'run'):
+            assert 'deriv' in entities
 
     # Clean up
     shutil.rmtree(deriv_path)

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -78,27 +78,23 @@ def test_get_keys(return_bids_test_dir):
     assert modalities == ['meg']
 
 
-@pytest.mark.parametrize(
-    'entity, expected_vals, kwargs',
-    [
-        ('bogus', None, None),
-        ('subject', [subject_id], None),
-        ('session', [session_id], None),
-        ('run', [run, '02'], None),
-        ('acquisition', ['calibration', 'crosstalk'], None),
-        ('task', [task], None),
-        ('subject', [], dict(ignore_subjects=[subject_id])),
-        ('subject', [], dict(ignore_subjects=subject_id)),
-        ('session', [], dict(ignore_sessions=[session_id])),
-        ('session', [], dict(ignore_sessions=session_id)),
-        ('run', [run], dict(ignore_runs=['02'])),
-        ('run', [run], dict(ignore_runs='02')),
-        ('task', [], dict(ignore_tasks=[task])),
-        ('task', [], dict(ignore_tasks=task)),
-        ('run', [run, '02'], dict(ignore_runs=['bogus'])),
-        ('run', [], dict(ignore_datatypes=['meg']))
-    ]
-)
+@pytest.mark.parametrize('entity, expected_vals, kwargs',
+                         [('bogus', None, None),
+                          ('subject', [subject_id], None),
+                          ('session', [session_id], None),
+                          ('run', [run, '02'], None),
+                          ('acquisition', ['calibration', 'crosstalk'], None),
+                          ('task', [task], None),
+                          ('subject', [], dict(ignore_subjects=[subject_id])),
+                          ('subject', [], dict(ignore_subjects=subject_id)),
+                          ('session', [], dict(ignore_sessions=[session_id])),
+                          ('session', [], dict(ignore_sessions=session_id)),
+                          ('run', [run], dict(ignore_runs=['02'])),
+                          ('run', [run], dict(ignore_runs='02')),
+                          ('task', [], dict(ignore_tasks=[task])),
+                          ('task', [], dict(ignore_tasks=task)),
+                          ('run', [run, '02'], dict(ignore_runs=['bogus'])),
+                          ('run', [], dict(ignore_datatypes=['meg']))])
 def test_get_entity_vals(entity, expected_vals, kwargs, return_bids_test_dir):
     """Test getting a list of entities."""
     bids_root = return_bids_test_dir


### PR DESCRIPTION
Add a new parameter `ignore_dirs`, allowing users to specify which directories to ignore when getting entity values. Defaults to the exclusion of `derivatives` and `sourcedata`.


Closes #907
cc @agramfort @adam2392 

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
