### PR TITLE
MRG: When anonymizing, transfer trigger codes

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -51,7 +51,7 @@ Enhancements
 
 - The command ``mne_bids count_events`` gained new parameters: ``--output`` to direct the output into a CSV file; ``--overwrite`` to overwrite an existing file; and  ``--silent`` to suppress output of the event counts to the console, by `Richard Höchenberger`_ (:gh:`888`)
 
-- The new function :func:`mne_bids.anonymize_dataset` can be used to anonymize an entire BIDS dataset, by `Richard Höchenberger`_ (:gh:`893`)
+- The new function :func:`mne_bids.anonymize_dataset` can be used to anonymize an entire BIDS dataset, by `Richard Höchenberger`_ (:gh:`893`, :gh:`914`)
 
 - :meth:`mne_bids.BIDSPath.find_empty_room` gained a new parameter ``use_sidecar_only`` to limit empty-room search to the metadata stored in the sidecar files, by `Richard Höchenberger`_ (:gh:`893`)
 

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -3149,6 +3149,16 @@ def test_anonymize_dataset(_bids_validate, tmpdir):
     assert (bids_root_anon / 'sub-emptyroom' / 'ses-19221211' / 'meg' /
             'sub-emptyroom_ses-19221211_task-noise_meg.fif').exists()
 
+    events_tsv_orig_bp = bids_path.copy().update(
+        suffix='events', extension='.tsv'
+    )
+    events_tsv_anonymized_bp = events_tsv_orig_bp.copy().update(
+        subject='1', root=bids_root_anon
+    )
+    events_tsv_orig = _from_tsv(events_tsv_orig_bp)
+    events_tsv_anonymized = _from_tsv(events_tsv_anonymized_bp)
+    assert events_tsv_orig == events_tsv_anonymized
+
     # Explicitly specify multiple data types
     bids_root_anon = tmpdir / 'bids-anonymized-1'
     anonymize_dataset(


### PR DESCRIPTION
Previously, anonymization would cause a new assignment of trigger codes, which could lead to confusion and inconsistencies across participants – or even within participants across runs (different values for the same event types)

We now simply overwrite the trigger codes in the anonymized `*_events.tsv` files with the original codes.

This problem is directly related to #223, and the solution implemented here is merely a workaround (which is good enough for now)


Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
