### PR TITLE
Neuroscan Support

### DIFF
--- a/doc/authors.rst
+++ b/doc/authors.rst
@@ -31,3 +31,4 @@
 .. _Kambiz Tavabi: https://github.com/ktavabi
 .. _Franziska von Albedyll: https://www.researchgate.net/profile/Franziska-Von-Albedyll
 .. _Simon Kern: https://github.com/skjerns
+.. _Yorguin Mantilla: https://github.com/yjmantilla

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -30,6 +30,7 @@ People who contributed to this release (in alphabetical order):
 * `Mainak Jas`_
 * `Richard Höchenberger`_
 * `Stefan Appelhoff`_
+* `Yorguin Mantilla`_
 
 Detailed list of changes
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -37,7 +38,7 @@ Detailed list of changes
 Enhancements
 ^^^^^^^^^^^^
 
-- ...
+- Add support for CNT (Neuroscan) files in :func:`mne_bids.write_raw_bids`, by `Yorguin Mantilla`_ (:gh:`924`)
 
 API and behavior changes
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/mne_bids/config.py
+++ b/mne_bids/config.py
@@ -52,7 +52,7 @@ eeg_manufacturers = {'.vhdr': 'BrainProducts', '.eeg': 'BrainProducts',
                      '.set': 'n/a', '.fdt': 'n/a',
                      '.lay': 'Persyst', '.dat': 'Persyst',
                      '.EEG': 'Nihon Kohden',
-                     '.cnt': 'Neuroscan'}
+                     '.cnt': 'Neuroscan', '.CNT': 'Neuroscan'}
 
 ieeg_manufacturers = {'.vhdr': 'BrainProducts', '.eeg': 'BrainProducts',
                       '.edf': 'n/a', '.EDF': 'n/a', '.set': 'n/a',
@@ -68,7 +68,7 @@ reader = {'.con': io.read_raw_kit, '.sqd': io.read_raw_kit,
           '.bdf': io.read_raw_bdf,
           '.set': io.read_raw_eeglab, '.lay': io.read_raw_persyst,
           '.EEG': io.read_raw_nihon,
-          '.cnt': io.read_raw_cnt}
+          '.cnt': io.read_raw_cnt, '.CNT': io.read_raw_cnt}
 
 
 # Merge the manufacturer dictionaries in a python2 / python3 compatible way
@@ -92,7 +92,7 @@ allowed_extensions_eeg = ['.vhdr',  # BrainVision, accompanied by .vmrk, .eeg
                           '.edf',  # European Data Format
                           '.bdf',  # Biosemi
                           '.set',  # EEGLAB, potentially accompanied by .fdt
-                          '.cnt']  # Neuroscan
+                          ]
 
 allowed_extensions_ieeg = ['.vhdr',  # BrainVision, accompanied by .vmrk, .eeg
                            '.edf',  # European Data Format
@@ -111,7 +111,7 @@ ALLOWED_DATATYPE_EXTENSIONS = {'meg': allowed_extensions_meg,
 # recommended formats
 ALLOWED_INPUT_EXTENSIONS = \
     allowed_extensions_meg + allowed_extensions_eeg + \
-    allowed_extensions_ieeg + ['.lay', '.EEG']
+    allowed_extensions_ieeg + ['.lay', '.EEG', '.cnt', '.CNT']
 
 # allowed suffixes (i.e. last "_" delimiter in the BIDS filenames before
 # the extension)

--- a/mne_bids/config.py
+++ b/mne_bids/config.py
@@ -51,7 +51,8 @@ eeg_manufacturers = {'.vhdr': 'BrainProducts', '.eeg': 'BrainProducts',
                      '.BDF': 'Biosemi',
                      '.set': 'n/a', '.fdt': 'n/a',
                      '.lay': 'Persyst', '.dat': 'Persyst',
-                     '.EEG': 'Nihon Kohden'}
+                     '.EEG': 'Nihon Kohden',
+                     '.cnt': 'Neuroscan'}
 
 ieeg_manufacturers = {'.vhdr': 'BrainProducts', '.eeg': 'BrainProducts',
                       '.edf': 'n/a', '.EDF': 'n/a', '.set': 'n/a',
@@ -66,7 +67,8 @@ reader = {'.con': io.read_raw_kit, '.sqd': io.read_raw_kit,
           '.edf': io.read_raw_edf, '.EDF': io.read_raw_edf,
           '.bdf': io.read_raw_bdf,
           '.set': io.read_raw_eeglab, '.lay': io.read_raw_persyst,
-          '.EEG': io.read_raw_nihon}
+          '.EEG': io.read_raw_nihon,
+          '.cnt': io.read_raw_cnt}
 
 
 # Merge the manufacturer dictionaries in a python2 / python3 compatible way
@@ -90,7 +92,7 @@ allowed_extensions_eeg = ['.vhdr',  # BrainVision, accompanied by .vmrk, .eeg
                           '.edf',  # European Data Format
                           '.bdf',  # Biosemi
                           '.set',  # EEGLAB, potentially accompanied by .fdt
-                          ]
+                          '.cnt']  # Neuroscan
 
 allowed_extensions_ieeg = ['.vhdr',  # BrainVision, accompanied by .vmrk, .eeg
                            '.edf',  # European Data Format

--- a/mne_bids/inspect.py
+++ b/mne_bids/inspect.py
@@ -13,7 +13,7 @@ import mne
 from mne.utils import logger, verbose
 from mne.fixes import _compare_version
 
-if _compare_version(mne.__version__, '<', '1.0.dev0'):
+if _compare_version(mne.__version__, '<', '1.0.dev0'):  # pragma: no cover
     from mne.preprocessing import annotate_flat
     _annotate_flat_func = annotate_flat
 else:
@@ -142,7 +142,7 @@ def _inspect_raw(*, bids_path, l_freq, h_freq, find_flat, show_annotations):
                 min_duration=0.05,
                 bad_percent=5
             )
-        else:  # annotate_flat
+        else:  # pragma: no cover
             flat_annot, flat_chans = annotate_flat(
                 raw=raw,
                 min_duration=0.05

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -78,9 +78,10 @@ warning_str = dict(
               'blocks:RuntimeWarning:mne',
     brainvision_unit='ignore:Encountered unsupported '
                      'non-voltage units*.:UserWarning',
-    cnt_warning1='ignore:.*Could not parse meas date from the header. Setting to None.',
+    cnt_warning1='ignore:.*Could not parse meas date from the header. '
+                 'Setting to None.',
     cnt_warning2='ignore:.*Could not define the number of bytes automatically.'
-                  ' Defaulting to 2.',
+                 ' Defaulting to 2.',
     no_hand='ignore:.*Not setting subject handedness.:RuntimeWarning:mne'
 )
 
@@ -110,7 +111,7 @@ test_eegieeg_data = [
     ('EDF', 'test_reduced.edf', _read_raw_edf),
     ('Persyst', 'sub-pt1_ses-02_task-monitor_acq-ecog_run-01_clip2.lay', _read_raw_persyst),  # noqa
     ('NihonKohden', 'MB0400FU.EEG', _read_raw_nihon),
-    ('CNT','scan41_short.cnt',_read_raw_cnt),
+    ('CNT', 'scan41_short.cnt', _read_raw_cnt),
 ]
 test_convert_data = test_eegieeg_data.copy()
 test_convert_data.append(('CTF', 'testdata_ctf.ds', _read_raw_ctf))
@@ -125,10 +126,10 @@ test_convertmeg_data = [
 test_converteeg_data = [
     ('Persyst', 'BrainVision', 'sub-pt1_ses-02_task-monitor_acq-ecog_run-01_clip2.lay', _read_raw_persyst),  # noqa
     ('NihonKohden', 'BrainVision', 'MB0400FU.EEG', _read_raw_nihon),
-    ('CNT','BrainVision','scan41_short.cnt',_read_raw_cnt),
+    ('CNT', 'BrainVision', 'scan41_short.cnt', _read_raw_cnt),
     ('Persyst', 'EDF', 'sub-pt1_ses-02_task-monitor_acq-ecog_run-01_clip2.lay', _read_raw_persyst),  # noqa
     ('NihonKohden', 'EDF', 'MB0400FU.EEG', _read_raw_nihon),
-    ('CNT','EDF','scan41_short.cnt',_read_raw_cnt)
+    ('CNT', 'EDF', 'scan41_short.cnt', _read_raw_cnt)
 ]
 
 
@@ -1194,7 +1195,8 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate, tmp_path):
             bids_output_path = write_raw_bids(**kwargs)
     elif dir_name == 'CNT':
         with pytest.warns(RuntimeWarning,
-                            match='Encountered data in "int" format. Converting to float32.'):
+                          match='Encountered data in "int" format. '
+                          'Converting to float32.'):
             bids_output_path = write_raw_bids(**kwargs)
     else:
         with pytest.warns(RuntimeWarning,
@@ -1241,7 +1243,8 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate, tmp_path):
             write_raw_bids(**kwargs)
     elif dir_name == 'CNT':
         with pytest.warns(RuntimeWarning,
-                            match='Encountered data in "int" format. Converting to float32.'):
+                          match='Encountered data in "int" format. '
+                          'Converting to float32.'):
             write_raw_bids(**kwargs)
     else:
         with pytest.warns(RuntimeWarning,
@@ -1266,7 +1269,8 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate, tmp_path):
             write_raw_bids(**kwargs)
     elif dir_name == 'CNT':
         with pytest.warns(RuntimeWarning,
-                            match='Encountered data in "int" format. Converting to float32.'):
+                          match='Encountered data in "int" format. '
+                          'Converting to float32.'):
             write_raw_bids(**kwargs)
     else:
         with pytest.warns(RuntimeWarning,
@@ -1331,7 +1335,8 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate, tmp_path):
             write_raw_bids(**kwargs)
     elif dir_name == 'CNT':
         with pytest.warns(RuntimeWarning,
-                            match='Encountered data in "int" format. Converting to float32.'):
+                          match='Encountered data in "int" format. '
+                          'Converting to float32.'):
             write_raw_bids(**kwargs)
     else:
         with pytest.warns(RuntimeWarning,
@@ -1381,7 +1386,8 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate, tmp_path):
                 write_raw_bids(**kwargs)
         elif dir_name == 'CNT':
             with pytest.warns(RuntimeWarning,
-                                match='Encountered data in "int" format. Converting to float32.'):
+                              match='Encountered data in "int" format. '
+                              'Converting to float32.'):
                 write_raw_bids(**kwargs)
         else:
             with pytest.warns(RuntimeWarning,
@@ -1417,7 +1423,8 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate, tmp_path):
             write_raw_bids(**kwargs)
     elif dir_name == 'CNT':
         with pytest.warns(RuntimeWarning,
-                            match='Encountered data in "int" format. Converting to float32.'):
+                          match='Encountered data in "int" format. '
+                          'Converting to float32.'):
             write_raw_bids(**kwargs)
     else:
         with pytest.warns(RuntimeWarning,
@@ -1458,7 +1465,8 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate, tmp_path):
             write_raw_bids(**kwargs)
     elif dir_name == 'CNT':
         with pytest.warns(RuntimeWarning,
-                            match='Encountered data in "int" format. Converting to float32.'):
+                          match='Encountered data in "int" format. '
+                          'Converting to float32.'):
             write_raw_bids(**kwargs)
     else:
         with pytest.warns(RuntimeWarning,
@@ -1510,7 +1518,8 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate, tmp_path):
             write_raw_bids(**kwargs)
     elif dir_name == 'CNT':
         with pytest.warns(RuntimeWarning,
-                            match='Encountered data in "int" format. Converting to float32.'):
+                          match='Encountered data in "int" format. '
+                          'Converting to float32.'):
             write_raw_bids(**kwargs)
     else:
         with pytest.warns(RuntimeWarning,
@@ -1566,7 +1575,8 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate, tmp_path):
                 output_path = _test_anonymize(tmp_path / 'b', raw, bids_path)
         elif dir_name == 'CNT':
             with pytest.warns(RuntimeWarning,
-                                match='Encountered data in "int" format. Converting to float32.'):
+                              match='Encountered data in "int" format. '
+                              'Converting to float32.'):
                 write_raw_bids(**kwargs)
                 output_path = _test_anonymize(tmp_path / 'c', raw, bids_path)
         else:
@@ -2863,7 +2873,7 @@ def test_sidecar_encoding(_bids_validate, tmp_path):
     warning_str['cnt_warning1'],
     warning_str['cnt_warning2'],
     warning_str['no_hand'],
-    )
+)
 def test_convert_eeg_formats(dir_name, format, fname, reader, tmp_path):
     """Test conversion of EEG/iEEG manufacturer fmt to BrainVision/EDF."""
     bids_root = tmp_path / format
@@ -2887,7 +2897,8 @@ def test_convert_eeg_formats(dir_name, format, fname, reader, tmp_path):
                 bids_output_path = write_raw_bids(**kwargs)
         elif dir_name == 'CNT':
             with pytest.warns(RuntimeWarning,
-                              match='Encountered data in "int" format. Converting to float32.'):
+                              match='Encountered data in "int" format. '
+                              'Converting to float32.'):
                 bids_output_path = write_raw_bids(**kwargs)
         else:
             with pytest.warns(RuntimeWarning,
@@ -2938,7 +2949,7 @@ def test_convert_eeg_formats(dir_name, format, fname, reader, tmp_path):
     warning_str['cnt_warning1'],
     warning_str['cnt_warning2'],
     warning_str['no_hand'],
-    )
+)
 def test_format_conversion_overwrite(dir_name, format, fname, reader,
                                      tmp_path):
     """Test that overwrite works when format is passed to write_raw_bids."""
@@ -2973,7 +2984,7 @@ def test_format_conversion_overwrite(dir_name, format, fname, reader,
     warning_str['cnt_warning1'],
     warning_str['cnt_warning2'],
     warning_str['no_hand'],
-    )
+)
 def test_error_write_meg_as_eeg(dir_name, format, fname, reader, tmp_path):
     """Test error writing as BrainVision EEG data for MEG."""
     bids_root = tmp_path / 'bids1'
@@ -3033,7 +3044,7 @@ def test_convert_meg_formats(dir_name, format, fname, reader, tmp_path):
     warning_str['cnt_warning1'],
     warning_str['cnt_warning2'],
     warning_str['no_hand'],
-    )
+)
 def test_convert_raw_errors(dir_name, fname, reader, tmp_path):
     """Test errors when converting raw file formats."""
     bids_root = tmp_path / 'bids_1'

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -77,7 +77,11 @@ warning_str = dict(
     edfblocks='ignore:.*EDF format requires equal-length data '
               'blocks:RuntimeWarning:mne',
     brainvision_unit='ignore:Encountered unsupported '
-                     'non-voltage units*.:UserWarning'
+                     'non-voltage units*.:UserWarning',
+    cnt_warning1='ignore:.*Could not parse meas date from the header. Setting to None.',
+    cnt_warning2='ignore:.*Could not define the number of bytes automatically.'
+                  ' Defaulting to 2.',
+    no_hand='ignore:.*Not setting subject handedness.:RuntimeWarning:mne'
 )
 
 
@@ -99,12 +103,14 @@ _read_raw_eeglab = _wrap_read_raw(mne.io.read_raw_eeglab)
 _read_raw_brainvision = _wrap_read_raw(mne.io.read_raw_brainvision)
 _read_raw_persyst = _wrap_read_raw(mne.io.read_raw_persyst)
 _read_raw_nihon = _wrap_read_raw(mne.io.read_raw_nihon)
+_read_raw_cnt = _wrap_read_raw(mne.io.read_raw_cnt)
 
 # parametrized directory, filename and reader for EEG/iEEG data formats
 test_eegieeg_data = [
     ('EDF', 'test_reduced.edf', _read_raw_edf),
     ('Persyst', 'sub-pt1_ses-02_task-monitor_acq-ecog_run-01_clip2.lay', _read_raw_persyst),  # noqa
-    ('NihonKohden', 'MB0400FU.EEG', _read_raw_nihon)
+    ('NihonKohden', 'MB0400FU.EEG', _read_raw_nihon),
+    ('CNT','scan41_short.cnt',_read_raw_cnt),
 ]
 test_convert_data = test_eegieeg_data.copy()
 test_convert_data.append(('CTF', 'testdata_ctf.ds', _read_raw_ctf))
@@ -119,8 +125,10 @@ test_convertmeg_data = [
 test_converteeg_data = [
     ('Persyst', 'BrainVision', 'sub-pt1_ses-02_task-monitor_acq-ecog_run-01_clip2.lay', _read_raw_persyst),  # noqa
     ('NihonKohden', 'BrainVision', 'MB0400FU.EEG', _read_raw_nihon),
+    ('CNT','BrainVision','scan41_short.cnt',_read_raw_cnt),
     ('Persyst', 'EDF', 'sub-pt1_ses-02_task-monitor_acq-ecog_run-01_clip2.lay', _read_raw_persyst),  # noqa
     ('NihonKohden', 'EDF', 'MB0400FU.EEG', _read_raw_nihon),
+    ('CNT','EDF','scan41_short.cnt',_read_raw_cnt)
 ]
 
 
@@ -1161,7 +1169,10 @@ def test_vhdr(_bids_validate, tmp_path):
 @pytest.mark.filterwarnings(
     warning_str['nasion_not_found'],
     warning_str['brainvision_unit'],
-    warning_str['channel_unit_changed']
+    warning_str['channel_unit_changed'],
+    warning_str['cnt_warning1'],
+    warning_str['cnt_warning2'],
+    warning_str['no_hand'],
 )
 def test_eegieeg(dir_name, fname, reader, _bids_validate, tmp_path):
     """Test write_raw_bids conversion for EEG/iEEG data formats."""
@@ -1180,6 +1191,10 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate, tmp_path):
     elif dir_name == 'NihonKohden':
         with pytest.warns(RuntimeWarning,
                           match='Encountered data in "short" format'):
+            bids_output_path = write_raw_bids(**kwargs)
+    elif dir_name == 'CNT':
+        with pytest.warns(RuntimeWarning,
+                            match='Encountered data in "int" format. Converting to float32.'):
             bids_output_path = write_raw_bids(**kwargs)
     else:
         with pytest.warns(RuntimeWarning,
@@ -1224,6 +1239,10 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate, tmp_path):
         with pytest.warns(RuntimeWarning,
                           match='Encountered data in "short" format'):
             write_raw_bids(**kwargs)
+    elif dir_name == 'CNT':
+        with pytest.warns(RuntimeWarning,
+                            match='Encountered data in "int" format. Converting to float32.'):
+            write_raw_bids(**kwargs)
     else:
         with pytest.warns(RuntimeWarning,
                           match='Encountered data in "double" format'):
@@ -1244,6 +1263,10 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate, tmp_path):
     elif dir_name == 'NihonKohden':
         with pytest.warns(RuntimeWarning,
                           match='Encountered data in "short" format'):
+            write_raw_bids(**kwargs)
+    elif dir_name == 'CNT':
+        with pytest.warns(RuntimeWarning,
+                            match='Encountered data in "int" format. Converting to float32.'):
             write_raw_bids(**kwargs)
     else:
         with pytest.warns(RuntimeWarning,
@@ -1306,6 +1329,10 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate, tmp_path):
         with pytest.warns(RuntimeWarning,
                           match='Encountered data in "short" format'):
             write_raw_bids(**kwargs)
+    elif dir_name == 'CNT':
+        with pytest.warns(RuntimeWarning,
+                            match='Encountered data in "int" format. Converting to float32.'):
+            write_raw_bids(**kwargs)
     else:
         with pytest.warns(RuntimeWarning,
                           match='Encountered data in "double" format'):
@@ -1335,8 +1362,12 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate, tmp_path):
 
     # check that scans list is properly converted to brainvision
     if check_version('pybv', '0.6') or dir_name == 'EDF':
-        daysback_min, daysback_max = _get_anonymization_daysback(raw)
-        daysback = (daysback_min + daysback_max) // 2
+        if raw.info['meas_date'] is not None:
+            daysback_min, daysback_max = _get_anonymization_daysback(raw)
+            daysback = (daysback_min + daysback_max) // 2
+        else:
+            # just pass back any arbitrary number if no measurement date
+            daysback = 3300
 
         kwargs = dict(raw=raw, bids_path=bids_path,
                       anonymize=dict(daysback=daysback), overwrite=True)
@@ -1347,6 +1378,10 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate, tmp_path):
         elif dir_name == 'Persyst':
             with pytest.warns(RuntimeWarning,
                               match='Encountered data in "double" format'):
+                write_raw_bids(**kwargs)
+        elif dir_name == 'CNT':
+            with pytest.warns(RuntimeWarning,
+                                match='Encountered data in "int" format. Converting to float32.'):
                 write_raw_bids(**kwargs)
         else:
             with pytest.warns(RuntimeWarning,
@@ -1379,6 +1414,10 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate, tmp_path):
     elif dir_name == 'NihonKohden':
         with pytest.warns(RuntimeWarning,
                           match='Encountered data in "short" format'):
+            write_raw_bids(**kwargs)
+    elif dir_name == 'CNT':
+        with pytest.warns(RuntimeWarning,
+                            match='Encountered data in "int" format. Converting to float32.'):
             write_raw_bids(**kwargs)
     else:
         with pytest.warns(RuntimeWarning,
@@ -1416,6 +1455,10 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate, tmp_path):
     elif dir_name == 'NihonKohden':
         with pytest.warns(RuntimeWarning,
                           match='Encountered data in "short" format'):
+            write_raw_bids(**kwargs)
+    elif dir_name == 'CNT':
+        with pytest.warns(RuntimeWarning,
+                            match='Encountered data in "int" format. Converting to float32.'):
             write_raw_bids(**kwargs)
     else:
         with pytest.warns(RuntimeWarning,
@@ -1464,6 +1507,10 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate, tmp_path):
     elif dir_name == 'NihonKohden':
         with pytest.warns(RuntimeWarning,
                           match='Encountered data in "short" format'):
+            write_raw_bids(**kwargs)
+    elif dir_name == 'CNT':
+        with pytest.warns(RuntimeWarning,
+                            match='Encountered data in "int" format. Converting to float32.'):
             write_raw_bids(**kwargs)
     else:
         with pytest.warns(RuntimeWarning,
@@ -1517,11 +1564,16 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate, tmp_path):
             with pytest.warns(RuntimeWarning, match=match):
                 write_raw_bids(**kwargs)  # Just copies.
                 output_path = _test_anonymize(tmp_path / 'b', raw, bids_path)
+        elif dir_name == 'CNT':
+            with pytest.warns(RuntimeWarning,
+                                match='Encountered data in "int" format. Converting to float32.'):
+                write_raw_bids(**kwargs)
+                output_path = _test_anonymize(tmp_path / 'c', raw, bids_path)
         else:
             with pytest.warns(RuntimeWarning,
                               match='Encountered data in "double" format'):
                 write_raw_bids(**kwargs)  # Converts.
-                output_path = _test_anonymize(tmp_path / 'c', raw, bids_path)
+                output_path = _test_anonymize(tmp_path / 'd', raw, bids_path)
         _bids_validate(output_path)
 
 
@@ -2806,7 +2858,12 @@ def test_sidecar_encoding(_bids_validate, tmp_path):
 @pytest.mark.parametrize(
     'dir_name, format, fname, reader', test_converteeg_data)
 @pytest.mark.filterwarnings(
-    warning_str['channel_unit_changed'], warning_str['edfblocks'])
+    warning_str['channel_unit_changed'],
+    warning_str['edfblocks'],
+    warning_str['cnt_warning1'],
+    warning_str['cnt_warning2'],
+    warning_str['no_hand'],
+    )
 def test_convert_eeg_formats(dir_name, format, fname, reader, tmp_path):
     """Test conversion of EEG/iEEG manufacturer fmt to BrainVision/EDF."""
     bids_root = tmp_path / format
@@ -2827,6 +2884,10 @@ def test_convert_eeg_formats(dir_name, format, fname, reader, tmp_path):
         if dir_name == 'NihonKohden':
             with pytest.warns(RuntimeWarning,
                               match='Encountered data in "short" format'):
+                bids_output_path = write_raw_bids(**kwargs)
+        elif dir_name == 'CNT':
+            with pytest.warns(RuntimeWarning,
+                              match='Encountered data in "int" format. Converting to float32.'):
                 bids_output_path = write_raw_bids(**kwargs)
         else:
             with pytest.warns(RuntimeWarning,
@@ -2872,7 +2933,12 @@ def test_convert_eeg_formats(dir_name, format, fname, reader, tmp_path):
 @pytest.mark.parametrize(
     'dir_name, format, fname, reader', test_converteeg_data)
 @pytest.mark.filterwarnings(
-    warning_str['channel_unit_changed'], warning_str['edfblocks'])
+    warning_str['channel_unit_changed'],
+    warning_str['edfblocks'],
+    warning_str['cnt_warning1'],
+    warning_str['cnt_warning2'],
+    warning_str['no_hand'],
+    )
 def test_format_conversion_overwrite(dir_name, format, fname, reader,
                                      tmp_path):
     """Test that overwrite works when format is passed to write_raw_bids."""
@@ -2902,7 +2968,12 @@ def test_format_conversion_overwrite(dir_name, format, fname, reader,
 @requires_version('mne', '0.22')
 @pytest.mark.parametrize(
     'dir_name, format, fname, reader', test_converteeg_data)
-@pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
+@pytest.mark.filterwarnings(
+    warning_str['channel_unit_changed'],
+    warning_str['cnt_warning1'],
+    warning_str['cnt_warning2'],
+    warning_str['no_hand'],
+    )
 def test_error_write_meg_as_eeg(dir_name, format, fname, reader, tmp_path):
     """Test error writing as BrainVision EEG data for MEG."""
     bids_root = tmp_path / 'bids1'
@@ -2957,7 +3028,12 @@ def test_convert_meg_formats(dir_name, format, fname, reader, tmp_path):
 
 
 @pytest.mark.parametrize('dir_name, fname, reader', test_convert_data)
-@pytest.mark.filterwarnings(warning_str['channel_unit_changed'])
+@pytest.mark.filterwarnings(
+    warning_str['channel_unit_changed'],
+    warning_str['cnt_warning1'],
+    warning_str['cnt_warning2'],
+    warning_str['no_hand'],
+    )
 def test_convert_raw_errors(dir_name, fname, reader, tmp_path):
     """Test errors when converting raw file formats."""
     bids_root = tmp_path / 'bids_1'


### PR DESCRIPTION
PR Description
--------------

PR to add support of .cnt files.

Closes #922 



Output of make pep just said:

```
"Running flake8"
0
"Running pydocstyle"
"Checking MANIFEST.in"
lists of files in version control and sdist match
```

I ran the tests locally and it said ``237 passed``  (at the end).

Documentation build ended with:

```
Sphinx-Gallery successfully executed 13 out of 13 files subselected by:

    gallery_conf["filename_pattern"] = '^((?!sgskip).)*$'
    gallery_conf["ignore_pattern"]   = '__init__\\.py'

after excluding 0 files that had previously been run (based on MD5).

embedding documentation hyperlinks...
embedding documentation hyperlinks for auto_examples... [100%] update_bids_datasets.htmlhtml
make[1]: Leaving directory 'Y:/code/mne-bids/doc'
cd doc/ && make view
make[1]: Entering directory 'Y:/code/mne-bids/doc'
make[1]: Leaving directory 'Y:/code/mne-bids/doc'
```


Let me know if anything else is required, like an specific test for cnt files.

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
