### PR TITLE
MRG: Don't store age, sex, handedness for empty-room in participants.tsv

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -56,6 +56,9 @@ Bug fixes
 
 - :func:`mne_bids.make_report` now correctly handles `participant.tsv` files that only contain a `participant_id` column, by `Simon Kern`_ (:gh:`912`)
 
+- :func:`mne_bids.write_raw_bids` doesn't store age, handedness, and sex in `participants.tsv` anymore for empty-room recordings, by `Richard Höchenberger`_ (:gh:`935`)
+
+
 :doc:`Find out what was new in previous releases <whats_new_previous_releases>`
 
 .. include:: authors.rst

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -303,14 +303,11 @@ def _participants_tsv(raw, subject_id, fname, overwrite=False):
         False, an error will be raised.
 
     """
-    subject_id = 'sub-' + subject_id
-    data = OrderedDict(participant_id=[subject_id])
-
     subject_age = "n/a"
     sex = "n/a"
     hand = 'n/a'
     subject_info = raw.info.get('subject_info', None)
-    if subject_info is not None:
+    if subject_id != 'emptyroom' and subject_info is not None:
         # add sex
         sex = _map_options(what='sex', key=subject_info.get('sex', 0),
                            fro='mne', to='bids')
@@ -336,6 +333,8 @@ def _participants_tsv(raw, subject_id, fname, overwrite=False):
         else:
             subject_age = "n/a"
 
+    subject_id = 'sub-' + subject_id
+    data = OrderedDict(participant_id=[subject_id])
     data.update({'age': [subject_age], 'sex': [sex], 'hand': [hand]})
 
     if os.path.exists(fname):
@@ -1533,8 +1532,10 @@ def write_raw_bids(raw, bids_path, events_data=None, event_id=None,
     _readme(bids_path.datatype, readme_fname, False)
 
     # save all participants meta data
-    _participants_tsv(raw, bids_path.subject, participants_tsv_fname,
-                      overwrite)
+    _participants_tsv(
+        raw=raw, subject_id=bids_path.subject, fname=participants_tsv_fname,
+        overwrite=overwrite
+    )
     _participants_json(participants_json_fname, True)
 
     # for MEG, we only write coordinate system


### PR DESCRIPTION
I came across some datasets where, for whatever reason, a participant age etc. were included in `raw.info['subject_info']` for empty-room recordings. This PR makes it so that such info isn't added to `participants.tsv` anymore.

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
