### PR TITLE
MRG: Fix handling of n/a event values when auto-renaming events on read

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
         # restore cache from last build. Unless __init__.py has changed since then
         - restore_cache:
             keys:
-              - data-cache-2-{{ checksum "./mne_bids/__init__.py" }}
+              - data-cache-3-{{ checksum "./mne_bids/__init__.py" }}
 
         # Also restore pip cache to speed up installations
         - restore_cache:
@@ -48,7 +48,7 @@ jobs:
 
         # Store the data cache
         - save_cache:
-            key: data-cache-2-{{ checksum "./mne_bids/__init__.py" }}
+            key: data-cache-3-{{ checksum "./mne_bids/__init__.py" }}
             paths:
               - ~/mne_data
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
         # restore cache from last build. Unless __init__.py has changed since then
         - restore_cache:
             keys:
-              - data-cache-3-{{ checksum "./mne_bids/__init__.py" }}
+              - data-cache-4-{{ checksum "./mne_bids/__init__.py" }}
 
         # Also restore pip cache to speed up installations
         - restore_cache:
@@ -48,7 +48,7 @@ jobs:
 
         # Store the data cache
         - save_cache:
-            key: data-cache-3-{{ checksum "./mne_bids/__init__.py" }}
+            key: data-cache-4-{{ checksum "./mne_bids/__init__.py" }}
             paths:
               - ~/mne_data
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -54,9 +54,11 @@ Bug fixes
 
 - Forcing EDF conversion in :func:`mne_bids.write_raw_bids` properly uses the ``overwrite`` parameter now, by `Adam Li`_ (:gh:`930`)
 
-- :func:`mne_bids.make_report` now correctly handles `participant.tsv` files that only contain a `participant_id` column, by `Simon Kern`_ (:gh:`912`)
+- :func:`mne_bids.make_report` now correctly handles ``participant.tsv`` files that only contain a ``participant_id`` column, by `Simon Kern`_ (:gh:`912`)
 
-- :func:`mne_bids.write_raw_bids` doesn't store age, handedness, and sex in `participants.tsv` anymore for empty-room recordings, by `Richard Höchenberger`_ (:gh:`935`)
+- :func:`mne_bids.write_raw_bids` doesn't store age, handedness, and sex in ``participants.tsv`` anymore for empty-room recordings, by `Richard Höchenberger`_ (:gh:`935`)
+
+- When :func:`mne_bids.read_raw_bids` automatically creates new hierarchical event names based on event values (in cases where the same ``trial_type`` was assigned to different ``value``s in ``*_events.tsv``), ``'n/a'`` values will now be converted to ``'na'``, by `Richard Höchenberger`_ (:gh:`937`)
 
 
 :doc:`Find out what was new in previous releases <whats_new_previous_releases>`

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -416,7 +416,9 @@ def _handle_events_reading(events_fname, raw):
                         f'The event "{trial_type}" refers to multiple event '
                         f'values. Creating hierarchical event names.')
                     for ii in idx:
-                        new_name = f'{trial_type}/{values[ii]}'
+                        value = values[ii]
+                        value = 'na' if value == 'n/a' else value
+                        new_name = f'{trial_type}/{value}'
                         logger.info(f'    Renaming event: {trial_type} -> '
                                     f'{new_name}')
                         trial_types[ii] = new_name

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -347,11 +347,12 @@ def test_handle_events_reading(tmp_path):
         raw = _handle_events_reading(events_fname, raw)
     events, event_id = mne.events_from_annotations(raw)
 
-    # Test with same `trial_type` referring to different `value`
-    events = {'onset': [11, 12, 13],
-              'duration': ['n/a', 'n/a', 'n/a'],
-              'trial_type': ["event1", "event1", "event2"],
-              'value': [1, 2, 3]}
+    # Test with same `trial_type` referring to different `value`:
+    # The events should be renamed automatically
+    events = {'onset': [11, 12, 13, 14, 15],
+              'duration': ['n/a', 'n/a', 'n/a', 'n/a', 'n/a'],
+              'trial_type': ["event1", "event1", "event2", "event3", "event3"],
+              'value': [1, 2, 3, 4, 'n/a']}
     events_fname = tmp_path / 'bids3' / 'sub-01_task-test_events.json'
     events_fname.parent.mkdir()
     _to_tsv(events, events_fname)
@@ -359,9 +360,11 @@ def test_handle_events_reading(tmp_path):
     raw = _handle_events_reading(events_fname, raw)
     events, event_id = mne.events_from_annotations(raw)
 
-    assert len(events) == 3
+    assert len(events) == 5
     assert 'event1/1' in event_id
     assert 'event1/2' in event_id
+    assert 'event3/4' in event_id
+    assert 'event3/na' in event_id  # 'n/a' value should become 'na'
     # The event with unique value mapping should not be renamed
     assert 'event2' in event_id
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -87,6 +87,8 @@ filterwarnings =
     ignore:Function mark_bad_channels is deprecated.*:DeprecationWarning
     # This is for Python 3.10+ and MNE <1.0
     ignore:The distutils package is deprecated.*:DeprecationWarning
+    # Python 3.10+ and NumPy 1.22 (and maybe also newer NumPy versions?)
+    ignore:.*distutils\.sysconfig module is deprecated.*:DeprecationWarning
 
 [pydocstyle]
 convention = pep257


### PR DESCRIPTION
Fixes #936

Old:
```
The event "left" refers to multiple event values. Creating hierarchical event names.
    Renaming event: left -> left/n/a
    Renaming event: left -> left/n/a
    Renaming event: left -> left/1
    Renaming event: left -> left/n/a
    Renaming event: left -> left/n/a
```

New:
```
The event "left" refers to multiple event values. Creating hierarchical event names.
    Renaming event: left -> left/na
    Renaming event: left -> left/na
    Renaming event: left -> left/1
    Renaming event: left -> left/na
    Renaming event: left -> left/na
```



WIP:

- [x] Add tests
- [x] Add changelog entry

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [x] All comments resolved
- [ ] This is not your own PR
- [x] All CIs are happy
- [x] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [x] PR description includes phrase "closes <#issue-number>"
