### PR TITLE
MAINT: Fix setup

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [metadata]
 name = mne-bids
-version = attr: mne_bids.__version__
 url = https://github.com/mne-tools/mne-bids
 author = mne-bids developers
 maintainer = Mainak Jas

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open('mne_bids/__init__.py', 'r') as fid:
     for line in fid:
         line = line.strip()
         if line.startswith('__version__ = '):
-            version = line.split('=')[0].split('#')[0].strip('\'')
+            version = line.split(' = ')[1].split('#')[0].strip('\'')
             break
 if version is None:
     raise RuntimeError('Could not determine version')

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,19 @@ SETUP_REQUIRES = ["setuptools >= 46.4.0"]
 # This enables setuptools to install wheel on-the-fly
 SETUP_REQUIRES += ["wheel"] if "bdist_wheel" in sys.argv else []
 
+version = None
+with open('mne_bids/__init__.py', 'r') as fid:
+    for line in fid:
+        line = line.strip()
+        if line.startswith('__version__ = '):
+            version = line.split('=')[0].split('#')[0].strip('\'')
+            break
+if version is None:
+    raise RuntimeError('Could not determine version')
+
+
 if __name__ == "__main__":
     setup(
+        version=version,
         setup_requires=SETUP_REQUIRES,
     )


### PR DESCRIPTION
On latest `main` in a clean env, `pip install -ve.` does not work:
```
$ python -m venv create mnebids
$ source mnebids/bin/activate
$ cd mne-bids
$ pip install -ve .
Using pip 20.3.4 from /home/larsoner/python/mnebids/lib/python3.10/site-packages/pip (python 3.10)
Non-user install because user site-packages disabled
...
      File "/home/larsoner/python/mnebids/lib/python3.10/site-packages/setuptools/config.py", line 515, in _parse_version
        version = self._parse_attr(value, self.package_dir)
      File "/home/larsoner/python/mnebids/lib/python3.10/site-packages/setuptools/config.py", line 349, in _parse_attr
        module = import_module(module_name)
      File "/usr/lib/python3.10/importlib/__init__.py", line 126, in import_module
        return _bootstrap._gcd_import(name[level:], package, level)
...
      File "/home/larsoner/python/mne-bids/mne_bids/__init__.py", line 5, in <module>
        from mne_bids.report import make_report
      File "/home/larsoner/python/mne-bids/mne_bids/report.py", line 10, in <module>
        import numpy as np
    ModuleNotFoundError: No module named 'numpy'
```
This import is attempted because `version` is not supplied. (This failure was originally seen [on MNE-Python CircleCI](https://app.circleci.com/pipelines/github/mne-tools/mne-python/12408/workflows/66212d02-4680-4c3a-9d64-bd54a44c204b/jobs/40630)).One solution is to change this:
```
SETUP_REQUIRES = ["setuptools >= 46.4.0"]
```
to
```
SETUP_REQUIRES = ["setuptools >= 46.4.0", "numpy", "jinja2", "mne"]
```
But a cleaner solution I think is just to explicitly parse the version from `__init__.py`. Then the command works correctly, presumably because of `pip` magic to know what the dependencies of the library are (?), it actually finds the same set (plus what `mne-0.24.1` requires):
```
...
Installing collected packages: numpy, scipy, MarkupSafe, mne, jinja2, mne-bids
...
Successfully installed MarkupSafe-2.0.1 jinja2-3.0.3 mne-0.24.1 mne-bids numpy-1.22.1 scipy-1.7.3
Removed build tracker: '/tmp/pip-req-tracker-s0jv846l'
```


