### PR TITLE
[MRG] explicitly declare pymatreader an optional dep for EEGLAB

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -97,6 +97,8 @@ jobs:
         python -c 'import nibabel; print(nibabel.__version__)'
         python -c 'import matplotlib; print(matplotlib.__version__)'
         python -c 'import pandas; print(pandas.__version__)'
+        python -c 'import pymatreader; print(pymatreader.__version__)'
+        python -c 'import EDFlib; print("EDFlib has no .__version__")'
 
   test:
     timeout-minutes: 60
@@ -151,15 +153,13 @@ jobs:
       if: "matrix.mne-version == 'mne-stable'"
       run: |
         git clone --depth 1 https://github.com/mne-tools/mne-python.git -b maint/0.24
-        cd ./mne-python
-        pip install -e .[hdf5]
+        pip install -e ./mne-python
 
     - name: Install MNE (main)
       if: "matrix.mne-version == 'mne-main'"
       run: |
         git clone --depth 1 https://github.com/mne-tools/mne-python.git -b main
-        cd ./mne-python
-        pip install -e .[hdf5]
+        pip install -e ./mne-python
 
     - name: Install BIDS validator (stable)
       if: "matrix.bids-validator-version == 'validator-stable'"

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2018-2021, mne-bids developers
+Copyright (c) 2018-2022, mne-bids developers
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -17,9 +17,10 @@ Optional:
 
 * ``nibabel`` (>=2.5, for processing MRI data)
 * ``pybv`` (>=0.6, for writing BrainVision data)
+* ``pymatreader`` (>=0.0.29 , for operations with EEGLAB data)
 * ``matplotlib`` (>=3.1.0, for using the interactive data inspector)
 * ``pandas`` (>=0.24.0, for generating event statistics)
-* ``EDFlib-Python`` (>=1.0.2, for writing EDF data)
+* ``EDFlib-Python`` (>=1.0.6, for writing EDF data)
 
 We recommend the `Anaconda <https://www.anaconda.com/download/>`_ Python distribution.
 We require that you **use Python 3.7 or higher**.

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,5 +1,5 @@
 nilearn
-sphinx <4.3
+sphinx
 sphinx_gallery
 sphinx-copybutton
 pydata-sphinx-theme

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,8 @@ full =
   pybv >= 0.6
   matplotlib >= 3.1.0
   pandas >= 0.24.0
-  EDFlib-Python >= 1.0.2
+  EDFlib-Python >= 1.0.6
+  pymatreader >= 0.0.29
 
 [options.entry_points]
 console_scripts =

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -6,7 +6,8 @@ pandas>=0.24.0
 nibabel>=2.5
 pybv>=0.6
 openneuro-py>=2022.1
-EDFlib-Python>=1.0.2
+EDFlib-Python>=1.0.6
+pymatreader>=0.0.29
 pytest
 pytest-cov
 pytest-sugar


### PR DESCRIPTION
Follow up to #951 - I think it's better to declare pymatreader an optional dependency, which it will become as soon as we drop mne < 1.0

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [x] All comments resolved
- [x] This is not your own PR
- [x] All CIs are happy
- [x] PR title starts with [MRG]
- ~~[whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated~~
- ~~PR description includes phrase "closes <#issue-number>"~~
