### PR TITLE
[ENH, WIP] Add support for BIDS template standard coordinates

### DIFF
--- a/mne_bids/config.py
+++ b/mne_bids/config.py
@@ -153,7 +153,7 @@ ALLOWED_PATH_ENTITIES_SHORT = {'sub': 'subject', 'ses': 'session',
 # Annotations to never remove during reading or writing
 ANNOTATIONS_TO_KEEP = ('BAD_ACQ_SKIP',)
 
-coordsys_standard_template = [
+BIDS_STANDARD_TEMPLATE_COORDINATE_FRAMES = [
     'ICBM452AirSpace',
     'ICBM452Warp5Space',
     'IXI549Space',
@@ -199,7 +199,7 @@ coordsys_meg = ['CTF', 'ElektaNeuromag', '4DBti', 'KitYokogawa', 'ChietiItab']
 coordsys_eeg = ['CapTrak']
 coordsys_ieeg = ['Pixels', 'ACPC']
 coordsys_wildcard = ['Other']
-coordsys_shared = (coordsys_standard_template +
+coordsys_shared = (BIDS_STANDARD_TEMPLATE_COORDINATE_FRAMES +
                    coordsys_standard_template_deprecated +
                    coordsys_wildcard)
 
@@ -282,7 +282,7 @@ MNE_STR_TO_FRAME = dict(
 MNE_FRAME_TO_STR = {val: key for key, val in MNE_STR_TO_FRAME.items()}
 
 # see BIDS specification for description we copied over from each
-BIDS_COORD_FRAME_DESCRIPTIONS = {
+BIDS_COORD_FRAME_DESCRIPTIONS = dict(**{
     'acpc': 'The origin of the coordinate system is at the Anterior '
             'Commissure and the negative y-axis is passing through the '
             'Posterior Commissure. The positive z-axis is passing through '
@@ -304,7 +304,59 @@ BIDS_COORD_FRAME_DESCRIPTIONS = {
     'fsaverage': 'Defined by FreeSurfer, the MRI (surface RAS) origin is '
                  'at the center of a 256×256×256 mm^3 anisotropic volume '
                  '(may not be in the center of the head).',
-}
+    'icbm452airspace': 'Reference space defined by the "average of 452 '
+                       'T1-weighted MRIs of normal young adult brains" '
+                       'with "linear transforms of the subjects into the '
+                       'atlas space using a 12-parameter affine '
+                       'transformation"',
+    'icbm452warp5space': 'Reference space defined by the "average of 452 '
+                         'T1-weighted MRIs of normal young adult brains" '
+                         '"based on a 5th order polynomial transformation '
+                         'into the atlas space"',
+    'ixi549space': 'Reference space defined by the average of the "549 (...) '
+                   'subjects from the IXI dataset" linearly transformed to '
+                   'ICBM MNI 452.',
+    'fsaveragesym': 'The fsaverage is a dual template providing both '
+                    'volumetric and surface coordinates references. The '
+                    'volumetric template corresponds to a FreeSurfer variant '
+                    'of MNI305 space. The fsaverageSym atlas also defines a '
+                    'symmetric surface reference system (formerly described '
+                    'as fsaveragesym).',
+    'fslr': 'The fsLR is a dual template providing both volumetric and '
+            'surface coordinates references. The volumetric template '
+            'corresponds to MNI152NLin6Asym. Surface templates are given '
+            'at several sampling densities: 164k (used by HCP pipelines '
+            'for 3T and 7T anatomical analysis), 59k (used by HCP pipelines '
+            'for 7T MRI bold and DWI analysis), 32k (used by HCP pipelines '
+            'for 3T MRI bold and DWI analysis), or 4k (used by HCP '
+            'pipelines for MEG analysis) fsaverage_LR surface '
+            'reconstructed from the T1w image.',
+    'mnicolin27': 'Average of 27 T1 scans of a single subject.',
+    'mni152lin': 'Also known as ICBM (version with linear coregistration).',
+    'mni152nlin6sym': 'Also known as symmetric ICBM 6th generation '
+                      '(non-linear coregistration).',
+    'mni152nlin6asym': 'A variation of MNI152NLin6Sym built by A. Janke that '
+                       'is released as the MNI template of FSL. Volumetric '
+                       'templates included with HCP-Pipelines correspond to '
+                       'this template too.',
+    'mni305': 'Also known as avg305.',
+    'nihpd': 'Pediatric templates generated from the NIHPD sample. Available '
+             'for different age groups (4.5–18.5 y.o., 4.5–8.5 y.o., '
+             '7–11 y.o., 7.5–13.5 y.o., 10–14 y.o., 13–18.5 y.o. This '
+             'template also comes in either -symmetric or -asymmetric flavor.',
+    'oasis30antsoasisants':
+        'See https://figshare.com/articles/ANTs_ANTsR_Brain_Templates/915436',
+    'oasis30atropos':
+        'See https://mindboggle.info/data.html',
+    'talairach': 'Piecewise linear scaling of the brain is implemented as '
+                 'described in TT88.',
+    'uncinfant': 'Infant Brain Atlases from Neonates to 1- and 2-year-olds.'
+},
+    **{f'mni152nlin2009{letter}{sym}': 'Also known as ICBM '
+       '(non-linear coregistration with 40 iterations, '
+       'released in 2009). It comes in either three different flavours '
+       'each in symmetric or asymmetric version.'
+       for letter in ('a', 'b', 'c') for sym in ('Sym', 'Asym')})
 
 REFERENCES = {'mne-bids':
               'Appelhoff, S., Sanderson, M., Brooks, T., Vliet, M., '

--- a/mne_bids/config.py
+++ b/mne_bids/config.py
@@ -198,17 +198,22 @@ coordsys_standard_template_deprecated = [
 coordsys_meg = ['CTF', 'ElektaNeuromag', '4DBti', 'KitYokogawa', 'ChietiItab']
 coordsys_eeg = ['CapTrak']
 coordsys_ieeg = ['Pixels', 'ACPC']
-coordsys_wildcard = ['Other']
 coordsys_shared = (BIDS_STANDARD_TEMPLATE_COORDINATE_FRAMES +
-                   coordsys_standard_template_deprecated +
-                   coordsys_wildcard)
+                   coordsys_standard_template_deprecated)
 
 ALLOWED_SPACES = dict()
-ALLOWED_SPACES['meg'] = coordsys_shared + coordsys_meg + coordsys_eeg
-ALLOWED_SPACES['eeg'] = coordsys_shared + coordsys_meg + coordsys_eeg
+ALLOWED_SPACES['meg'] = ALLOWED_SPACES['eeg'] = \
+    coordsys_shared + coordsys_meg + coordsys_eeg
 ALLOWED_SPACES['ieeg'] = coordsys_shared + coordsys_ieeg
 ALLOWED_SPACES['anat'] = None
 ALLOWED_SPACES['beh'] = None
+
+# write only
+ALLOWED_SPACES_WRITE = dict()
+ALLOWED_SPACES_WRITE['meg'] = ALLOWED_SPACES_WRITE['eeg'] = \
+    BIDS_STANDARD_TEMPLATE_COORDINATE_FRAMES + coordsys_meg + coordsys_eeg
+ALLOWED_SPACES_WRITE['ieeg'] = \
+    BIDS_STANDARD_TEMPLATE_COORDINATE_FRAMES + coordsys_ieeg
 
 # See: https://bids-specification.readthedocs.io/en/latest/99-appendices/04-entity-table.html#encephalography-eeg-ieeg-and-meg  # noqa
 ENTITY_VALUE_TYPE = {
@@ -259,9 +264,6 @@ MNE_TO_BIDS_FRAMES = {
     'head': 'CapTrak',
     'mni_tal': 'fsaverage',
     # 'fs_tal': 'fsaverage',  # XXX: not used
-    'unknown': 'Other',
-    'ras': 'Other',
-    'mri': 'Other'
 }
 
 # these coordinate frames in mne-python are related to scalp/meg
@@ -287,6 +289,13 @@ BIDS_COORD_FRAME_DESCRIPTIONS = dict(**{
             'Commissure and the negative y-axis is passing through the '
             'Posterior Commissure. The positive z-axis is passing through '
             'a mid-hemispheric point in the superior direction.',
+    'pixels': 'If electrodes are localized in 2D space (only x and y are '
+              'specified and z is n/a), then the positions in this file '
+              'must correspond to the locations expressed in pixels on '
+              'the photo/drawing/rendering of the electrodes on the brain. '
+              'In this case, coordinates must be (row,column) pairs, with '
+              '(0,0) corresponding to the upper left pixel and (N,0) '
+              'corresponding to the lower left pixel.',
     'ctf': 'ALS orientation and the origin between the ears',
     'elektaneuromag': 'RAS orientation and the origin between the ears',
     '4dbti': 'ALS orientation and the origin between the ears',

--- a/mne_bids/tests/test_dig.py
+++ b/mne_bids/tests/test_dig.py
@@ -16,8 +16,7 @@ import mne
 from mne.datasets import testing
 from mne_bids import BIDSPath, write_raw_bids
 from mne_bids.dig import _write_dig_bids, _read_dig_bids
-from mne_bids.config import (ALLOWED_SPACES_WRITE, BIDS_TO_MNE_FRAMES,
-                             BIDS_STANDARD_TEMPLATE_COORDINATE_FRAMES)
+from mne_bids.config import ALLOWED_SPACES_WRITE, BIDS_TO_MNE_FRAMES
 
 import warnings
 warnings.filterwarnings('ignore', category=DeprecationWarning)

--- a/mne_bids/tests/test_dig.py
+++ b/mne_bids/tests/test_dig.py
@@ -1,0 +1,128 @@
+# -*- coding: utf-8 -*-
+"""Test the digitizations.
+
+For each supported coordinate frame, implement a test.
+"""
+# Authors: Alex Rockhill <aprockhill@mailbox.org>
+#
+# License: BSD-3-Clause
+
+import os
+import os.path as op
+import numpy as np
+import pytest
+
+import mne
+from mne.datasets import testing
+from mne_bids import BIDSPath, write_raw_bids
+from mne_bids.dig import _write_dig_bids, _read_dig_bids
+from mne_bids.config import (ALLOWED_SPACES_WRITE, BIDS_TO_MNE_FRAMES,
+                             BIDS_STANDARD_TEMPLATE_COORDINATE_FRAMES)
+
+import warnings
+warnings.filterwarnings('ignore', category=DeprecationWarning)
+
+
+base_path = op.join(op.dirname(mne.__file__), 'io')
+subject_id = '01'
+session_id = '01'
+run = '01'
+acq = '01'
+run2 = '02'
+task = 'testing'
+
+_bids_path = BIDSPath(
+    subject=subject_id, session=session_id, run=run, acquisition=acq,
+    task=task)
+
+data_path = testing.data_path()
+raw_fname = op.join(data_path, 'MEG', 'sample',
+                    'sample_audvis_trunc_raw.fif')
+raw = mne.io.read_raw(raw_fname)
+raw.info['line_freq'] = 60
+montage = raw.get_montage()
+
+
+def test_dig_io(tmp_path):
+    """Test passing different coordinate frames give proper warnings."""
+    bids_root = tmp_path / 'bids1'
+    for datatype in ('eeg', 'ieeg'):
+        os.makedirs(op.join(bids_root, 'sub-01', 'ses-01', datatype))
+
+    # test no coordinate frame in dig or in bids_path.space
+    mnt = montage.copy()
+    mnt.apply_trans(mne.transforms.Transform('head', 'unknown'))
+    for datatype in ('eeg', 'ieeg'):
+        bids_path = _bids_path.copy().update(root=bids_root, datatype=datatype,
+                                             space=None)
+        with pytest.warns(RuntimeWarning,
+                          match='Coordinate frame could not be inferred'):
+            _write_dig_bids(bids_path, raw, mnt, acpc_aligned=True)
+
+    # test coordinate frame-BIDSPath.space mismatch
+    mnt = montage.copy()
+    bids_path = _bids_path.copy().update(
+        root=bids_root, datatype='eeg', space='fsaverage')
+    with pytest.raises(ValueError, match='Coordinates in the montage'):
+        _write_dig_bids(bids_path, raw, mnt)
+
+    # test weird raw coordinate frame with BIDSPath.space
+    mnt = montage.copy()
+    mnt.apply_trans(mne.transforms.Transform('head', 'meg'))
+    bids_path = _bids_path.copy().update(
+        root=bids_root, datatype='eeg', space='CapTrak')
+    with pytest.raises(ValueError, match='inconsistent'):
+        _write_dig_bids(bids_path, raw, mnt)
+
+    # test MEG space conflict fif (ElektaNeuromag) != CTF
+    bids_path = _bids_path.copy().update(
+        root=bids_root, datatype='meg', space='CTF')
+    with pytest.raises(ValueError, match='conflicts'):
+        write_raw_bids(raw, bids_path)
+
+
+def test_dig_eeg_ieeg(tmp_path):
+    """Test that eeg and ieeg dig are stored properly."""
+    bids_root = tmp_path / 'bids1'
+    for datatype in ('eeg', 'ieeg'):
+        os.makedirs(op.join(bids_root, 'sub-01', 'ses-01', datatype))
+
+    for datatype in ('eeg', 'ieeg'):
+        bids_path = _bids_path.copy().update(root=bids_root, datatype=datatype)
+        for coord_frame in ALLOWED_SPACES_WRITE[datatype]:
+            bids_path.update(space=coord_frame)
+            mnt = montage.copy()
+            pos = mnt.get_positions()
+            mne_coord_frame = BIDS_TO_MNE_FRAMES.get(coord_frame, None)
+            if mne_coord_frame is None:
+                mnt.apply_trans(mne.transforms.Transform('head', 'unknown'))
+            else:
+                mnt.apply_trans(mne.transforms.Transform(
+                    'head', mne_coord_frame))
+            _write_dig_bids(bids_path, raw, mnt, acpc_aligned=True)
+            electrodes_path = bids_path.copy().update(
+                task=None, run=None, suffix='electrodes', extension='.tsv')
+            coordsystem_path = bids_path.copy().update(
+                task=None, run=None, suffix='coordsystem', extension='.json')
+            if bids_path.space == 'Pixels':
+                with pytest.warns(RuntimeWarning,
+                                  match='not recognized by mne'):
+                    _read_dig_bids(electrodes_path, coordsystem_path,
+                                   datatype, raw)
+            elif mne_coord_frame is None:
+                with pytest.warns(RuntimeWarning,
+                                  match='not implemented in MNE'):
+                    _read_dig_bids(electrodes_path, coordsystem_path,
+                                   datatype, raw)
+            else:
+                _read_dig_bids(electrodes_path, coordsystem_path,
+                               datatype, raw)
+            mnt2 = raw.get_montage()
+            pos2 = mnt2.get_positions()
+            np.testing.assert_array_almost_equal(
+                np.array(list(pos['ch_pos'].values())),
+                np.array(list(pos2['ch_pos'].values())))
+            if mne_coord_frame is None:
+                assert pos2['coord_frame'] == 'unknown'
+            else:
+                assert pos2['coord_frame'] == mne_coord_frame

--- a/mne_bids/tests/test_dig.py
+++ b/mne_bids/tests/test_dig.py
@@ -106,7 +106,7 @@ def test_dig_eeg_ieeg(tmp_path):
                 task=None, run=None, suffix='coordsystem', extension='.json')
             if bids_path.space == 'Pixels':
                 with pytest.warns(RuntimeWarning,
-                                  match='not recognized by mne'):
+                                  match='not recognized by MNE'):
                     _read_dig_bids(electrodes_path, coordsystem_path,
                                    datatype, raw)
             elif mne_coord_frame is None:

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -47,8 +47,7 @@ from mne_bids.tsv_handler import _from_tsv, _to_tsv
 from mne_bids.sidecar_updates import _update_sidecar, update_sidecar_json
 from mne_bids.path import _find_matching_sidecar, _parse_ext
 from mne_bids.pick import coil_type
-from mne_bids.config import (REFERENCES, BIDS_COORD_FRAME_DESCRIPTIONS,
-                             BIDS_STANDARD_TEMPLATE_COORDINATE_FRAMES)
+from mne_bids.config import REFERENCES, BIDS_COORD_FRAME_DESCRIPTIONS
 
 base_path = op.join(op.dirname(mne.__file__), 'io')
 subject_id = '01'
@@ -1586,16 +1585,6 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate, tmp_path):
                 write_raw_bids(**kwargs)  # Converts.
                 output_path = _test_anonymize(tmp_path / 'd', raw, bids_path)
         _bids_validate(output_path)
-
-
-def test_ieeg_standard_templates(_bids_validate, tmp_path):
-    """Test that raw ieeg files can be written using standard templates."""
-    bids_root = tmp_path / 'bids1'
-    bids_path = _bids_path.copy().update(root=bids_root, datatype='ieeg')
-    data_path = testing.data_path()
-    raw_fname = op.join(data_path, 'MEG', 'sample',
-                        'sample_audvis_trunc_raw.fif')
-    raw = _read_raw_fif(raw_fname)
 
 
 def test_bdf(_bids_validate, tmp_path):

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -47,7 +47,8 @@ from mne_bids.tsv_handler import _from_tsv, _to_tsv
 from mne_bids.sidecar_updates import _update_sidecar, update_sidecar_json
 from mne_bids.path import _find_matching_sidecar, _parse_ext
 from mne_bids.pick import coil_type
-from mne_bids.config import REFERENCES, BIDS_COORD_FRAME_DESCRIPTIONS
+from mne_bids.config import (REFERENCES, BIDS_COORD_FRAME_DESCRIPTIONS,
+                             BIDS_STANDARD_TEMPLATE_COORDINATE_FRAMES)
 
 base_path = op.join(op.dirname(mne.__file__), 'io')
 subject_id = '01'
@@ -1585,6 +1586,16 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate, tmp_path):
                 write_raw_bids(**kwargs)  # Converts.
                 output_path = _test_anonymize(tmp_path / 'd', raw, bids_path)
         _bids_validate(output_path)
+
+
+def test_ieeg_standard_templates(_bids_validate, tmp_path):
+    """Test that raw ieeg files can be written using standard templates."""
+    bids_root = tmp_path / 'bids1'
+    bids_path = _bids_path.copy().update(root=bids_root, datatype='ieeg')
+    data_path = testing.data_path()
+    raw_fname = op.join(data_path, 'MEG', 'sample',
+                        'sample_audvis_trunc_raw.fif')
+    raw = _read_raw_fif(raw_fname)
 
 
 def test_bdf(_bids_validate, tmp_path):

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1545,8 +1545,16 @@ def write_raw_bids(raw, bids_path, events_data=None, event_id=None,
 
     # for MEG, we only write coordinate system
     if bids_path.datatype == 'meg' and not data_is_emptyroom:
+        if bids_path.space is None:
+            sensor_coord_system = orient
+        elif orient == 'n/a':
+            sensor_coord_system = bids_path.space
+        elif orient.lower() != bids_path.space.lower():
+            raise ValueError(f'BIDSPath.space {bids_path.space} conflicts'
+                             f'with filetype {ext} which has coordinate '
+                             f'frame {orient}')
         _write_coordsystem_json(raw=raw, unit=unit, hpi_coord_system=orient,
-                                sensor_coord_system=orient,
+                                sensor_coord_system=sensor_coord_system,
                                 fname=coordsystem_path.fpath,
                                 datatype=bids_path.datatype,
                                 overwrite=overwrite)


### PR DESCRIPTION
Fixes #961
Fixes #962

So the issue was that groups wanted to use the standard template coordinate frames but they are currently just mapped to other and then we ask them to change it manually. We have these frames already in the config file so the solution with this PR is to set them to other in the `raw` object returned by `read_raw_bids` and then explain to them that MNE does not recognize these coordinate frames so they will be treated as `unknown` but you can basically treat it like `mri` and find the fiducials and make a head->template trans.

The channels and coordinate system writing and reading is a bit of a jalopy at the moment with a bunch of things added and it's really hard to follow so I simplified but this will undoubtably break all the tests which I haven't fixed yet.

I'm pushing this now to ask for advice on what's going on with the ieeg example. In the last section, I set a transform, it gets saved in those transformed coordinates, I add back the fiducials and `compute_native_head_t` but it's way off:

```
Original: <Transform | head->unknown>
[[  1.    0.1   0.2  10.1]
 [ -0.1   1.    0.1 -20.3]
 [  0.2  -0.1   1.  -30.7]
 [  0.    0.    0.    1. ]]
Recovered: <Transform | unknown->head>
[[ 0.97590007 -0.09759001  0.19518001 -5.84352394]
 [ 0.11789673  0.98844615 -0.09526055 15.95020087]
 [-0.18362846  0.11597587  0.97613021 34.17615497]
 [ 0.          0.          0.          1.        ]]
```

No idea what's going on there, maybe someone who wrote montage code could help a bit.

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
