### PR TITLE
[ENH, MRG] Simplify reading dig

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -54,7 +54,7 @@ Enhancements
 
 - :func:`mne_bids.update_anat_landmarks` can now directly work with fiducials saved from the MNE-Python coregistration GUI or :func:`mne.io.write_fiducials`, by Richard Höchenberger`_ (:gh:`977`)
 
-- Add message about non-MNE-Python supported coordinate frames being set to 'unknown' when being read in, by `Alex Rockhill`_ (:gh:`979`)
+- All non-MNE-Python BIDS coordinate frames are now set to ``'unknown'`` on reading, by `Alex Rockhill`_ (:gh:`979`)
 
 API and behavior changes
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -54,6 +54,8 @@ Enhancements
 
 - :func:`mne_bids.update_anat_landmarks` can now directly work with fiducials saved from the MNE-Python coregistration GUI or :func:`mne.io.write_fiducials`, by Richard Höchenberger`_ (:gh:`977`)
 
+- Add message about non-MNE-Python supported coordinate frames being set to 'unknown' when being read in, by `Alex Rockhill`_ (:gh:`979`)
+
 API and behavior changes
 ^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/mne_bids/config.py
+++ b/mne_bids/config.py
@@ -205,18 +205,27 @@ coordsys_standard_template_deprecated = [
     'UNCInfant2V23',
 ]
 
-coordsys_meg = ['CTF', 'ElektaNeuromag', '4DBti', 'KitYokogawa', 'ChietiItab']
-coordsys_eeg = ['CapTrak']
-coordsys_ieeg = ['Pixels', 'ACPC']
+# accepted BIDS formats, which may be subject to change
+# depending on the specification
+BIDS_IEEG_COORDINATE_FRAMES = ['ACPC', 'Pixels']
+BIDS_MEG_COORDINATE_FRAMES = ['CTF', 'ElektaNeuromag',
+                              '4DBti', 'KitYokogawa',
+                              'ChietiItab']
+BIDS_EEG_COORDINATE_FRAMES = ['CapTrak']
+
+# accepted coordinate SI units
+BIDS_COORDINATE_UNITS = ['m', 'cm', 'mm']
 coordsys_wildcard = ['Other']
-coordsys_shared = (coordsys_standard_template +
-                   coordsys_standard_template_deprecated +
-                   coordsys_wildcard)
+BIDS_SHARED_COORDINATE_FRAMES = (coordsys_standard_template +
+                                 coordsys_standard_template_deprecated +
+                                 coordsys_wildcard)
 
 ALLOWED_SPACES = dict()
-ALLOWED_SPACES['meg'] = coordsys_shared + coordsys_meg + coordsys_eeg
-ALLOWED_SPACES['eeg'] = coordsys_shared + coordsys_meg + coordsys_eeg
-ALLOWED_SPACES['ieeg'] = coordsys_shared + coordsys_ieeg
+ALLOWED_SPACES['meg'] = ALLOWED_SPACES['eeg'] = \
+    BIDS_SHARED_COORDINATE_FRAMES + BIDS_MEG_COORDINATE_FRAMES + \
+    BIDS_EEG_COORDINATE_FRAMES
+ALLOWED_SPACES['ieeg'] = \
+    BIDS_SHARED_COORDINATE_FRAMES + BIDS_IEEG_COORDINATE_FRAMES
 ALLOWED_SPACES['anat'] = None
 ALLOWED_SPACES['beh'] = None
 
@@ -235,17 +244,6 @@ ENTITY_VALUE_TYPE = {
     'extension': 'label'
 }
 
-# accepted BIDS formats, which may be subject to change
-# depending on the specification
-BIDS_IEEG_COORDINATE_FRAMES = ['ACPC', 'Pixels', 'Other']
-BIDS_MEG_COORDINATE_FRAMES = ['CTF', 'ElektaNeuromag',
-                              '4DBti', 'KitYokogawa',
-                              'ChietiItab', 'Other']
-BIDS_EEG_COORDINATE_FRAMES = ['CapTrak']
-
-# accepted coordinate SI units
-BIDS_COORDINATE_UNITS = ['m', 'cm', 'mm']
-
 # mapping from supported BIDs coordinate frames -> MNE
 BIDS_TO_MNE_FRAMES = {
     'CTF': 'ctf_head',
@@ -256,8 +254,7 @@ BIDS_TO_MNE_FRAMES = {
     'CapTrak': 'head',
     'ACPC': 'mri',  # assumes T1 is ACPC-aligned, if not the coordinates are lost  # noqa
     'fsaverage': 'mni_tal',  # XXX: note fsaverage and MNI305 are the same  # noqa
-    'MNI305': 'mni_tal',
-    'Other': 'unknown'
+    'MNI305': 'mni_tal'
 }
 
 # mapping from supported MNE coordinate frames -> BIDS

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -3642,7 +3642,7 @@ def test_write_dig(tmpdir):
     coordsystem_path = bids_path.copy().update(
         task=None, run=None, suffix='coordsystem', extension='.json')
     with pytest.warns(RuntimeWarning,
-                      match='recognized by mne-python'):
+                      match='not an MNE-Python coordinate frame'):
         _read_dig_bids(electrodes_path, coordsystem_path,
                        bids_path.datatype, raw)
     montage2 = raw.get_montage()


### PR DESCRIPTION
Okay, this is the penultimate PR from #973. This simplifies the reading logic for digitizations to give a consistent warning for all templates. It also allows 'unknown' to be set as the coordinate frame for MEG data, which technically should be allowable because template coordinate frames are acceptable for MEG too. It gets rid of most of the specific references to 'Other' in reading which is my favorite part because that really shouldn't be a part of BIDS.

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [x] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [x] PR description includes phrase "closes <#issue-number>"
