### PR TITLE
FIX: zenodo metadata

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -105,7 +105,7 @@
   "upload_type": "software",
   "access_right": "open",
   "language": "eng",
-  "related_identifies": [
+  "related_identifiers": [
     {
       "relation": "isSupplementedBy",
       "identifier": "https://github.com/mne-tools/mne-bids/",
@@ -114,7 +114,7 @@
     {
       "relation": "isSupplementedBy",
       "identifier": "10.21105/joss.01896",
-      "resource_type": "article"
+      "resource_type": "publication-article"
     },
     {
       "relation": "isSupplementedBy",


### PR DESCRIPTION
PR Description
--------------

fixing one typo and one wrong classifier I introduced into the metadata in #953. This lead to the 0.10 release not being stored automatically on zenodo --> I'll add it manually there, and the next release should be stored automatically again with these fixes (I just checked it with [pyprep](https://github.com/sappelhoff/pyprep), so it works)

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
