### PR TITLE
[MAINT, MRG] remove voxels from example

### DIFF
--- a/examples/convert_ieeg_to_bids.py
+++ b/examples/convert_ieeg_to_bids.py
@@ -462,6 +462,9 @@ ch_pos = mne.transforms.apply_trans(vox_ras_t, ch_pos)
 montage_ras = mne.channels.make_dig_montage(
     ch_pos=dict(zip(pos['ch_pos'].keys(), ch_pos)), coord_frame='ras')
 
+# specify our standard template coordinate system space
+bids_path.update(datatype='ieeg', space='fsaverage')
+
 # write to BIDS, this time with a template coordinate system in voxels
 write_raw_bids(raw, bids_path, anonymize=dict(daysback=40000),
                montage=montage_ras, overwrite=True)

--- a/mne_bids/dig.py
+++ b/mne_bids/dig.py
@@ -33,7 +33,6 @@ def _handle_electrodes_reading(electrodes_fname, coord_frame,
     """Read associated electrodes.tsv and populate raw.
 
     Handle xyz coordinates and coordinate frame of each channel.
-    Assumes units of coordinates are in 'm'.
     """
     logger.info('Reading electrode '
                 'coords from {}.'.format(electrodes_fname))


### PR DESCRIPTION
https://github.com/bids-standard/bids-specification/pull/1031 specifies that template data should be in ``scanner RAS`` so we should remove the ``voxel`` example and clarify that ``surface RAS`` == ``scanner RAS`` for ``fsaverage``.

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
