### PR TITLE
[MRG] update make_dataset_description

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -47,7 +47,7 @@ Detailed list of changes
 🧐 API and behavior changes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-- ...
+- :func:`mne_bids.make_dataset_description` now accepts keyword arguments only, and can now also write the following metadata: ``HEDVersion``, ``EthicsApprovals``, ``GeneratedBy``, and ``SourceDatasets``, by `Stefan Appelhoff`_ (:gh:`406`)
 
 🛠 Requirements
 ^^^^^^^^^^^^^^^

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -1253,7 +1253,7 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate, tmp_path):
                           match='Encountered data in "double" format'):
             write_raw_bids(**kwargs)
 
-    make_dataset_description(bids_root, name="test",
+    make_dataset_description(path=bids_root, name="test",
                              authors=["test1", "test2"], overwrite=True)
     dataset_description_fpath = op.join(bids_root, "dataset_description.json")
     with open(dataset_description_fpath, 'r', encoding='utf-8') as f:


### PR DESCRIPTION
PR Description
--------------

:boom: breaking change for [`make_dataset_description`](https://mne.tools/mne-bids/stable/generated/mne_bids.make_dataset_description.html#mne_bids.make_dataset_description)

I did the following:
- require keyword arguments only
- change the order of keyword arguments to be in line with the BIDS spec ordering (this is easier for users, who will often have the spec open to read the text while typing it into mne-bids)
- add new metadata options, as they are available in BIDS
- add some input checks so that we only allow writing valid data
- make the docstr a bit more precise

To do
- [x] add some tests

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [x] All comments resolved
- [x] This is not your own PR
- [x] All CIs are happy
- [x] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- ~~[ ] PR description includes phrase "closes <#issue-number>"~~
