### PR TITLE
MRG: Simplify storage of empty-room data

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -42,7 +42,7 @@ Detailed list of changes
 🚀 Enhancements
 ^^^^^^^^^^^^^^^
 
-- ...
+- You can now write raw data and an associated empty-room recording with just a single call to :func:`mne_bids.write_raw_bids`: the ``empty_room`` parameter now also accepts a :class:`mne.io.Raw` data object. The empty-room session name will be derived from the recording date automatically, , by `Richard Höchenberger`_ (:gh:`xxx`)
 
 🧐 API and behavior changes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/examples/convert_empty_room.py
+++ b/examples/convert_empty_room.py
@@ -1,12 +1,12 @@
 """
 .. _ex-convert-empty-room:
 
-==========================================
-09. Storing empty room data in BIDS format
-==========================================
+====================================
+09. Manually storing empty room data
+====================================
 
-This example demonstrates how to store empty room data in BIDS format
-and how to retrieve them.
+This example demonstrates how to store empty room data "manually" in the BIDS
+format and how to retrieve them.
 """
 
 # Authors: Mainak Jas <mainakjas@gmail.com>
@@ -17,6 +17,15 @@ and how to retrieve them.
 # We are dealing with MEG data, which is often accompanied by so-called
 # "empty room" recordings for noise modeling. Below we show that we can use
 # MNE-BIDS to also save such a recording with the just converted data.
+#
+# .. note::
+#    The steps described below should only be followed if you intend to store
+#    empty-room and experimental data in **separate** steps for some reason.
+#    Otherwise, we recommend you store both with a **single** call to
+#    :func:`mne_bids.write_raw_bids` by passing the empty-room raw data via the
+#    ``empty_room`` parameter, as demonstrated in :ref:`ex-convert-mne-sample`.
+#    What is described in the example below is targeted towards advanced users
+#    only.
 #
 # Let us first import mne_bids.
 

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1605,7 +1605,6 @@ def write_raw_bids(raw, bids_path, events_data=None, event_id=None,
             task='noise',
             run=None
         )
-        del er_date, er_session
         write_raw_bids(
             raw=empty_room,
             bids_path=er_bids_path,
@@ -1621,7 +1620,7 @@ def write_raw_bids(raw, bids_path, events_data=None, event_id=None,
             verbose=verbose
         )
         associated_er_path = er_bids_path.fpath
-        del er_bids_path
+        del er_bids_path, er_date, er_session
     elif isinstance(empty_room, BIDSPath):
         if bids_path.datatype != 'meg':
             raise ValueError('"empty_room" is only supported for '

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1349,6 +1349,9 @@ def write_raw_bids(raw, bids_path, events_data=None, event_id=None,
         If a :class:`~mne_bids.BIDSPath`, the ``root`` attribute must be the
         same as in ``bids_path``. Pass ``None`` (default) if you do not wish to
         specify an associated empty-room recording.
+
+        .. versionchanged:: 0.11
+           Accepts :class:`~mne.io.Raw` data.
     allow_preload : bool
         If ``True``, allow writing of preloaded raw objects (i.e.,
         ``raw.preload`` is ``True``). Because the original file is ignored, you

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1496,7 +1496,7 @@ def write_raw_bids(raw, bids_path, events_data=None, event_id=None,
                            'array. You need to pass both, or neither.')
 
     _validate_type(item=empty_room, item_name='empty_room',
-                   types=(mne.io.Raw, BIDSPath, None))
+                   types=(mne.io.BaseRaw, BIDSPath, None))
     _validate_type(montage, (mne.channels.DigMontage, None), 'montage')
     _validate_type(acpc_aligned, bool, 'acpc_aligned')
 
@@ -1594,14 +1594,14 @@ def write_raw_bids(raw, bids_path, events_data=None, event_id=None,
 
     associated_er_path = None
 
-    if isinstance(empty_room, mne.io.Raw):
+    if isinstance(empty_room, mne.io.BaseRaw):
         er_date = empty_room.info['meas_date']
         if not er_date:
             raise ValueError(
                 'The empty-room raw data must have a valid measurement date '
                 'set. Please update its info["meas_date"] field.'
             )
-        er_session = f'{er_date.year:04}{er_date.month:02}{er_date.day:02}'
+        er_session = er_date.strftime("%Y%m%d")
         er_bids_path = bids_path.copy().update(
             subject='emptyroom',
             session=er_session,


### PR DESCRIPTION
This modifies `write_raw_bids()` such that its `empty_room` parameter now can accept a `Raw` object directly. The measurement date is extracted automatically to create the correct empty-room session name

Fixes #895

cc @agramfort


Describe your PR here

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [x] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [x] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [x] PR description includes phrase "closes <#issue-number>"
