### PR TITLE
WIP: Allow storage of crosstalk and fine-calibration via write_raw_bids()

### DIFF
--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1208,8 +1208,8 @@ def make_dataset_description(*, path, name, hed_version=None,
 
 @verbose
 def write_raw_bids(
-    raw, bids_path, *,
-    events_data=None, event_id=None,
+    raw, bids_path, events_data=None, event_id=None,
+    *,
     anonymize=None, format='auto', symlink=False,
     empty_room=None, meg_calibration=None, meg_crosstalk=None,
     allow_preload=False,

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1576,7 +1576,7 @@ def write_raw_bids(
     bids_path = (bids_path.copy()
                  .update(datatype=datatype, suffix=datatype, extension=ext))
 
-    if bids_path.data_type != 'meg':
+    if bids_path.datatype != 'meg':
         if empty_room is not None:
             raise ValueError('Cannot specify empty_room for non-MEG data.')
         if meg_calibration is not None:

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1923,7 +1923,7 @@ def write_raw_bids(
                 bids_path=bids_path,
                 verbose=verbose
             )
-        if meg_crosstalk is None:
+        if meg_crosstalk is not None:
             logger.info('Writing MEG crosstalk file.')
             write_meg_crosstalk(
                 fname=meg_crosstalk,


### PR DESCRIPTION
@agramfort WDYT?

The idea is that with these changes and the changes to empty-room handling we just merged into `main`, users would only have to call a single function -- `write_raw_bids()` -- once to get all their MEG data stored: experimental data, empty-room, fine-calibration and crosstalk.

Currently, this requires 3 function calls:
- `write_raw_bids()`
- `write_meg_calibration()`
- `write_meg_crosstalk()`

With these changes here, it would come down to `write_raw_bids(raw, bids_path, empty_room=..., meg_calibration=..., meg_crosstalk=...)` and you'd be all set.


Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
