### PR TITLE
MRG: Suppress MaxShield warning in many places

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -42,7 +42,7 @@ Detailed list of changes
 🚀 Enhancements
 ^^^^^^^^^^^^^^^
 
-- You can now write raw data and an associated empty-room recording with just a single call to :func:`mne_bids.write_raw_bids`: the ``empty_room`` parameter now also accepts a :class:`mne.io.Raw` data object. The empty-room session name will be derived from the recording date automatically, , by `Richard Höchenberger`_ (:gh:`xxx`)
+- You can now write raw data and an associated empty-room recording with just a single call to :func:`mne_bids.write_raw_bids`: the ``empty_room`` parameter now also accepts a :class:`mne.io.Raw` data object. The empty-room session name will be derived from the recording date automatically, by `Richard Höchenberger`_ (:gh:`xxx`)
 
 🧐 API and behavior changes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -57,7 +57,9 @@ Detailed list of changes
 🪲 Bug fixes
 ^^^^^^^^^^^^
 
-- Fix ACPC in ``surface RAS`` instead of ``scanner RAS`` in :ref:`ieeg-example` and add convenience functions :func:`mne_bids.convert_montage_to_ras` and :func:`mne_bids.convert_montage_to_mri` to help, by `Alex Rockhill`_ :gh:`990`
+- Fix ACPC in ``surface RAS`` instead of ``scanner RAS`` in :ref:`ieeg-example` and add convenience functions :func:`mne_bids.convert_montage_to_ras` and :func:`mne_bids.convert_montage_to_mri` to help, by `Alex Rockhill`_ (:gh:`990`)
+
+- Suppress superfluous warnings about MaxShield in many functions when handling Elekta/Neuromag/MEGIN data, by `Richard Höchenberger`_ (:gh:`1000`)
 
 :doc:`Find out what was new in previous releases <whats_new_previous_releases>`
 

--- a/mne_bids/commands/mne_bids_raw_to_bids.py
+++ b/mne_bids/commands/mne_bids_raw_to_bids.py
@@ -72,7 +72,7 @@ def run():
 
     allow_maxshield = False
     if opt.raw_fname.endswith('.fif'):
-        allow_maxshield = True
+        allow_maxshield = 'yes'
 
     raw = _read_raw(opt.raw_fname, hpi=opt.hpi, electrode=opt.electrode,
                     hsp=opt.hsp, config_path=opt.config,

--- a/mne_bids/inspect.py
+++ b/mne_bids/inspect.py
@@ -128,7 +128,7 @@ def _inspect_raw(*, bids_path, l_freq, h_freq, find_flat, show_annotations):
 
     extra_params = dict()
     if bids_path.extension == '.fif':
-        extra_params['allow_maxshield'] = True
+        extra_params['allow_maxshield'] = 'yes'
     raw = read_raw_bids(bids_path, extra_params=extra_params, verbose='error')
     old_bads = raw.info['bads'].copy()
     old_annotations = raw.annotations.copy()
@@ -229,7 +229,7 @@ def _save_annotations(*, annotations, bids_path):
     # to events, which will be stored in the *_events.tsv sidecar.
     extra_params = dict()
     if bids_path.extension == '.fif':
-        extra_params['allow_maxshield'] = True
+        extra_params['allow_maxshield'] = 'yes'
 
     raw = read_raw_bids(bids_path=bids_path, extra_params=extra_params,
                         verbose='warning')

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -111,7 +111,7 @@ def _find_matched_empty_room(bids_path):
             _, ext = _parse_ext(er_fname)
             extra_params = None
             if ext == '.fif':
-                extra_params = dict(allow_maxshield=True)
+                extra_params = dict(allow_maxshield='yes')
 
             er_raw = read_raw_bids(bids_path=er_bids_path,
                                    extra_params=extra_params)

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -961,7 +961,7 @@ def get_head_mri_trans(bids_path, extra_params=None, t1_bids_path=None,
     if extra_params is None:
         extra_params = dict()
     if ext == '.fif':
-        extra_params['allow_maxshield'] = True
+        extra_params['allow_maxshield'] = 'yes'
 
     raw = read_raw_bids(bids_path=meg_bids_path, extra_params=extra_params)
 

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -646,7 +646,7 @@ def test_handle_info_reading(tmp_path):
 @pytest.mark.filterwarnings(warning_str['maxshield'])
 def test_handle_chpi_reading(tmp_path):
     """Test reading of cHPI information."""
-    raw = _read_raw_fif(raw_fname_chpi, allow_maxshield=True)
+    raw = _read_raw_fif(raw_fname_chpi, allow_maxshield='yes')
     root = tmp_path / 'chpi'
     root.mkdir()
     bids_path = BIDSPath(subject='01', session='01',

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -741,7 +741,7 @@ def test_chpi(_bids_validate, tmp_path, format):
         raw = _read_raw_fif(fif_raw_fname)
     elif format == 'fif':
         fif_raw_fname = op.join(data_path, 'SSS', 'test_move_anon_raw.fif')
-        raw = _read_raw_fif(fif_raw_fname, allow_maxshield=True)
+        raw = _read_raw_fif(fif_raw_fname, allow_maxshield='yes')
     elif format == 'ctf':
         ctf_raw_fname = op.join(data_path, 'CTF', 'testdata_ctf.ds')
         raw = _read_raw_ctf(ctf_raw_fname)


### PR DESCRIPTION
When reading FIFF files that contain Neuromag data recorded with active shielding enabled, MNE-Python by default raises an exception unless `allow_maxshield` is specified. We used to set it to `True` in all applicable places. However, this would still issue a warning.

Setting it to `'yes'` instead suppresses this warning.

Consequently, I've changed all but one occurance of `allow_maxshield` to `'yes'` now. The only exception is in `read_raw_bids()`, where I believe it still makes sense to issue the warning. For all other places,
like `write_raw_bids()`, `get_head_mri_trans()` etc., the warning is gone now.


Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [x] All comments resolved
- [ ] This is not your own PR
- [x] All CIs are happy
- [x] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
