### PR TITLE
MRG: Make Inspector work even if mne-qt-browser is installed

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -61,6 +61,8 @@ Detailed list of changes
 
 - Suppress superfluous warnings about MaxShield in many functions when handling Elekta/Neuromag/MEGIN data, by `Richard Höchenberger`_ (:gh:`1000`)
 
+- The MNE-BIDS Inspector didn't work if ``mne-qt-browser`` was installed and used as the default plotting backend, as the Inspector currently only supports the Matplotlib backend, by `Richard Höchenberger`_ (:gh:`1007`)
+
 :doc:`Find out what was new in previous releases <whats_new_previous_releases>`
 
 .. include:: authors.rst

--- a/mne_bids/inspect.py
+++ b/mne_bids/inspect.py
@@ -12,6 +12,7 @@ import mne
 
 from mne.utils import logger, verbose
 from mne.fixes import _compare_version
+from mne.viz import use_browser_backend
 
 if _compare_version(mne.__version__, '<', '1.0.dev0'):  # pragma: no cover
     from mne.preprocessing import annotate_flat
@@ -155,10 +156,14 @@ def _inspect_raw(*, bids_path, l_freq, h_freq, find_flat, show_annotations):
         flat_chans = []
 
     show_options = bids_path.datatype == 'meg'
-    fig = raw.plot(title=f'{bids_path.root.name}: {bids_path.basename}',
-                   highpass=l_freq, lowpass=h_freq,
-                   show_options=show_options,
-                   block=False, show=False, verbose='warning')
+
+    with use_browser_backend('matplotlib'):
+        fig = raw.plot(
+            title=f'{bids_path.root.name}: {bids_path.basename}',
+            highpass=l_freq, lowpass=h_freq,
+            show_options=show_options,
+            block=False, show=False, verbose='warning'
+        )
 
     # Add our own event handlers so that when the MNE Raw Browser is being
     # closed, our dialog box will pop up, asking whether to save changes.


### PR DESCRIPTION
We now explicitly request a Matploblib plotting context for bringing up the Inspector. Otherwise, MNE will default to
using the qt-browser if installed, and our current implementation of the Inspector will fail to launch.

This didn't show up in unit tests before as we're using the Agg backend there.

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [x] All comments resolved
- [x] This is not your own PR
- [ ] All CIs are happy
- [x] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
