### PR TITLE
amended `_write_electrodes_tsv` to exclude writing stim channels to electrodes.tsv

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -71,6 +71,7 @@ Detailed list of changes
 - :func:`~mne_bids.copyfiles.copyfile_brainvision` can now deal with ``.dat`` file extension, by `Dominik Welke`_ (:gh:`1008`)
 
 - :func:`~mne_bids.print_dir_tree` now correctly expands ``~`` to the user's home directory, by `Richard Höchenberger`_ (:gh:`1013`)
+- :func:`~mne_bids.write_raw_bids` now correctly excludes stim channels when writing to electrodes.tsv, by `Scott Huberty_` (:gh:`1023`)
 
 :doc:`Find out what was new in previous releases <whats_new_previous_releases>`
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -71,6 +71,7 @@ Detailed list of changes
 - :func:`~mne_bids.copyfiles.copyfile_brainvision` can now deal with ``.dat`` file extension, by `Dominik Welke`_ (:gh:`1008`)
 
 - :func:`~mne_bids.print_dir_tree` now correctly expands ``~`` to the user's home directory, by `Richard Höchenberger`_ (:gh:`1013`)
+
 - :func:`~mne_bids.write_raw_bids` now correctly excludes stim channels when writing to electrodes.tsv, by `Scott Huberty_` (:gh:`1023`)
 
 :doc:`Find out what was new in previous releases <whats_new_previous_releases>`

--- a/mne_bids/dig.py
+++ b/mne_bids/dig.py
@@ -138,7 +138,11 @@ def _write_electrodes_tsv(raw, fname, datatype, overwrite=False):
     # create list of channel coordinates and names
     x, y, z, names = list(), list(), list(), list()
     for ch in raw.info['chs']:
-        if (
+        if ch['kind'] == FIFF.FIFFV_STIM_CH:
+            logger.debug(f"Not writing stim chan {ch['ch_name']} "
+                         f"to electrodes.tsv")
+            continue
+        elif (
             np.isnan(ch['loc'][:3]).any() or
             np.allclose(ch['loc'][:3], 0)
         ):

--- a/mne_bids/tests/test_dig.py
+++ b/mne_bids/tests/test_dig.py
@@ -336,7 +336,6 @@ def test_electrodes_io(tmp_path):
     (bids_root / 'sub-01' / 'ses-01' / 'eeg').mkdir(exist_ok=True)
     write_raw_bids(raw, bids_path)
 
-    # test 1
     with open(bids_path.directory /
               'sub-01_ses-01_acq-01_space-CapTrak_electrodes.tsv') as sidecar:
         n_entries = len([line for line in sidecar
@@ -348,18 +347,3 @@ def test_electrodes_io(tmp_path):
             .pick_types(eeg=True)
             .ch_names
         )
-
-    # test 2
-    with pytest.warns(RuntimeWarning) as record:
-        read_raw_bids(bids_path)
-        # list of warnings emitted by read_raw_bids
-        warnings = [record[i].message for i in range(len(record))]
-
-        # if the following test fails, then channels without
-        # associated electrodes were written to electrodes.tsv
-        # and mne.set_montage will issue a warning about these channels
-        # during read_raw_bids
-        if any('There are channels without locations'
-                in str(message) for message in warnings):
-            pytest.fail('1 or more channels without associated electrodes were'
-                        ' written to electrodes.tsv')

--- a/mne_bids/tests/test_dig.py
+++ b/mne_bids/tests/test_dig.py
@@ -334,7 +334,7 @@ def test_electrodes_io(tmp_path):
     raw.pick_types(eeg=True, stim=True)  # we don't need meg channels
     bids_root = tmp_path / 'bids1'
     bids_path = _bids_path.copy().update(root=bids_root, datatype='eeg')
-    os.makedirs(op.join(bids_root, 'sub-01', 'ses-01', 'eeg'), exist_ok=True)
+    (bids_root / 'sub-01' / 'ses-01' / 'eeg').mkdir(exist_ok=True)
     write_raw_bids(raw, bids_path)
 
     # test 1

--- a/mne_bids/tests/test_dig.py
+++ b/mne_bids/tests/test_dig.py
@@ -333,11 +333,19 @@ def test_electrodes_io(tmp_path):
     raw.pick_types(eeg=True, stim=True)  # we don't need meg channels
     bids_root = tmp_path / 'bids1'
     bids_path = _bids_path.copy().update(root=bids_root, datatype='eeg')
-    write_raw_bids(raw, bids_path)
+    write_raw_bids(raw=raw, bids_path=bids_path)
 
-    electrodes_fpath = 'sub-01_ses-01_acq-01_space-CapTrak_electrodes.tsv'
-    with open(bids_path.directory /
-              electrodes_fpath, encoding='utf-8') as sidecar:
+    electrodes_path = (
+        bids_path.copy()
+        .update(
+            task=None,
+            run=None,
+            space='CapTrak',
+            suffix='electrodes',
+            extension='.tsv'
+        )
+    )
+    with open(electrodes_path, encoding='utf-8') as sidecar:
         n_entries = len([line for line in sidecar
                          if 'name' not in line])  # don't need the header
         # only eeg chs w/ electrode pos should be written to electrodes.tsv

--- a/mne_bids/tests/test_dig.py
+++ b/mne_bids/tests/test_dig.py
@@ -328,8 +328,7 @@ def test_convert_montage():
 
 
 def test_electrodes_io(tmp_path):
-    '''test that only channels with associated electrodes were written to
-       electrodes sidecar.'''
+    """Ensure only electrodes end up in *_electrodes.json."""
     raw = _load_raw()
     raw.pick_types(eeg=True, stim=True)  # we don't need meg channels
     bids_root = tmp_path / 'bids1'

--- a/mne_bids/tests/test_dig.py
+++ b/mne_bids/tests/test_dig.py
@@ -333,8 +333,6 @@ def test_electrodes_io(tmp_path):
     raw.pick_types(eeg=True, stim=True)  # we don't need meg channels
     bids_root = tmp_path / 'bids1'
     bids_path = _bids_path.copy().update(root=bids_root, datatype='eeg')
-    (bids_root / 'sub-01' / 'ses-01' / 'eeg').mkdir(parents=True,
-                                                    exist_ok=True)
     write_raw_bids(raw, bids_path)
 
     with open(bids_path.directory /

--- a/mne_bids/tests/test_dig.py
+++ b/mne_bids/tests/test_dig.py
@@ -342,7 +342,4 @@ def test_electrodes_io(tmp_path):
         n_entries = len([line for line in sidecar
                          if 'name' not in line])  # don't need the header
         # only eeg chs w/ electrode pos should be written to electrodes.tsv
-        assert n_entries == len(
-            raw
-            .get_channel_types('eeg')
-        )
+        assert n_entries == len(raw.get_channel_types('eeg'))

--- a/mne_bids/tests/test_dig.py
+++ b/mne_bids/tests/test_dig.py
@@ -335,8 +335,9 @@ def test_electrodes_io(tmp_path):
     bids_path = _bids_path.copy().update(root=bids_root, datatype='eeg')
     write_raw_bids(raw, bids_path)
 
+    electrodes_fpath = 'sub-01_ses-01_acq-01_space-CapTrak_electrodes.tsv'
     with open(bids_path.directory /
-              'sub-01_ses-01_acq-01_space-CapTrak_electrodes.tsv') as sidecar:
+              electrodes_fpath, encoding='utf-8') as sidecar:
         n_entries = len([line for line in sidecar
                          if 'name' not in line])  # don't need the header
         # only eeg chs w/ electrode pos should be written to electrodes.tsv

--- a/mne_bids/tests/test_dig.py
+++ b/mne_bids/tests/test_dig.py
@@ -333,7 +333,8 @@ def test_electrodes_io(tmp_path):
     raw.pick_types(eeg=True, stim=True)  # we don't need meg channels
     bids_root = tmp_path / 'bids1'
     bids_path = _bids_path.copy().update(root=bids_root, datatype='eeg')
-    (bids_root / 'sub-01' / 'ses-01' / 'eeg').mkdir(exist_ok=True)
+    (bids_root / 'sub-01' / 'ses-01' / 'eeg').mkdir(parents=True,
+                                                    exist_ok=True)
     write_raw_bids(raw, bids_path)
 
     with open(bids_path.directory /
@@ -343,7 +344,5 @@ def test_electrodes_io(tmp_path):
         # only eeg chs w/ electrode pos should be written to electrodes.tsv
         assert n_entries == len(
             raw
-            .copy()
-            .pick_types(eeg=True)
-            .ch_names
+            .get_channel_types('eeg')
         )

--- a/mne_bids/tests/test_dig.py
+++ b/mne_bids/tests/test_dig.py
@@ -342,8 +342,12 @@ def test_electrodes_io(tmp_path):
         n_entries = len([line for line in sidecar
                          if 'name' not in line])  # don't need the header
         # only eeg chs w/ electrode pos should be written to electrodes.tsv
-        assert n_entries == len(raw.copy().pick_types(eeg=True)
-                                          .info['ch_names'])
+        assert n_entries == len(
+            raw
+            .copy()
+            .pick_types(eeg=True)
+            .ch_names
+        )
 
     # test 2
     with pytest.warns(RuntimeWarning) as record:


### PR DESCRIPTION

closes #1022 

`make tests` and `make pep` passed on my local machine, fingers crossed!