### PR TITLE
[MRG] FIX: Use os.replace instead of os.rename when copying CTF files (needed for windows)

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -82,7 +82,7 @@ Detailed list of changes
 
 - :func:`~mne_bids.read_raw_bids` doesn't populate ``raw.info['subject_info']`` with invalid values anymore, preventing users from writing the data to disk again, by `Richard Höchenberger`_ (:gh:`1031`)
 
-- Writing and copying CTF files now works on Windows when files previously exist (``overwrite=True``), by `Stefan Appelhoff`_ (:gh:`1035`)
+- Writing and copying CTF files now works on Windows when files already exist (``overwrite=True``), by `Stefan Appelhoff`_ (:gh:`1035`)
 
 :doc:`Find out what was new in previous releases <whats_new_previous_releases>`
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -82,6 +82,8 @@ Detailed list of changes
 
 - :func:`~mne_bids.read_raw_bids` doesn't populate ``raw.info['subject_info']`` with invalid values anymore, preventing users from writing the data to disk again, by `Richard Höchenberger`_ (:gh:`1031`)
 
+- Writing and copying CTF files now works on Windows when files previously exist (``overwrite=True``), by `Stefan Appelhoff`_ (:gh:`1035`)
+
 :doc:`Find out what was new in previous releases <whats_new_previous_releases>`
 
 .. include:: authors.rst

--- a/mne_bids/copyfiles.py
+++ b/mne_bids/copyfiles.py
@@ -162,8 +162,8 @@ def copyfile_ctf(src, dest):
     bids_folder_name = op.splitext(op.split(dest)[-1])[0]
     for fname in fnames:
         ext = op.splitext(fname)[-1]
-        os.rename(op.join(dest, fname),
-                  op.join(dest, bids_folder_name + ext))
+        os.replace(op.join(dest, fname),
+                   op.join(dest, bids_folder_name + ext))
 
 
 def copyfile_kit(src, dest, subject_id, session_id,


### PR DESCRIPTION
xref: https://mne.discourse.group/t/using-mne-bids-to-convert-ctf-data-to-bids-format/5336/17

PR Description
--------------

replace seems to be windows friendly.

Merge checklist
---------------

Maintainer, please confirm the following before merging.
If applicable:

- [x] All comments are resolved
- [x] This is not your own PR
- [x] All CIs are happy
- [x] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [x] New contributors have been added to [.zenodo.json](https://github.com/mne-tools/mne-bids/blob/main/.zenodo.json)
- [x] PR description includes phrase "closes <#issue-number>"
