### PR TITLE
Fixes for EEGLAB: do not 'simplify cells' when loading.

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -86,7 +86,7 @@ Detailed list of changes
 
 - :func:`~mne_bids.read_raw_bids` doesn't populate ``raw.info['subject_info']`` with invalid values anymore, preventing users from writing the data to disk again, by `Richard Höchenberger`_ (:gh:`1031`)
 
-- Writing EEGLAB files was sometimes broken when ``.set`` and ``.fdt`` pairs were supplied. This is now fixed in :func:`~mne_bids.copyfile_eeglab`, by `Stefan Appelhoff`_ (:gh:`1039`)
+- Writing EEGLAB files was sometimes broken when ``.set`` and ``.fdt`` pairs were supplied. This is now fixed in :func:`~mne_bids.copyfiles.copyfile_eeglab`, by `Stefan Appelhoff`_ (:gh:`1039`)
 
 - Writing and copying CTF files now works on Windows when files already exist (``overwrite=True``), by `Stefan Appelhoff`_ (:gh:`1035`)
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -86,6 +86,8 @@ Detailed list of changes
 
 - :func:`~mne_bids.read_raw_bids` doesn't populate ``raw.info['subject_info']`` with invalid values anymore, preventing users from writing the data to disk again, by `Richard Höchenberger`_ (:gh:`1031`)
 
+- Writing EEGLAB files was sometimes broken when ``.set`` and ``.fdt`` pairs were supplied. This is now fixed in :func:`~mne_bids.copyfile_eeglab`, by `Stefan Appelhoff`_ (:gh:`1039`)
+
 - Writing and copying CTF files now works on Windows when files already exist (``overwrite=True``), by `Stefan Appelhoff`_ (:gh:`1035`)
 
 - Instead of deleting files and raising cryptic errors, an intentional error message is now sent when calling :func:`~mne_bids.write_raw_bids` with the source file identical to the destination file, unless ``format`` is specified, by `Adam Li`_ and `Stefan Appelhoff`_ (:gh:`889`)

--- a/mne_bids/copyfiles.py
+++ b/mne_bids/copyfiles.py
@@ -496,12 +496,11 @@ def copyfile_edf(src, dest, anonymize=None):
 
 
 def copyfile_eeglab(src, dest):
-    """Copy an EEGLAB file to a new location and adjust .fdt pointer in file.
+    """Copy an EEGLAB file to a new location.
 
-    Sometimes an EEGLAB .set file comes with a .fdt binary file that contains
-    the data. When moving a .set file, we need to check for an associated .fdt
-    file and move it to an appropriate location as well as update an internal
-    pointer within the .set file.
+    If the EEGLAB ``.set`` file comes with an accompanying ``.fdt`` binary file
+    that contains the actual data, this function will copy this file, too, and
+    update all internal pointers in the new ``.set`` file.
 
     Parameters
     ----------

--- a/mne_bids/copyfiles.py
+++ b/mne_bids/copyfiles.py
@@ -29,6 +29,7 @@ from mne.utils import logger, verbose, warn
 
 from mne_bids.path import BIDSPath, _parse_ext, _mkdir_p
 from mne_bids.utils import _get_mrk_meas_date, _check_anonymize
+import numpy as np
 
 
 def _copytree(src, dst, **kwargs):
@@ -495,12 +496,12 @@ def copyfile_edf(src, dest, anonymize=None):
 
 
 def copyfile_eeglab(src, dest):
-    """Copy a EEGLAB files to a new location and adjust pointer to '.fdt' file.
+    """Copy an EEGLAB file to a new location and adjust .fdt pointer in file.
 
-    Some EEGLAB .set files come with a .fdt binary file that contains the data.
-    When moving a .set file, we need to check for an associated .fdt file and
-    move it to an appropriate location as well as update an internal pointer
-    within the .set file.
+    Sometimes an EEGLAB .set file comes with a .fdt binary file that contains
+    the data. When moving a .set file, we need to check for an associated .fdt
+    file and move it to an appropriate location as well as update an internal
+    pointer within the .set file.
 
     Parameters
     ----------
@@ -529,27 +530,40 @@ def copyfile_eeglab(src, dest):
                          f' but got {ext_src}, {ext_dest}')
 
     # Load the EEG struct
+    # NOTE: do *not* simplify cells, because this changes the underlying
+    # structure and potentially breaks re-reading of the file
     uint16_codec = None
-    eeg = loadmat(file_name=src, simplify_cells=True,
+    eeg = loadmat(file_name=src, simplify_cells=False,
                   appendmat=False, uint16_codec=uint16_codec)
     oldstyle = False
     if 'EEG' in eeg:
         eeg = eeg['EEG']
         oldstyle = True
 
-    if isinstance(eeg['data'], str):
+    try:
         # If the data field is a string, it points to a .fdt file in src dir
-        fdt_fname = eeg['data']
-        assert fdt_fname.endswith('.fdt')
-        head, tail = op.split(src)
+        if isinstance(eeg['data'][0, 0][0], str):
+            has_fdt_link = True
+    except IndexError:
+        has_fdt_link = False
+
+    if has_fdt_link:
+        fdt_fname = eeg['data'][0, 0][0]
+
+        assert fdt_fname.endswith('.fdt'), f'Unexpected fdt name: {fdt_fname}'
+        head, _ = op.split(src)
         fdt_path = op.join(head, fdt_fname)
 
         # Copy the .fdt file and give it a new name
-        sh.copyfile(fdt_path, fname_dest + '.fdt')
+        fdt_name_new = fname_dest + '.fdt'
+        sh.copyfile(fdt_path, fdt_name_new)
 
         # Now adjust the pointer in the .set file
-        head, tail = op.split(fname_dest + '.fdt')
-        eeg['data'] = tail
+        # NOTE: Clunky numpy code is to match MATLAB structure for "savemat"
+        _, tail = op.split(fdt_name_new)
+        new_value = np.empty((1, 1), dtype=object)
+        new_value[0, 0] = np.atleast_1d(np.array(tail))
+        eeg['data'] = new_value
 
         # Save the EEG dictionary as a Matlab struct again
         mdict = dict(EEG=eeg) if oldstyle else eeg

--- a/mne_bids/tests/test_copyfiles.py
+++ b/mne_bids/tests/test_copyfiles.py
@@ -11,7 +11,6 @@ from pathlib import Path
 import pytest
 
 import mne
-from mne.fixes import _compare_version
 from mne.datasets import testing
 from mne_bids import BIDSPath
 from mne_bids.path import _parse_ext
@@ -198,16 +197,10 @@ def test_copyfile_edfbdf_uppercase(tmp_path):
                           'test_raw_2021.set'))
 def test_copyfile_eeglab(tmp_path, fname):
     """Test the copying of EEGlab set and fdt files."""
-    if (
-        fname == 'test_raw_chanloc.set' and
-        _compare_version(testing.get_version(), '<', '0.112')
-    ):
-        return
-
     bids_root = str(tmp_path)
     data_path = op.join(testing.data_path(), 'EEGLAB')
     raw_fname = op.join(data_path, fname)
-    new_name = op.join(bids_root, 'tested_conversion.set')
+    new_name = op.join(bids_root, f'CONVERTED_{fname}.set')
 
     # IO error testing
     with pytest.raises(ValueError, match="Need to move data with same ext"):


### PR DESCRIPTION
<!--
Thanks for contributing this pull request (PR).
If this is your first time, make sure to read
[CONTRIBUTING.md](https://github.com/mne-tools/mne-bids/blob/main/CONTRIBUTING.md)
-->

PR Description
--------------

<!--Describe your PR here-->
I think I found the problem with #991 

closes #991 

@cmadjar **it'd be great if you could try this fix**. Install it by:

```shell
pip uninstall mne_bids
pip install pip install git+https://github.com/sappelhoff/mne-bids.git@use/mne/export
```

if you want to go back, simply uninstall `mne_bids` again and re-install the version you want.

I think the problem was that we used [`loadmat`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.io.loadmat.html) with `simplify_cells`, which changes the MATLAB "structure" and leads to problems when writing back.

In the long run it'd still be nicer to switch to "mne.export" for this.

Merge checklist
---------------

Maintainer, please confirm the following before merging.
If applicable:

- [ ] All comments are resolved
- [ ] This is not your own PR
- [x] All CIs are happy
- [ ] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [x] New contributors have been added to [CITATION.cff](https://github.com/mne-tools/mne-bids/blob/main/CITATION.cff)
- [x] PR description includes phrase "closes <#issue-number>"
