### PR TITLE
MRG: Set channel type to misc if we cannot perform a proper conversion from BIDS to MNE channel types

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -94,6 +94,8 @@ Detailed list of changes
 
 - Internal helper function to :func:`~mne_bids.read_raw_bids` would reject BrainVision data if ``_scans.tsv`` listed a ``.eeg`` file instead of ``.vhdr``, by `Teon Brooks`_ (:gh:`1034`)
 
+- Whenever :func:`~mne_bids.read_raw_bids` encounters a channel type that currently doesn't translate into an appropriate MNE channel type, the channel type will now be set to ``'misc``. Previously, seemingly arbitrary channel types would be applied, e.g. ``'eeg'`` for GSR and temperature channels, by `Richard Höchenberger`_ (:gh:`1052`)
+
 :doc:`Find out what was new in previous releases <whats_new_previous_releases>`
 
 .. include:: authors.rst

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -515,7 +515,7 @@ def _handle_channels_reading(channels_fname, raw):
     for ch_name, ch_type in zip(ch_names_tsv, ch_types_json):
         # We don't map MEG channels for now, as there's no clear 1:1 mapping
         # from BIDS to MNE coil types.
-        if ch_type in (
+        if ch_type.upper() in (
             'MEGGRADAXIAL', 'MEGMAG', 'MEGREFGRADAXIAL', 'MEGGRADPLANAR',
             'MEGREFMAG', 'MEGOTHER'
         ):

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -507,12 +507,19 @@ def _handle_channels_reading(channels_fname, raw):
     # Now we can do some work.
     # The "type" column is mandatory in BIDS. We can use it to set channel
     # types in the raw data using a mapping between channel types
-    channel_type_dict = dict()
+    channel_type_bids_mne_map = dict()
 
     # Get the best mapping we currently have from BIDS to MNE nomenclature
     bids_to_mne_ch_types = _get_ch_type_mapping(fro='bids', to='mne')
     ch_types_json = channels_dict['type']
     for ch_name, ch_type in zip(ch_names_tsv, ch_types_json):
+        # We don't map MEG channels for now, as there's no clear 1:1 mapping
+        # from BIDS to MNE coil types.
+        if ch_type in (
+            'MEGGRADAXIAL', 'MEGMAG', 'MEGREFGRADAXIAL', 'MEGGRADPLANAR',
+            'MEGREFMAG', 'MEGOTHER'
+        ):
+            continue
 
         # Try to map from BIDS nomenclature to MNE, leave channel type
         # untouched if we are uncertain
@@ -530,8 +537,16 @@ def _handle_channels_reading(channels_fname, raw):
                        'will raise an error in the future.')
                 warn(msg)
 
-        if updated_ch_type is not None:
-            channel_type_dict[ch_name] = updated_ch_type
+        if updated_ch_type is None:
+            # We don't have an appropriate mapping, so make it a "misc" channel
+            channel_type_bids_mne_map[ch_name] = 'misc'
+            warn(
+                f'No BIDS -> MNE mapping found for channel type "{ch_type}". '
+                f'Type of channel "{ch_name}" will be set to "misc".'
+            )
+        else:
+            # We found a mapping, so use it
+            channel_type_bids_mne_map[ch_name] = updated_ch_type
 
     # Special handling for (synthesized) stimulus channel
     synthesized_stim_ch_name = 'STI 014'
@@ -556,16 +571,19 @@ def _handle_channels_reading(channels_fname, raw):
                 raw.rename_channels({raw_ch_name: bids_ch_name})
 
     # Set the channel types in the raw data according to channels.tsv
-    ch_type_map_avail = {
+    channel_type_bids_mne_map_available_channels = {
         ch_name: ch_type
-        for ch_name, ch_type in channel_type_dict.items()
+        for ch_name, ch_type in channel_type_bids_mne_map.items()
         if ch_name in raw.ch_names
     }
-    ch_diff = set(channel_type_dict.keys()) - set(ch_type_map_avail.keys())
+    ch_diff = (
+        set(channel_type_bids_mne_map.keys()) -
+        set(channel_type_bids_mne_map_available_channels.keys())
+    )
     if ch_diff:
         warn(f'Cannot set channel type for the following channels, as they '
              f'are missing in the raw data: {", ".join(sorted(ch_diff))}')
-    raw.set_channel_types(ch_type_map_avail)
+    raw.set_channel_types(channel_type_bids_mne_map_available_channels)
 
     # Set bad channels based on _channels.tsv sidecar
     if 'status' in channels_dict:

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -67,6 +67,7 @@ def _get_ch_type_mapping(fro='mne', to='bids'):
         mapping = dict(eeg='EEG', misc='MISC', stim='TRIG', emg='EMG',
                        ecog='ECOG', seeg='SEEG', eog='EOG', ecg='ECG',
                        resp='RESP', bio='MISC', dbs='DBS',
+                       # NIRS
                        fnirs_cw_amplitude='NIRSCWAMPLITUDE',
                        # MEG channels
                        meggradaxial='MEGGRADAXIAL', megmag='MEGMAG',
@@ -77,7 +78,10 @@ def _get_ch_type_mapping(fro='mne', to='bids'):
     elif fro == 'bids' and to == 'mne':
         mapping = dict(EEG='eeg', MISC='misc', TRIG='stim', EMG='emg',
                        ECOG='ecog', SEEG='seeg', EOG='eog', ECG='ecg',
-                       RESP='resp', NIRS='fnirs_cw_amplitude',
+                       RESP='resp',
+                       # NIRS
+                       NIRSCWAMPLITUDE='fnirs_cw_amplitude',
+                       NIRS='fnirs_cw_amplitude',
                        # No MEG channels for now (see Notes above)
                        # Many to one mapping
                        VEOG='eog', HEOG='eog', DBS='dbs')

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -78,7 +78,7 @@ def _get_ch_type_mapping(fro='mne', to='bids'):
         mapping = dict(EEG='eeg', MISC='misc', TRIG='stim', EMG='emg',
                        ECOG='ecog', SEEG='seeg', EOG='eog', ECG='ecg',
                        RESP='resp', NIRS='fnirs_cw_amplitude',
-                       # No MEG channels for now
+                       # No MEG channels for now (see Notes above)
                        # Many to one mapping
                        VEOG='eog', HEOG='eog', DBS='dbs')
     else:


### PR DESCRIPTION
Previously, e.g. GSR and temperature channels could end up as "eeg" channels, for example.

Fixes #1048

Merge checklist
---------------

Maintainer, please confirm the following before merging.
If applicable:

- [x] All comments are resolved
- [ ] This is not your own PR
- [x] All CIs are happy
- [x] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] New contributors have been added to [CITATION.cff](https://github.com/mne-tools/mne-bids/blob/main/CITATION.cff)
- [x] PR description includes phrase "closes <#issue-number>"
