### PR TITLE
Make write_raw_bids() raise if an unsuitable extension is provided in the BIDSPath

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -96,6 +96,8 @@ Detailed list of changes
 
 - Whenever :func:`~mne_bids.read_raw_bids` encounters a channel type that currently doesn't translate into an appropriate MNE channel type, the channel type will now be set to ``'misc``. Previously, seemingly arbitrary channel types would be applied, e.g. ``'eeg'`` for GSR and temperature channels, by `Richard Höchenberger`_ (:gh:`1052`)
 
+- If the :class:`~mne_bids.BIDSPath` passed to :func:`~mne_bids.write_raw_bids` contains an incompatible combination of ``datatype`` and ``extension``, we now raise an exception instead of silently overriding the user-specified extension, by `Richard Höchenberger`_ (:gh:`xxx`)
+
 :doc:`Find out what was new in previous releases <whats_new_previous_releases>`
 
 .. include:: authors.rst

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1524,6 +1524,20 @@ def write_raw_bids(raw, bids_path, events_data=None, event_id=None,
             '"bids_path.task = <task>"'
         )
 
+    if (
+        (bids_path.datatype is not None and
+         bids_path.extension is not None) and
+        (bids_path.extension not in
+         ALLOWED_DATATYPE_EXTENSIONS[bids_path.datatype])
+    ):
+        allowed_extensions = ALLOWED_DATATYPE_EXTENSIONS[bids_path.datatype]
+        raise ValueError(
+            f'You requested to write {bids_path.datatype} data with '
+            f'extension {bids_path.extension} (as specified in bids_path), '
+            f'but this is not allowed. '
+            f'Please use one of: {", ".join(allowed_extensions)}'
+        )
+
     if events_data is not None and event_id is None:
         raise RuntimeError('You passed events_data, but no event_id '
                            'dictionary. You need to pass both, or neither.')
@@ -1818,13 +1832,6 @@ def write_raw_bids(raw, bids_path, events_data=None, event_id=None,
                 'However, this is not possible since you set symlink=True. '
                 'Deactivate symbolic links by passing symlink=False to allow '
                 'file format conversion.')
-
-    # check if there is an BIDS-unsupported MEG format
-    if bids_path.datatype == 'meg' and convert and not anonymize:
-        raise ValueError(
-            f"Got file extension {ext} for MEG data, "
-            f"expected one of "
-            f"{', '.join(sorted(ALLOWED_DATATYPE_EXTENSIONS['meg']))}")
 
     if not convert:
         logger.info(f'Copying data files to {bids_path.fpath.name}')


### PR DESCRIPTION
Some extensions / formats are only allowed for certain data types, e.g. `.vhdr` is (i)EEG-only.

When passing a `BIDSPath` containing both `datatype` and `extension` to `write_raw_bids()`, in case of a mismatch we would previously simply silently replace the incorrect `extension`, effectively writing to a location (and file format) the user didn't expect.

We now raise an exception in such situations.

Fixes #1041

Merge checklist
---------------

Maintainer, please confirm the following before merging.
If applicable:

- [ ] All comments are resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] New contributors have been added to [CITATION.cff](https://github.com/mne-tools/mne-bids/blob/main/CITATION.cff)
- [ ] PR description includes phrase "closes <#issue-number>"
