### PR TITLE
Fix BIDSPath.basename for cases where only an extension was provided

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -108,6 +108,8 @@ Detailed list of changes
 
 - Whenever :func:`~mne_bids.read_raw_bids` encounters a channel type that currently doesn't translate into an appropriate MNE channel type, the channel type will now be set to ``'misc``. Previously, seemingly arbitrary channel types would be applied, e.g. ``'eeg'`` for GSR and temperature channels, by `Richard Höchenberger`_ (:gh:`1052`)
 
+- Fix the ``basename`` of :class:`~mne_bids.BIDSPath` when the path only consists of a filename extension. Previously, the ``basename`` would be empty, by `Richard Höchenberger`_ (:gh:`1062`)
+
 :doc:`Find out what was new in previous releases <whats_new_previous_releases>`
 
 .. include:: authors.rst

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -329,7 +329,7 @@ class BIDSPath(object):
     @property
     def basename(self):
         """Path basename."""
-        basename = []
+        basename_components = []
         for key, val in self.entities.items():
             if val is not None and key != 'datatype':
                 # convert certain keys to shorthand
@@ -338,15 +338,23 @@ class BIDSPath(object):
                     in ALLOWED_PATH_ENTITIES_SHORT.items()
                 }
                 key = long_to_short_entity[key]
-                basename.append(f'{key}-{val}')
+                basename_components.append(f'{key}-{val}')
 
         if self.suffix is not None:
-            if self.extension is not None:
-                basename.append(f'{self.suffix}{self.extension}')
-            else:
-                basename.append(self.suffix)
+            basename_components.append(self.suffix)
 
-        basename = '_'.join(basename)
+        basename = '_'.join(basename_components)
+
+        # We're almost done! Now just append an extension if we have it.
+        if self.extension is not None:
+            if self.extension.startswith('.'):
+                ext = self.extension
+            else:
+                ext = f'.{self.extension}'
+
+            basename += ext
+            del ext
+
         return basename
 
     @property

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -528,6 +528,11 @@ def test_bids_path(return_bids_test_dir):
     # Same test, but exploiting the fact that bids_fpath is a pathlib.Path
     assert bids_fpath.name == bids_path.basename
 
+    # basename should be just the extension if nothing else is provided
+    # (the is a regression test)
+    bids_path = BIDSPath(extension='.vhdr')
+    assert bids_path.basename == '.vhdr'
+
     # confirm BIDSPath assigns properties correctly
     bids_path = BIDSPath(subject=subject_id,
                          session=session_id)


### PR DESCRIPTION
```python
#%%
from mne_bids import BIDSPath
bp = BIDSPath(extension='.vhdr')
bp
```

`main`:
<img width="165" alt="Screen Shot 2022-09-01 at 20 55 03" src="https://user-images.githubusercontent.com/2046265/187991856-bab492cd-1181-4734-940e-9f07ce2a1e56.png">

this PR:
<img width="165" alt="Screen Shot 2022-09-01 at 20 55 19" src="https://user-images.githubusercontent.com/2046265/187991887-e66f6724-9290-4479-bf1c-220ddf817906.png">

Merge checklist
---------------

Maintainer, please confirm the following before merging.
If applicable:

- [ ] All comments are resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] New contributors have been added to [CITATION.cff](https://github.com/mne-tools/mne-bids/blob/main/CITATION.cff)
- [ ] PR description includes phrase "closes <#issue-number>"
