### PR TITLE
MRG: Remove special-casing for NIRS bids-validator

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -124,22 +124,6 @@ jobs:
             mne-version: mne-main
             bids-validator-version: validator-main
 
-          # Tests with the NIRS branch of bids-validator
-          - os: ubuntu-latest
-            python-version: "3.10"
-            mne-version: mne-main
-            bids-validator-version: validator-NIRS
-
-          - os: macos-latest
-            python-version: "3.10"
-            mne-version: mne-main
-            bids-validator-version: validator-NIRS
-
-          - os: windows-latest
-            python-version: "3.10"
-            mne-version: mne-main
-            bids-validator-version: validator-NIRS
-
     env:
       TZ: Europe/Berlin
       FORCE_COLOR: true
@@ -197,16 +181,8 @@ jobs:
         popd
         echo "BIDS_VALIDATOR_BRANCH=main" >> $GITHUB_ENV
 
-    - name: Download BIDS validator (NIRS)
-      if: "matrix.bids-validator-version == 'validator-NIRS'"
-      run: |
-        pushd ..
-        git clone --depth 1 --branch nirs https://github.com/rob-luke/bids-validator.git
-        popd
-        echo "BIDS_VALIDATOR_BRANCH=NIRS" >> $GITHUB_ENV
-
-    - name: Install BIDS validator (main or NIRS)
-      if: ${{ (matrix.bids-validator-version == 'validator-main') || (matrix.bids-validator-version == 'validator-NIRS') }}
+    - name: Install BIDS validator (main)
+      if: "matrix.bids-validator-version == 'validator-main'"
       run: |
         pushd ..
         cd bids-validator

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -1719,10 +1719,6 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate, tmp_path):
         _bids_validate(output_path)
 
 
-@pytest.mark.skipif(
-    os.environ.get('BIDS_VALIDATOR_BRANCH') != 'NIRS',
-    reason="requires Rob's NIRS branch of bids-validator"
-)
 def test_snirf(_bids_validate, tmp_path):
     """Test write_raw_bids conversion for SNIRF data."""
     raw_fname = op.join(testing.data_path(), 'SNIRF', 'MNE-NIRS', '20220217',


### PR DESCRIPTION
The stable bids-validator now officially supports NIRS, so there's no need anymore for using Rob's personal branch.

cc @rob-luke 


Merge checklist
---------------

Maintainer, please confirm the following before merging.
If applicable:

- [ ] All comments are resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] New contributors have been added to [CITATION.cff](https://github.com/mne-tools/mne-bids/blob/main/CITATION.cff)
- [ ] PR description includes phrase "closes <#issue-number>"
