### PR TITLE
[MRG] Suggest alternatives when value not found in list

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -49,6 +49,8 @@ Detailed list of changes
 
 - :func:`~mne_bids.write_raw_bids` now supports EGI format, by `Anand Saini`_, `Scott Huberty`_ and `Mathieu Scheltienne`_ (:gh:`1006`)
 
+- When a given subject cannot be found, valid suggestions are now printed, by `Eric Larson`_ (:gh:`1066`)
+
 - TSV files that are empty (i.e., only a header row is present) are now handled more robustly and a warning is issued, by `Stefan Appelhoff`_ (:gh:`1038`)
 
 🧐 API and behavior changes

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -189,7 +189,7 @@ def _verbose_list_index(lst, val, *, allow_all=False):
     try:
         return lst.index(val)
     except ValueError as exc:
-        extra = get_close_matches(lst, val)
+        extra = get_close_matches(str(val), [str(ll) for ll in lst])
         if allow_all and not extra:
             extra = lst
         extra = f'. Did you mean one of {extra}?' if extra else ''

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -184,11 +184,12 @@ def _read_events(events, event_id, raw, bids_path=None):
 
 
 def _verbose_list_index(lst, val, *, allow_all=False):
-    # try to "return lst.index(val)" but be more informative/verbose when
-    # it fails
+    # try to "return lst.index(val)" for list of str, but be more
+    # informative/verbose when it fails
     try:
         return lst.index(val)
     except ValueError as exc:
+        # Use str cast here to deal with pathlib.Path instances
         extra = get_close_matches(str(val), [str(ll) for ll in lst])
         if allow_all and not extra:
             extra = lst

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -183,7 +183,9 @@ def _read_events(events, event_id, raw, bids_path=None):
     return all_events, all_dur, all_desc
 
 
-def _safe_index(lst, val, *, allow_all=False):
+def _verbose_list_index(lst, val, *, allow_all=False):
+    # try to "return lst.index(val)" but be more informative/verbose when
+    # it fails
     try:
         return lst.index(val)
     except ValueError as exc:
@@ -197,7 +199,7 @@ def _safe_index(lst, val, *, allow_all=False):
 def _handle_participants_reading(participants_fname, raw, subject):
     participants_tsv = _from_tsv(participants_fname)
     subjects = participants_tsv['participant_id']
-    row_ind = _safe_index(subjects, subject, allow_all=True)
+    row_ind = _verbose_list_index(subjects, subject, allow_all=True)
     raw.info['subject_info'] = dict()  # start from scratch
 
     # set data from participants tsv into subject_info
@@ -262,7 +264,7 @@ def _handle_scans_reading(scans_fname, raw, bids_path):
     if all(suffix in ('.vhdr', '.eeg', '.vmrk') for suffix in acq_suffixes):
         ext = fnames[0].suffix
         data_fname = Path(data_fname).with_suffix(ext)
-    row_ind = _safe_index(fnames, data_fname)
+    row_ind = _verbose_list_index(fnames, data_fname)
 
     # check whether all split files have the same acq_time
     # and throw an error if they don't
@@ -277,7 +279,8 @@ def _handle_scans_reading(scans_fname, raw, bids_path):
         ))
         split_acq_times = []
         for split_f in split_fnames:
-            split_acq_times.append(acq_times[_safe_index(fnames, split_f)])
+            split_acq_times.append(
+                acq_times[_verbose_list_index(fnames, split_f)])
         if len(set(split_acq_times)) != 1:
             raise ValueError("Split files must have the same acq_time.")
 


### PR DESCRIPTION
<!--
Thanks for contributing this pull request (PR).
If this is your first time, make sure to read
[CONTRIBUTING.md](https://github.com/mne-tools/mne-bids/blob/main/CONTRIBUTING.md)
-->

PR Description
--------------

When `lst.index(val)` fails (e.g., `subjects.index(subject)`), try to help people out with suggestions. I was on this PR when I got the traceback in #1065:

> ValueError: 'sub-001' is not in list. Did you mean one of ['CQ2', 'BT4', 'CQ1', 'CQ3', 'CP9', 'CA7', 'CB6', 'BV2', 'CP8', 'CP1', 'CP2', 'CO9', 'CP5', 'CL1', 'BL7', 'CO3', 'CE2', 'CV6', 'CJ2', 'CY8']?

I figured subject lists are generally short enough to `allow_all` to be given (if there are no close matches), but wasn't sure about the others. But they can easily be added elsewhere or tweaked in these cases by follow-up PRs by heavier/more experienced users and devs of MNE-BIDS.

Merge checklist
---------------

Maintainer, please confirm the following before merging.
If applicable:

- [ ] All comments are resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] New contributors have been added to [CITATION.cff](https://github.com/mne-tools/mne-bids/blob/main/CITATION.cff)
- [ ] PR description includes phrase "closes <#issue-number>"
