### PR TITLE
Fix chpi write

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -36,6 +36,7 @@ The following authors had contributed before. Thank you for sticking around! �
 * `Robert Luke`_
 * `Stefan Appelhoff`_
 * `Dominik Welke`_
+* `Eduard Ort`_
 
 Detailed list of changes
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -74,6 +75,7 @@ Detailed list of changes
 
 - Until now, :class:`mne_bids.BIDSPath` prepends extensions with a period "." automatically. We intend to remove this undocumented side-effect and now emit a ``FutureWarning`` if an ``extension`` that does not start with a ``.`` is provided. Starting with MNE-BIDS 0.12, an exception will be raised in this case, by `Richard Höchenberger`_ (:gh:`1061`)
 
+
 🛠 Requirements
 ^^^^^^^^^^^^^^^
 
@@ -107,6 +109,9 @@ Detailed list of changes
 - Internal helper function to :func:`~mne_bids.read_raw_bids` would reject BrainVision data if ``_scans.tsv`` listed a ``.eeg`` file instead of ``.vhdr``, by `Teon Brooks`_ (:gh:`1034`)
 
 - Whenever :func:`~mne_bids.read_raw_bids` encounters a channel type that currently doesn't translate into an appropriate MNE channel type, the channel type will now be set to ``'misc``. Previously, seemingly arbitrary channel types would be applied, e.g. ``'eeg'`` for GSR and temperature channels, by `Richard Höchenberger`_ (:gh:`1052`)
+
+- Fix the incorrect setting of the fields `ContinuousHeadLocalization` and `HeadCoilFrequency` for Neuromag meg recordings, by `Eduard Ort`_ (:gh:`1067`)
+
 
 :doc:`Find out what was new in previous releases <whats_new_previous_releases>`
 

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -14,6 +14,8 @@ import shutil as sh
 import numpy as np
 from numpy.testing import assert_almost_equal
 
+from pkg_resources import parse_version
+
 import mne
 from mne.io.constants import FIFF
 from mne.utils import requires_nibabel, object_diff, requires_version
@@ -715,8 +717,8 @@ def test_handle_chpi_reading(tmp_path):
     # cHPI frequency mismatch
     if parse_version(mne.__version__) <= parse_version('1.1'):
         assert 'ContinuousHeadLocalization' not in meg_json_data
-        assert 'HeadCoilFrequency' not in meg_json_data 
-    else:       
+        assert 'HeadCoilFrequency' not in meg_json_data
+    else:
         meg_json_data_freq_mismatch = meg_json_data.copy()
         meg_json_data_freq_mismatch['HeadCoilFrequency'][0] = 123
         _write_json(meg_json_path, meg_json_data_freq_mismatch, overwrite=True)

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -724,10 +724,8 @@ def test_fif(_bids_validate, tmp_path):
     assert 'GradientOrder' in software_filters['SpatialCompensation']
     assert (software_filters['SpatialCompensation']['GradientOrder'] ==
             raw.compensation_grade)
-from IPython import embed as shell
-shell()
-tmp_path = 'Desktop'
-format='fif'
+
+
 @pytest.mark.parametrize('format', ('fif_no_chpi', 'fif', 'ctf', 'kit'))
 @pytest.mark.filterwarnings(warning_str['maxshield'])
 def test_chpi(_bids_validate, tmp_path, format):
@@ -753,7 +751,7 @@ def test_chpi(_bids_validate, tmp_path, format):
         raw = _read_raw_kit(kit_raw_fname, mrk=kit_hpi_fname,
                             elp=kit_electrode_fname, hsp=kit_headshape_fname)
 
-    bids_root = tmp_path + '/bids'
+    bids_root = tmp_path / 'bids'
     bids_path = _bids_path.copy().update(root=bids_root, datatype='meg')
 
     write_raw_bids(raw, bids_path)

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -724,8 +724,10 @@ def test_fif(_bids_validate, tmp_path):
     assert 'GradientOrder' in software_filters['SpatialCompensation']
     assert (software_filters['SpatialCompensation']['GradientOrder'] ==
             raw.compensation_grade)
-
-
+from IPython import embed as shell
+shell()
+tmp_path = 'Desktop'
+format='fif'
 @pytest.mark.parametrize('format', ('fif_no_chpi', 'fif', 'ctf', 'kit'))
 @pytest.mark.filterwarnings(warning_str['maxshield'])
 def test_chpi(_bids_validate, tmp_path, format):
@@ -751,7 +753,7 @@ def test_chpi(_bids_validate, tmp_path, format):
         raw = _read_raw_kit(kit_raw_fname, mrk=kit_hpi_fname,
                             elp=kit_electrode_fname, hsp=kit_headshape_fname)
 
-    bids_root = tmp_path / 'bids'
+    bids_root = tmp_path + '/bids'
     bids_path = _bids_path.copy().update(root=bids_root, datatype='meg')
 
     write_raw_bids(raw, bids_path)
@@ -766,8 +768,8 @@ def test_chpi(_bids_validate, tmp_path, format):
 
     elif format in ['fif_no_chpi', 'fif']:
         if parse_version(mne.__version__) <= parse_version('1.1'):
-            assert meg_json_data['ContinuousHeadLocalization'] is True
-            assert meg_json_data['HeadCoilFrequency'] is False
+            assert 'ContinuousHeadLocalization' not in meg_json_data
+            assert 'HeadCoilFrequency' not in meg_json_data
         else:
             if format == 'fif_no_chpi':
                 assert meg_json_data['ContinuousHeadLocalization'] is False
@@ -780,10 +782,10 @@ def test_chpi(_bids_validate, tmp_path, format):
     elif format == 'kit':
         # no cHPI info is contained in the sample data
         assert meg_json_data['ContinuousHeadLocalization'] is False
-        assert meg_json_data['HeadCoilFrequency'] == "n/a"
+        assert meg_json_data['HeadCoilFrequency'] == []
     elif format == 'ctf':
         assert meg_json_data['ContinuousHeadLocalization'] is True
-        assert meg_json_data['HeadCoilFrequency'] == "n/a"
+        assert meg_json_data['HeadCoilFrequency'] == []
 
 
 @pytest.mark.filterwarnings(warning_str['channel_unit_changed'])

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -766,8 +766,8 @@ def test_chpi(_bids_validate, tmp_path, format):
 
     elif format in ['fif_no_chpi', 'fif']:
         if parse_version(mne.__version__) <= parse_version('1.1'):
-            assert meg_json_data['ContinuousHeadLocalization'] is None
-            assert meg_json_data['HeadCoilFrequency'] is None
+            assert meg_json_data['ContinuousHeadLocalization'] is True
+            assert meg_json_data['HeadCoilFrequency'] is False
         else:
             if format == 'fif_no_chpi':
                 assert meg_json_data['ContinuousHeadLocalization'] is False
@@ -780,10 +780,10 @@ def test_chpi(_bids_validate, tmp_path, format):
     elif format == 'kit':
         # no cHPI info is contained in the sample data
         assert meg_json_data['ContinuousHeadLocalization'] is False
-        assert meg_json_data['HeadCoilFrequency'] is None
+        assert meg_json_data['HeadCoilFrequency'] == "n/a"
     elif format == 'ctf':
         assert meg_json_data['ContinuousHeadLocalization'] is True
-        assert meg_json_data['HeadCoilFrequency'] is None
+        assert meg_json_data['HeadCoilFrequency'] == "n/a"
 
 
 @pytest.mark.filterwarnings(warning_str['channel_unit_changed'])

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -780,11 +780,10 @@ def test_chpi(_bids_validate, tmp_path, format):
     elif format == 'kit':
         # no cHPI info is contained in the sample data
         assert meg_json_data['ContinuousHeadLocalization'] is False
-        assert meg_json_data['HeadCoilFrequency'] == []
+        assert meg_json_data['HeadCoilFrequency'] is None
     elif format == 'ctf':
         assert meg_json_data['ContinuousHeadLocalization'] is True
-        assert_array_equal(meg_json_data['HeadCoilFrequency'],
-                           np.array([]))
+        assert meg_json_data['HeadCoilFrequency'] is None
 
 
 @pytest.mark.filterwarnings(warning_str['channel_unit_changed'])

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -845,6 +845,7 @@ def _sidecar_json(raw, task, manufacturer, fname, datatype,
                 mne.chpi.extract_chpi_locs_kit(raw)
                 chpi = True
             except (RuntimeError, ValueError):
+                chpi = False
                 logger.info('Could not find cHPI information in raw data.')
         else:
             # XXX: Remove this version check when support for mne <1.2

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -839,6 +839,7 @@ def _sidecar_json(raw, task, manufacturer, fname, datatype,
                 mne.chpi.extract_chpi_locs_ctf(raw)
                 chpi = True
             except RuntimeError:
+                chpi = False
                 logger.info('Could not find cHPI information in raw data.')
         elif isinstance(raw, RawKIT):
             try:

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -29,6 +29,7 @@ from mne.io.constants import FIFF
 from mne.io.pick import channel_type, _picks_to_idx
 from mne.io import BaseRaw, read_fiducials
 from mne.channels.channels import _unit2human
+from mne.chpi import (get_active_chpi, get_chpi_info)
 from mne.utils import (check_version, has_nibabel, logger, warn, Bunch,
                        _validate_type, get_subjects_dir, verbose,
                        ProgressBar)
@@ -846,13 +847,17 @@ def _sidecar_json(raw, task, manufacturer, fname, datatype,
             except (RuntimeError, ValueError):
                 logger.info('Could not find cHPI information in raw data.')
         else:
-            n_active_hpi = mne.chpi.get_active_chpi(raw)
-            chpi = n_active_hpi.sum() > 0
-            if chpi:
-                hpi_freqs, _, _ = mne.chpi.get_chpi_info(info=raw.info,
-                                                         on_missing='ignore')
+            if parse_version(mne.__version__) > parse_version('1.1'):
+                n_active_hpi = get_active_chpi(raw)
+                chpi = n_active_hpi.sum() > 0
+                if chpi:
+                    hpi_freqs, _, _ = get_chpi_info(info=raw.info,
+                                                    on_missing='ignore')
+                else:
+                    hpi_freqs = []
             else:
-                hpi_freqs = []
+                chpi = None
+                hpi_freqs = None
 
     elif datatype == 'meg':
         logger.info('Cannot check for & write continuous head localization '

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -846,10 +846,14 @@ def _sidecar_json(raw, task, manufacturer, fname, datatype,
             except (RuntimeError, ValueError):
                 logger.info('Could not find cHPI information in raw data.')
         else:
-            hpi_freqs, _, _ = mne.chpi.get_chpi_info(info=raw.info,
-                                                     on_missing='ignore')
-            if hpi_freqs.size > 0:
-                chpi = True
+            n_active_hpi = mne.chpi.get_active_chpi(raw)
+            chpi = n_active_hpi.sum() > 0
+            if chpi:
+                hpi_freqs, _, _ = mne.chpi.get_chpi_info(info=raw.info,
+                                                         on_missing='ignore')
+            else:
+                hpi_freqs = None
+
     elif datatype == 'meg':
         logger.info('Cannot check for & write continuous head localization '
                     'information: requires MNE-Python >= 0.24')

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -29,7 +29,7 @@ from mne.io.constants import FIFF
 from mne.io.pick import channel_type, _picks_to_idx
 from mne.io import BaseRaw, read_fiducials
 from mne.channels.channels import _unit2human
-from mne.chpi import (get_active_chpi, get_chpi_info)
+from mne.chpi import get_chpi_info
 from mne.utils import (check_version, has_nibabel, logger, warn, Bunch,
                        _validate_type, get_subjects_dir, verbose,
                        ProgressBar)
@@ -848,13 +848,15 @@ def _sidecar_json(raw, task, manufacturer, fname, datatype,
                 logger.info('Could not find cHPI information in raw data.')
         else:
             if parse_version(mne.__version__) > parse_version('1.1'):
-                n_active_hpi = get_active_chpi(raw)
+                n_active_hpi = mne.chpi.get_active_chpi(raw)
                 chpi = n_active_hpi.sum() > 0
                 if chpi:
                     hpi_freqs, _, _ = get_chpi_info(info=raw.info,
                                                     on_missing='ignore')
                 else:
                     hpi_freqs = []
+            # XXX: Remove this when support for mne <1.2 is dropped and
+            # also remove the version check above
             else:
                 chpi = None
                 hpi_freqs = None

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -28,7 +28,7 @@ from mne import Epochs
 from mne.io.constants import FIFF
 from mne.io.pick import channel_type, _picks_to_idx
 from mne.io import BaseRaw, read_fiducials
-from mne.channels.channels import _unit2human
+from mne.channels.channels import (_unit2human, _get_meg_system)
 from mne.chpi import get_chpi_info
 from mne.utils import (check_version, has_nibabel, logger, warn, Bunch,
                        _validate_type, get_subjects_dir, verbose,
@@ -826,29 +826,27 @@ def _sidecar_json(raw, task, manufacturer, fname, datatype,
     }
 
     # Compile cHPI information, if any.
-    from mne.io.ctf import RawCTF
-    from mne.io.kit.kit import RawKIT
-
+    system, _ = _get_meg_system(raw.info)
     chpi = None
     hpi_freqs = []
     if (datatype == 'meg' and
             parse_version(mne.__version__) > parse_version('0.23')):
         # We need to handle different data formats differently
-        if isinstance(raw, RawCTF):
+        if system == 'CTF_275':
             try:
                 mne.chpi.extract_chpi_locs_ctf(raw)
                 chpi = True
             except RuntimeError:
                 chpi = False
                 logger.info('Could not find cHPI information in raw data.')
-        elif isinstance(raw, RawKIT):
+        elif system == 'KIT':
             try:
                 mne.chpi.extract_chpi_locs_kit(raw)
                 chpi = True
             except (RuntimeError, ValueError):
                 chpi = False
                 logger.info('Could not find cHPI information in raw data.')
-        else:
+        elif system in ['122m', '306m']:
             # XXX: Remove this version check when support for mne <1.2
             # is dropped
             if parse_version(mne.__version__) > parse_version('1.1'):

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -852,7 +852,7 @@ def _sidecar_json(raw, task, manufacturer, fname, datatype,
                 hpi_freqs, _, _ = mne.chpi.get_chpi_info(info=raw.info,
                                                          on_missing='ignore')
             else:
-                hpi_freqs = None
+                hpi_freqs = []
 
     elif datatype == 'meg':
         logger.info('Cannot check for & write continuous head localization '

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -852,7 +852,8 @@ def _sidecar_json(raw, task, manufacturer, fname, datatype,
             # XXX: Remove this version check when support for mne <1.2
             # is dropped
             if parse_version(mne.__version__) > parse_version('1.1'):
-                n_active_hpi = mne.chpi.get_active_chpi(raw)
+                n_active_hpi = mne.chpi.get_active_chpi(raw,
+                                                        on_missing='ignore')
                 chpi = bool(n_active_hpi.sum() > 0)
                 if chpi:
                     hpi_freqs, _, _ = get_chpi_info(info=raw.info,


### PR DESCRIPTION
PR Description
--------------
closes #940 
Given the added functionality in [mne-python](https://github.com/mne-tools/mne-python/pull/11122), I adapted the way the status of the hpi's is determined for neuromag files. Essentially, if any of the hpi's were active for at least one timepoint the field is set. 

I wasn't sure what to do about the `HeadCoilFrequency` field. It seems like it is set regardless of the hpi status, but I think it is confusing (and rather pointless), to have the frequencies listed even though non of them were active. So I set them to None in case of inactive hpi.

Also the functionality would require the latest version of mne-python (1.2)

Merge checklist
---------------

Maintainer, please confirm the following before merging.
If applicable:

- [x] All comments are resolved
- [x] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] New contributors have been added to [CITATION.cff](https://github.com/mne-tools/mne-bids/blob/main/CITATION.cff)
- [x] PR description includes phrase "closes <#issue-number>"
