### PR TITLE
fix CI after upstream changes

### DIFF
--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -84,6 +84,7 @@ warning_str = dict(
                  'Setting to None.',
     cnt_warning2='ignore:.*Could not define the number of bytes automatically.'
                  ' Defaulting to 2.',
+    cnt_warning3='ignore:.*Coordinate frame could not be inferred.*',
     no_hand='ignore:.*Not setting subject handedness.:RuntimeWarning:mne',
     no_montage=r'ignore:Not setting position of.*channel found in '
                r'montage.*:RuntimeWarning:mne',
@@ -3228,6 +3229,7 @@ def test_convert_meg_formats(dir_name, format, fname, reader, tmp_path):
     warning_str['channel_unit_changed'],
     warning_str['cnt_warning1'],
     warning_str['cnt_warning2'],
+    warning_str['cnt_warning3'],
     warning_str['no_hand'],
 )
 def test_convert_raw_errors(dir_name, fname, reader, tmp_path):

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -125,7 +125,7 @@ def _channels_tsv(raw, fname, overwrite=False):
         ch_type.append(map_chs[_channel_type])
         description.append(map_desc[_channel_type])
     low_cutoff, high_cutoff = (raw.info['highpass'], raw.info['lowpass'])
-    if raw._orig_units is not None:
+    if raw._orig_units:
         units = [raw._orig_units.get(ch, 'n/a') for ch in raw.ch_names]
     else:
         units = [_unit2human.get(ch_i['unit'], 'n/a')


### PR DESCRIPTION
<!--
Thanks for contributing this pull request (PR).
If this is your first time, make sure to read
[CONTRIBUTING.md](https://github.com/mne-tools/mne-bids/blob/main/CONTRIBUTING.md)
-->

PR Description
--------------

goes together with

- https://github.com/mne-tools/mne-python/pull/11212

to fix the CI

identified in

- https://github.com/mne-tools/mne-bids/pull/1066#issuecomment-1242791526

Also fixes a bug with `_orig_units`, because the format has changed upstream in:

- https://github.com/mne-tools/mne-python/pull/11160

ready for merge after the MNE-Python PR above has been merged.

Merge checklist
---------------

Maintainer, please confirm the following before merging.
If applicable:

- [ ] All comments are resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] New contributors have been added to [CITATION.cff](https://github.com/mne-tools/mne-bids/blob/main/CITATION.cff)
- [ ] PR description includes phrase "closes <#issue-number>"
