### PR TITLE
Provide more helpful error messages when trying to write non-prelaoded concatenated data

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -79,6 +79,7 @@ Detailed list of changes
 
 - Until now, :class:`mne_bids.BIDSPath` prepends extensions with a period "." automatically. We intend to remove this undocumented side-effect and now emit a ``FutureWarning`` if an ``extension`` that does not start with a ``.`` is provided. Starting with MNE-BIDS 0.12, an exception will be raised in this case, by `Richard Höchenberger`_ (:gh:`1061`)
 
+- Provide a more helpful error message when trying to write non-preloaded concatenated data, by `Richard Höchenberger`_ (:gh:`#1075`)
 
 🛠 Requirements
 ^^^^^^^^^^^^^^^

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1623,8 +1623,15 @@ def write_raw_bids(
         elif format == 'FIF':
             ext = '.fif'
         else:
-            raise ValueError('For preloaded data, you must specify a valid '
-                             'format. See "allow_preload".')
+            msg = (
+                'For preloaded data, you must set the "format" parameter '
+                'to one of: BrainVision, EDF, or FIF'
+            )
+            if format != 'auto':  # the default was changed
+                msg += f', but got: "{format}"'
+
+            raise ValueError(msg)
+
         raw_orig = raw
 
     # Check times
@@ -1635,15 +1642,15 @@ def write_raw_bids(
         else:
             msg = ("The raw data you want to write contains {comp} time "
                    "points than the raw data on disk. It is possible that you "
-                   "{guess} your data, which write_raw_bids() won't accept.")
+                   "{guess} your data.")
             if len(raw.times) < len(raw_orig.times):
                 msg = msg.format(comp='fewer', guess='cropped')
             elif len(raw.times) > len(raw_orig.times):
                 msg = msg.format(comp='more', guess='concatenated')
 
-        msg += (' If you believe you have a valid use case that should be '
-                'supported, please reach out to the developers at '
-                'https://github.com/mne-tools/mne-bids/issues')
+        msg += (' To write the data, please preload it and pass '
+                '"allow_preload=True" and the "format" parameter to '
+                'write_raw_bids().')
         raise ValueError(msg)
 
     # Initialize BIDSPath


### PR DESCRIPTION
This came up on the forum: https://mne.discourse.group/t/mne-bids-structure-one-subject-is-different/5687/4

<!--
Thanks for contributing this pull request (PR).
If this is your first time, make sure to read
[CONTRIBUTING.md](https://github.com/mne-tools/mne-bids/blob/main/CONTRIBUTING.md)
-->

PR Description
--------------

<!--Describe your PR here-->

Merge checklist
---------------

Maintainer, please confirm the following before merging.
If applicable:

- [ ] All comments are resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] New contributors have been added to [CITATION.cff](https://github.com/mne-tools/mne-bids/blob/main/CITATION.cff)
- [ ] PR description includes phrase "closes <#issue-number>"
