### PR TITLE
avoid creating many Annotations objects in for loop

### DIFF
--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -491,8 +491,8 @@ def _handle_events_reading(events_fname, raw):
                                         description=descriptions)
     raw.set_annotations(annot_from_events)
 
-    annot_idx_to_keep = [idx for idx, annot in enumerate(annot_from_raw)
-                         if annot['description'] in ANNOTATIONS_TO_KEEP]
+    annot_idx_to_keep = [idx for idx, descr in enumerate(annot_from_raw.description)
+                         if descr in ANNOTATIONS_TO_KEEP]
     annot_to_keep = annot_from_raw[annot_idx_to_keep]
 
     if len(annot_to_keep):


### PR DESCRIPTION
without this fix read_raw_bids on a subject from https://openneuro.org/datasets/ds003825 takes 600s on my laptop. With this fix it's < 3s. 