### PR TITLE
ENH: Better error message

### DIFF
--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -953,8 +953,11 @@ class BIDSPath(object):
             )
             er_bids_path = _find_matched_empty_room(self)
 
-        if er_bids_path is not None:
-            assert er_bids_path.fpath.exists()
+        if er_bids_path is not None and not er_bids_path.fpath.exists():
+            raise RuntimeError(
+                f'Empty-room BIDS path resolved but not found:\n'
+                f'{er_bids_path}\n'
+                'Check your BIDS dataset for completeness.')
 
         return er_bids_path
 

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -954,7 +954,7 @@ class BIDSPath(object):
             er_bids_path = _find_matched_empty_room(self)
 
         if er_bids_path is not None and not er_bids_path.fpath.exists():
-            raise RuntimeError(
+            raise FileNotFoundError(
                 f'Empty-room BIDS path resolved but not found:\n'
                 f'{er_bids_path}\n'
                 'Check your BIDS dataset for completeness.')

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -960,10 +960,18 @@ def test_find_empty_room(return_bids_test_dir, tmp_path):
 
     # Retrieve empty-room BIDSPath
     assert bids_path.find_empty_room() == er_associated_bids_path
+    assert bids_path.find_empty_room(
+        use_sidecar_only=True) == er_associated_bids_path
 
     # Should only work for MEG
     with pytest.raises(ValueError, match='only supported for MEG'):
         bids_path.copy().update(datatype='eeg').find_empty_room()
+
+    # Raises an error if the file is missing
+    os.remove(er_associated_bids_path.fpath)
+
+    with pytest.raises(FileNotFoundError, match='Empty-room BIDS .* not foun'):
+        bids_path.find_empty_room(use_sidecar_only=True)
 
     # Don't create `AssociatedEmptyRoom` entry in sidecar – we should now
     # retrieve the empty-room recording closer in time

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -969,7 +969,6 @@ def test_find_empty_room(return_bids_test_dir, tmp_path):
 
     # Raises an error if the file is missing
     os.remove(er_associated_bids_path.fpath)
-
     with pytest.raises(FileNotFoundError, match='Empty-room BIDS .* not foun'):
         bids_path.find_empty_room(use_sidecar_only=True)
 


### PR DESCRIPTION
Running MNE-BIDS-Pipeline I got a slightly cryptic error:
```
  File "/home/larsoner/python/mne-bids-pipeline/mne_bids_pipeline/scripts/preprocessing/_02_frequency_filter.py", line 101, in get_input_fnames_frequency_filter
    in_files[f'raw_run-{run}'].find_empty_room()
  File "/home/larsoner/python/mne-bids/mne_bids/path.py", line 957, in find_empty_room
    assert er_bids_path.fpath.exists()

AssertionError
```
I realized the problem with my dataset (I excluded some files while downloading), but I think this new error message would have helped:
```
  File "/home/larsoner/python/mne-bids-pipeline/mne_bids_pipeline/scripts/preprocessing/_02_frequency_filter.py", line 101, in get_input_fnames_frequency_filter
    in_files[f'raw_run-{run}'].find_empty_room()
  File "/home/larsoner/python/mne-bids/mne_bids/path.py", line 957, in find_empty_room
    raise FileNotFoundError(

FileNotFoundError: Empty-room BIDS path resolved but not found:
/home/larsoner/mne_data/ds000247/sub-emptyroom/ses-18901014/meg/sub-emptyroom_ses-18901014_task-noise_run-01_meg.ds
Check your BIDS dataset for completeness.
```