### PR TITLE
ENH: Allow returning candidate BIDSPaths

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -37,6 +37,7 @@ Detailed list of changes
 ^^^^^^^^^^^^^^^
 
 - Speed up :func:`mne_bids.read_raw_bids` when lots of events are present by `Alexandre Gramfort`_ (:gh:`1079`)
+- Add the option ``return_candidates`` to :meth:`mne_bids.BIDSPath.find_empty_room` by `Eric Larson`_ (:gh:`1083`)
 
 🧐 API and behavior changes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -949,6 +949,7 @@ class BIDSPath(object):
             er_bids_path = get_bids_path_from_fname(emptytoom_path)
             er_bids_path.root = self.root
             er_bids_path.datatype = 'meg'
+            candidates = None
         elif use_sidecar_only:
             logger.info(
                 'The MEG sidecar file does not contain an '

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -960,8 +960,11 @@ def test_find_empty_room(return_bids_test_dir, tmp_path):
 
     # Retrieve empty-room BIDSPath
     assert bids_path.find_empty_room() == er_associated_bids_path
-    assert bids_path.find_empty_room(
-        use_sidecar_only=True) == er_associated_bids_path
+    for use_sidecar_only in [True, False]:  # same result either way
+        path, candidates = bids_path.find_empty_room(
+            use_sidecar_only=use_sidecar_only, return_candidates=True)
+        assert path == er_associated_bids_path
+        assert candidates is None
 
     # Should only work for MEG
     with pytest.raises(ValueError, match='only supported for MEG'):
@@ -975,11 +978,14 @@ def test_find_empty_room(return_bids_test_dir, tmp_path):
     # Don't create `AssociatedEmptyRoom` entry in sidecar – we should now
     # retrieve the empty-room recording closer in time
     write_raw_bids(raw, bids_path=bids_path, empty_room=None, overwrite=True)
-    assert bids_path.find_empty_room() == er_matching_date_bids_path
+    path, candidates = bids_path.find_empty_room(return_candidates=True)
+    assert path == er_matching_date_bids_path
+    assert er_matching_date_bids_path in candidates
 
     # If we enforce searching only via `AssociatedEmptyRoom`, we should get no
     # result
-    assert bids_path.find_empty_room(use_sidecar_only=True) is None
+    assert bids_path.find_empty_room(
+        use_sidecar_only=True, return_candidates) == (None, None)
 
 
 @pytest.mark.filterwarnings(warning_str['channel_unit_changed'])

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -985,7 +985,7 @@ def test_find_empty_room(return_bids_test_dir, tmp_path):
     # If we enforce searching only via `AssociatedEmptyRoom`, we should get no
     # result
     assert bids_path.find_empty_room(
-        use_sidecar_only=True, return_candidates) == (None, None)
+        use_sidecar_only=True, return_candidates=True) == (None, None)
 
 
 @pytest.mark.filterwarnings(warning_str['channel_unit_changed'])

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -5,7 +5,7 @@ matplotlib>=3.1
 pandas>=0.24.0
 nibabel>=2.5
 pybv>=0.7.3
-git+https://github.com/larsoner/openneuro-py@iterate#egg=openneuro-py
+openneuro-py>=2022.2
 EDFlib-Python>=1.0.6
 pymatreader>=0.0.29
 pytest

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -5,7 +5,7 @@ matplotlib>=3.1
 pandas>=0.24.0
 nibabel>=2.5
 pybv>=0.7.3
-openneuro-py>=2022.1
+git+https://github.com/larsoner/openneuro-py@iterate#egg=openneuro-py
 EDFlib-Python>=1.0.6
 pymatreader>=0.0.29
 pytest


### PR DESCRIPTION
For MNE-BIDS-Pipeline, we want to know the set of input files that each function uses during each step. In one step, we call `raw_bids_path.find_empty_room()`, which could use the sidecar or traverse a bunch of files (potentially) to find the best-matching empty-room file. This PR adds a `return_candidates=False` kwarg that will return `None` if the sidecar was used, or a list of `BIDSPath` instances if files were traversed.