### PR TITLE
ENH: Make suggestion

### DIFF
--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -12,6 +12,7 @@ import json
 import re
 from datetime import datetime, timezone
 from difflib import get_close_matches
+import os
 
 import numpy as np
 import mne
@@ -720,7 +721,17 @@ def read_raw_bids(bids_path, extra_params=None, verbose=None):
                 break
 
     if not raw_path.exists():
-        raise FileNotFoundError(f'File does not exist: {raw_path}')
+        options = os.listdir(bids_path.directory)
+        matches = get_close_matches(bids_path.basename, options)
+        msg = f'File does not exist:\n{raw_path}'
+        if matches:
+            msg += (
+                '\nDid you mean one of:\n' +
+                '\n'.join(matches) +
+                '\ninstead of:\n' +
+                bids_path.basename
+            )
+        raise FileNotFoundError(msg)
     if config_path is not None and not config_path.exists():
         raise FileNotFoundError(f'config directory not found: {config_path}')
 

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -1297,6 +1297,7 @@ def test_channels_tsv_raw_mismatch(tmp_path):
         read_raw_bids(bids_path)
 
 
+@testing.requires_testing_data
 def test_file_not_found(tmp_path):
     """Check behavior if the requested file cannot be found."""
     # First a path with a filename extension.
@@ -1312,6 +1313,15 @@ def test_file_not_found(tmp_path):
     bp.extension = None
     with pytest.raises(FileNotFoundError, match='File does not exist'):
         read_raw_bids(bids_path=bp)
+
+    bp.update(extension='.fif')
+    _read_raw_fif(raw_fname, verbose=False).save(bp.fpath)
+    with pytest.warns(RuntimeWarning, match=r'channels\.tsv'):
+        read_raw_bids(bp)  # smoke test
+
+    bp.update(task=None)
+    with pytest.raises(FileNotFoundError, match='Did you mean'):
+        read_raw_bids(bp)
 
 
 @requires_version('mne', '1.2')


### PR DESCRIPTION
Gives a more helpful error message:
```
FileNotFoundError: File does not exist:
/mnt/bakraid/larsoner/opm_reading/tutorial_OPM_data/sub-001/ses-001/meg/sub-001_ses-001_task-noise_run-001_meg
Did you mean one of:
sub-001_ses-001_task-noise_run-001_meg.bin
sub-001_ses-001_task-noise_run-001_meg.json
sub-001_ses-001_task-noise_run-001_nulls.tsv
instead of:
sub-001_ses-001_task-noise_run-001_meg
```
In this case the file can't be read because `.bin` OPM reading isn't implemented in MNE-Python, but this makes it easier to find other errors like a bad `task` as well.