### PR TITLE
fix: nirs convert only auto accepted

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -31,6 +31,7 @@ The following authors had contributed before. Thank you for sticking around! �
 * `Alexandre Gramfort`_
 * `Eric Larson`_
 * `Richard Höchenberger`_
+* `Stefan Appelhoff`_
 
 Detailed list of changes
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -56,7 +57,7 @@ Detailed list of changes
 ^^^^^^^^^^^^
 
 - When writing data containing :class:`mne.Annotations` **and** passing events to :func:`~mne_bids.write_raw_bids`, previously, annotations whose description did not appear in ``event_id`` were silently dropped. We now raise an exception and request users to specify mappings between descriptions and event codes in this case. It is still possible to omit ``event_id`` if no ``events`` are passed, by `Richard Höchenberger`_ (:gh:`1084`)
-
+- When working with NIRS data, raise the correct error message when a faulty ``format`` argument is passed to :func:`~mne_bids.write_raw_bids`, by `Stefan Appelhoff`_ (:gh:`1092`)
 
 :doc:`Find out what was new in previous releases <whats_new_previous_releases>`
 

--- a/mne_bids/config.py
+++ b/mne_bids/config.py
@@ -16,10 +16,12 @@ ALLOWED_DATATYPES = EPHY_ALLOWED_DATATYPES + ['anat', 'beh']
 MEG_CONVERT_FORMATS = ['FIF', 'auto']
 EEG_CONVERT_FORMATS = ['BrainVision', 'auto']
 IEEG_CONVERT_FORMATS = ['BrainVision', 'auto']
+NIRS_CONVERT_FORMATS = ['auto']
 CONVERT_FORMATS = {
     'meg': MEG_CONVERT_FORMATS,
     'eeg': EEG_CONVERT_FORMATS,
-    'ieeg': IEEG_CONVERT_FORMATS
+    'ieeg': IEEG_CONVERT_FORMATS,
+    'nirs': NIRS_CONVERT_FORMATS,
 }
 
 # Orientation of the coordinate system dependent on manufacturer

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -1810,6 +1810,10 @@ def test_snirf(_bids_validate, tmp_path):
     assert rawbids.annotations.description[2] == 'Control'
     assert raw.times[-1] == rawbids.times[-1]
 
+    with pytest.raises(ValueError,
+                       match='The input "format" FIF is not an accepted.*'):
+        write_raw_bids(raw, bids_path, overwrite=True, format="FIF")
+
     # Test with different optode coordinate frame
     raw = _read_raw_snirf(raw_fname, optode_frame="mri")
     write_raw_bids(raw, bids_path, overwrite=True)


### PR DESCRIPTION
<!--
Thanks for contributing this pull request (PR).
If this is your first time, make sure to read
[CONTRIBUTING.md](https://github.com/mne-tools/mne-bids/blob/main/CONTRIBUTING.md)
-->

PR Description
--------------

fixes https://mne.discourse.group/t/write-raw-bids-and-snirf/5843

**without** this fix, passing a NIRS file with a `format` other than `"auto"` to `write_raw_brainvision` will run into an issue at this line: https://github.com/mne-tools/mne-bids/blob/a552a53ad1942c34f8b564ca7499079a1b7fdeb6/mne_bids/write.py#L1905

**with** this fix, a sensible error is raised, namely: users should use `format="auto"` with NIRS files.


Merge checklist
---------------

Maintainer, please confirm the following before merging.
If applicable:

- [ ] All comments are resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] New contributors have been added to [CITATION.cff](https://github.com/mne-tools/mne-bids/blob/main/CITATION.cff)
- [ ] PR description includes phrase "closes <#issue-number>"
