### PR TITLE
BUG: Fix API for candidates

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -41,6 +41,7 @@ Detailed list of changes
 
 - Speed up :func:`mne_bids.read_raw_bids` when lots of events are present by `Alexandre Gramfort`_ (:gh:`1079`)
 - Add :meth:`mne_bids.BIDSPath.get_empty_room_candidates` to get the candidate empty-room files that could be used by :meth:`mne_bids.BIDSPath.find_empty_room` by `Eric Larson`_ (:gh:`1083`, :gh:`1093`)
+- Add :meth:`mne_bids.BIDSPath.find_matching_sidecar` to find the sidecar file associated with a given file path by `Eric Larson`_ (:gh:`1093`)
 - When writing data via :func:`~mne_bids.write_raw_bids`, it is now possible to specify a custom mapping of :class:`mne.Annotations` descriptions to event codes via the ``event_id`` parameter. Previously, passing this parameter would always require to also pass ``events``, and using a custom event code mapping for annotations was impossible, by `Richard Höchenberger`_ (:gh:`1084`)
 
 🧐 API and behavior changes

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -40,7 +40,7 @@ Detailed list of changes
 ^^^^^^^^^^^^^^^
 
 - Speed up :func:`mne_bids.read_raw_bids` when lots of events are present by `Alexandre Gramfort`_ (:gh:`1079`)
-- Add the option ``return_candidates`` to :meth:`mne_bids.BIDSPath.find_empty_room` by `Eric Larson`_ (:gh:`1083`)
+- Add :meth:`mne_bids.BIDSPath.get_empty_room_candidates` to get the candidate empty-room files that could be used by :meth:`mne_bids.BIDSPath.find_empty_room` by `Eric Larson`_ (:gh:`1083`, :gh:`1093`)
 - When writing data via :func:`~mne_bids.write_raw_bids`, it is now possible to specify a custom mapping of :class:`mne.Annotations` descriptions to event codes via the ``event_id`` parameter. Previously, passing this parameter would always require to also pass ``events``, and using a custom event code mapping for annotations was impossible, by `Richard Höchenberger`_ (:gh:`1084`)
 
 🧐 API and behavior changes

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -28,7 +28,7 @@ from mne_bids.utils import (_check_key_val, _check_empty_room_basename,
                             param_regex, _ensure_tuple)
 
 
-def _find_matched_empty_room(bids_path):
+def _find_empty_room_candidates(bids_path):
     """Get matching empty-room file for an MEG recording."""
     # Check whether we have a BIDS root.
     bids_root = bids_path.root
@@ -37,23 +37,15 @@ def _find_matched_empty_room(bids_path):
                          'Please use `bids_path.update(root="<root>")` '
                          'to set the root of the BIDS folder to read.')
 
-    from mne_bids import read_raw_bids  # avoid circular import.
     bids_path = bids_path.copy()
 
     datatype = 'meg'  # We're only concerned about MEG data here
-    bids_fname = bids_path.update(suffix=datatype,
-                                  root=bids_root).fpath
+    bids_fname = bids_path.update(suffix=datatype).fpath
     _, ext = _parse_ext(bids_fname)
-    raw = read_raw_bids(bids_path=bids_path)
-    if raw.info['meas_date'] is None:
-        raise ValueError('The provided recording does not have a measurement '
-                         'date set. Cannot get matching empty-room file.')
-
-    ref_date = raw.info['meas_date']
     emptyroom_dir = BIDSPath(root=bids_root, subject='emptyroom').directory
 
     if not emptyroom_dir.exists():
-        return None, list()
+        return list()
 
     # Find the empty-room recording sessions.
     emptyroom_session_dirs = [x for x in emptyroom_dir.iterdir()
@@ -78,13 +70,6 @@ def _find_matched_empty_room(bids_path):
                     (not item.suffix and item.is_dir())):  # Hopefully BTi?
                 candidate_er_fnames.append(item.name)
 
-    # Walk through recordings, trying to extract the recording date:
-    # First, from the filename; and if that fails, from `info['meas_date']`.
-    best_er_bids_path = None
-    min_delta_t = np.inf
-    date_tie = False
-
-    failed_to_get_er_date_count = 0
     candidates = list()
     for er_fname in candidate_er_fnames:
         # get entities from filenamme
@@ -93,6 +78,29 @@ def _find_matched_empty_room(bids_path):
         er_bids_path.root = bids_root
         er_bids_path.datatype = 'meg'
         candidates.append(er_bids_path)
+
+    return candidates
+
+
+def _find_matched_empty_room(bids_path):
+    from mne_bids import read_raw_bids  # avoid circular import.
+    candidates = _find_empty_room_candidates(bids_path)
+
+    # Walk through recordings, trying to extract the recording date:
+    # First, from the filename; and if that fails, from `info['meas_date']`.
+    best_er_bids_path = None
+    min_delta_t = np.inf
+    date_tie = False
+    failed_to_get_er_date_count = 0
+    bids_path = bids_path.copy().update(datatype='meg')
+    raw = read_raw_bids(bids_path=bids_path)
+    if raw.info['meas_date'] is None:
+        raise ValueError('The provided recording does not have a measurement '
+                         'date set. Cannot get matching empty-room file.')
+    ref_date = raw.info['meas_date']
+    del bids_path, raw
+    for er_bids_path in candidates:
+        # get entities from filenamme
         er_meas_date = None
 
         # Try to extract date from filename.
@@ -106,7 +114,7 @@ def _find_matched_empty_room(bids_path):
                 pass
 
         if er_meas_date is None:  # No luck so far! Check info['meas_date']
-            _, ext = _parse_ext(er_fname)
+            _, ext = _parse_ext(er_bids_path.fpath)
             extra_params = None
             if ext == '.fif':
                 extra_params = dict(allow_maxshield='yes')
@@ -139,7 +147,7 @@ def _find_matched_empty_room(bids_path):
                'same recording date. Selecting the first match.')
         warn(msg)
 
-    return best_er_bids_path, candidates
+    return best_er_bids_path
 
 
 class BIDSPath(object):
@@ -895,8 +903,7 @@ class BIDSPath(object):
                                  f'{ALLOWED_FILENAME_SUFFIX}.')
 
     @verbose
-    def find_empty_room(self, use_sidecar_only=False, *,
-                        return_candidates=False, verbose=None):
+    def find_empty_room(self, use_sidecar_only=False, *, verbose=None):
         """Find the corresponding empty-room file of an MEG recording.
 
         This will only work if the ``.root`` attribute of the
@@ -909,9 +916,6 @@ class BIDSPath(object):
             sidecar JSON file or not. If ``False``, first look for the entry,
             and if unsuccessful, try to find the best-matching empty-room
             recording in the dataset based on the measurement date.
-        return_candidates : bool
-            If True (default False), return candidate filenames checked during
-            the search for the best-matching empty-room recording.
         %(verbose)s
 
         Returns
@@ -919,11 +923,6 @@ class BIDSPath(object):
         BIDSPath | None
             The path corresponding to the best-matching empty-room measurement.
             Returns ``None`` if none was found.
-        list | None
-            The candidates checked during the search for the best-matching
-            empty-room recording. Only returned if ``return_candidates`` is
-            ``True``. Will be None if a sidecar is used to find the empty-room
-            recording.
         """
         if self.datatype not in ('meg', None):
             raise ValueError('Empty-room data is only supported for MEG '
@@ -949,21 +948,20 @@ class BIDSPath(object):
             er_bids_path = get_bids_path_from_fname(emptytoom_path)
             er_bids_path.root = self.root
             er_bids_path.datatype = 'meg'
-            candidates = None
         elif use_sidecar_only:
             logger.info(
                 'The MEG sidecar file does not contain an '
                 '"AssociatedEmptyRoom" entry. Aborting search for an '
                 'empty-room recording, as you passed use_sidecar_only=True'
             )
-            return None if not return_candidates else (None, None)
+            return None
         else:
             logger.info(
                 'The MEG sidecar file does not contain an '
                 '"AssociatedEmptyRoom" entry. Will try to find a matching '
                 'empty-room recording based on the measurement date …'
             )
-            er_bids_path, candidates = _find_matched_empty_room(self)
+            er_bids_path = _find_matched_empty_room(self)
 
         if er_bids_path is not None and not er_bids_path.fpath.exists():
             raise FileNotFoundError(
@@ -971,10 +969,22 @@ class BIDSPath(object):
                 f'{er_bids_path}\n'
                 'Check your BIDS dataset for completeness.')
 
-        out = er_bids_path
-        if return_candidates:
-            out = (out, candidates)
-        return out
+        return er_bids_path
+
+    def get_empty_room_candidates(self):
+        """Get the list of empty-room candidates for the given file.
+
+        Returns
+        -------
+        candidates : list of BIDSPath
+            The candidate files that will be checked if the sidecar does not
+            contain an "AssociatedEmptyRoom" entry.
+
+        Notes
+        -----
+        .. versionadded:: 0.12.0
+        """
+        return _find_empty_room_candidates(self)
 
     @property
     def meg_calibration_fpath(self):

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -19,7 +19,7 @@ from mne_bids import (get_datatypes, get_entity_vals, print_dir_tree,
                       BIDSPath, write_raw_bids, read_raw_bids,
                       write_meg_calibration, write_meg_crosstalk)
 from mne_bids.path import (_parse_ext, get_entities_from_fname,
-                           _find_best_candidates, _find_matching_sidecar,
+                           _find_best_candidates,
                            _filter_fnames, search_folder_for_text,
                            get_bids_path_from_fname)
 from mne_bids.config import ALLOWED_PATH_ENTITIES_SHORT
@@ -370,44 +370,42 @@ def test_find_matching_sidecar(return_bids_test_dir, tmp_path):
     bids_path = _bids_path.copy().update(root=bids_root)
 
     # Now find a sidecar
-    sidecar_fname = _find_matching_sidecar(bids_path,
-                                           suffix='coordsystem',
-                                           extension='.json')
+    sidecar_fname = bids_path.find_matching_sidecar(
+        suffix='coordsystem', extension='.json')
     expected_file = op.join('sub-01', 'ses-01', 'meg',
                             'sub-01_ses-01_coordsystem.json')
-    assert sidecar_fname.endswith(expected_file)
+    assert str(sidecar_fname).endswith(expected_file)
 
     # Find multiple sidecars, tied in score, triggering an error
     with pytest.raises(RuntimeError, match='Expected to find a single'):
-        open(sidecar_fname.replace('coordsystem.json',
-                                   '2coordsystem.json'), 'w').close()
+        open(str(sidecar_fname).replace('coordsystem.json',
+                                        '2coordsystem.json'), 'w').close()
         print_dir_tree(bids_root)
-        _find_matching_sidecar(bids_path,
-                               suffix='coordsystem', extension='.json')
+        bids_path.find_matching_sidecar(
+            suffix='coordsystem', extension='.json')
 
     # Find nothing and raise.
     with pytest.raises(RuntimeError, match='Did not find any'):
-        fname = _find_matching_sidecar(bids_path, suffix='foo',
-                                       extension='.bogus')
+        bids_path.find_matching_sidecar(suffix='foo', extension='.bogus')
 
     # Find nothing and receive None and a warning.
     on_error = 'warn'
     with pytest.warns(RuntimeWarning, match='Did not find any'):
-        fname = _find_matching_sidecar(bids_path, suffix='foo',
-                                       extension='.bogus', on_error=on_error)
+        fname = bids_path.find_matching_sidecar(
+            suffix='foo', extension='.bogus', on_error=on_error)
     assert fname is None
 
     # Find nothing and receive None.
     on_error = 'ignore'
-    fname = _find_matching_sidecar(bids_path, suffix='foo',
-                                   extension='.bogus', on_error=on_error)
+    fname = bids_path.find_matching_sidecar(
+        suffix='foo', extension='.bogus', on_error=on_error)
     assert fname is None
 
     # Invalid on_error.
     on_error = 'hello'
     with pytest.raises(ValueError, match='Acceptable values for on_error are'):
-        _find_matching_sidecar(bids_path, suffix='coordsystem',
-                               extension='.json', on_error=on_error)
+        bids_path.find_matching_sidecar(
+            suffix='coordsystem', extension='.json', on_error=on_error)
 
     # Test behavior of suffix and extension params when suffix and extension
     # are also (not) present in the passed BIDSPath
@@ -429,7 +427,7 @@ def test_find_matching_sidecar(return_bids_test_dir, tmp_path):
 
     for bp_suffix in (None, 'eeg'):
         bids_path.suffix = bp_suffix
-        s = _find_matching_sidecar(bids_path=bids_path, suffix='events')
+        s = bids_path.find_matching_sidecar(suffix='events')
         assert Path(s).name == 'sub-test_task-task_events.json'
 
     # extension parameter should always override BIDSPath.extension
@@ -437,15 +435,14 @@ def test_find_matching_sidecar(return_bids_test_dir, tmp_path):
 
     for bp_extension in (None, '.json'):
         bids_path.extension = bp_extension
-        s = _find_matching_sidecar(bids_path=bids_path, extension='.tsv')
+        s = bids_path.find_matching_sidecar(extension='.tsv')
         assert Path(s).name == 'sub-test_task-task_events.tsv'
 
     # If suffix and extension parameters are not passed, use BIDSPath
     # attributes
-    bids_path.suffix = 'events'
-    bids_path.extension = '.tsv'
-    s = _find_matching_sidecar(bids_path=bids_path)
-    assert Path(s).name == 'sub-test_task-task_events.tsv'
+    bids_path.update(suffix='events', extension='.tsv')
+    s = bids_path.find_matching_sidecar()
+    assert s.name == 'sub-test_task-task_events.tsv'
 
 
 @testing.requires_testing_data
@@ -868,7 +865,10 @@ def test_find_empty_room(return_bids_test_dir, tmp_path):
     bids_path = BIDSPath(subject='01', session='01',
                          task='audiovisual', run='01',
                          root=bids_root, suffix='meg')
+    with pytest.warns(RuntimeWarning, match='Did not find any'):
+        assert bids_path.find_matching_sidecar(on_error='warn') is None
     write_raw_bids(raw, bids_path, overwrite=True, verbose=False)
+    assert bids_path.find_matching_sidecar().is_file()
 
     # No empty-room data present.
     er_basename = bids_path.find_empty_room()

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -865,10 +865,7 @@ def test_find_empty_room(return_bids_test_dir, tmp_path):
     bids_path = BIDSPath(subject='01', session='01',
                          task='audiovisual', run='01',
                          root=bids_root, suffix='meg')
-    with pytest.warns(RuntimeWarning, match='Did not find any'):
-        assert bids_path.find_matching_sidecar(on_error='warn') is None
     write_raw_bids(raw, bids_path, overwrite=True, verbose=False)
-    assert bids_path.find_matching_sidecar().is_file()
 
     # No empty-room data present.
     er_basename = bids_path.find_empty_room()
@@ -953,10 +950,13 @@ def test_find_empty_room(return_bids_test_dir, tmp_path):
 
     # Now we write experimental data and associate it with the earlier
     # empty-room recording
+    with pytest.raises(RuntimeError, match='Did not find any'):
+        bids_path.find_matching_sidecar()
     bids_path = (er_matching_date_bids_path.copy()
                  .update(subject='01', session=None, task='task'))
     write_raw_bids(raw, bids_path=bids_path,
                    empty_room=er_associated_bids_path)
+    assert bids_path.find_matching_sidecar().is_file()
 
     # Retrieve empty-room BIDSPath
     assert bids_path.find_empty_room() == er_associated_bids_path

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -961,10 +961,10 @@ def test_find_empty_room(return_bids_test_dir, tmp_path):
     # Retrieve empty-room BIDSPath
     assert bids_path.find_empty_room() == er_associated_bids_path
     for use_sidecar_only in [True, False]:  # same result either way
-        path, candidates = bids_path.find_empty_room(
-            use_sidecar_only=use_sidecar_only, return_candidates=True)
+        path = bids_path.find_empty_room(use_sidecar_only=use_sidecar_only)
         assert path == er_associated_bids_path
-        assert candidates is None
+    candidates = bids_path.get_empty_room_candidates()
+    assert len(candidates) == 2
 
     # Should only work for MEG
     with pytest.raises(ValueError, match='only supported for MEG'):
@@ -978,14 +978,14 @@ def test_find_empty_room(return_bids_test_dir, tmp_path):
     # Don't create `AssociatedEmptyRoom` entry in sidecar – we should now
     # retrieve the empty-room recording closer in time
     write_raw_bids(raw, bids_path=bids_path, empty_room=None, overwrite=True)
-    path, candidates = bids_path.find_empty_room(return_candidates=True)
+    path = bids_path.find_empty_room()
+    candidates = bids_path.get_empty_room_candidates()
     assert path == er_matching_date_bids_path
     assert er_matching_date_bids_path in candidates
 
     # If we enforce searching only via `AssociatedEmptyRoom`, we should get no
     # result
-    assert bids_path.find_empty_room(
-        use_sidecar_only=True, return_candidates=True) == (None, None)
+    assert bids_path.find_empty_room(use_sidecar_only=True) is None
 
 
 @pytest.mark.filterwarnings(warning_str['channel_unit_changed'])

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -2966,12 +2966,12 @@ def test_coordsystem_json_compliance(
         assert coordsystem_json['EEGCoordinateSystemDescription'] == \
             BIDS_COORD_FRAME_DESCRIPTIONS['captrak']
     elif datatype == 'ieeg' and coord_frame == 'mni_tal':
-        assert 'space-fsaverage' in coordsystem_fname
+        assert 'space-fsaverage' in str(coordsystem_fname)
         assert coordsystem_json['iEEGCoordinateSystem'] == 'fsaverage'
         assert coordsystem_json['iEEGCoordinateSystemDescription'] == \
             BIDS_COORD_FRAME_DESCRIPTIONS['fsaverage']
     elif datatype == 'ieeg' and coord_frame == 'mri':
-        assert 'space-ACPC' in coordsystem_fname
+        assert 'space-ACPC' in str(coordsystem_fname)
         assert coordsystem_json['iEEGCoordinateSystem'] == 'ACPC'
         assert coordsystem_json['iEEGCoordinateSystemDescription'] == \
             BIDS_COORD_FRAME_DESCRIPTIONS['acpc']


### PR DESCRIPTION
<!--
Thanks for contributing this pull request (PR).
If this is your first time, make sure to read
[CONTRIBUTING.md](https://github.com/mne-tools/mne-bids/blob/main/CONTRIBUTING.md)
-->

PR Description
--------------

So in #1083 I added `return_candidates=True`, but this doesn't really solve the use case. The "list all candidates" step needs to be *separate* from the "traverse and read all candidates", and it's not currently. This PR splits them. Now instead of doing:
```
fname, candidates = bids_path.find_empty_room(return_candidates=True)
```
you do
```
candidates = bids_path.get_empty_room_candidates()
fname = bids_path.find_empty_room()
```
And the `get_empty_room_candidates` does not read any files, just lists/globs filenames so should be very fast (and negligible I/O overhead).

Merge checklist
---------------

Maintainer, please confirm the following before merging.
If applicable:

- [ ] All comments are resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] New contributors have been added to [CITATION.cff](https://github.com/mne-tools/mne-bids/blob/main/CITATION.cff)
- [ ] PR description includes phrase "closes <#issue-number>"
