### PR TITLE
ENH: Better error message on fpath

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -8,5 +8,5 @@ matplotlib
 pillow
 pandas
 setuptools
-mne-nirs
+https://github.com/mne-tools/mne-nirs/zipball/main
 seaborn

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -43,6 +43,7 @@ Detailed list of changes
 - Add :meth:`mne_bids.BIDSPath.get_empty_room_candidates` to get the candidate empty-room files that could be used by :meth:`mne_bids.BIDSPath.find_empty_room` by `Eric Larson`_ (:gh:`1083`, :gh:`1093`)
 - Add :meth:`mne_bids.BIDSPath.find_matching_sidecar` to find the sidecar file associated with a given file path by `Eric Larson`_ (:gh:`1093`)
 - When writing data via :func:`~mne_bids.write_raw_bids`, it is now possible to specify a custom mapping of :class:`mne.Annotations` descriptions to event codes via the ``event_id`` parameter. Previously, passing this parameter would always require to also pass ``events``, and using a custom event code mapping for annotations was impossible, by `Richard Höchenberger`_ (:gh:`1084`)
+- Improve error message when :obj:`~mne_bids.BIDSPath.fpath` cannot be uniquely resolved by `Eric Larson`_ (:gh:`1097`)
 
 🧐 API and behavior changes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -13,6 +13,7 @@ from os import path as op
 from pathlib import Path
 from datetime import datetime
 import json
+from textwrap import indent
 from typing import Optional
 
 import numpy as np
@@ -625,8 +626,13 @@ class BIDSPath(object):
                     bids_fpath = op.join(data_path, self.basename)
                 # if paths still cannot be resolved, then there is an error
                 elif len(matching_paths) > 1:
+                    matching_paths_str = "\n".join(sorted(matching_paths))
                     msg = ('Found more than one matching data file for the '
-                           'requested recording. Cannot proceed due to the '
+                           'requested recording. While searching:\n'
+                           f'{indent(repr(self), "    ")}\n'
+                           f'Found {len(matching_paths)} paths:\n'
+                           f'{indent(matching_paths_str, "    ")}\n'
+                           'Cannot proceed due to the '
                            'ambiguity. This is likely a problem with your '
                            'BIDS dataset. Please run the BIDS validator on '
                            'your data.')


### PR DESCRIPTION
Improves the error message from:
```
RuntimeError: Found more than one matching data file for the requested recording.
Cannot proceed due to the ambiguity. This is likely a problem with your BIDS dataset.
Please run the BIDS validator on your data.
```
to
```
RuntimeError: Found more than one matching data file for the requested recording. While searching:
    BIDSPath(
    root: /home/larsoner/mne_data/ds004024
    datatype: eeg
    basename: sub-CON001_ses-async14ms_task-rest)
Found 4 paths:
    /home/larsoner/mne_data/ds004024/sub-CON001/ses-async14ms/eeg/sub-CON001_ses-async14ms_task-rest_run-01_eeg.vhdr
    /home/larsoner/mne_data/ds004024/sub-CON001/ses-async14ms/eeg/sub-CON001_ses-async14ms_task-rest_run-02_eeg.vhdr
    /home/larsoner/mne_data/ds004024/sub-CON001/ses-async14ms/eeg/sub-CON001_ses-async14ms_task-rest_run-03_eeg.vhdr
    /home/larsoner/mne_data/ds004024/sub-CON001/ses-async14ms/eeg/sub-CON001_ses-async14ms_task-rest_run-04_eeg.vhdr
Cannot proceed due to the ambiguity. This is likely a problem with your BIDS dataset.
Please run the BIDS validator on your data.
```
which allowed me to see the problem/ambiguity easily.