### PR TITLE
ENH: Auto warning stacklevel

### DIFF
--- a/mne_bids/copyfiles.py
+++ b/mne_bids/copyfiles.py
@@ -25,10 +25,10 @@ from scipy.io import loadmat, savemat
 import mne
 from mne.io import (read_raw_brainvision, read_raw_edf, read_raw_bdf,
                     anonymize_info)
-from mne.utils import logger, verbose, warn
+from mne.utils import logger, verbose
 
 from mne_bids.path import BIDSPath, _parse_ext, _mkdir_p
-from mne_bids.utils import _get_mrk_meas_date, _check_anonymize
+from mne_bids.utils import _get_mrk_meas_date, _check_anonymize, warn
 import numpy as np
 
 

--- a/mne_bids/dig.py
+++ b/mne_bids/dig.py
@@ -14,7 +14,7 @@ import warnings
 import mne
 import numpy as np
 from mne.io.constants import FIFF
-from mne.utils import (logger, warn, _validate_type, _check_option,
+from mne.utils import (logger, _validate_type, _check_option,
                        has_nibabel, get_subjects_dir)
 from mne.io.pick import _picks_to_idx
 
@@ -25,7 +25,7 @@ from mne_bids.config import (ALLOWED_SPACES, BIDS_COORDINATE_UNITS,
                              BIDS_STANDARD_TEMPLATE_COORDINATE_SYSTEMS)
 from mne_bids.tsv_handler import _from_tsv
 from mne_bids.utils import (_scale_coord_to_meters, _write_json, _write_tsv,
-                            verbose)
+                            verbose, warn)
 from mne_bids.path import BIDSPath
 
 data_dir = Path(__file__).parent / 'data'

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -17,7 +17,7 @@ from textwrap import indent
 from typing import Optional
 
 import numpy as np
-from mne.utils import warn, logger, _validate_type, verbose, _check_fname
+from mne.utils import logger, _validate_type, verbose, _check_fname
 
 from mne_bids.config import (
     ALLOWED_PATH_ENTITIES, ALLOWED_FILENAME_EXTENSIONS,
@@ -26,7 +26,7 @@ from mne_bids.config import (
     ALLOWED_SPACES,
     reader, ENTITY_VALUE_TYPE)
 from mne_bids.utils import (_check_key_val, _check_empty_room_basename,
-                            param_regex, _ensure_tuple)
+                            param_regex, _ensure_tuple, warn)
 
 
 def _find_empty_room_candidates(bids_path):

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -18,9 +18,7 @@ import numpy as np
 import mne
 from mne import io, read_events, events_from_annotations
 from mne.io.pick import pick_channels_regexp
-from mne.utils import (
-    has_nibabel, logger, warn, get_subjects_dir
-)
+from mne.utils import has_nibabel, logger, get_subjects_dir
 from mne.coreg import fit_matched_points
 from mne.transforms import apply_trans
 
@@ -29,7 +27,7 @@ from mne_bids.tsv_handler import _from_tsv, _drop
 from mne_bids.config import (ALLOWED_DATATYPE_EXTENSIONS,
                              ANNOTATIONS_TO_KEEP,
                              reader, _map_options)
-from mne_bids.utils import _get_ch_type_mapping, verbose
+from mne_bids.utils import _get_ch_type_mapping, verbose, warn
 from mne_bids.path import (BIDSPath, _parse_ext, _find_matching_sidecar,
                            _infer_datatype, get_bids_path_from_fname)
 

--- a/mne_bids/report/_report.py
+++ b/mne_bids/report/_report.py
@@ -9,13 +9,14 @@ from pathlib import Path
 
 import numpy as np
 import jinja2
-from mne.utils import warn, logger, verbose
+from mne.utils import logger, verbose
 
 from mne_bids.config import DOI, ALLOWED_DATATYPES
 from mne_bids.tsv_handler import _from_tsv
 from mne_bids.path import (get_bids_path_from_fname, get_datatypes,
                            get_entity_vals, BIDSPath,
                            _parse_ext, _find_matching_sidecar)
+from mne_bids.utils import warn
 
 
 jinja_env = jinja2.Environment(

--- a/mne_bids/tsv_handler.py
+++ b/mne_bids/tsv_handler.py
@@ -2,7 +2,6 @@
 from collections import OrderedDict
 from copy import deepcopy
 
-from mne.utils import warn
 import numpy as np
 
 
@@ -140,6 +139,7 @@ def _from_tsv(fname, dtypes=None):
         Keys are the column names, and values are the column data.
 
     """
+    from .utils import warn  # avoid circular import
     data = np.loadtxt(fname, dtype=str, delimiter='\t', ndmin=2,
                       comments=None, encoding='utf-8-sig')
     column_names = data[0, :]

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -469,4 +469,4 @@ def warn(message, category=RuntimeWarning, module='mne_bids',
 
 
 # Some of the defaults here will be wrong but it should be close enough
-warn.__doc__ = _warn.__doc__
+warn.__doc__ = getattr(_warn, '__doc__', None)

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -17,7 +17,7 @@ import numpy as np
 from mne.channels import make_standard_montage
 from mne.io.kit.kit import get_kit_info
 from mne.io.pick import pick_types
-from mne.utils import warn, logger, verbose
+from mne.utils import warn as _warn, logger, verbose
 
 from mne_bids.tsv_handler import _to_tsv
 
@@ -456,3 +456,13 @@ def _check_datatype(raw, datatype):
             '`bids_path.update(datatype="<datatype>")` or use '
             'raw.set_channel_types to set the correct channel types in '
             'the raw object.')
+
+
+def warn(message, category=RuntimeWarning, module='mne_bids',
+         ignore_namespaces=('mne', 'mne_bids')):
+    _warn(
+        message,
+        category=category,
+        module=module,
+        ignore_namespaces=ignore_namespaces,
+    )

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -459,10 +459,14 @@ def _check_datatype(raw, datatype):
 
 
 def warn(message, category=RuntimeWarning, module='mne_bids',
-         ignore_namespaces=('mne', 'mne_bids')):
+         ignore_namespaces=('mne', 'mne_bids')):  # noqa: D103
     _warn(
         message,
         category=category,
         module=module,
         ignore_namespaces=ignore_namespaces,
     )
+
+
+# Some of the defaults here will be wrong but it should be close enough
+warn.__doc__ = _warn.__doc__

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -30,7 +30,7 @@ from mne.io.pick import channel_type, _picks_to_idx
 from mne.io import BaseRaw, read_fiducials
 from mne.channels.channels import (_unit2human, _get_meg_system)
 from mne.chpi import get_chpi_info
-from mne.utils import (check_version, has_nibabel, logger, warn, Bunch,
+from mne.utils import (check_version, has_nibabel, logger, Bunch,
                        _validate_type, get_subjects_dir, verbose,
                        ProgressBar)
 import mne.preprocessing
@@ -40,7 +40,7 @@ from mne_bids.dig import _write_dig_bids, _write_coordsystem_json
 from mne_bids.utils import (_write_json, _write_tsv, _write_text,
                             _age_on_date, _infer_eeg_placement_scheme,
                             _get_ch_type_mapping, _check_anonymize,
-                            _stamp_to_dt, _handle_datatype)
+                            _stamp_to_dt, _handle_datatype, warn)
 from mne_bids import (BIDSPath, read_raw_bids, get_anonymization_daysback,
                       get_bids_path_from_fname)
 from mne_bids.path import _parse_ext, _mkdir_p, _path_to_str


### PR DESCRIPTION
Make use of the `ignore_namespaces` to make messages like this with an unhelpful `stacklevel`:
```
/home/larsoner/python/mne-bids/mne_bids/path.py:1583: RuntimeWarning: Did not find any events.tsv associated with sub-0001_task-AEF_run-01.

The search_str was "/home/larsoner/mne_data/ds000246/sub-0001/**/meg/sub-0001*events.tsv"
  warn(msg)
/home/larsoner/python/mne-bids/mne_bids/read.py:580: RuntimeWarning: No BIDS -> MNE mapping found for channel type "SYSCLOCK". Type of channel "SCLK01-177" will be set to "misc".
  warn(
/home/larsoner/python/mne-bids/mne_bids/read.py:580: RuntimeWarning: No BIDS -> MNE mapping found for channel type "OTHER". Type of channel "HADC001-4408" will be set to "misc".
```
automagically resolve to a more helpful stacklevel:
```
/home/larsoner/python/mne-bids-pipeline/mne_bids_pipeline/_import_data.py:338: RuntimeWarning: Did not find any events.tsv associated with sub-0001_task-AEF_run-01.

The search_str was "/home/larsoner/mne_data/ds000246/sub-0001/**/meg/sub-0001*events.tsv"
  raw = read_raw_bids(bids_path=bids_path,
/home/larsoner/python/mne-bids-pipeline/mne_bids_pipeline/_import_data.py:338: RuntimeWarning: No BIDS -> MNE mapping found for channel type "SYSCLOCK". Type of channel "SCLK01-177" will be set to "misc".
  raw = read_raw_bids(bids_path=bids_path,
/home/larsoner/python/mne-bids-pipeline/mne_bids_pipeline/_import_data.py:338: RuntimeWarning: No BIDS -> MNE mapping found for channel type "OTHER". Type of channel "HADC001-4408" will be set to "misc".
```

As an aside, any reason all of mne-bids's imports are absolute, e.g. `from mne_bids.utils import warn` rather than relative like `from .utils import warn`? I think the latter is more standard, worth switching them in a follow-up PR?