### PR TITLE
Install MNE-Python stable from PyPI instead of GitHub

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -154,8 +154,7 @@ jobs:
     - name: Install MNE (stable)
       if: "matrix.mne-version == 'mne-stable'"
       run: |
-        git clone --depth 1 --single-branch --branch maint/1.2 https://github.com/mne-tools/mne-python.git
-        python -m pip install -e ./mne-python
+        python -m pip install mne
 
     - name: Install MNE (main)
       if: "matrix.mne-version == 'mne-main'"


### PR DESCRIPTION
We constantly forget to update the branch name, so we're often not using latest stable in our CI tests when we think we are.

Let's simply install from PyPI instead.

Merge checklist
---------------

Maintainer, please confirm the following before merging.
If applicable:

- [ ] All comments are resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] New contributors have been added to [CITATION.cff](https://github.com/mne-tools/mne-bids/blob/main/CITATION.cff)
- [ ] PR description includes phrase "closes <#issue-number>"
