### PR TITLE
MRG: Don't create directories when accessing BIDSPath.fpath

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -57,6 +57,7 @@ Detailed list of changes
 - Fix ``raw_to_bids`` CLI tool to properly recognize boolean and numeric values for the ``line_freq`` and ``overwrite`` parameters, by `Stefan Appelhoff`_ (:gh:`1125`)
 - Fix :func:`~mne_bids.copyfiles.copyfile_eeglab` to prevent data type conversion leading to an ``eeg_checkset`` failure when trying to load the file in EEGLAB, by `Laetitia Fesselier`_ (:gh:`1122`)
 - Improve compatibility with latest MNE-Python, by `Eric Larson`_ (:gh:`1128`)
+- Working with :class:`~mne_bids.BIDSPath`` would sometimes inadvertently create new directories, contaminating the BIDS dataset, by `Richard Höchenberger`_ (:gh:`1139`)
 
 :doc:`Find out what was new in previous releases <whats_new_previous_releases>`
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -57,7 +57,7 @@ Detailed list of changes
 - Fix ``raw_to_bids`` CLI tool to properly recognize boolean and numeric values for the ``line_freq`` and ``overwrite`` parameters, by `Stefan Appelhoff`_ (:gh:`1125`)
 - Fix :func:`~mne_bids.copyfiles.copyfile_eeglab` to prevent data type conversion leading to an ``eeg_checkset`` failure when trying to load the file in EEGLAB, by `Laetitia Fesselier`_ (:gh:`1122`)
 - Improve compatibility with latest MNE-Python, by `Eric Larson`_ (:gh:`1128`)
-- Working with :class:`~mne_bids.BIDSPath`` would sometimes inadvertently create new directories, contaminating the BIDS dataset, by `Richard Höchenberger`_ (:gh:`1139`)
+- Working with :class:`~mne_bids.BIDSPath` would sometimes inadvertently create new directories, contaminating the BIDS dataset, by `Richard Höchenberger`_ (:gh:`1139`)
 
 :doc:`Find out what was new in previous releases <whats_new_previous_releases>`
 

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -1059,8 +1059,9 @@ def _get_matching_bidspaths_from_filesystem(bids_path):
         datatype = _infer_datatype(root=bids_root,
                                    sub=sub, ses=ses)
 
-    data_dir = BIDSPath(subject=sub, session=ses, datatype=datatype,
-                        root=bids_root).mkdir().directory
+    data_dir = BIDSPath(
+        subject=sub, session=ses, datatype=datatype, root=bids_root
+    ).directory
 
     # For BTI data, just return the directory with a '.pdf' extension
     # to facilitate reading in mne-bids

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -1,5 +1,6 @@
 """Test for the MNE BIDSPath functions."""
 # Authors: Adam Li <adam2392@gmail.com>
+#          Richard Höchenberger <richard.hoechenberger@gmail.com>
 #
 # License: BSD-3-Clause
 import os
@@ -1258,3 +1259,10 @@ def test_deprecation():
     """Test deprecated behavior."""
     with pytest.warns(FutureWarning, match='This will raise an exception'):
         BIDSPath(extension='vhdr')  # no leading period
+
+
+def test_dont_create_dirs_on_fpath_access(tmp_path):
+    """Regression test: don't create directories when accessing .fpath."""
+    bp = BIDSPath(subject='01', datatype='eeg', root=tmp_path)
+    bp.fpath  # accessing .fpath is required for this regression test
+    assert not (tmp_path / 'sub-01').exists()


### PR DESCRIPTION
Don't unexpectedly create directories when users don't actually intend to alter the BIDS dataset.

The problem was reported by multiple users on the forum:
https://mne.discourse.group/t/bidspath-creating-new-directory-when-specified-dir-doesnt-exist/6928

And it's also something that has actually bothered me for years.

I simply removed an `.mkdir()` call, which seemed unnecessary anyway.

Fails on `main`, passes on this branch:
```python
from pathlib import Path
import tempfile
from mne_bids import BIDSPath, print_dir_tree


with tempfile.TemporaryDirectory() as bids_root:
    bids_root = Path(bids_root)
    bp = BIDSPath(subject='01', datatype='eeg', root=bids_root)
    bp.fpath  # accessing .fpath is required for this regression test
    assert not (bids_root / 'sub-01').exists()
```

Merge checklist
---------------

Maintainer, please confirm the following before merging.
If applicable:

- [ ] All comments are resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] New contributors have been added to [CITATION.cff](https://github.com/mne-tools/mne-bids/blob/main/CITATION.cff)
- [ ] PR description includes phrase "closes <#issue-number>"
