### PR TITLE
MRG: Drop support for MNE-Python <1.3, add new CI job to cover "previous stable" MNE version

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -114,7 +114,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.8", "3.10"]  # Oldest and newest supported versions
-        mne-version: [mne-stable, mne-prev-stable]
+        mne-version: [mne-stable]
         bids-validator-version: [validator-stable]
 
         include:
@@ -123,6 +123,11 @@ jobs:
             python-version: "3.10"
             mne-version: mne-main
             bids-validator-version: validator-main
+          # Test previous MNE stable only on a single system so save CI resources
+          - os: ubuntu-latest
+            python-version: "3.8"
+            mne-version: mne-prev-stable
+            bids-validator-version: validator-stable
 
     env:
       TZ: Europe/Berlin

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -114,7 +114,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.8", "3.10"]  # Oldest and newest supported versions
-        mne-version: [mne-stable]
+        mne-version: [mne-stable, mne-prev-stable]
         bids-validator-version: [validator-stable]
 
         include:
@@ -153,6 +153,12 @@ jobs:
 
     - name: Install MNE (stable)
       if: "matrix.mne-version == 'mne-stable'"
+      run: |
+        git clone --single-branch --branch maint/1.4 https://github.com/mne-tools/mne-python.git
+        python -m pip install -e ./mne-python
+
+    - name: Install MNE (previous stable)
+      if: "matrix.mne-version == 'mne-prev-stable'"
       run: |
         git clone --single-branch --branch maint/1.3 https://github.com/mne-tools/mne-python.git
         python -m pip install -e ./mne-python

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -12,7 +12,7 @@ Dependencies
 
 Required:
 
-* ``mne`` (>=1.2)
+* ``mne`` (>=1.3)
 * ``numpy`` (>=1.18.1)
 * ``scipy`` (>=1.4.1, or >=1.5.0 for certain operations with EEGLAB data)
 * ``setuptools`` (>=46.4.0)

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -48,7 +48,7 @@ Detailed list of changes
 🛠 Requirements
 ^^^^^^^^^^^^^^^
 
-- ...
+- MNE-BIDS now requires MNE-Python 1.3 or newer.
 
 🪲 Bug fixes
 ^^^^^^^^^^^^

--- a/mne_bids/commands/tests/test_cli.py
+++ b/mne_bids/commands/tests/test_cli.py
@@ -148,11 +148,7 @@ def test_mark_bad_channels_single_file(tmp_path):
         mne_bids_mark_channels.run()
 
     # Check the data was properly written
-    if check_version("mne", "1.3"):
-        raw = read_raw_bids(bids_path=bids_path, verbose=False)
-    else:
-        with pytest.warns(RuntimeWarning, match='The unit for chann*'):
-            raw = read_raw_bids(bids_path=bids_path, verbose=False)
+    raw = read_raw_bids(bids_path=bids_path, verbose=False)
     assert set(old_bads + ch_names) == set(raw.info['bads'])
 
     # Test resetting bad channels.
@@ -164,11 +160,7 @@ def test_mark_bad_channels_single_file(tmp_path):
     print('Finished running the reset...')
 
     # Check the data was properly written
-    if check_version("mne", "1.3"):
-        raw = read_raw_bids(bids_path=bids_path)
-    else:
-        with pytest.warns(RuntimeWarning, match='The unit for chann*'):
-            raw = read_raw_bids(bids_path=bids_path)
+    raw = read_raw_bids(bids_path=bids_path)
     assert raw.info['bads'] == []
 
 
@@ -210,13 +202,7 @@ def test_mark_bad_channels_multiple_files(tmp_path):
 
     # Check the data was properly written
     for subject in subjects:
-        if check_version("mne", "1.3"):
-            raw = read_raw_bids(bids_path=bids_path.copy()
-                                .update(subject=subject))
-        else:
-            with pytest.warns(RuntimeWarning, match='The unit for chann*'):
-                raw = read_raw_bids(bids_path=bids_path.copy()
-                                    .update(subject=subject))
+        raw = read_raw_bids(bids_path=bids_path.copy().update(subject=subject))
         assert set(old_bads + ch_names) == set(raw.info['bads'])
 
 

--- a/mne_bids/commands/tests/test_cli.py
+++ b/mne_bids/commands/tests/test_cli.py
@@ -18,7 +18,7 @@ with warnings.catch_warnings():
     import mne
 
 from mne.datasets import testing
-from mne.utils import ArgvSetter, requires_pandas, check_version
+from mne.utils import ArgvSetter, requires_pandas
 from mne.utils._testing import requires_module
 
 from mne_bids.commands import (mne_bids_raw_to_bids,

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -15,13 +15,11 @@ import shutil as sh
 import numpy as np
 from numpy.testing import assert_almost_equal
 
-from pkg_resources import parse_version
-
 import mne
 from mne.datasets import testing
 from mne.io.constants import FIFF
 from mne.utils import object_diff
-from mne.utils import assert_dig_allclose, check_version
+from mne.utils import assert_dig_allclose
 
 from mne_bids import BIDSPath
 from mne_bids.config import (MNE_STR_TO_FRAME, BIDS_SHARED_COORDINATE_FRAMES,
@@ -723,8 +721,7 @@ def test_handle_chpi_reading(tmp_path):
     meg_json_data_freq_mismatch['HeadCoilFrequency'][0] = 123
     _write_json(meg_json_path, meg_json_data_freq_mismatch, overwrite=True)
 
-    with pytest.warns(RuntimeWarning,
-                        match='Defaulting to .* mne.Raw object'):
+    with pytest.warns(RuntimeWarning, match='Defaulting to .* mne.Raw object'):
         raw_read = read_raw_bids(bids_path)
 
     # cHPI "off" according to sidecar, but present in the data

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -146,9 +146,6 @@ test_converteeg_data = [
 
 data_path = testing.data_path(download=False)
 
-bad_frame_xfail = pytest.mark.xfail(
-    check_version('mne', '1.2'), reason='Coordinate frame bug in MNE 1.2')
-
 
 def _test_anonymize(root, raw, bids_path, events_fname=None, event_id=None):
     """Write data to `root` for testing anonymization."""
@@ -772,17 +769,13 @@ def test_chpi(_bids_validate, tmp_path, format):
         assert 'ContinuousHeadLocalization' not in meg_json_data
         assert 'HeadCoilFrequency' not in meg_json_data
     elif format in ['fif_no_chpi', 'fif']:
-        if parse_version(mne.__version__) <= parse_version('1.1'):
-            assert 'ContinuousHeadLocalization' not in meg_json_data
-            assert 'HeadCoilFrequency' not in meg_json_data
-        else:
-            if format == 'fif_no_chpi':
-                assert meg_json_data['ContinuousHeadLocalization'] is False
-                assert meg_json_data['HeadCoilFrequency'] == []
-            elif format == 'fif':
-                assert meg_json_data['ContinuousHeadLocalization'] is True
-                assert_array_almost_equal(meg_json_data['HeadCoilFrequency'],
-                                          [83., 143., 203., 263., 323.])
+        if format == 'fif_no_chpi':
+            assert meg_json_data['ContinuousHeadLocalization'] is False
+            assert meg_json_data['HeadCoilFrequency'] == []
+        elif format == 'fif':
+            assert meg_json_data['ContinuousHeadLocalization'] is True
+            assert_array_almost_equal(meg_json_data['HeadCoilFrequency'],
+                                      [83., 143., 203., 263., 323.])
     elif format == 'kit':
         # no cHPI info is contained in the sample data
         assert meg_json_data['ContinuousHeadLocalization'] is False
@@ -930,10 +923,7 @@ def test_kit(_bids_validate, tmp_path):
 
     _bids_validate(bids_root)
     assert op.exists(bids_root / 'participants.tsv')
-    if check_version("mne", "1.3"):
-        with pytest.warns(RuntimeWarning, match=".* changed from V to NA"):
-            read_raw_bids(bids_path=kit_bids_path)
-    else:
+    with pytest.warns(RuntimeWarning, match=".* changed from V to NA"):
         read_raw_bids(bids_path=kit_bids_path)
 
     # ensure the marker file is produced in the right place
@@ -1231,7 +1221,6 @@ def test_vhdr(_bids_validate, tmp_path):
     warning_str['no_montage'],
 )
 @testing.requires_testing_data
-@bad_frame_xfail
 def test_eegieeg(dir_name, fname, reader, _bids_validate, tmp_path):
     """Test write_raw_bids conversion for EEG/iEEG data formats."""
     bids_root = tmp_path / 'bids1'
@@ -1791,10 +1780,7 @@ def test_bdf(_bids_validate, tmp_path):
     # Now read the raw data back from BIDS, with the tampered TSV, to show
     # that the channels.tsv truly influences how read_raw_bids sets ch_types
     # in the raw data object
-    if check_version("mne", "1.3"):
-        with pytest.warns(RuntimeWarning, match="Fp1 has changed from V .*"):
-            raw = read_raw_bids(bids_path=bids_path)
-    else:
+    with pytest.warns(RuntimeWarning, match="Fp1 has changed from V .*"):
         raw = read_raw_bids(bids_path=bids_path)
     assert coil_type(raw.info, test_ch_idx) == 'misc'
     with pytest.raises(TypeError, match="unexpected keyword argument 'foo'"):
@@ -3122,7 +3108,6 @@ def test_sidecar_encoding(_bids_validate, tmp_path):
     warning_str['no_hand'],
 )
 @testing.requires_testing_data
-@bad_frame_xfail
 def test_convert_eeg_formats(dir_name, format, fname, reader, tmp_path):
     """Test conversion of EEG/iEEG manufacturer fmt to BrainVision/EDF."""
     bids_root = tmp_path / format
@@ -3203,7 +3188,6 @@ def test_convert_eeg_formats(dir_name, format, fname, reader, tmp_path):
     warning_str['no_hand'],
 )
 @testing.requires_testing_data
-@bad_frame_xfail
 def test_format_conversion_overwrite(dir_name, format, fname, reader,
                                      tmp_path):
     """Test that overwrite works when format is passed to write_raw_bids."""
@@ -3299,7 +3283,6 @@ def test_convert_meg_formats(dir_name, format, fname, reader, tmp_path):
     warning_str['no_hand'],
 )
 @testing.requires_testing_data
-@bad_frame_xfail
 def test_convert_raw_errors(dir_name, fname, reader, tmp_path):
     """Test errors when converting raw file formats."""
     bids_root = tmp_path / 'bids_1'
@@ -3845,10 +3828,7 @@ def test_repeat_write_location(tmpdir):
     bids_path = write_raw_bids(raw, bids_path, verbose=False)
 
     # Read back in
-    if check_version("mne", "1.3"):
-        with pytest.warns(RuntimeWarning, match=".* has changed from NA to V"):
-            raw = read_raw_bids(bids_path, verbose=False)
-    else:
+    with pytest.warns(RuntimeWarning, match=".* has changed from NA to V"):
         raw = read_raw_bids(bids_path, verbose=False)
 
     # Re-writing with src == dest should error

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ project_urls =
 [options]
 python_requires = ~= 3.8
 install_requires =
-  mne >= 1.2
+  mne >= 1.3
   numpy >= 1.18.1
   scipy >= 1.4.1
   setuptools

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,6 +1,6 @@
 numpy>=1.18.1
 scipy>=1.5.0
-mne>=1.2
+mne>=1.3
 matplotlib<3.7
 pandas>=1.0.0
 nibabel>=2.5


### PR DESCRIPTION
PR Description
--------------

We commonly only support the latest 2 stable versions of MNE-Python. Hence I'm doing some related cleanups here.

Merge checklist
---------------

Maintainer, please confirm the following before merging.
If applicable:

- [x] All comments are resolved
- [x] This is not your own PR
- [x] All CIs are happy
- [x] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [x] New contributors have been added to [CITATION.cff](https://github.com/mne-tools/mne-bids/blob/main/CITATION.cff)
- [x] PR description includes phrase "closes <#issue-number>"
