### PR TITLE
[MRG] fix(write.py): throw warning instead of error on conflicting bids versions

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -163,6 +163,10 @@ authors:
       family-names: Vanhoecke
       orcid: 'https://orcid.org/0000-0002-9857-1519'
       affiliation: 'Movement Disorder and Neuromodulation Unit, Department of Neurology, Charité – Universitätsmedizin Berlin, Germany'
+    - given-names: Ford
+      family-names: McDonald
+      affiliation: 'Behavior and NeuroData Core, Brown University, Providence, RI, USA'
+      orcid: 'https://orcid.org/0009-0004-5099-7109'
     - given-names: Alexandre
       family-names: Gramfort
       affiliation: 'Université Paris-Saclay, Inria, CEA, Palaiseau, France'
@@ -256,10 +260,6 @@ preferred-citation:
       family-names: Larson
       affiliation: 'Institute for Learning and Brain Sciences, University of Washington, Seattle, WA, USA'
       orcid: 'https://orcid.org/0000-0003-4782-5360'
-    - given-names: Ford
-      family-names: McDonald
-      affiliation: 'Behavior and NeuroData Core, Brown University, Providence, RI, USA'
-      orcid: 'https://orcid.org/0009-0004-5099-7109'
     - given-names: Alexandre
       family-names: Gramfort
       affiliation: 'Université Paris-Saclay, Inria, CEA, Palaiseau, France'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -256,6 +256,10 @@ preferred-citation:
       family-names: Larson
       affiliation: 'Institute for Learning and Brain Sciences, University of Washington, Seattle, WA, USA'
       orcid: 'https://orcid.org/0000-0003-4782-5360'
+    - given-names: Ford
+      family-names: McDonald
+      affiliation: 'Behavior and NeuroData Core, Brown University, Providence, RI, USA'
+      orcid: 'https://orcid.org/0009-0004-5099-7109'
     - given-names: Alexandre
       family-names: Gramfort
       affiliation: 'Université Paris-Saclay, Inria, CEA, Palaiseau, France'

--- a/doc/authors.rst
+++ b/doc/authors.rst
@@ -42,3 +42,4 @@
 .. _Moritz Gerster: http://moritz-gerster.com
 .. _Laetitia Fesselier: https://github.com/laemtl
 .. _Jonathan Vanhoecke: https://github.com/JonathanVHoecke
+.. _Ford McDonald: https://github.com/fordmcdonald

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -32,6 +32,7 @@ The following authors had contributed before. Thank you for sticking around! �
 * `Richard Höchenberger`_
 * `Eric Larson`_
 * `Stefan Appelhoff`_
+* `Ford McDonald`_
 
 Detailed list of changes
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -60,6 +61,7 @@ Detailed list of changes
 - Fix :func:`~mne_bids.copyfiles.copyfile_eeglab` to prevent data type conversion leading to an ``eeg_checkset`` failure when trying to load the file in EEGLAB, by `Laetitia Fesselier`_ (:gh:`1126`)
 - Improve compatibility with latest MNE-Python, by `Eric Larson`_ (:gh:`1128`)
 - Working with :class:`~mne_bids.BIDSPath` would sometimes inadvertently create new directories, contaminating the BIDS dataset, by `Richard Höchenberger`_ (:gh:`1139`)
+- Fix thrown error if the BIDSVersion defined in dataset_description.json file does not match the MNE compliant BIDSVersion, ensuring backwards compatibility across BIDS complient tools. by `Ford McDonald`` _ (:gh:`1147``)
 
 :doc:`Find out what was new in previous releases <whats_new_previous_releases>`
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -61,7 +61,7 @@ Detailed list of changes
 - Fix :func:`~mne_bids.copyfiles.copyfile_eeglab` to prevent data type conversion leading to an ``eeg_checkset`` failure when trying to load the file in EEGLAB, by `Laetitia Fesselier`_ (:gh:`1126`)
 - Improve compatibility with latest MNE-Python, by `Eric Larson`_ (:gh:`1128`)
 - Working with :class:`~mne_bids.BIDSPath` would sometimes inadvertently create new directories, contaminating the BIDS dataset, by `Richard Höchenberger`_ (:gh:`1139`)
-- Fix thrown error if the BIDSVersion defined in dataset_description.json file does not match the MNE compliant BIDSVersion, ensuring backwards compatibility across BIDS complient tools. by `Ford McDonald`` _ (:gh:`1147``)
+- Fix thrown error if the ``BIDSVersion`` defined in ``dataset_description.json`` file does not match the MNE-BIDS compliant ``BIDSVersion``, ensuring backwards compatibility across BIDS complient tools, by `Ford McDonald`_ (:gh:`1147`)
 
 :doc:`Find out what was new in previous releases <whats_new_previous_releases>`
 

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -414,7 +414,7 @@ def test_make_dataset_description(tmp_path, monkeypatch):
         make_dataset_description(path=tmp_path, name="tst", source_datasets=s_ds)
 
     monkeypatch.setattr(write, "BIDS_VERSION", "old")
-    with pytest.raises(ValueError, match="Previous BIDS version used"):
+    with pytest.warns(UserWarning, match="Conflicting BIDSVersion found*"):
         make_dataset_description(path=tmp_path, name="tst")
 
 

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from datetime import datetime, timezone, timedelta
 import shutil
 from collections import defaultdict, OrderedDict
+import warnings
 
 from pkg_resources import parse_version
 
@@ -1324,11 +1325,13 @@ def make_dataset_description(
         with open(fname, "r", encoding="utf-8-sig") as fin:
             orig_cols = json.load(fin)
         if "BIDSVersion" in orig_cols and orig_cols["BIDSVersion"] != BIDS_VERSION:
-            raise ValueError(
-                "Previous BIDS version used, please redo the "
-                "conversion to BIDS in a new directory "
-                "after ensuring all software is updated"
+            warnings.warn(
+                "Conflicting BIDSVersion found in dataset_description.json!"
+                "Consider setting BIDS root to a new directory and redo "
+                "conversion after ensuring all software has been updated."
+                "Original dataset description will not be overwritten."
             )
+            overwrite = False
         for key in description:
             if description[key] is None or not overwrite:
                 description[key] = orig_cols.get(key, None)

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1326,9 +1326,9 @@ def make_dataset_description(
             orig_cols = json.load(fin)
         if "BIDSVersion" in orig_cols and orig_cols["BIDSVersion"] != BIDS_VERSION:
             warnings.warn(
-                "Conflicting BIDSVersion found in dataset_description.json!"
+                "Conflicting BIDSVersion found in dataset_description.json! "
                 "Consider setting BIDS root to a new directory and redo "
-                "conversion after ensuring all software has been updated."
+                "conversion after ensuring all software has been updated. "
                 "Original dataset description will not be overwritten."
             )
             overwrite = False


### PR DESCRIPTION
PR Description
--------------

This PR fixes the issue where an error is thrown if the BIDSVersion defined in the dataset_description.json file does not match the MNE compliant BIDSVersion.  This ensures that MNE functions in accordance with the backwards compatible nature of BIDS. 

If there is a discrepancy between the versions, a user warning will be thrown and the dataset_description.json file will NOT be overwritten for preexisting keys. 

Unit tests for the make_dataset_description function have been updated accordingly. 

Resolves: https://github.com/mne-tools/mne-bids/issues/767#issuecomment-1587876515

Merge checklist
---------------

Maintainer, please confirm the following before merging.
If applicable:

- [x] All comments are resolved
- [x] This is not your own PR
- [x] All CIs are happy
- [x] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [x] New contributors have been added to [CITATION.cff](https://github.com/mne-tools/mne-bids/blob/main/CITATION.cff)
- [x] PR description includes phrase "closes <#issue-number>"
