### PR TITLE
Add ability to delete files from a BIDS dataset

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -163,6 +163,10 @@ authors:
       family-names: Vanhoecke
       orcid: 'https://orcid.org/0000-0002-9857-1519'
       affiliation: 'Movement Disorder and Neuromodulation Unit, Department of Neurology, Charité – Universitätsmedizin Berlin, Germany'
+    - given-names: Pierre
+      family-names: Guetschel
+      orcid: 'https://orcid.org/0000-0002-8933-7640'
+      affiliation: 'Donders Institute for Brain, Cognition and Behaviour, Radboud University, Nijmegen, Netherlands'
     - given-names: Alexandre
       family-names: Gramfort
       affiliation: 'Université Paris-Saclay, Inria, CEA, Palaiseau, France'

--- a/doc/authors.rst
+++ b/doc/authors.rst
@@ -42,3 +42,4 @@
 .. _Moritz Gerster: http://moritz-gerster.com
 .. _Laetitia Fesselier: https://github.com/laemtl
 .. _Jonathan Vanhoecke: https://github.com/JonathanVHoecke
+.. _Pierre Guetschel: https://github.com/PierreGtch

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -26,6 +26,7 @@ The following authors contributed for the first time. Thank you so much! 🤩
 
 * `Laetitia Fesselier`_
 * `Jonathan Vanhoecke`_
+* `Pierre Guetschel`_
 
 The following authors had contributed before. Thank you for sticking around! 🤘
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -33,6 +33,7 @@ The following authors had contributed before. Thank you for sticking around! ðŸ¤
 * `Richard HÃ¶chenberger`_
 * `Eric Larson`_
 * `Stefan Appelhoff`_
+* `Adam Li`_
 
 Detailed list of changes
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -40,6 +40,7 @@ Detailed list of changes
 ^^^^^^^^^^^^^^^
 
 - :class:`~mne_bids.BIDSPath` now supports the new ``"sessions"`` suffix, by `Jonathan Vanhoecke`_ and `Richard Höchenberger`_ (:gh:`1137`)
+- The :func:`~mne_bids.BIDSPath.rm` method will safely delete all the files compatible with that path and update the ``scans.tsv`` and ``participants.tsv`` files accordingly, by `Pierre Guetschel`_ and `Adam Li`_ (:gh:`1149`)
 
 🧐 API and behavior changes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -636,7 +636,7 @@ class BIDSPath(object):
         corresponding sidecar files, and the data file itself.
 
         Deleting all files of a subject will update the
-        ``*participants.tsv`` file.
+        ``*_participants.tsv`` file.
 
 
         Parameters

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -718,9 +718,6 @@ class BIDSPath(object):
                 )
                 paths_to_update.setdefault(scans_fpath, []).append(bids_path)
             subjects.add(bids_path.subject)
-        paths_to_update = {
-            k: v for k, v in paths_to_update.items() if k not in paths_to_delete
-        }
 
         files_to_delete = set(p.fpath for p in paths_to_delete)
         for subject in subjects:
@@ -773,6 +770,8 @@ class BIDSPath(object):
             bids_path.fpath.unlink()
 
         for scans_fpath, bids_paths in paths_to_update.items():
+            if not scans_fpath.exists():
+                continue
             # get the relative datatype of these bids files
             bids_fnames = [op.join(p.datatype, p.fpath.name) for p in bids_paths]
 

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -631,9 +631,9 @@ class BIDSPath(object):
     def rm(self, *, safe_remove=True, verbose=None):
         """Safely delete a set of files inside BIDS dataset.
 
-        Deleting a scan that conforms to the bids-validator, will
-        delete both the row in the ``*scans.tsv`` file, and also
-        the corresponding sidecar files and the data file itself.
+        Deleting a scan that conforms to the bids-validator will
+        remove the respective row in ``*_scans.tsv``,  the
+        corresponding sidecar files, and the data file itself.
 
         Deleting all files of a subject will update the
         ``*participants.tsv`` file.

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -37,7 +37,7 @@ from mne_bids.utils import (
     _ensure_tuple,
     warn,
 )
-
+from mne_bids.tsv_handler import (_from_tsv, _drop, _to_tsv)
 
 def _find_empty_room_candidates(bids_path):
     """Get matching empty-room file for an MEG recording."""
@@ -625,6 +625,78 @@ class BIDSPath(object):
         """
         self.directory.mkdir(parents=True, exist_ok=exist_ok)
         return self
+
+    def rm(self, safe_remove=True, verbose=True):
+        """Safely delete a set of files inside BIDS dataset.
+
+        Deleting a scan that conforms to the bids-validator, will
+        delete both the row in the ``*scans.tsv`` file, and also
+        the corresponding sidecar files and the data file itself.
+
+        Deleting all files of a subject will update the
+        ``*participants.tsv`` file.
+        """
+        # only proceed if root is defined
+        if self.root is None:
+            raise RuntimeError('Cannot remove files from BIDS dataset')
+
+        # get file paths to delete
+        paths_to_delete = self.match()
+        pretty_paths = '\n'.join(paths_to_delete)
+
+        if verbose:
+            print(f'Deleting the following files:\n '
+                  f'{pretty_paths}')
+
+        if safe_remove:
+            proceed = input(f'Do you want to delete the '
+                            f'following files (Y/n): \n{pretty_paths}')
+            if proceed.lower() != 'y':
+                return
+
+        subjects = set()
+        # remove files one by one
+        for bids_path in paths_to_delete:
+            bids_path.fpath.unlink()
+
+            # if a datatype is present, then check
+            # if a scan is deleted or not
+            datatype = bids_path.datatype
+            if datatype is not None:
+                # read in the corresponding scans file
+                scans_fpath = _find_matching_sidecar(bids_path,
+                                                     suffix='scans.tsv',
+                                                     allow_fail=False)
+                scans_tsv = _from_tsv(scans_fpath)
+                scans_fnames = scans_tsv['filename']
+
+                # get the relative datatype of this bids file
+                bids_fname = op.join(datatype, bids_path.fpath.name)
+                if bids_fname in scans_fnames:
+                    scans_tsv = _drop(scans_tsv, bids_fname, 'filename')
+                    _to_tsv(scans_tsv, scans_fpath)
+            subjects.add(bids_path.subject)
+
+        for subject in subjects:
+            # check existence of files in the sub dir
+            subj_path = BIDSPath(root=self.root,
+                                 subject=subject).directory
+            subj_files = [fpath for fpath in subj_path.rglob('*')
+                          if fpath.is_file()]
+            if len(subj_files) == 0:
+                # update the participants tsv
+                participants_tsv_fpath = op.join(
+                    self.root, 'participants.tsv')
+                participants_tsv = _from_tsv(participants_tsv_fpath)
+
+                # delete the subject data directory
+                sh.rmtree(subj_path)
+
+                # resave the participants.tsv file
+                participants_tsv = _drop(participants_tsv, self.subject,
+                                         'participant_id')
+                _to_tsv(participants_tsv, participants_tsv_fpath)
+
 
     @property
     def fpath(self):

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -682,7 +682,7 @@ class BIDSPath(object):
                 paths_to_update.setdefault(scans_fpath, []).append(bids_path)
             subjects.add(bids_path.subject)
 
-        files_to_delete = set(map(lambda p: p.fpath, paths_to_delete))
+        files_to_delete = set(p.fpath for p in paths_to_delete)
         for subject in subjects:
             # check existence of files in the subject dir
             subj_path = BIDSPath(root=self.root, subject=subject)
@@ -695,29 +695,29 @@ class BIDSPath(object):
 
         # Execution:
         pretty_delete_paths = "\n".join(
-            map(
-                str,
-                paths_to_delete
-                + list(map(lambda p: p.directory, subjects_paths_to_delete)),
-            )
+            [
+                str(p)
+                for p in paths_to_delete
+                + [p.directory for p in subjects_paths_to_delete]
+            ]
         )
         pretty_update_paths = "\n".join(
-            map(
-                str,
-                list(paths_to_update.keys())
+            [
+                str(p)
+                for p in list(paths_to_update.keys())
                 + (
                     [participants_tsv_fpath]
                     if participants_tsv_fpath is not None
                     else []
-                ),
-            )
+                )
+            ]
         )
-        summary = (
-            f"Delete:\n"
-            f"{pretty_delete_paths}\n"
-            f"Update:\n"
-            f"{pretty_update_paths}\n"
-        )
+        summary = ""
+        if pretty_delete_paths:
+            summary += f"Delete:\n{pretty_delete_paths}\n"
+        if pretty_update_paths:
+            summary += f"Update:\n{pretty_update_paths}\n"
+
         if safe_remove:
             choice = input(
                 "Please, confirm you want execute the following operations:\n"
@@ -734,9 +734,8 @@ class BIDSPath(object):
             if not scans_fpath.exists():
                 continue
             # get the relative datatype of these bids files
-            bids_fnames = list(
-                map(lambda p: op.join(p.datatype, p.fpath.name), bids_paths)
-            )
+            bids_fnames = [op.join(p.datatype, p.fpath.name) for p in bids_paths]
+
             scans_tsv = _from_tsv(scans_fpath)
             scans_tsv = _drop(scans_tsv, bids_fnames, "filename")
             _to_tsv(scans_tsv, scans_fpath)

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -629,7 +629,7 @@ class BIDSPath(object):
 
     @verbose
     def rm(self, *, safe_remove=True, verbose=None):
-        """Safely delete a set of files inside BIDS dataset.
+        """Safely delete a set of files from a BIDS dataset.
 
         Deleting a scan that conforms to the bids-validator will
         remove the respective row in ``*_scans.tsv``,  the

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -652,6 +652,41 @@ class BIDSPath(object):
         -------
         self : BIDSPath
             The BIDSPath object.
+
+        Examples
+        --------
+        Remove one specific run:
+
+        >>> bids_path = BIDSPath(subject='01', session='01', run="01", root='/bids_dataset').rm()
+        Please, confirm you want to execute the following operations:
+        Delete:
+        /bids_dataset/sub-01/ses-01/meg/sub-01_ses-01_run-01_channels.tsv
+        /bids_dataset/sub-01/ses-01/meg/sub-01_ses-01_run-01_events.json
+        /bids_dataset/sub-01/ses-01/meg/sub-01_ses-01_run-01_events.tsv
+        /bids_dataset/sub-01/ses-01/meg/sub-01_ses-01_run-01_meg.fif
+        /bids_dataset/sub-01/ses-01/meg/sub-01_ses-01_run-01_meg.json
+        Update:
+        /bids_dataset/sub-01/ses-01/sub-01_ses-01_scans.tsv
+        I confirm [y/N]>? y
+
+        Remove all the files of a specific subject:
+
+        >>> bids_path = BIDSPath(subject='01', root='/bids_dataset', check=False).rm()
+        Please, confirm you want to execute the following operations:
+        Delete:
+        /bids_dataset/sub-01/ses-01/meg/sub-01_ses-01_acq-calibration_meg.dat
+        /bids_dataset/sub-01/ses-01/meg/sub-01_ses-01_acq-crosstalk_meg.fif
+        /bids_dataset/sub-01/ses-01/meg/sub-01_ses-01_coordsystem.json
+        /bids_dataset/sub-01/ses-01/meg/sub-01_ses-01_run-02_channels.tsv
+        /bids_dataset/sub-01/ses-01/meg/sub-01_ses-01_run-02_events.json
+        /bids_dataset/sub-01/ses-01/meg/sub-01_ses-01_run-02_events.tsv
+        /bids_dataset/sub-01/ses-01/meg/sub-01_ses-01_run-02_meg.fif
+        /bids_dataset/sub-01/ses-01/meg/sub-01_ses-01_run-02_meg.json
+        /bids_dataset/sub-01/ses-01/sub-01_ses-01_scans.tsv
+        /bids_dataset/sub-01
+        Update:
+        /bids_dataset/participants.tsv
+        I confirm [y/N]>? y
         """
         # only proceed if root is defined
         if self.root is None:
@@ -720,8 +755,8 @@ class BIDSPath(object):
 
         if safe_remove:
             choice = input(
-                "Please, confirm you want execute the following operations:\n"
-                f"{summary}\nI confirm [y/N]:"
+                "Please, confirm you want to execute the following operations:\n"
+                f"{summary}\nI confirm [y/N]"
             )
             if choice.lower() != "y":
                 return

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -628,7 +628,7 @@ class BIDSPath(object):
         return self
 
     @verbose
-    def rm(self, safe_remove=True, verbose=None):
+    def rm(self, *, safe_remove=True, verbose=None):
         """Safely delete a set of files inside BIDS dataset.
 
         Deleting a scan that conforms to the bids-validator, will

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -684,7 +684,7 @@ class BIDSPath(object):
 
         files_to_delete = set(map(lambda p: p.fpath, paths_to_delete))
         for subject in subjects:
-            # check existence of files in the sub dir
+            # check existence of files in the subject dir
             subj_path = BIDSPath(root=self.root, subject=subject)
             subj_files = [
                 fpath for fpath in subj_path.directory.rglob("*") if fpath.is_file()

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -660,7 +660,7 @@ class BIDSPath(object):
         # Planning:
         paths_matched = self.match(ignore_json=False, check=self.check)
         subjects = set()
-        paths_to_delete = []
+        paths_to_delete = list()
         paths_to_update = {}
         subjects_paths_to_delete = []
         participants_tsv_fpath = None

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -657,8 +657,8 @@ class BIDSPath(object):
         --------
         Remove one specific run:
 
-        >>> bids_path = BIDSPath(subject='01', session='01', run="01",
-        ...                      root='/bids_dataset').rm()
+        >>> bids_path = BIDSPath(subject='01', session='01', run="01",  # doctest: +SKIP
+        ...                      root='/bids_dataset').rm()  # doctest: +SKIP
         Please, confirm you want to execute the following operations:
         Delete:
         /bids_dataset/sub-01/ses-01/meg/sub-01_ses-01_run-01_channels.tsv
@@ -672,7 +672,8 @@ class BIDSPath(object):
 
         Remove all the files of a specific subject:
 
-        >>> bids_path = BIDSPath(subject='01', root='/bids_dataset', check=False).rm()
+        >>> bids_path = BIDSPath(subject='01', root='/bids_dataset',  # doctest: +SKIP
+        ...                      check=False).rm()  # doctest: +SKIP
         Please, confirm you want to execute the following operations:
         Delete:
         /bids_dataset/sub-01/ses-01/meg/sub-01_ses-01_acq-calibration_meg.dat

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -744,7 +744,6 @@ class BIDSPath(object):
         subjects_to_delete = []
         for subj_path in subjects_paths_to_delete:
             if subj_path.directory.exists():
-                # subj_path.directory.rmdir()
                 sh.rmtree(subj_path.directory)
             subjects_to_delete.append(subj_path.subject)
         if subjects_to_delete and participants_tsv_fpath.exists():

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -716,6 +716,9 @@ class BIDSPath(object):
                 )
                 paths_to_update.setdefault(scans_fpath, []).append(bids_path)
             subjects.add(bids_path.subject)
+        paths_to_update = {
+            k: v for k, v in paths_to_update.items() if k not in paths_to_delete
+        }
 
         files_to_delete = set(p.fpath for p in paths_to_delete)
         for subject in subjects:
@@ -728,7 +731,7 @@ class BIDSPath(object):
                 subjects_paths_to_delete.append(subj_path)
                 participants_tsv_fpath = self.root / "participants.tsv"
 
-        # Execution:
+        # Informing:
         pretty_delete_paths = "\n".join(
             [
                 str(p)
@@ -762,12 +765,12 @@ class BIDSPath(object):
                 return
         else:
             logger.info(f"Executing the following operations:\n{summary}")
+
+        # Execution:
         for bids_path in paths_to_delete:
             bids_path.fpath.unlink()
 
         for scans_fpath, bids_paths in paths_to_update.items():
-            if not scans_fpath.exists():
-                continue
             # get the relative datatype of these bids files
             bids_fnames = [op.join(p.datatype, p.fpath.name) for p in bids_paths]
 

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -37,7 +37,7 @@ from mne_bids.utils import (
     _ensure_tuple,
     warn,
 )
-from mne_bids.tsv_handler import (_from_tsv, _drop, _to_tsv)
+from mne_bids.tsv_handler import _from_tsv, _drop, _to_tsv
 
 
 def _find_empty_room_candidates(bids_path):
@@ -85,7 +85,7 @@ def _find_empty_room_candidates(bids_path):
         for item in dir_contents:
             item = Path(item)
             if (item.suffix in allowed_extensions) or (
-                    not item.suffix and item.is_dir()
+                not item.suffix and item.is_dir()
             ):  # Hopefully BTi?
                 candidate_er_fnames.append(item.name)
 
@@ -326,39 +326,39 @@ class BIDSPath(object):
     """
 
     def __init__(
-            self,
-            subject=None,
-            session=None,
-            task=None,
-            acquisition=None,
-            run=None,
-            processing=None,
-            recording=None,
-            space=None,
-            split=None,
-            description=None,
-            root=None,
-            suffix=None,
-            extension=None,
-            datatype=None,
-            check=True,
+        self,
+        subject=None,
+        session=None,
+        task=None,
+        acquisition=None,
+        run=None,
+        processing=None,
+        recording=None,
+        space=None,
+        split=None,
+        description=None,
+        root=None,
+        suffix=None,
+        extension=None,
+        datatype=None,
+        check=True,
     ):
         if all(
-                ii is None
-                for ii in [
-                    subject,
-                    session,
-                    task,
-                    acquisition,
-                    run,
-                    processing,
-                    recording,
-                    space,
-                    description,
-                    root,
-                    suffix,
-                    extension,
-                ]
+            ii is None
+            for ii in [
+                subject,
+                session,
+                task,
+                acquisition,
+                run,
+                processing,
+                recording,
+                space,
+                description,
+                root,
+                suffix,
+                extension,
+            ]
         ):
             raise ValueError("At least one parameter must be given.")
 
@@ -655,7 +655,7 @@ class BIDSPath(object):
         """
         # only proceed if root is defined
         if self.root is None:
-            raise RuntimeError('Cannot remove files from BIDS dataset')
+            raise RuntimeError("Cannot remove files from BIDS dataset")
 
         # Planning:
         paths_matched = self.match(ignore_json=False, check=self.check)
@@ -670,10 +670,14 @@ class BIDSPath(object):
             # if a scan is deleted or not
             if bids_path.datatype is not None:
                 # read in the corresponding scans file
-                scans_fpath = bids_path.copy().update(datatype=None).find_matching_sidecar(
-                    suffix='scans',
-                    extension='.tsv',
-                    on_error='raise',
+                scans_fpath = (
+                    bids_path.copy()
+                    .update(datatype=None)
+                    .find_matching_sidecar(
+                        suffix="scans",
+                        extension=".tsv",
+                        on_error="raise",
+                    )
                 )
                 paths_to_update.setdefault(scans_fpath, []).append(bids_path)
             subjects.add(bids_path.subject)
@@ -681,32 +685,48 @@ class BIDSPath(object):
         files_to_delete = set(map(lambda p: p.fpath, paths_to_delete))
         for subject in subjects:
             # check existence of files in the sub dir
-            subj_path = BIDSPath(root=self.root,
-                                 subject=subject)
-            subj_files = [fpath for fpath in subj_path.directory.rglob('*')
-                          if fpath.is_file()]
+            subj_path = BIDSPath(root=self.root, subject=subject)
+            subj_files = [
+                fpath for fpath in subj_path.directory.rglob("*") if fpath.is_file()
+            ]
             if set(subj_files) <= files_to_delete:
                 subjects_paths_to_delete.append(subj_path)
-                participants_tsv_fpath = self.root / 'participants.tsv'
+                participants_tsv_fpath = self.root / "participants.tsv"
 
         # Execution:
-        pretty_delete_paths = '\n'.join(
-            map(str, paths_to_delete + list(map(lambda p: p.directory, subjects_paths_to_delete))))
-        pretty_update_paths = '\n'.join(map(str, list(paths_to_update.keys()) + (
-            [participants_tsv_fpath] if participants_tsv_fpath is not None else [])
-                                            ))
+        pretty_delete_paths = "\n".join(
+            map(
+                str,
+                paths_to_delete
+                + list(map(lambda p: p.directory, subjects_paths_to_delete)),
+            )
+        )
+        pretty_update_paths = "\n".join(
+            map(
+                str,
+                list(paths_to_update.keys())
+                + (
+                    [participants_tsv_fpath]
+                    if participants_tsv_fpath is not None
+                    else []
+                ),
+            )
+        )
         summary = (
-            f'Delete:\n'
-            f'{pretty_delete_paths}\n'
-            f'Update:\n'
-            f'{pretty_update_paths}\n'
+            f"Delete:\n"
+            f"{pretty_delete_paths}\n"
+            f"Update:\n"
+            f"{pretty_update_paths}\n"
         )
         if safe_remove:
-            choice = input(f'Please, confirm you want execute the following operations:\n{summary}\nI confirm [y/N]:')
-            if choice.lower() != 'y':
+            choice = input(
+                "Please, confirm you want execute the following operations:\n"
+                f"{summary}\nI confirm [y/N]:"
+            )
+            if choice.lower() != "y":
                 return
         else:
-            logger.info(f'Executing the following operations:\n{summary}')
+            logger.info(f"Executing the following operations:\n{summary}")
         for bids_path in paths_to_delete:
             bids_path.fpath.unlink()
 
@@ -714,9 +734,11 @@ class BIDSPath(object):
             if not scans_fpath.exists():
                 continue
             # get the relative datatype of these bids files
-            bids_fnames = list(map(lambda p: op.join(p.datatype, p.fpath.name), bids_paths))
+            bids_fnames = list(
+                map(lambda p: op.join(p.datatype, p.fpath.name), bids_paths)
+            )
             scans_tsv = _from_tsv(scans_fpath)
-            scans_tsv = _drop(scans_tsv, bids_fnames, 'filename')
+            scans_tsv = _drop(scans_tsv, bids_fnames, "filename")
             _to_tsv(scans_tsv, scans_fpath)
 
         subjects_to_delete = []
@@ -727,8 +749,9 @@ class BIDSPath(object):
             subjects_to_delete.append(subj_path.subject)
         if subjects_to_delete and participants_tsv_fpath.exists():
             participants_tsv = _from_tsv(participants_tsv_fpath)
-            participants_tsv = _drop(participants_tsv, subjects_to_delete,
-                                     'participant_id')
+            participants_tsv = _drop(
+                participants_tsv, subjects_to_delete, "participant_id"
+            )
             _to_tsv(participants_tsv, participants_tsv_fpath)
 
         return self
@@ -760,7 +783,7 @@ class BIDSPath(object):
             # not None, then BIDSPath will infer the dataset
             # else, return the relative path with the basename
             if (
-                    self.suffix is None or self.extension is None
+                self.suffix is None or self.extension is None
             ) and self.root is not None:
                 # get matching BIDSPaths inside the bids root
                 matching_paths = _get_matching_bidspaths_from_filesystem(self)
@@ -780,7 +803,7 @@ class BIDSPath(object):
                     ]
 
                 if self.split is None and (
-                        not matching_paths or "_split-" in matching_paths[0]
+                    not matching_paths or "_split-" in matching_paths[0]
                 ):
                     # try finding FIF split files (only first one)
                     this_self = self.copy().update(split="01")
@@ -1003,7 +1026,7 @@ class BIDSPath(object):
 
         # perform error check on scans
         if (
-                self.suffix == "scans" and self.extension == ".tsv"
+            self.suffix == "scans" and self.extension == ".tsv"
         ) and _check_non_sub_ses_entity(self):
             raise ValueError(
                 "scans.tsv file name can only contain "
@@ -1290,13 +1313,13 @@ def _get_matching_bidspaths_from_filesystem(bids_path):
 def _check_non_sub_ses_entity(bids_path):
     """Check existence of non subject/session entities in BIDSPath."""
     if (
-            bids_path.task
-            or bids_path.acquisition
-            or bids_path.run
-            or bids_path.space
-            or bids_path.recording
-            or bids_path.split
-            or bids_path.processing
+        bids_path.task
+        or bids_path.acquisition
+        or bids_path.run
+        or bids_path.space
+        or bids_path.recording
+        or bids_path.split
+        or bids_path.processing
     ):
         return True
     return False
@@ -1357,7 +1380,7 @@ def _truncate_tsv_line(line, lim=10):
 
 
 def search_folder_for_text(
-        entry, folder, extensions=(".json", ".tsv"), line_numbers=True, return_str=False
+    entry, folder, extensions=(".json", ".tsv"), line_numbers=True, return_str=False
 ):
     """Find any particular string entry in the text files of a folder.
 
@@ -1759,9 +1782,9 @@ def _find_matching_sidecar(bids_path, suffix=None, extension=None, on_error="rai
     elif len(best_candidates) > 1:
         # More than one candidates were tied for best match
         msg = (
-                f"Expected to find a single {search_suffix} file "
-                f"associated with {bids_path.basename}, "
-                f"but found {len(candidate_list)}:\n\n" + "\n".join(candidate_list)
+            f"Expected to find a single {search_suffix} file "
+            f"associated with {bids_path.basename}, "
+            f"but found {len(candidate_list)}:\n\n" + "\n".join(candidate_list)
         )
     msg += f'\n\nThe search_str was "{search_str_complete}"'
     if on_error == "raise":
@@ -1818,23 +1841,23 @@ def get_datatypes(root, verbose=None):
 
 @verbose
 def get_entity_vals(
-        root,
-        entity_key,
-        *,
-        ignore_subjects="emptyroom",
-        ignore_sessions=None,
-        ignore_tasks=None,
-        ignore_runs=None,
-        ignore_processings=None,
-        ignore_spaces=None,
-        ignore_acquisitions=None,
-        ignore_splits=None,
-        ignore_descriptions=None,
-        ignore_modalities=None,
-        ignore_datatypes=None,
-        ignore_dirs=("derivatives", "sourcedata"),
-        with_key=False,
-        verbose=None,
+    root,
+    entity_key,
+    *,
+    ignore_subjects="emptyroom",
+    ignore_sessions=None,
+    ignore_tasks=None,
+    ignore_runs=None,
+    ignore_processings=None,
+    ignore_spaces=None,
+    ignore_acquisitions=None,
+    ignore_splits=None,
+    ignore_descriptions=None,
+    ignore_modalities=None,
+    ignore_datatypes=None,
+    ignore_dirs=("derivatives", "sourcedata"),
+    with_key=False,
+    verbose=None,
 ):
     """Get list of values associated with an `entity_key` in a BIDS dataset.
 
@@ -1989,18 +2012,18 @@ def get_entity_vals(
         # Skip ignored directories
         # XXX In Python 3.9, we can use Path.is_relative_to() here
         if any(
-                [str(filename).startswith(str(ignore_dir)) for ignore_dir in ignore_dirs]
+            [str(filename).startswith(str(ignore_dir)) for ignore_dir in ignore_dirs]
         ):
             continue
 
         if ignore_datatypes and filename.parent.name in ignore_datatypes:
             continue
         if ignore_subjects and any(
-                [filename.stem.startswith(f"sub-{s}_") for s in ignore_subjects]
+            [filename.stem.startswith(f"sub-{s}_") for s in ignore_subjects]
         ):
             continue
         if ignore_sessions and any(
-                [f"_ses-{s}_" in filename.stem for s in ignore_sessions]
+            [f"_ses-{s}_" in filename.stem for s in ignore_sessions]
         ):
             continue
         if ignore_tasks and any([f"_task-{t}_" in filename.stem for t in ignore_tasks]):
@@ -2008,27 +2031,27 @@ def get_entity_vals(
         if ignore_runs and any([f"_run-{r}_" in filename.stem for r in ignore_runs]):
             continue
         if ignore_processings and any(
-                [f"_proc-{p}_" in filename.stem for p in ignore_processings]
+            [f"_proc-{p}_" in filename.stem for p in ignore_processings]
         ):
             continue
         if ignore_spaces and any(
-                [f"_space-{s}_" in filename.stem for s in ignore_spaces]
+            [f"_space-{s}_" in filename.stem for s in ignore_spaces]
         ):
             continue
         if ignore_acquisitions and any(
-                [f"_acq-{a}_" in filename.stem for a in ignore_acquisitions]
+            [f"_acq-{a}_" in filename.stem for a in ignore_acquisitions]
         ):
             continue
         if ignore_splits and any(
-                [f"_split-{s}_" in filename.stem for s in ignore_splits]
+            [f"_split-{s}_" in filename.stem for s in ignore_splits]
         ):
             continue
         if ignore_descriptions and any(
-                [f"_desc-{d}_" in filename.stem for d in ignore_descriptions]
+            [f"_desc-{d}_" in filename.stem for d in ignore_descriptions]
         ):
             continue
         if ignore_modalities and any(
-                [f"_{k}" in filename.stem for k in ignore_modalities]
+            [f"_{k}" in filename.stem for k in ignore_modalities]
         ):
             continue
 
@@ -2155,20 +2178,20 @@ def _path_to_str(var):
 
 
 def _filter_fnames(
-        fnames,
-        *,
-        subject=None,
-        session=None,
-        task=None,
-        acquisition=None,
-        run=None,
-        processing=None,
-        recording=None,
-        space=None,
-        split=None,
-        description=None,
-        suffix=None,
-        extension=None,
+    fnames,
+    *,
+    subject=None,
+    session=None,
+    task=None,
+    acquisition=None,
+    run=None,
+    processing=None,
+    recording=None,
+    space=None,
+    split=None,
+    description=None,
+    suffix=None,
+    extension=None,
 ):
     """Filter a list of BIDS filenames / paths based on BIDS entity values.
 
@@ -2217,19 +2240,19 @@ def _filter_fnames(
     ext_str = r"(" + "|".join(extension) + ")" if extension else r".([^_]+)"
 
     regexp = (
-            leading_path_str
-            + sub_str
-            + ses_str
-            + task_str
-            + acq_str
-            + run_str
-            + proc_str
-            + space_str
-            + rec_str
-            + split_str
-            + desc_str
-            + suffix_str
-            + ext_str
+        leading_path_str
+        + sub_str
+        + ses_str
+        + task_str
+        + acq_str
+        + run_str
+        + proc_str
+        + space_str
+        + rec_str
+        + split_str
+        + desc_str
+        + suffix_str
+        + ext_str
     )
 
     # Convert to str so we can apply the regexp ...
@@ -2244,21 +2267,21 @@ def _filter_fnames(
 
 
 def find_matching_paths(
-        root,
-        subjects=None,
-        sessions=None,
-        tasks=None,
-        acquisitions=None,
-        runs=None,
-        processings=None,
-        recordings=None,
-        spaces=None,
-        splits=None,
-        descriptions=None,
-        suffixes=None,
-        extensions=None,
-        datatypes=None,
-        check=False,
+    root,
+    subjects=None,
+    sessions=None,
+    tasks=None,
+    acquisitions=None,
+    runs=None,
+    processings=None,
+    recordings=None,
+    spaces=None,
+    splits=None,
+    descriptions=None,
+    suffixes=None,
+    extensions=None,
+    datatypes=None,
+    check=False,
 ):
     """Get list of all matching paths for all matching entity values.
 

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -655,7 +655,7 @@ class BIDSPath(object):
         """
         # only proceed if root is defined
         if self.root is None:
-            raise RuntimeError("Cannot remove files from BIDS dataset")
+            raise RuntimeError("The root must not be None to remove files.")
 
         # Planning:
         paths_matched = self.match(ignore_json=False, check=self.check)

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -657,7 +657,8 @@ class BIDSPath(object):
         --------
         Remove one specific run:
 
-        >>> bids_path = BIDSPath(subject='01', session='01', run="01", root='/bids_dataset').rm()
+        >>> bids_path = BIDSPath(subject='01', session='01', run="01",
+        ...                      root='/bids_dataset').rm()
         Please, confirm you want to execute the following operations:
         Delete:
         /bids_dataset/sub-01/ses-01/meg/sub-01_ses-01_run-01_channels.tsv

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -261,7 +261,7 @@ def test_make_folders(tmp_path):
 def test_rm(return_bids_test_dir, capsys, tmp_path_factory):
     """Test the BIDSPath.rm method to remove files"""
     # for some reason, mne's logger can't be captured by caplog....
-    bids_root = str(tmp_path_factory)
+    bids_root = str(tmp_path_factory.mktemp("test_rm") / "mnebids_utils_test_bids_ds")
     shutil.copytree(return_bids_test_dir, bids_root)
 
     # without providing all the entities, ambiguous when trying

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -172,8 +172,7 @@ def test_search_folder_for_text(capsys):
     assert "sub-01_ses-eeg_task-rest_eeg.json" in captured.out
     assert (
         "    1    name      type      units     low_cutof high_cuto descripti sampling_ status    status_de\n"  # noqa: E501
-        "    2    Fp1       EEG       µV        0.0159154 1000.0    ElectroEn 5000.0    good      n/a"
-        # noqa: E501
+        "    2    Fp1       EEG       µV        0.0159154 1000.0    ElectroEn 5000.0    good      n/a"  # noqa: E501
     ) in captured.out
     # test if pathlib.Path object
     search_folder_for_text("n/a", Path(test_dir))

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -171,10 +171,10 @@ def test_search_folder_for_text(capsys):
     captured = capsys.readouterr()
     assert "sub-01_ses-eeg_task-rest_eeg.json" in captured.out
     assert (
-               "    1    name      type      units     low_cutof high_cuto descripti sampling_ status    status_de\n"  # noqa: E501
-               "    2    Fp1       EEG       µV        0.0159154 1000.0    ElectroEn 5000.0    good      n/a"
-               # noqa: E501
-           ) in captured.out
+        "    1    name      type      units     low_cutof high_cuto descripti sampling_ status    status_de\n"  # noqa: E501
+        "    2    Fp1       EEG       µV        0.0159154 1000.0    ElectroEn 5000.0    good      n/a"
+        # noqa: E501
+    ) in captured.out
     # test if pathlib.Path object
     search_folder_for_text("n/a", Path(test_dir))
 
@@ -182,9 +182,9 @@ def test_search_folder_for_text(capsys):
     out = search_folder_for_text("n/a", test_dir, line_numbers=False, return_str=True)
     assert "sub-01_ses-eeg_task-rest_eeg.json" in out
     assert (
-               "    name      type      units     low_cutof high_cuto descripti sampling_ status    status_de\n"  # noqa: E501
-               "    Fp1       EEG       µV        0.0159154 1000.0    ElectroEn 5000.0    good      n/a"  # noqa: E501
-           ) in out
+        "    name      type      units     low_cutof high_cuto descripti sampling_ status    status_de\n"  # noqa: E501
+        "    Fp1       EEG       µV        0.0159154 1000.0    ElectroEn 5000.0    good      n/a"  # noqa: E501
+    ) in out
 
 
 def test_print_dir_tree(capsys):
@@ -260,7 +260,7 @@ def test_make_folders(tmp_path):
 
 
 def test_rm(return_bids_test_dir, capsys):
-    """ Test the BIDSPath.rm method to remove files """
+    """Test the BIDSPath.rm method to remove files"""
     # for some reason, mne's logger can't be captured by caplog....
     bids_root = return_bids_test_dir
 
@@ -269,7 +269,7 @@ def test_rm(return_bids_test_dir, capsys):
     bids_path = BIDSPath(
         subject=subject_id,
         session=session_id,
-        run='01',
+        run="01",
         acquisition=acq,
         task=task,
         root=bids_root,
@@ -277,14 +277,18 @@ def test_rm(return_bids_test_dir, capsys):
 
     # Delete one run:
     deleted_paths = bids_path.match(ignore_json=False)
-    updated_paths = [bids_path.copy().update(datatype=None).find_matching_sidecar(
-        suffix='scans',
-        extension='.tsv',
-        on_error='raise',
-    )]
+    updated_paths = [
+        bids_path.copy()
+        .update(datatype=None)
+        .find_matching_sidecar(
+            suffix="scans",
+            extension=".tsv",
+            on_error="raise",
+        )
+    ]
     expected = ["Executing the following operations:", "Delete:", "Update:", ""]
     expected += map(str, deleted_paths + updated_paths)
-    bids_path.rm(safe_remove=False, verbose='INFO')
+    bids_path.rm(safe_remove=False, verbose="INFO")
     captured = capsys.readouterr().out
     assert set(captured.splitlines()) == set(expected)
 
@@ -295,25 +299,29 @@ def test_rm(return_bids_test_dir, capsys):
         root=bids_root,
     )
     deleted_paths = bids_path.match(ignore_json=False)
-    deleted_paths += [BIDSPath(
-        root=bids_path.root,
-        subject=bids_path.subject,
-    ).directory]
+    deleted_paths += [
+        BIDSPath(
+            root=bids_path.root,
+            subject=bids_path.subject,
+        ).directory
+    ]
     updated_paths = [
-        bids_path.copy().update(datatype=None).find_matching_sidecar(
-            suffix='scans',
-            extension='.tsv',
-            on_error='raise',
+        bids_path.copy()
+        .update(datatype=None)
+        .find_matching_sidecar(
+            suffix="scans",
+            extension=".tsv",
+            on_error="raise",
         ),
-        bids_path.root / 'participants.tsv',
+        bids_path.root / "participants.tsv",
     ]
     expected = ["Executing the following operations:", "Delete:", "Update:", ""]
     expected += map(str, deleted_paths + updated_paths)
-    bids_path.rm(safe_remove=False, verbose='INFO')
+    bids_path.rm(safe_remove=False, verbose="INFO")
     captured2 = capsys.readouterr().out
     assert set(captured2.splitlines()) == set(expected)
-    print('\n'.join(captured))
-    print('\n'.join(captured2))
+    print("\n".join(captured))
+    print("\n".join(captured2))
 
 
 def test_parse_ext():
@@ -367,8 +375,8 @@ def test_get_bids_path_from_fname(fname):
         "sub-01_ses-02_task-test_run-3_split-01_desc-filtered.fif",
         "sub-01_ses-02_task-test_run-3_split-01_desc-filtered",
         (
-                "/bids_root/sub-01/ses-02/meg/"
-                + "sub-01_ses-02_task-test_run-3_split-01_desc-filtered_meg.fif"
+            "/bids_root/sub-01/ses-02/meg/"
+            + "sub-01_ses-02_task-test_run-3_split-01_desc-filtered_meg.fif"
         ),
     ],
 )
@@ -400,8 +408,8 @@ def test_get_entities_from_fname(fname):
     [
         "sub-01_ses-02_task-test_run-3_split-01_meg.fif",
         (
-                "/bids_root/sub-01/ses-02/meg/"
-                "sub-01_ses-02_task-test_run-3_split-01_meg.fif"
+            "/bids_root/sub-01/ses-02/meg/"
+            "sub-01_ses-02_task-test_run-3_split-01_meg.fif"
         ),
         "sub-01_ses-02_task-test_run-3_split-01_foo-tfr_meg.fif",
     ],
@@ -520,7 +528,7 @@ def test_find_matching_sidecar(return_bids_test_dir, tmp_path):
     bids_path.mkdir()
 
     for suffix, extension in zip(
-            ["eeg", "eeg", "events", "events"], [".fif", ".json", ".tsv", ".json"]
+        ["eeg", "eeg", "events", "events"], [".fif", ".json", ".tsv", ".json"]
     ):
         bids_path.suffix = suffix
         bids_path.extension = extension
@@ -797,19 +805,19 @@ def test_bids_path(return_bids_test_dir):
     bids_path = BIDSPath(subject="01", task="noise", datatype="eeg")
 
     for entity in (
-            "subject",
-            "session",
-            "task",
-            "run",
-            "acquisition",
-            "processing",
-            "recording",
-            "space",
-            "suffix",
-            "extension",
-            "datatype",
-            "root",
-            "split",
+        "subject",
+        "session",
+        "task",
+        "run",
+        "acquisition",
+        "processing",
+        "recording",
+        "space",
+        "suffix",
+        "extension",
+        "datatype",
+        "root",
+        "split",
     ):
         if entity == "run":
             new_val = "01"
@@ -850,18 +858,18 @@ def test_make_filenames():
     )
     assert BIDSPath(**prefix_data).basename == expected_str
     assert (
-            BIDSPath(**prefix_data)
-            == (Path("sub-one") / "ses-two" / "ieeg" / expected_str).as_posix()
+        BIDSPath(**prefix_data)
+        == (Path("sub-one") / "ses-two" / "ieeg" / expected_str).as_posix()
     )
 
     # subsets of keys works
     assert (
-            BIDSPath(subject="one", task="three", run=4).basename
-            == "sub-one_task-three_run-04"
+        BIDSPath(subject="one", task="three", run=4).basename
+        == "sub-one_task-three_run-04"
     )
     assert (
-            BIDSPath(subject="one", task="three", suffix="meg", extension=".json").basename
-            == "sub-one_task-three_meg.json"
+        BIDSPath(subject="one", task="three", suffix="meg", extension=".json").basename
+        == "sub-one_task-three_meg.json"
     )
 
     with pytest.raises(ValueError):
@@ -884,8 +892,8 @@ def test_make_filenames():
         BIDSPath(**prefix_data)
     basename = BIDSPath(**prefix_data, check=False)
     assert (
-            basename.basename
-            == "sub-one_ses-two_task-three_acq-four_run-01_proc-six_rec-seven_ieeg.h5"
+        basename.basename
+        == "sub-one_ses-two_task-three_acq-four_run-01_proc-six_rec-seven_ieeg.h5"
     )  # noqa
 
     # what happens with scans.tsv file
@@ -1178,8 +1186,8 @@ def test_find_empty_room(return_bids_test_dir, tmp_path):
     anonymize_info(raw.info)
     write_raw_bids(raw, bids_path, overwrite=True, format="FIF")
     with pytest.raises(
-            ValueError,
-            match="The provided recording does not " "have a measurement date set",
+        ValueError,
+        match="The provided recording does not " "have a measurement date set",
     ):
         bids_path.find_empty_room()
 
@@ -1420,16 +1428,16 @@ def test_datasetdescription_with_bidspath(return_bids_test_dir):
         check=False,
     )
     assert (
-            bids_path.fpath.as_posix()
-            == Path(f"{return_bids_test_dir}/dataset_description.json").as_posix()
+        bids_path.fpath.as_posix()
+        == Path(f"{return_bids_test_dir}/dataset_description.json").as_posix()
     )
 
     # setting it via update should work
     bids_path = BIDSPath(root=return_bids_test_dir, extension=".json", check=True)
     bids_path.update(suffix="dataset_description", check=False)
     assert (
-            bids_path.fpath.as_posix()
-            == Path(f"{return_bids_test_dir}/dataset_description.json").as_posix()
+        bids_path.fpath.as_posix()
+        == Path(f"{return_bids_test_dir}/dataset_description.json").as_posix()
     )
 
 

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -287,7 +287,7 @@ def test_rm(return_bids_test_dir, capsys):
         )
     ]
     expected = ["Executing the following operations:", "Delete:", "Update:", ""]
-    expected += map(str, deleted_paths + updated_paths)
+    expected += [str(p) for p in deleted_paths + updated_paths]
     bids_path.rm(safe_remove=False, verbose="INFO")
     captured = capsys.readouterr().out
     assert set(captured.splitlines()) == set(expected)
@@ -316,7 +316,7 @@ def test_rm(return_bids_test_dir, capsys):
         bids_path.root / "participants.tsv",
     ]
     expected = ["Executing the following operations:", "Delete:", "Update:", ""]
-    expected += map(str, deleted_paths + updated_paths)
+    expected += [str(p) for p in deleted_paths + updated_paths]
     bids_path.rm(safe_remove=False, verbose="INFO")
     captured2 = capsys.readouterr().out
     assert set(captured2.splitlines()) == set(expected)

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -39,7 +39,6 @@ from mne_bids.config import ALLOWED_PATH_ENTITIES_SHORT
 
 from test_read import _read_raw_fif, warning_str
 
-
 subject_id = "01"
 session_id = "01"
 run = "01"
@@ -172,9 +171,10 @@ def test_search_folder_for_text(capsys):
     captured = capsys.readouterr()
     assert "sub-01_ses-eeg_task-rest_eeg.json" in captured.out
     assert (
-        "    1    name      type      units     low_cutof high_cuto descripti sampling_ status    status_de\n"  # noqa: E501
-        "    2    Fp1       EEG       µV        0.0159154 1000.0    ElectroEn 5000.0    good      n/a"  # noqa: E501
-    ) in captured.out
+               "    1    name      type      units     low_cutof high_cuto descripti sampling_ status    status_de\n"  # noqa: E501
+               "    2    Fp1       EEG       µV        0.0159154 1000.0    ElectroEn 5000.0    good      n/a"
+               # noqa: E501
+           ) in captured.out
     # test if pathlib.Path object
     search_folder_for_text("n/a", Path(test_dir))
 
@@ -182,9 +182,9 @@ def test_search_folder_for_text(capsys):
     out = search_folder_for_text("n/a", test_dir, line_numbers=False, return_str=True)
     assert "sub-01_ses-eeg_task-rest_eeg.json" in out
     assert (
-        "    name      type      units     low_cutof high_cuto descripti sampling_ status    status_de\n"  # noqa: E501
-        "    Fp1       EEG       µV        0.0159154 1000.0    ElectroEn 5000.0    good      n/a"  # noqa: E501
-    ) in out
+               "    name      type      units     low_cutof high_cuto descripti sampling_ status    status_de\n"  # noqa: E501
+               "    Fp1       EEG       µV        0.0159154 1000.0    ElectroEn 5000.0    good      n/a"  # noqa: E501
+           ) in out
 
 
 def test_print_dir_tree(capsys):
@@ -259,6 +259,63 @@ def test_make_folders(tmp_path):
     os.chdir(curr_dir)
 
 
+def test_rm(return_bids_test_dir, capsys):
+    """ Test the BIDSPath.rm method to remove files """
+    # for some reason, mne's logger can't be captured by caplog....
+    bids_root = return_bids_test_dir
+
+    # without providing all the entities, ambiguous when trying
+    # to use fpath
+    bids_path = BIDSPath(
+        subject=subject_id,
+        session=session_id,
+        run='01',
+        acquisition=acq,
+        task=task,
+        root=bids_root,
+    )
+
+    # Delete one run:
+    deleted_paths = bids_path.match(ignore_json=False)
+    updated_paths = [bids_path.copy().update(datatype=None).find_matching_sidecar(
+        suffix='scans',
+        extension='.tsv',
+        on_error='raise',
+    )]
+    expected = ["Executing the following operations:", "Delete:", "Update:", ""]
+    expected += map(str, deleted_paths + updated_paths)
+    bids_path.rm(safe_remove=False, verbose='INFO')
+    captured = capsys.readouterr().out
+    assert set(captured.splitlines()) == set(expected)
+
+    # delete the last run of a subject:
+    bids_path = BIDSPath(
+        subject=subject_id,
+        session=session_id,
+        root=bids_root,
+    )
+    deleted_paths = bids_path.match(ignore_json=False)
+    deleted_paths += [BIDSPath(
+        root=bids_path.root,
+        subject=bids_path.subject,
+    ).directory]
+    updated_paths = [
+        bids_path.copy().update(datatype=None).find_matching_sidecar(
+            suffix='scans',
+            extension='.tsv',
+            on_error='raise',
+        ),
+        bids_path.root / 'participants.tsv',
+    ]
+    expected = ["Executing the following operations:", "Delete:", "Update:", ""]
+    expected += map(str, deleted_paths + updated_paths)
+    bids_path.rm(safe_remove=False, verbose='INFO')
+    captured2 = capsys.readouterr().out
+    assert set(captured2.splitlines()) == set(expected)
+    print('\n'.join(captured))
+    print('\n'.join(captured2))
+
+
 def test_parse_ext():
     """Test the file extension extraction."""
     f = "sub-05_task-matchingpennies.vhdr"
@@ -310,8 +367,8 @@ def test_get_bids_path_from_fname(fname):
         "sub-01_ses-02_task-test_run-3_split-01_desc-filtered.fif",
         "sub-01_ses-02_task-test_run-3_split-01_desc-filtered",
         (
-            "/bids_root/sub-01/ses-02/meg/"
-            + "sub-01_ses-02_task-test_run-3_split-01_desc-filtered_meg.fif"
+                "/bids_root/sub-01/ses-02/meg/"
+                + "sub-01_ses-02_task-test_run-3_split-01_desc-filtered_meg.fif"
         ),
     ],
 )
@@ -343,8 +400,8 @@ def test_get_entities_from_fname(fname):
     [
         "sub-01_ses-02_task-test_run-3_split-01_meg.fif",
         (
-            "/bids_root/sub-01/ses-02/meg/"
-            "sub-01_ses-02_task-test_run-3_split-01_meg.fif"
+                "/bids_root/sub-01/ses-02/meg/"
+                "sub-01_ses-02_task-test_run-3_split-01_meg.fif"
         ),
         "sub-01_ses-02_task-test_run-3_split-01_foo-tfr_meg.fif",
     ],
@@ -463,7 +520,7 @@ def test_find_matching_sidecar(return_bids_test_dir, tmp_path):
     bids_path.mkdir()
 
     for suffix, extension in zip(
-        ["eeg", "eeg", "events", "events"], [".fif", ".json", ".tsv", ".json"]
+            ["eeg", "eeg", "events", "events"], [".fif", ".json", ".tsv", ".json"]
     ):
         bids_path.suffix = suffix
         bids_path.extension = extension
@@ -740,19 +797,19 @@ def test_bids_path(return_bids_test_dir):
     bids_path = BIDSPath(subject="01", task="noise", datatype="eeg")
 
     for entity in (
-        "subject",
-        "session",
-        "task",
-        "run",
-        "acquisition",
-        "processing",
-        "recording",
-        "space",
-        "suffix",
-        "extension",
-        "datatype",
-        "root",
-        "split",
+            "subject",
+            "session",
+            "task",
+            "run",
+            "acquisition",
+            "processing",
+            "recording",
+            "space",
+            "suffix",
+            "extension",
+            "datatype",
+            "root",
+            "split",
     ):
         if entity == "run":
             new_val = "01"
@@ -793,18 +850,18 @@ def test_make_filenames():
     )
     assert BIDSPath(**prefix_data).basename == expected_str
     assert (
-        BIDSPath(**prefix_data)
-        == (Path("sub-one") / "ses-two" / "ieeg" / expected_str).as_posix()
+            BIDSPath(**prefix_data)
+            == (Path("sub-one") / "ses-two" / "ieeg" / expected_str).as_posix()
     )
 
     # subsets of keys works
     assert (
-        BIDSPath(subject="one", task="three", run=4).basename
-        == "sub-one_task-three_run-04"
+            BIDSPath(subject="one", task="three", run=4).basename
+            == "sub-one_task-three_run-04"
     )
     assert (
-        BIDSPath(subject="one", task="three", suffix="meg", extension=".json").basename
-        == "sub-one_task-three_meg.json"
+            BIDSPath(subject="one", task="three", suffix="meg", extension=".json").basename
+            == "sub-one_task-three_meg.json"
     )
 
     with pytest.raises(ValueError):
@@ -827,8 +884,8 @@ def test_make_filenames():
         BIDSPath(**prefix_data)
     basename = BIDSPath(**prefix_data, check=False)
     assert (
-        basename.basename
-        == "sub-one_ses-two_task-three_acq-four_run-01_proc-six_rec-seven_ieeg.h5"
+            basename.basename
+            == "sub-one_ses-two_task-three_acq-four_run-01_proc-six_rec-seven_ieeg.h5"
     )  # noqa
 
     # what happens with scans.tsv file
@@ -1121,8 +1178,8 @@ def test_find_empty_room(return_bids_test_dir, tmp_path):
     anonymize_info(raw.info)
     write_raw_bids(raw, bids_path, overwrite=True, format="FIF")
     with pytest.raises(
-        ValueError,
-        match="The provided recording does not " "have a measurement date set",
+            ValueError,
+            match="The provided recording does not " "have a measurement date set",
     ):
         bids_path.find_empty_room()
 
@@ -1363,16 +1420,16 @@ def test_datasetdescription_with_bidspath(return_bids_test_dir):
         check=False,
     )
     assert (
-        bids_path.fpath.as_posix()
-        == Path(f"{return_bids_test_dir}/dataset_description.json").as_posix()
+            bids_path.fpath.as_posix()
+            == Path(f"{return_bids_test_dir}/dataset_description.json").as_posix()
     )
 
     # setting it via update should work
     bids_path = BIDSPath(root=return_bids_test_dir, extension=".json", check=True)
     bids_path.update(suffix="dataset_description", check=False)
     assert (
-        bids_path.fpath.as_posix()
-        == Path(f"{return_bids_test_dir}/dataset_description.json").as_posix()
+            bids_path.fpath.as_posix()
+            == Path(f"{return_bids_test_dir}/dataset_description.json").as_posix()
     )
 
 

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -51,7 +51,7 @@ _bids_path = BIDSPath(
 )
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def return_bids_test_dir(tmp_path_factory):
     """Return path to a written test BIDS dir."""
     bids_root = str(tmp_path_factory.mktemp("mnebids_utils_test_bids_ds"))

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -51,7 +51,7 @@ _bids_path = BIDSPath(
 )
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="session")
 def return_bids_test_dir(tmp_path_factory):
     """Return path to a written test BIDS dir."""
     bids_root = str(tmp_path_factory.mktemp("mnebids_utils_test_bids_ds"))
@@ -258,10 +258,11 @@ def test_make_folders(tmp_path):
     os.chdir(curr_dir)
 
 
-def test_rm(return_bids_test_dir, capsys):
+def test_rm(return_bids_test_dir, capsys, tmp_path_factory):
     """Test the BIDSPath.rm method to remove files"""
     # for some reason, mne's logger can't be captured by caplog....
-    bids_root = return_bids_test_dir
+    bids_root = str(tmp_path_factory)
+    shutil.copytree(return_bids_test_dir, bids_root)
 
     # without providing all the entities, ambiguous when trying
     # to use fpath


### PR DESCRIPTION
<!--
Thanks for contributing this pull request (PR).
If this is your first time, make sure to read
[CONTRIBUTING.md](https://github.com/mne-tools/mne-bids/blob/main/CONTRIBUTING.md)
-->

PR Description
--------------
Add a `BIDSPath.rm` method to delete all the matching files and update the `scans.tsv` and `participants.tsv` files accordingly

C.f. #547, #443

closes #439

Merge checklist
---------------

Maintainer, please confirm the following before merging.
If applicable:

- [x] All comments are resolved
- [x] This is not your own PR
- [x] All CIs are happy
- [x] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [x] New contributors have been added to [CITATION.cff](https://github.com/mne-tools/mne-bids/blob/main/CITATION.cff)
- [x] PR description includes phrase "closes <#issue-number>"
