### PR TITLE
test minimal vs full mne-bids install

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -116,19 +116,30 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.8", "3.11"]  # Oldest and newest supported versions
         mne-version: [mne-stable]
+        mne-bids-install: [full]
         bids-validator-version: [validator-stable]
 
         include:
-          # Only test devel versions with Python 3.11
+          # special test runs running only on single CI systems to save resources
+          # Test development versions
           - os: ubuntu-latest
             python-version: "3.11"
             mne-version: mne-main
+            mne-bids-install: full
             bids-validator-version: validator-main
-          # Test previous MNE stable only on a single system so save CI resources
+          # Test previous MNE stable version
           - os: ubuntu-latest
             python-version: "3.8"
             mne-version: mne-prev-stable
+            mne-bids-install: full
             bids-validator-version: validator-stable
+          # Test minimal mne-bids install
+          - os: ubuntu-latest
+            python-version: "3.11"
+            mne-version: mne-stable
+            mne-bids-install: minimal
+            bids-validator-version: validator-stable
+
 
     env:
       TZ: Europe/Berlin
@@ -215,8 +226,13 @@ jobs:
         which python
         mne sys_info
 
-    - name: Install MNE-BIDS
+    - name: Install MNE-BIDS (minimal)
+      if: "matrix.mne-bids-install == 'minimal'"
       run: python -m pip install -e .
+
+    - name: Install MNE-BIDS (full)
+      if: "matrix.mne-bids-install == 'full'"
+      run: python -m pip install -e .[full]
 
     # Only run on a limited set of jobs
     - name: Run pytest without testing data


### PR DESCRIPTION
explicitly testing a full and a minimal mne-bids install.

I think in practice this currently does not make a difference, but I think it's good to have the infrastructure here.