### PR TITLE
MRG: Fix BIDSPath.basename for cases where only an extension was provided

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -67,6 +67,7 @@ Detailed list of changes
 - Working with :class:`~mne_bids.BIDSPath` would sometimes inadvertently create new directories, contaminating the BIDS dataset, by `Richard Höchenberger`_ (:gh:`1139`)
 - Fix thrown error if the ``BIDSVersion`` defined in ``dataset_description.json`` file does not match the MNE-BIDS compliant ``BIDSVersion``, ensuring backwards compatibility across BIDS complient tools, by `Ford McDonald`_ (:gh:`1147`)
 - Copying BTi files without a headshape file will no longer raise an error, the file will simply be copied, and the missing headshape file will be ignored, by `Stefan Appelhoff`_ (:gh:`1158`)
+- Fix the ``basename`` of :class:`~mne_bids.BIDSPath` when the path only consists of a filename extension. Previously, the ``basename`` would be empty, by `Richard Höchenberger`_ (:gh:`1163`)
 
 :doc:`Find out what was new in previous releases <whats_new_previous_releases>`
 

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -411,12 +411,13 @@ class BIDSPath(object):
                 basename.append(f"{key}-{val}")
 
         if self.suffix is not None:
-            if self.extension is not None:
-                basename.append(f"{self.suffix}{self.extension}")
-            else:
-                basename.append(self.suffix)
+            basename.append(self.suffix)
 
+        # Populate basename without extension first, then append the extension
         basename = "_".join(basename)
+        if self.extension is not None:
+            basename += self.extension
+
         return basename
 
     @property

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -665,6 +665,10 @@ def test_bids_path(return_bids_test_dir):
     # Same test, but exploiting the fact that bids_fpath is a pathlib.Path
     assert bids_fpath.name == bids_path.basename
 
+    # basename should be just the extension if nothing else is provided
+    bids_path = BIDSPath(extension=".vhdr")
+    assert bids_path.basename == ".vhdr"
+
     # confirm BIDSPath assigns properties correctly
     bids_path = BIDSPath(subject=subject_id, session=session_id)
     assert bids_path.subject == subject_id


### PR DESCRIPTION
This supersedes the old PR #1062


Closes #1062
