### PR TITLE
MRG: Use explicitly public namespaces

### DIFF
--- a/mne_bids/dig.py
+++ b/mne_bids/dig.py
@@ -658,7 +658,7 @@ def template_to_head(info, space, coord_frame="auto", unit="auto", verbose=None)
         coordinates.
 
     """
-    _validate_type(info, mne.io.Info)
+    _validate_type(info, mne.Info)
     _check_option("space", space, BIDS_STANDARD_TEMPLATE_COORDINATE_SYSTEMS)
     _check_option("coord_frame", coord_frame, ("auto", "mri", "mri_voxel", "ras"))
     _check_option("unit", unit, ("auto", "m", "mm"))

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -17,7 +17,7 @@ import os
 import numpy as np
 import mne
 from mne import io, read_events, events_from_annotations
-from mne.io.pick import pick_channels_regexp
+from mne import pick_channels_regexp
 from mne.utils import logger, get_subjects_dir
 from mne.coreg import fit_matched_points
 from mne.transforms import apply_trans

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -16,7 +16,7 @@ from os import path as op
 import numpy as np
 from mne.channels import make_standard_montage
 from mne.io.kit.kit import get_kit_info
-from mne.io.pick import pick_types
+from mne import pick_types
 from mne.utils import warn as _warn, logger, verbose
 
 from mne_bids.tsv_handler import _to_tsv

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -23,9 +23,9 @@ import numpy as np
 from scipy import linalg
 import mne
 from mne.transforms import _get_trans, apply_trans, rotation, translation
-from mne import Epochs
+from mne import Epochs, channel_type
 from mne.io.constants import FIFF
-from mne.io.pick import channel_type, _picks_to_idx
+from mne.io.pick import _picks_to_idx
 from mne.io import BaseRaw, read_fiducials
 from mne.channels.channels import _unit2human, _get_meg_system
 from mne.chpi import get_chpi_info


### PR DESCRIPTION
In https://github.com/mne-tools/mne-python/pull/11903 we're trying to make some mne/io stuff private. This changes mne-bids to use the explicitly public API