### PR TITLE
MRG: Correctly handle reading when BIDS channel order differs from Raw

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -21,6 +21,7 @@ The following authors contributed for the first time. Thank you so much! 🤩
 
 The following authors had contributed before. Thank you for sticking around! 🤘
 
+* `Richard Höchenberger`_
 * `Stefan Appelhoff`_
 
 Detailed list of changes
@@ -44,7 +45,7 @@ Detailed list of changes
 🪲 Bug fixes
 ^^^^^^^^^^^^
 
-- nothing yet
+- Fix reading when the channel order differs between ``*_channels.tsv`` and the raw data file, which would previously throw an error, by `Richard Höchenberger`_ (:gh:`1171`)
 
 :doc:`Find out what was new in previous releases <whats_new_previous_releases>`
 

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -642,9 +642,7 @@ def _handle_channels_reading(channels_fname, raw):
             f"set channel names."
         )
     else:
-        for bids_ch_name, raw_ch_name in zip(ch_names_tsv, raw.ch_names.copy()):
-            if bids_ch_name != raw_ch_name:
-                raw.rename_channels({raw_ch_name: bids_ch_name})
+        raw.rename_channels(dict(zip(raw.ch_names, ch_names_tsv)))
 
     # Set the channel types in the raw data according to channels.tsv
     channel_type_bids_mne_map_available_channels = {


### PR DESCRIPTION
Fixes #1170

@moritz-gerster does this fix your problem?


Merge checklist
---------------

Maintainer, please confirm the following before merging.
If applicable:

- [ ] All comments are resolved
- [ ] This is not your own PR
- [x] All CIs are happy
- [x] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] New contributors have been added to [CITATION.cff](https://github.com/mne-tools/mne-bids/blob/main/CITATION.cff)
- [x] PR description includes phrase "closes <#issue-number>"
