### PR TITLE
Fix numpy 2.0 deprecation

### DIFF
--- a/mne_bids/tsv_handler.py
+++ b/mne_bids/tsv_handler.py
@@ -80,7 +80,7 @@ def _contains_row(data, row_data):
         # https://github.com/mne-tools/mne-bids/pull/372
         row_value = np.array(row_value, dtype=data_value.dtype)
 
-        column_mask = np.in1d(data_value, row_value)
+        column_mask = np.isin(data_value, row_value)
         mask = column_mask if mask is None else (mask & column_mask)
     return np.any(mask)
 
@@ -115,7 +115,7 @@ def _drop(data, values, column):
         dtype = np.array(values).dtype
     values = np.array(values, dtype=dtype)
 
-    mask = np.in1d(new_data_col, values, invert=True)
+    mask = np.isin(new_data_col, values, invert=True)
     for key in new_data.keys():
         new_data[key] = np.array(new_data[key])[mask].tolist()
     return new_data


### PR DESCRIPTION
Got:

```
ERROR mne_icalabel/annotation/tests/test_bids.py::test_write_channels_tsv - DeprecationWarning: `in1d` is deprecated. Use `np.isin` instead.
ERROR mne_icalabel/annotation/tests/test_bids.py::test_mark_components - DeprecationWarning: `in1d` is deprecated. Use `np.isin` instead.
```

with the traceback:

```
<decorator-gen-449>:10: in write_raw_bids
    ???
/opt/hostedtoolcache/Python/3.11.6/x64/lib/python3.11/site-packages/mne_bids/write.py:1994: in write_raw_bids
    _channels_tsv(raw, channels_path.fpath, overwrite)
/opt/hostedtoolcache/Python/3.11.6/x64/lib/python3.11/site-packages/mne_bids/write.py:192: in _channels_tsv
    ch_data = _drop(ch_data, ignored_channels, "name")
/opt/hostedtoolcache/Python/3.11.6/x64/lib/python3.11/site-packages/mne_bids/tsv_handler.py:118: in _drop
    mask = np.in1d(new_data_col, values, invert=True)
```

when running `mne-icalalbel` pytest against `mne_bids` (main) and `numpy` 2.0.