### PR TITLE
[MRG] add CSS to truncate long version string

### DIFF
--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -18,3 +18,16 @@ span.option {
 .prev-next-bottom a.right-next {
   text-align: right;
 }
+
+/* ************************************************* truncate version string */
+div.navbar-item:first-child {
+  overflow-x: hidden;
+}
+a.navbar-brand.logo {
+  flex-shrink: 1;
+  overflow-x: hidden;
+}
+p.logo__title {
+  overflow-x: hidden;
+  text-overflow: ellipsis;
+}

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -17,7 +17,7 @@ Version 0.15 (unreleased)
 
 The following authors contributed for the first time. Thank you so much! 🤩
 
-* nobody yet
+* `Daniel McCloy`_
 
 The following authors had contributed before. Thank you for sticking around! 🤘
 
@@ -63,6 +63,8 @@ Detailed list of changes
 - The package build backend has been switched from ``setuptools`` to ``hatchling``. This
   only affects users who build and install MNE-BIDS from source, and should not lead to
   changed runtime behavior, by `Richard Höchenberger`_ (:gh:`1204`)
+- Display of the version number on the website is now truncated for over-long version strings,
+  by `Daniel McCloy`_ (:gh:`1206`)
 
 :doc:`Find out what was new in previous releases <whats_new_previous_releases>`
 


### PR DESCRIPTION
<!--
Thanks for contributing this pull request (PR).
If this is your first time, make sure to read
[CONTRIBUTING.md](https://github.com/mne-tools/mne-bids/blob/main/CONTRIBUTING.md)
-->

PR Description
--------------

closes #1205 by truncating long version strings (with `text-overflow: ellipsis`)

Merge checklist
---------------

Maintainer, please confirm the following before merging.
If applicable:

- [ ] All comments are resolved
- [ ] This is not your own PR
- [x] All CIs are happy
- [x] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [x] New contributors have been added to [CITATION.cff](https://github.com/mne-tools/mne-bids/blob/main/CITATION.cff)
- [x] PR description includes phrase "closes <#issue-number>"
