### PR TITLE
Do not zero-pad indices in BIDSPath entities anymore; do not warn about prepending missing dots for extensions

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -50,7 +50,7 @@ Detailed list of changes
 🪲 Bug fixes
 ^^^^^^^^^^^^
 
-- nothing yet
+- Allow integer types to be passed to :class:`mne_bids.BIDSPath` by `Alex Rockhill`_ (:gh:`1215`)
 
 ⚕️ Code health
 ^^^^^^^^^^^^^^

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -40,6 +40,10 @@ Detailed list of changes
 
 - The experimental support for running MNE-BIDS examples from your browser using Binder has
   been removed, by `Stefan Appelhoff`_ (:gh:`1202`)
+- MNE-BIDS will no longer zero-pad ("zfill") entity indices passed to :class:`~mne_bids.BIDSPath`.
+  For example, If ``run=1`` is passed to MNE-BIDS, it will no longer be silently auto-converted to ``run-01``, by `Alex Rockhill`_ (:gh:`1215`)
+- MNE-BIDS will no longer warn about missing leading punctuation marks for extensions passed :class:`~mne_bids.BIDSPath`.
+  For example, MNE-BIDS will now silently auto-convert ``edf`` to ```.edf``, by `Alex Rockhill`_ (:gh:`1215`)
 
 🛠 Requirements
 ^^^^^^^^^^^^^^^
@@ -53,7 +57,6 @@ Detailed list of changes
 🪲 Bug fixes
 ^^^^^^^^^^^^
 
-- Allow integer types to be passed to :class:`mne_bids.BIDSPath`, by `Alex Rockhill`_ (:gh:`1215`)
 - The datatype in the dataframe returned by :func:`mne_bids.stats.count_events` is now
   ``pandas.Int64Dtype`` instead of ``float64``, by `Eric Larson`_ (:gh:`1227`)
 

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -958,34 +958,21 @@ class BIDSPath:
                     f"Key must be one of " f"{ALLOWED_PATH_ENTITIES}, got {key}"
                 )
 
+            if isinstance(val, int):
+                kwargs[key] = f"{val:02}"
+
             if ENTITY_VALUE_TYPE[key] == "label":
-                if isinstance(val, int):
-                    val = str(val)
                 _validate_type(val, types=(None, str), item_name=key)
             else:
                 assert ENTITY_VALUE_TYPE[key] == "index"
                 _validate_type(val, types=(int, str, None), item_name=key)
                 if isinstance(val, str) and not val.isdigit():
                     raise ValueError(f"{key} is not an index (Got {val})")
-                elif isinstance(val, int):
-                    kwargs[key] = f"{val:02}"
 
         # ensure extension starts with a '.'
         extension = kwargs.get("extension")
         if extension is not None and not extension.startswith("."):
-            warn(
-                f'extension should start with a period ".", but got: '
-                f'"{extension}". Prepending "." to form: ".{extension}". '
-                f"This will raise an exception starting with MNE-BIDS 0.12.",
-                category=FutureWarning,
-            )
             kwargs["extension"] = f".{extension}"
-            # Uncomment in 0.12, and remove above code:
-            #
-            # raise ValueError(
-            #     f'Extension must start wie a period ".", but got: '
-            #     f'{extension}'
-            # )
         del extension
 
         # error check entities

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -965,7 +965,7 @@ class BIDSPath:
                 _validate_type(val, types=(int, str, None), item_name=key)
                 if isinstance(val, str) and not val.isdigit():
                     raise ValueError(f"{key} is not an index (Got {val})")
-                else:
+                elif isinstance(val, int):
                     kwargs[key] = f"{val}"
 
         # ensure extension starts with a '.'

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -966,7 +966,7 @@ class BIDSPath:
                 if isinstance(val, str) and not val.isdigit():
                     raise ValueError(f"{key} is not an index (Got {val})")
                 elif isinstance(val, int):
-                    kwargs[key] = f"{val:02}"
+                    kwargs[key] = f"{val}"
 
         # ensure extension starts with a '.'
         extension = kwargs.get("extension")

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -959,6 +959,8 @@ class BIDSPath:
                 )
 
             if ENTITY_VALUE_TYPE[key] == "label":
+                if isinstance(val, int):
+                    val = str(val)
                 _validate_type(val, types=(None, str), item_name=key)
             else:
                 assert ENTITY_VALUE_TYPE[key] == "index"

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -966,7 +966,7 @@ class BIDSPath:
                 if isinstance(val, str) and not val.isdigit():
                     raise ValueError(f"{key} is not an index (Got {val})")
                 elif isinstance(val, int):
-                    kwargs[key] = f"{val}"
+                    kwargs[key] = f"{val:02}"
 
         # ensure extension starts with a '.'
         extension = kwargs.get("extension")

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -958,9 +958,6 @@ class BIDSPath:
                     f"Key must be one of " f"{ALLOWED_PATH_ENTITIES}, got {key}"
                 )
 
-            if isinstance(val, int):
-                kwargs[key] = f"{val}"
-
             if ENTITY_VALUE_TYPE[key] == "label":
                 _validate_type(val, types=(None, str), item_name=key)
             else:
@@ -968,6 +965,8 @@ class BIDSPath:
                 _validate_type(val, types=(int, str, None), item_name=key)
                 if isinstance(val, str) and not val.isdigit():
                     raise ValueError(f"{key} is not an index (Got {val})")
+                else:
+                    kwargs[key] = f"{val}"
 
         # ensure extension starts with a '.'
         extension = kwargs.get("extension")

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -959,7 +959,7 @@ class BIDSPath:
                 )
 
             if isinstance(val, int):
-                kwargs[key] = f"{val:02}"
+                kwargs[key] = f"{val}"
 
             if ENTITY_VALUE_TYPE[key] == "label":
                 _validate_type(val, types=(None, str), item_name=key)

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -352,10 +352,10 @@ def test_parse_ext():
 @pytest.mark.parametrize(
     "fname",
     [
-        "sub-01_ses-02_task-test_run-3_split-01_meg.fif",
-        "sub-01_ses-02_task-test_run-3_split-01",
-        "/bids_root/sub-01/ses-02/meg/sub-01_ses-02_task-test_run-3_split-01_meg.fif",  # noqa: E501
-        "sub-01/ses-02/meg/sub-01_ses-02_task-test_run-3_split-01_meg.fif",
+        "sub-01_ses-02_task-test_run-3_split-1_meg.fif",
+        "sub-01_ses-02_task-test_run-3_split-1",
+        "/bids_root/sub-01/ses-02/meg/sub-01_ses-02_task-test_run-3_split-1_meg.fif",  # noqa: E501
+        "sub-01/ses-02/meg/sub-01_ses-02_task-test_run-3_split-1_meg.fif",
     ],
 )
 def test_get_bids_path_from_fname(fname):
@@ -377,12 +377,12 @@ def test_get_bids_path_from_fname(fname):
 @pytest.mark.parametrize(
     "fname",
     [
-        "sub-01_ses-02_task-test_run-3_split-01_desc-filtered_meg.fif",
-        "sub-01_ses-02_task-test_run-3_split-01_desc-filtered.fif",
-        "sub-01_ses-02_task-test_run-3_split-01_desc-filtered",
+        "sub-01_ses-02_task-test_run-3_split-1_desc-filtered_meg.fif",
+        "sub-01_ses-02_task-test_run-3_split-1_desc-filtered.fif",
+        "sub-01_ses-02_task-test_run-3_split-1_desc-filtered",
         (
             "/bids_root/sub-01/ses-02/meg/"
-            + "sub-01_ses-02_task-test_run-3_split-01_desc-filtered_meg.fif"
+            + "sub-01_ses-02_task-test_run-3_split-1_desc-filtered_meg.fif"
         ),
     ],
 )
@@ -394,7 +394,7 @@ def test_get_entities_from_fname(fname):
     assert params["run"] == "3"
     assert params["task"] == "test"
     assert params["description"] == "filtered"
-    assert params["split"] == "01"
+    assert params["split"] == "1"
     assert list(params.keys()) == [
         "subject",
         "session",
@@ -471,7 +471,7 @@ def test_get_entities_from_fname_errors(fname):
         # First candidate is disqualified (session doesn't match)
         (["sub-01_ses-01", "sub-01_ses-02"], ["sub-01_ses-02"]),
         # Multiple equally good candidates
-        (["sub-01_run-01", "sub-01_run-02"], ["sub-01_run-01", "sub-01_run-02"]),
+        (["sub-01_run-1", "sub-01_run-2"], ["sub-01_run-1", "sub-01_run-2"]),
     ],
 )
 def test_find_best_candidates(candidate_list, best_candidates):
@@ -796,7 +796,7 @@ def test_bids_path(return_bids_test_dir):
 
     # test that split gets properly set
     bids_path.update(split=1)
-    assert bids_path.basename == "sub-01_ses-02_task-03_split-01_ieeg.mat"
+    assert bids_path.basename == "sub-01_ses-02_task-03_split-1_ieeg.mat"
 
     # test home dir expansion
     bids_path = BIDSPath(root="~/foo")
@@ -858,7 +858,7 @@ def test_make_filenames():
         datatype="ieeg",
     )
     expected_str = (
-        "sub-one_ses-two_task-three_acq-four_run-01_proc-six_" "rec-seven_ieeg.json"
+        "sub-one_ses-two_task-three_acq-four_run-1_proc-six_" "rec-seven_ieeg.json"
     )
     assert BIDSPath(**prefix_data).basename == expected_str
     assert (
@@ -869,7 +869,7 @@ def test_make_filenames():
     # subsets of keys works
     assert (
         BIDSPath(subject="one", task="three", run=4).basename
-        == "sub-one_task-three_run-04"
+        == "sub-one_task-three_run-4"
     )
     assert (
         BIDSPath(subject="one", task="three", suffix="meg", extension=".json").basename
@@ -897,7 +897,7 @@ def test_make_filenames():
     basename = BIDSPath(**prefix_data, check=False)
     assert (
         basename.basename
-        == "sub-one_ses-two_task-three_acq-four_run-01_proc-six_rec-seven_ieeg.h5"
+        == "sub-one_ses-two_task-three_acq-four_run-1_proc-six_rec-seven_ieeg.h5"
     )  # noqa
 
     # what happens with scans.tsv file
@@ -960,7 +960,7 @@ def test_match(return_bids_test_dir):
     bids_path_01 = BIDSPath(root=bids_root, run="01")
     paths = bids_path_01.match()
     assert len(paths) == 3
-    assert paths[0].basename == ("sub-01_ses-01_task-testing_run-01_" "channels.tsv")
+    assert paths[0].basename == ("sub-01_ses-01_task-testing_run-01_channels.tsv")
 
     bids_path_01 = BIDSPath(root=bids_root, subject="unknown")
     paths = bids_path_01.match()

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -1342,6 +1342,9 @@ def test_find_emptyroom_no_meas_date(tmp_path):
 
 def test_bids_path_label_vs_index_entity():
     """Test entities that must be strings vs those that may be an int."""
+    match = "subject must be an instance of None or str"
+    with pytest.raises(TypeError, match=match):
+        BIDSPath(subject=1)
     match = "root must be an instance of path-like or None"
     with pytest.raises(TypeError, match=match):
         BIDSPath(root=1, subject="01")

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -1342,9 +1342,6 @@ def test_find_emptyroom_no_meas_date(tmp_path):
 
 def test_bids_path_label_vs_index_entity():
     """Test entities that must be strings vs those that may be an int."""
-    match = "subject must be an instance of None or str"
-    with pytest.raises(TypeError, match=match):
-        BIDSPath(subject=1)
     match = "root must be an instance of path-like or None"
     with pytest.raises(TypeError, match=match):
         BIDSPath(root=1, subject="01")
@@ -1472,12 +1469,6 @@ def test_setting_entities():
 
         setattr(bids_path, entity_name, None)
         assert getattr(bids_path, entity_name) is None
-
-
-def test_deprecation():
-    """Test deprecated behavior."""
-    with pytest.warns(FutureWarning, match="This will raise an exception"):
-        BIDSPath(extension="vhdr")  # no leading period
 
 
 def test_dont_create_dirs_on_fpath_access(tmp_path):


### PR DESCRIPTION
PR Description
--------------

I often have subject ids like `1` and `2` and I don't always store them as strings. I think it would be nice if `mne_bids` just handled this to allow for integer subject ids, runs, sessions, acquisitions etc.

Merge checklist
---------------

Maintainer, please confirm the following before merging.
If applicable:

- [x] All comments are resolved
- [x] This is not your own PR
- [x] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [x] New contributors have been added to [CITATION.cff](https://github.com/mne-tools/mne-bids/blob/main/CITATION.cff)
- [ ] PR description includes phrase "closes <#issue-number>"
