### PR TITLE
[MRG] BUG: Fix dtype bug for counts

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -51,7 +51,8 @@ Detailed list of changes
 🪲 Bug fixes
 ^^^^^^^^^^^^
 
-- nothing yet
+- The datatype in the dataframe returned by :func:`mne_bids.stats.count_events` is now
+  ``pandas.Int64Dtype`` instead of ``float64``.
 
 ⚕️ Code health
 ^^^^^^^^^^^^^^

--- a/mne_bids/stats.py
+++ b/mne_bids/stats.py
@@ -32,6 +32,12 @@ def count_events(root_or_path, datatype="auto"):
     counts : pandas.DataFrame
         The pandas dataframe containing all the counts of trial_type
         in all matching events.tsv files.
+
+    Notes
+    -----
+    .. versionchanged:: 0.15
+       Table values were changed from floats (with NaN for missing values)
+       to Pandas nullable integer arrays.
     """
     import pandas as pd
 
@@ -105,7 +111,8 @@ def count_events(root_or_path, datatype="auto"):
             groups.append("trial_type")
 
         counts = df.groupby(groups).size()
-        counts = counts.unstack()
+        counts = counts.unstack(fill_value=-1)
+        counts.replace(-1, pd.NA, inplace=True)
 
         if "BAD_ACQ_SKIP" in counts.columns:
             counts = counts.drop("BAD_ACQ_SKIP", axis=1)


### PR DESCRIPTION
<!--
Thanks for contributing this pull request (PR).
If this is your first time, make sure to read
[CONTRIBUTING.md](https://github.com/mne-tools/mne-bids/blob/main/CONTRIBUTING.md)
-->

PR Description
--------------

Counts should be integers, make them that way by filling with `-1` then converting to pandas Int64Dtype with `pd.NA`.

Merge checklist
---------------

Maintainer, please confirm the following before merging.
If applicable:

- [ ] All comments are resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] New contributors have been added to [CITATION.cff](https://github.com/mne-tools/mne-bids/blob/main/CITATION.cff)
- [ ] PR description includes phrase "closes <#issue-number>"
