### PR TITLE
In copyfile_ctf change suffix .meg4 to meg4 such that files with suff…

### DIFF
--- a/mne_bids/copyfiles.py
+++ b/mne_bids/copyfiles.py
@@ -158,7 +158,7 @@ def copyfile_ctf(src, dest):
         ".hist",
         ".infods",
         ".bak",
-        ".meg4",
+        "meg4",
         ".newds",
         ".res4",
     )


### PR DESCRIPTION
…ix .{int}_meg4 are also renamed

<!--
Thanks for contributing this pull request (PR).
If this is your first time, make sure to read
[CONTRIBUTING.md](https://github.com/mne-tools/mne-bids/blob/main/CONTRIBUTING.md)
-->

PR Description
--------------

In copyfile_ctf change suffix .meg4 to meg4 such that files with suffix .{int}_meg4 are also renamed. 

CTF datasets in .ds folders can be split into several files named  _.meg, .1_meg, .2_meg,_ ...
These files have until now been just copied from the original dataset without being renamed when using write_raw_bids.

The files are selected for renaming based on whether their name ends with the specified suffix, therefore this fix seems to solve the issue.
The problem was discussed here [https://mne.discourse.group/t/write-raw-bids-does-not-rename-all-data-files-of-the-ds-folder/8405](url)

Merge checklist
---------------

Maintainer, please confirm the following before merging.
If applicable:

- [ ] All comments are resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] New contributors have been added to [CITATION.cff](https://github.com/mne-tools/mne-bids/blob/main/CITATION.cff)
- [ ] PR description includes phrase "closes <#issue-number>"
