### PR TITLE
MRG: Fix documentation build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ _check_skip: &check_skip
 jobs:
   docs-build:
     machine:
-        image: ubuntu-2004:202111-01
+        image: default
     steps:
         - checkout
 
@@ -101,7 +101,7 @@ jobs:
 
   link-check:
     machine:
-        image: ubuntu-2004:202111-01
+        image: default
     steps:
       - checkout
 


### PR DESCRIPTION
The CircleCI image we used to use is not available anymore, see https://discuss.circleci.com/t/linux-image-deprecations-and-eol-for-2024/50177

Merge checklist
---------------

Maintainer, please confirm the following before merging.
If applicable:

- [ ] All comments are resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] New contributors have been added to [CITATION.cff](https://github.com/mne-tools/mne-bids/blob/main/CITATION.cff)
- [ ] PR description includes phrase "closes <#issue-number>"
