### PR TITLE
Fix string format `"blabla" "bla"`

### DIFF
--- a/mne_bids/commands/mne_bids_calibration_to_bids.py
+++ b/mne_bids/commands/mne_bids_calibration_to_bids.py
@@ -31,7 +31,7 @@ def run():
         dest="bids_root",
         help="The path of the folder containing the BIDS dataset",
     )
-    parser.add_option("--subject_id", dest="subject", help=("Subject name"))
+    parser.add_option("--subject_id", dest="subject", help="Subject name")
     parser.add_option("--session_id", dest="session", help="Session name")
     parser.add_option("--file", dest="fname", help="The path of the crosstalk file")
     parser.add_option(

--- a/mne_bids/commands/mne_bids_calibration_to_bids.py
+++ b/mne_bids/commands/mne_bids_calibration_to_bids.py
@@ -29,7 +29,7 @@ def run():
     parser.add_option(
         "--bids_root",
         dest="bids_root",
-        help="The path of the folder containing the BIDS " "dataset",
+        help="The path of the folder containing the BIDS dataset",
     )
     parser.add_option("--subject_id", dest="subject", help=("Subject name"))
     parser.add_option("--session_id", dest="session", help="Session name")

--- a/mne_bids/commands/mne_bids_count_events.py
+++ b/mne_bids/commands/mne_bids_count_events.py
@@ -37,7 +37,7 @@ def run():
         "--describe",
         dest="describe",
         action="store_true",
-        help=("If set print the descriptive statistics (min, max, etc.)."),
+        help="If set print the descriptive statistics (min, max, etc.).",
     )
 
     parser.add_option(

--- a/mne_bids/commands/mne_bids_count_events.py
+++ b/mne_bids/commands/mne_bids_count_events.py
@@ -37,7 +37,7 @@ def run():
         "--describe",
         dest="describe",
         action="store_true",
-        help=("If set print the descriptive statistics " "(min, max, etc.)."),
+        help=("If set print the descriptive statistics (min, max, etc.)."),
     )
 
     parser.add_option(
@@ -70,7 +70,7 @@ def run():
     if not all([opt.bids_root]):
         parser.print_help()
         parser.error(
-            "Arguments missing. You need to specify the " "--bids_root parameter."
+            "Arguments missing. You need to specify the --bids_root parameter."
         )
 
     if opt.output and Path(opt.output).exists() and not opt.overwrite:

--- a/mne_bids/commands/mne_bids_cp.py
+++ b/mne_bids/commands/mne_bids_cp.py
@@ -27,7 +27,7 @@ def run():
         "-i",
         "--input",
         dest="input",
-        help=(f"path to the input file. {accepted_formats_msg}"),
+        help=f"path to the input file. {accepted_formats_msg}",
         metavar="INPUT",
     )
 
@@ -35,7 +35,7 @@ def run():
         "-o",
         "--output",
         dest="output",
-        help=("path to the output file (MUST be same format as input file)"),
+        help="path to the output file (MUST be same format as input file)",
         metavar="OUTPUT",
     )
 

--- a/mne_bids/commands/mne_bids_cp.py
+++ b/mne_bids/commands/mne_bids_cp.py
@@ -14,9 +14,7 @@ def run():
     """Run the cp command."""
     from mne.commands.utils import get_optparser
 
-    accepted_formats_msg = (
-        "(accepted formats: BrainVision .vhdr, " "EEGLAB .set, CTF .ds)"
-    )
+    accepted_formats_msg = "(accepted formats: BrainVision .vhdr, EEGLAB .set, CTF .ds)"
 
     parser = get_optparser(
         __file__,
@@ -37,7 +35,7 @@ def run():
         "-o",
         "--output",
         dest="output",
-        help=("path to the output file (MUST be same format " "as input file)"),
+        help=("path to the output file (MUST be same format as input file)"),
         metavar="OUTPUT",
     )
 

--- a/mne_bids/commands/mne_bids_crosstalk_to_bids.py
+++ b/mne_bids/commands/mne_bids_crosstalk_to_bids.py
@@ -31,7 +31,7 @@ def run():
         dest="bids_root",
         help="The path of the folder containing the BIDS dataset",
     )
-    parser.add_option("--subject_id", dest="subject", help=("Subject name"))
+    parser.add_option("--subject_id", dest="subject", help="Subject name")
     parser.add_option("--session_id", dest="session", help="Session name")
     parser.add_option("--file", dest="fname", help="The path of the crosstalk file")
     parser.add_option(

--- a/mne_bids/commands/mne_bids_crosstalk_to_bids.py
+++ b/mne_bids/commands/mne_bids_crosstalk_to_bids.py
@@ -29,7 +29,7 @@ def run():
     parser.add_option(
         "--bids_root",
         dest="bids_root",
-        help="The path of the folder containing the BIDS " "dataset",
+        help="The path of the folder containing the BIDS dataset",
     )
     parser.add_option("--subject_id", dest="subject", help=("Subject name"))
     parser.add_option("--session_id", dest="session", help="Session name")
@@ -44,9 +44,7 @@ def run():
     opt, args = parser.parse_args()
     if args:
         parser.print_help()
-        parser.error(
-            f"Please do not specify arguments without flags. " f"Got: {args}.\n"
-        )
+        parser.error(f"Please do not specify arguments without flags. Got: {args}.\n")
 
     if opt.bids_root is None:
         parser.print_help()

--- a/mne_bids/commands/mne_bids_inspect.py
+++ b/mne_bids/commands/mne_bids_inspect.py
@@ -29,7 +29,7 @@ def run():
     parser.add_option(
         "--bids_root",
         dest="bids_root",
-        help="The path of the folder containing the BIDS " "dataset",
+        help="The path of the folder containing the BIDS dataset",
     )
     parser.add_option("--subject_id", dest="subject", help=("Subject name"))
     parser.add_option("--session_id", dest="session", help="Session name")
@@ -44,17 +44,17 @@ def run():
     parser.add_option(
         "--suffix",
         dest="suffix",
-        help="The filename suffix, i.e. the last part before " "the extension",
+        help="The filename suffix, i.e. the last part before the extension",
     )
     parser.add_option(
         "--ext",
         dest="extension",
-        help="The filename extension, including the leading " "period, e.g. .fif",
+        help="The filename extension, including the leading period, e.g. .fif",
     )
     parser.add_option(
         "--find_flat",
         dest="find_flat",
-        help="Whether to auto-detect flat channels and time " "segments",
+        help="Whether to auto-detect flat channels and time segments",
     )
     parser.add_option(
         "--l_freq", dest="l_freq", help="The high-pass filter cutoff frequency"

--- a/mne_bids/commands/mne_bids_inspect.py
+++ b/mne_bids/commands/mne_bids_inspect.py
@@ -31,7 +31,7 @@ def run():
         dest="bids_root",
         help="The path of the folder containing the BIDS dataset",
     )
-    parser.add_option("--subject_id", dest="subject", help=("Subject name"))
+    parser.add_option("--subject_id", dest="subject", help="Subject name")
     parser.add_option("--session_id", dest="session", help="Session name")
     parser.add_option("--task", dest="task", help="Task name")
     parser.add_option("--acq", dest="acquisition", help="Acquisition parameter")

--- a/mne_bids/commands/mne_bids_mark_channels.py
+++ b/mne_bids/commands/mne_bids_mark_channels.py
@@ -58,7 +58,7 @@ def run():
         dest="bids_root",
         help="The path of the folder containing the BIDS dataset",
     )
-    parser.add_option("--subject_id", dest="subject", help=("Subject name"))
+    parser.add_option("--subject_id", dest="subject", help="Subject name")
     parser.add_option("--session_id", dest="session", help="Session name")
     parser.add_option("--task", dest="task", help="Task name")
     parser.add_option("--acq", dest="acquisition", help="Acquisition parameter")

--- a/mne_bids/commands/mne_bids_mark_channels.py
+++ b/mne_bids/commands/mne_bids_mark_channels.py
@@ -56,7 +56,7 @@ def run():
     parser.add_option(
         "--bids_root",
         dest="bids_root",
-        help="The path of the folder containing the BIDS " "dataset",
+        help="The path of the folder containing the BIDS dataset",
     )
     parser.add_option("--subject_id", dest="subject", help=("Subject name"))
     parser.add_option("--session_id", dest="session", help="Session name")
@@ -71,12 +71,12 @@ def run():
     parser.add_option(
         "--suffix",
         dest="suffix",
-        help="The filename suffix, i.e. the last part before " "the extension",
+        help="The filename suffix, i.e. the last part before the extension",
     )
     parser.add_option(
         "--ext",
         dest="extension",
-        help="The filename extension, including the leading " "period, e.g. .fif",
+        help="The filename extension, including the leading period, e.g. .fif",
     )
     parser.add_option(
         "--verbose",
@@ -88,9 +88,7 @@ def run():
     opt, args = parser.parse_args()
     if args:
         parser.print_help()
-        parser.error(
-            f"Please do not specify arguments without flags. " f"Got: {args}.\n"
-        )
+        parser.error(f"Please do not specify arguments without flags. Got: {args}.\n")
 
     if opt.bids_root is None:
         parser.print_help()

--- a/mne_bids/commands/mne_bids_raw_to_bids.py
+++ b/mne_bids/commands/mne_bids_raw_to_bids.py
@@ -30,7 +30,7 @@ def run():
     parser.add_option(
         "--subject_id",
         dest="subject_id",
-        help=("subject name in BIDS compatible format " "(01, 02, etc.)"),
+        help=("subject name in BIDS compatible format (01, 02, etc.)"),
     )
     parser.add_option(
         "--task", dest="task", help="name of the task the data is based on"

--- a/mne_bids/commands/mne_bids_raw_to_bids.py
+++ b/mne_bids/commands/mne_bids_raw_to_bids.py
@@ -30,7 +30,7 @@ def run():
     parser.add_option(
         "--subject_id",
         dest="subject_id",
-        help=("subject name in BIDS compatible format (01, 02, etc.)"),
+        help="subject name in BIDS compatible format (01, 02, etc.)",
     )
     parser.add_option(
         "--task", dest="task", help="name of the task the data is based on"

--- a/mne_bids/commands/mne_bids_report.py
+++ b/mne_bids/commands/mne_bids_report.py
@@ -35,7 +35,7 @@ def run():
     if not all([opt.bids_root]):
         parser.print_help()
         parser.error(
-            "Arguments missing. You need to specify the " "--bids_root parameter."
+            "Arguments missing. You need to specify the --bids_root parameter."
         )
 
     report = make_report(opt.bids_root)

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -1141,7 +1141,7 @@ class BIDSPath:
             Returns ``None`` if none was found.
         """
         if self.datatype not in ("meg", None):
-            raise ValueError("Empty-room data is only supported for MEG " "datasets")
+            raise ValueError("Empty-room data is only supported for MEG datasets")
 
         if self.root is None:
             raise ValueError(
@@ -1251,7 +1251,7 @@ class BIDSPath:
         if self.root is None or self.subject is None:
             raise ValueError("root and subject must be set.")
         if self.datatype not in (None, "meg"):
-            raise ValueError("Can only find fine-calibration file for MEG " "datasets.")
+            raise ValueError("Can only find fine-calibration file for MEG datasets.")
 
         path = BIDSPath(
             subject=self.subject,

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -454,7 +454,7 @@ def _handle_info_reading(sidecar_fname, raw):
                     )
         else:
             addmsg = (
-                ".\n(Because no 'HeadCoilFrequency' data " "was found in the sidecar.)"
+                ".\n(Because no 'HeadCoilFrequency' data was found in the sidecar.)"
             )
             logger.info(msg.format(addmsg))
 

--- a/mne_bids/tests/test_copyfiles.py
+++ b/mne_bids/tests/test_copyfiles.py
@@ -74,7 +74,7 @@ def test_get_brainvision_paths(tmp_path):
 
 
 @pytest.mark.filterwarnings(
-    "ignore:.*Exception ignored.*:" "pytest.PytestUnraisableExceptionWarning"
+    "ignore:.*Exception ignored.*:pytest.PytestUnraisableExceptionWarning"
 )
 def test_copyfile_brainvision(tmp_path):
     """Test the copying of BrainVision vhdr, vmrk and eeg files."""

--- a/mne_bids/tests/test_dig.py
+++ b/mne_bids/tests/test_dig.py
@@ -239,9 +239,7 @@ def test_template_to_head():
     raw = _load_raw()
     montage_empty = mne.channels.make_dig_montage(hsp=[[0, 0, 0]])
     _set_montage_no_trans(raw, montage_empty)
-    with pytest.raises(
-        RuntimeError, match="No channel locations " "found in the montage"
-    ):
+    with pytest.raises(RuntimeError, match="No channel locations found in the montage"):
         template_to_head(raw.info, "fsaverage", coord_frame="auto")
 
     # test unexpected coordinate frame

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -961,7 +961,7 @@ def test_match(return_bids_test_dir):
     bids_path_01 = BIDSPath(root=bids_root, run="01")
     paths = bids_path_01.match()
     assert len(paths) == 3
-    assert paths[0].basename == ("sub-01_ses-01_task-testing_run-01_channels.tsv")
+    assert paths[0].basename == "sub-01_ses-01_task-testing_run-01_channels.tsv"
 
     bids_path_01 = BIDSPath(root=bids_root, subject="unknown")
     paths = bids_path_01.match()

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -859,7 +859,7 @@ def test_make_filenames():
         datatype="ieeg",
     )
     expected_str = (
-        "sub-one_ses-two_task-three_acq-four_run-1_proc-six_" "rec-seven_ieeg.json"
+        "sub-one_ses-two_task-three_acq-four_run-1_proc-six_rec-seven_ieeg.json"
     )
     assert BIDSPath(**prefix_data).basename == expected_str
     assert (
@@ -902,7 +902,7 @@ def test_make_filenames():
     )  # noqa
 
     # what happens with scans.tsv file
-    with pytest.raises(ValueError, match="scans.tsv file name " "can only contain"):
+    with pytest.raises(ValueError, match="scans.tsv file name can only contain"):
         BIDSPath(
             subject=subject_id,
             session=session_id,
@@ -1188,7 +1188,7 @@ def test_find_empty_room(return_bids_test_dir, tmp_path):
     write_raw_bids(raw, bids_path, overwrite=True, format="FIF")
     with pytest.raises(
         ValueError,
-        match="The provided recording does not " "have a measurement date set",
+        match="The provided recording does not have a measurement date set",
     ):
         bids_path.find_empty_room()
 

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -65,7 +65,7 @@ tiny_bids_root = mne_bids_root / "mne_bids" / "tests" / "data" / "tiny_bids"
 
 warning_str = dict(
     channel_unit_changed="ignore:The unit for chann*.:RuntimeWarning:mne",
-    meas_date_set_to_none="ignore:.*'meas_date' set to None:RuntimeWarning:" "mne",
+    meas_date_set_to_none="ignore:.*'meas_date' set to None:RuntimeWarning:mne",
     nasion_not_found="ignore:.*nasion not found:RuntimeWarning:mne",
     maxshield="ignore:.*Internal Active Shielding:RuntimeWarning:mne",
 )
@@ -100,7 +100,7 @@ def test_not_implemented(tmp_path):
         with open(raw_fname, "w", encoding="utf-8"):
             pass
         with pytest.raises(
-            ValueError, match=("there is no IO support for " "this file format yet")
+            ValueError, match=("there is no IO support for this file format yet")
         ):
             _read_raw(raw_fname)
 
@@ -867,7 +867,7 @@ def test_handle_eeg_coords_reading(tmp_path):
     )
     _update_sidecar(coordsystem_fname, "EEGCoordinateSystem", "besa")
     with pytest.warns(
-        RuntimeWarning, match="is not a BIDS-acceptable " "coordinate frame for EEG"
+        RuntimeWarning, match="is not a BIDS-acceptable coordinate frame for EEG"
     ):
         raw_test = read_raw_bids(bids_path)
         assert raw_test.info["dig"] is None
@@ -939,7 +939,7 @@ def test_handle_ieeg_coords_reading(bids_path, tmp_path):
         electrodes_dict[axis] = np.multiply(orig_electrodes_dict[axis], scaling)
     _to_tsv(electrodes_dict, electrodes_fname)
     with pytest.warns(
-        RuntimeWarning, match="Coordinate unit is not " "an accepted BIDS unit"
+        RuntimeWarning, match="Coordinate unit is not an accepted BIDS unit"
     ):
         raw_test = read_raw_bids(bids_path=bids_fname, verbose=False)
 
@@ -967,9 +967,7 @@ def test_handle_ieeg_coords_reading(bids_path, tmp_path):
         _update_sidecar(coordsystem_fname, "iEEGCoordinateSystem", coord_frame)
         # read in raw file w/ updated coordinate frame
         # and make sure all digpoints are MRI coordinate frame
-        with pytest.warns(
-            RuntimeWarning, match="not an MNE-Python " "coordinate frame"
-        ):
+        with pytest.warns(RuntimeWarning, match="not an MNE-Python coordinate frame"):
             raw_test = read_raw_bids(bids_path=bids_fname, verbose=False)
             assert raw_test.info["dig"] is not None
 
@@ -984,7 +982,7 @@ def test_handle_ieeg_coords_reading(bids_path, tmp_path):
             raw_test = read_raw_bids(bids_path=bids_fname, verbose=False)
         else:
             with pytest.warns(
-                RuntimeWarning, match="not an MNE-Python " "coordinate frame"
+                RuntimeWarning, match="not an MNE-Python coordinate frame"
             ):
                 raw_test = read_raw_bids(bids_path=bids_fname, verbose=False)
         assert raw_test.info["dig"] is not None
@@ -998,9 +996,7 @@ def test_handle_ieeg_coords_reading(bids_path, tmp_path):
 
     # if we delete the coordsystem.json file, an error will be raised
     os.remove(coordsystem_fname)
-    with pytest.raises(
-        RuntimeError, match="BIDS mandates that " "the coordsystem.json"
-    ):
+    with pytest.raises(RuntimeError, match="BIDS mandates that the coordsystem.json"):
         raw = read_raw_bids(bids_path=bids_fname, verbose=False)
 
     # test error message if electrodes is not a subset of Raw
@@ -1014,7 +1010,7 @@ def test_handle_ieeg_coords_reading(bids_path, tmp_path):
     _to_tsv(electrodes_dict, electrodes_fname)
     # popping off channels should not result in an error
     # however, a warning will be raised through mne-python
-    with pytest.warns(RuntimeWarning, match="DigMontage is " "only a subset of info"):
+    with pytest.warns(RuntimeWarning, match="DigMontage is only a subset of info"):
         read_raw_bids(bids_path=bids_fname, verbose=False)
 
     # make sure montage is set if there are coordinates w/ 'n/a'
@@ -1030,7 +1026,7 @@ def test_handle_ieeg_coords_reading(bids_path, tmp_path):
     # electrode coordinates should be nan
     # when coordinate is 'n/a'
     nan_chs = [electrodes_dict["name"][i] for i in [0, 3]]
-    with pytest.warns(RuntimeWarning, match="There are channels " "without locations"):
+    with pytest.warns(RuntimeWarning, match="There are channels without locations"):
         raw = read_raw_bids(bids_path=bids_fname, verbose=False)
         for idx, ch in enumerate(raw.info["chs"]):
             if ch["ch_name"] in nan_chs:

--- a/mne_bids/tests/test_update.py
+++ b/mne_bids/tests/test_update.py
@@ -150,7 +150,7 @@ def test_update_sidecar_jsons(
 
     # error should raise if the file path doesn't exist
     error_bids_path = sidecar_path.copy().update(subject="02")
-    with pytest.raises(RuntimeError, match="Sidecar file " "does not exist."):
+    with pytest.raises(RuntimeError, match="Sidecar file does not exist."):
         update_sidecar_json(error_bids_path, _get_sidecar_json_update_file)
 
 

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -81,7 +81,7 @@ _bids_path_minimal = BIDSPath(subject=subject_id, task=task)
 
 warning_str = dict(
     channel_unit_changed="ignore:The unit for chann*.:RuntimeWarning:mne",
-    meas_date_set_to_none="ignore:.*'meas_date' set to None:RuntimeWarning:" "mne",
+    meas_date_set_to_none="ignore:.*'meas_date' set to None:RuntimeWarning:mne",
     nasion_not_found="ignore:.*nasion not found:RuntimeWarning:mne",
     unraisable_exception="ignore:.*Exception ignored.*:"
     "pytest.PytestUnraisableExceptionWarning",
@@ -1501,7 +1501,7 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate, tmp_path):
 
     # electrodes are not written w/o landmarks
     with pytest.raises(
-        RuntimeError, match="'head' coordinate frame must " "contain nasion"
+        RuntimeError, match="'head' coordinate frame must contain nasion"
     ):
         if warning_to_catch[dir_name] is None:
             write_raw_bids(**kwargs)
@@ -3048,7 +3048,7 @@ def test_coordsystem_json_compliance(
     _write_json(coordsystem_fname, new_coordsystem_json, overwrite=True)
     kwargs.update(bids_path=bids_path.copy().update(run="03"))
     with pytest.raises(
-        RuntimeError, match="Trying to write coordsystem.json, " "but it already exists"
+        RuntimeError, match="Trying to write coordsystem.json, but it already exists"
     ):
         write_raw_bids(**kwargs)
     _write_json(coordsystem_fname, coordsystem_json, overwrite=True)
@@ -3068,7 +3068,7 @@ def test_coordsystem_json_compliance(
         kwargs.update(bids_path=bids_path.copy().update(run="04"))
         with pytest.raises(
             RuntimeError,
-            match="Trying to write electrodes.tsv, " "but it already exists",
+            match="Trying to write electrodes.tsv, but it already exists",
         ):
             write_raw_bids(**kwargs)
 
@@ -3459,7 +3459,7 @@ def test_error_write_meg_as_eeg(dir_name, format, fname, reader, tmp_path):
 
     # if we accidentally add MEG channels, then an error will occur
     raw.set_channel_types({raw.info["ch_names"][0]: "mag"})
-    with pytest.raises(ValueError, match="Got file extension .*" "for MEG data"):
+    with pytest.raises(ValueError, match="Got file extension .*for MEG data"):
         write_raw_bids(**kwargs)
 
 

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -203,7 +203,7 @@ def _age_on_date(bday, exp_date):
 
     """
     if exp_date < bday:
-        raise ValueError("The experimentation date must be after the birth " "date")
+        raise ValueError("The experimentation date must be after the birth date")
     if exp_date.month > bday.month:
         return exp_date.year - bday.year
     elif exp_date.month == bday.month:
@@ -439,7 +439,7 @@ def get_anonymization_daysback(raws, verbose=None):
             daysback_max_list.append(daysback_max)
     if not daysback_min_list or not daysback_max_list:
         raise ValueError(
-            "All measurement dates are None, " "pass any `daysback` value to anonymize."
+            "All measurement dates are None, pass any `daysback` value to anonymize."
         )
     daysback_min = max(daysback_min_list)
     daysback_max = min(daysback_max_list)

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1888,7 +1888,10 @@ def write_raw_bids(
             bids_path.update(extension=".fif")
         elif bids_path.datatype in ["eeg", "ieeg"]:
             if ext not in [".vhdr", ".edf", ".bdf", ".EDF"]:
-                warn("Converting data files to BrainVision format " "for anonymization")
+                warn(
+                    "Converting data files to BrainVision format for anonymization",
+                    stacklevel=2,
+                )
                 convert = True
                 bids_path.update(extension=".vhdr")
     # Read in Raw object and extract metadata from Raw object if needed
@@ -2091,7 +2094,7 @@ def write_raw_bids(
             warn("Converting data files to EEGLAB format")
             _write_raw_eeglab(raw, bids_path.fpath, overwrite=overwrite)
         else:
-            warn("Converting data files to BrainVision format")
+            warn(message="Converting data files to BrainVision format", stacklevel=2)
             bids_path.update(suffix=bids_path.datatype, extension=".vhdr")
             # XXX Should we write durations here too?
             _write_raw_brainvision(

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1888,10 +1888,7 @@ def write_raw_bids(
             bids_path.update(extension=".fif")
         elif bids_path.datatype in ["eeg", "ieeg"]:
             if ext not in [".vhdr", ".edf", ".bdf", ".EDF"]:
-                warn(
-                    "Converting data files to BrainVision format for anonymization",
-                    stacklevel=2,
-                )
+                warn("Converting data files to BrainVision format " "for anonymization")
                 convert = True
                 bids_path.update(extension=".vhdr")
     # Read in Raw object and extract metadata from Raw object if needed
@@ -2094,7 +2091,7 @@ def write_raw_bids(
             warn("Converting data files to EEGLAB format")
             _write_raw_eeglab(raw, bids_path.fpath, overwrite=overwrite)
         else:
-            warn(message="Converting data files to BrainVision format", stacklevel=2)
+            warn("Converting data files to BrainVision format")
             bids_path.update(suffix=bids_path.datatype, extension=".vhdr")
             # XXX Should we write durations here too?
             _write_raw_brainvision(

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1888,7 +1888,7 @@ def write_raw_bids(
             bids_path.update(extension=".fif")
         elif bids_path.datatype in ["eeg", "ieeg"]:
             if ext not in [".vhdr", ".edf", ".bdf", ".EDF"]:
-                warn("Converting data files to BrainVision format " "for anonymization")
+                warn("Converting data files to BrainVision format for anonymization")
                 convert = True
                 bids_path.update(extension=".vhdr")
     # Read in Raw object and extract metadata from Raw object if needed

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -134,7 +134,7 @@ def _channels_tsv(raw, fname, overwrite=False):
         bio="Biological",
         ias="Internal Active Shielding",
         dbs="Deep Brain Stimulation",
-        fnirs_cw_amplitude="Near Infrared Spectroscopy " "(continuous wave)",
+        fnirs_cw_amplitude="Near Infrared Spectroscopy (continuous wave)",
         resp="Respiration",
         gsr="Galvanic skin response (electrodermal activity, EDA)",
         temperature="Temperature",
@@ -999,16 +999,16 @@ def _deface(image, landmarks, deface):
             theta = deface["theta"]
 
     if not _is_numeric(inset):
-        raise ValueError("inset must be numeric (float, int). " "Got %s" % type(inset))
+        raise ValueError(f"inset must be numeric (float, int). Got {type(inset)}")
 
     if not _is_numeric(theta):
-        raise ValueError("theta must be numeric (float, int). " "Got %s" % type(theta))
+        raise ValueError(f"theta must be numeric (float, int). Got {type(theta)}")
 
     if inset < 0:
-        raise ValueError("inset should be positive, " "Got %s" % inset)
+        raise ValueError("inset should be positive, Got {inset}")
 
     if not 0 <= theta < 90:
-        raise ValueError("theta should be between 0 and 90 " "degrees. Got %s" % theta)
+        raise ValueError("theta should be between 0 and 90 degrees. Got {theta}")
 
     # get image data, make a copy
     image_data = image.get_fdata().copy()
@@ -1612,9 +1612,7 @@ def write_raw_bids(
 
     """
     if not isinstance(raw, BaseRaw):
-        raise ValueError(
-            "raw_file must be an instance of BaseRaw, " "got %s" % type(raw)
-        )
+        raise ValueError("raw_file must be an instance of BaseRaw, got %s" % type(raw))
 
     if raw.preload is not False and not allow_preload:
         raise ValueError(
@@ -1663,7 +1661,7 @@ def write_raw_bids(
         )
 
     if events is not None and event_id is None:
-        raise ValueError("You passed events, but no event_id " "dictionary.")
+        raise ValueError("You passed events, but no event_id dictionary.")
 
     _validate_type(
         item=empty_room, item_name="empty_room", types=(mne.io.BaseRaw, BIDSPath, None)
@@ -1702,7 +1700,7 @@ def write_raw_bids(
 
         if symlink and ext != ".fif":
             raise NotImplementedError(
-                "Symlinks are currently only supported " "for FIFF files."
+                "Symlinks are currently only supported for FIFF files."
             )
 
         raw_orig = reader[ext](**raw._init_kwargs)
@@ -2072,7 +2070,7 @@ def write_raw_bids(
                 bids_path.fpath.unlink()
         else:
             raise FileExistsError(
-                f'"{bids_path.fpath}" already exists. ' "Please set overwrite to True."
+                f'"{bids_path.fpath}" already exists. Please set overwrite to True.'
             )
 
     # File saving branching logic
@@ -2590,7 +2588,7 @@ def write_meg_calibration(calibration, bids_path, *, verbose=None):
         raise ValueError("bids_path must have root and subject set.")
     if bids_path.datatype not in (None, "meg"):
         raise ValueError(
-            "Can only write fine-calibration information for MEG " "datasets."
+            "Can only write fine-calibration information for MEG datasets."
         )
 
     _validate_type(
@@ -2660,7 +2658,7 @@ def write_meg_crosstalk(fname, bids_path, verbose=None):
         raise ValueError("bids_path must have root and subject set.")
     if bids_path.datatype not in (None, "meg"):
         raise ValueError(
-            "Can only write fine-calibration information for MEG " "datasets."
+            "Can only write fine-calibration information for MEG datasets."
         )
 
     _validate_type(fname, types=("path-like",), item_name="fname")


### PR DESCRIPTION
<!--
Thanks for contributing this pull request (PR).
If this is your first time, make sure to read
[CONTRIBUTING.md](https://github.com/mne-tools/mne-bids/blob/main/CONTRIBUTING.md)
-->

PR Description
--------------

I propose to change the `stacklevel` of a couple of warnings I encountered, because

```
<ipython-input-34-b78341704568>:1: RuntimeWarning: Converting data files to BrainVision format
```

is really not that informative and I would appreciate to quickly jump to the function issuing the warning.

While I was on it, I fixed probably all the occurrences of `"blabla" "bla"` strings.
I don't believe this minor maintenance PR needs a changelog entry.

Merge checklist
---------------

Maintainer, please confirm the following before merging.
If applicable:

- [ ] All comments are resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] New contributors have been added to [CITATION.cff](https://github.com/mne-tools/mne-bids/blob/main/CITATION.cff)
- [ ] PR description includes phrase "closes <#issue-number>"
