### PR TITLE
[MRG] _return_root_paths now only looks in subfolders of root starting with 'sub-'

### DIFF
--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -2441,6 +2441,10 @@ def _return_root_paths(root, datatype=None, ignore_json=True):
     else:
         paths = [p for p in paths if p.is_file()]
 
+    #only keep files which are of the form root/sub-*, such that we only look in 'sub'-folders
+    root_sub=str(root / 'sub-')
+    paths = [p for p in paths if str(p).startswith(root_sub)]
+
     return paths
 
 

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -2442,7 +2442,7 @@ def _return_root_paths(root, datatype=None, ignore_json=True):
         paths = [p for p in paths if p.is_file()]
 
     # only keep files which are of the form root/sub-*,
-    #  such that we only look in 'sub'-folders:
+    # such that we only look in 'sub'-folders:
     root_sub = str(root / "sub-")
     paths = [p for p in paths if str(p).startswith(root_sub)]
 

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -2441,7 +2441,8 @@ def _return_root_paths(root, datatype=None, ignore_json=True):
     else:
         paths = [p for p in paths if p.is_file()]
 
-    # only keep files which are of the form root/sub-*, such that we only look in 'sub'-folders
+    # only keep files which are of the form root/sub-*,
+    #  such that we only look in 'sub'-folders:
     root_sub = str(root / "sub-")
     paths = [p for p in paths if str(p).startswith(root_sub)]
 

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -2441,8 +2441,8 @@ def _return_root_paths(root, datatype=None, ignore_json=True):
     else:
         paths = [p for p in paths if p.is_file()]
 
-    #only keep files which are of the form root/sub-*, such that we only look in 'sub'-folders
-    root_sub=str(root / 'sub-')
+    # only keep files which are of the form root/sub-*, such that we only look in 'sub'-folders
+    root_sub = str(root / "sub-")
     paths = [p for p in paths if str(p).startswith(root_sub)]
 
     return paths


### PR DESCRIPTION

PR Description
--------------

In relation to this issue: https://github.com/mne-tools/mne-bids/issues/1127

I now submit this pull request. It's a pretty simple solution - after calling root.rglob(pattern), returned paths are filtered such that only those starting with root / 'sub-' are sent on. 

This closes #1127

Merge checklist
---------------

Maintainer, please confirm the following before merging.
If applicable:

- [ ] All comments are resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] New contributors have been added to [CITATION.cff](https://github.com/mne-tools/mne-bids/blob/main/CITATION.cff)
- [ ] PR description includes phrase "closes <#issue-number>"
