### PR TITLE
[MRG] auto-add event_id key for BAD_ACQ_SKIP

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -28,6 +28,7 @@ The following authors had contributed before. Thank you for sticking around! �
 * `Laetitia Fesselier`_
 * `Richard Höchenberger`_
 * `Stefan Appelhoff`_
+* `Daniel McCloy`_
 
 Detailed list of changes
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -46,6 +47,8 @@ Detailed list of changes
   For example, If ``run=1`` is passed to MNE-BIDS, it will no longer be silently auto-converted to ``run-01``, by `Alex Rockhill`_ (:gh:`1215`)
 - MNE-BIDS will no longer warn about missing leading punctuation marks for extensions passed :class:`~mne_bids.BIDSPath`.
   For example, MNE-BIDS will now silently auto-convert ``edf`` to ```.edf``, by `Alex Rockhill`_ (:gh:`1215`)
+- MNE-BIDS will no longer error during `~mne_bids.write_raw_bids` if there are ``BAD_ACQ_SKIP`` annotations in the raw file and no corresponding key in ``event_id``.
+  Instead, it will automatically add the necessary key and assign an unused integer event code to it. By `Daniel McCloy`_ (:gh:`1258`)
 
 🛠 Requirements
 ^^^^^^^^^^^^^^^

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -158,11 +158,9 @@ def _read_events(events, event_id, raw, bids_path=None):
             # auto-add entries to `event_id` for "special" annotation values
             # (but only if they're needed)
             if set(desc_without_id) & special_annots:
-                existing_ids = set(event_id.values())
                 for annot in special_annots:
-                    # don't change value if key is present; use a value guaranteed to
-                    # not be in use
-                    event_id.setdefault(annot, max(existing_ids) + 1)
+                    # use a value guaranteed to not be in use
+                    event_id = {annot: max(event_id.values()) + 1} | event_id
                 # remove the "special" annots from the list of problematic annots
                 desc_without_id = sorted(set(desc_without_id) - special_annots)
             if desc_without_id:

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -151,9 +151,20 @@ def _read_events(events, event_id, raw, bids_path=None):
                 'To specify custom event codes, please pass "event_id".'
             )
         else:
+            special_annots = {"BAD_ACQ_SKIP"}
             desc_without_id = sorted(
                 set(raw.annotations.description) - set(event_id.keys())
             )
+            # auto-add entries to `event_id` for "special" annotation values
+            # (but only if they're needed)
+            if set(desc_without_id) & special_annots:
+                existing_ids = set(event_id.values())
+                for annot in special_annots:
+                    # don't change value if key is present; use a value guaranteed to
+                    # not be in use
+                    event_id.setdefault(annot, max(existing_ids) + 1)
+                # remove the "special" annots from the list of problematic annots
+                desc_without_id = sorted(set(desc_without_id) - special_annots)
             if desc_without_id:
                 raise ValueError(
                     f"The provided raw data contains annotations, but "

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -160,7 +160,7 @@ def _read_events(events, event_id, raw, bids_path=None):
             if set(desc_without_id) & special_annots:
                 for annot in special_annots:
                     # use a value guaranteed to not be in use
-                    event_id = {annot: max(event_id.values()) + 1} | event_id
+                    event_id = {annot: max(event_id.values()) + 90000} | event_id
                 # remove the "special" annots from the list of problematic annots
                 desc_without_id = sorted(set(desc_without_id) - special_annots)
             if desc_without_id:

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -590,13 +590,16 @@ def test_adding_essential_annotations_to_dict(tmp_path):
     )
     raw.set_annotations(annotations)
     events = mne.find_events(raw)
+    event_id = sample_data_event_id.copy()
+    obj_id = id(event_id)
 
     # see that no error is raised for missing event_id key for BAD_ACQ_SKIP
     bids_path = BIDSPath(subject="01", task="task", datatype="meg", root=tmp_path)
     with pytest.warns(RuntimeWarning, match="Acquisition skips detected"):
-        write_raw_bids(
-            raw, bids_path, overwrite=True, events=events, event_id=sample_data_event_id
-        )
+        write_raw_bids(raw, bids_path, overwrite=True, events=events, event_id=event_id)
+    # make sure we didn't modify the user-passed dict
+    assert event_id == sample_data_event_id
+    assert obj_id == id(event_id)
 
 
 @pytest.mark.filterwarnings(warning_str["channel_unit_changed"])


### PR DESCRIPTION
<!--
Thanks for contributing this pull request (PR).
If this is your first time, make sure to read
[CONTRIBUTING.md](https://github.com/mne-tools/mne-bids/blob/main/CONTRIBUTING.md)
-->

PR Description
--------------

closes #1257 

`write_raw_bids` will now allow the situation where `BAD_ACQ_SKIP` annotations are present in the raw file, but no corresponding key is present in the user-passed `event_id` dict.

Merge checklist
---------------

Maintainer, please confirm the following before merging.
If applicable:

- [ ] All comments are resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [x] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [x] New contributors have been added to [CITATION.cff](https://github.com/mne-tools/mne-bids/blob/main/CITATION.cff)
- [x] PR description includes phrase "closes <#issue-number>"
