### PR TITLE
Maint: FIX CI failures (HED related)

### DIFF
--- a/doc/sphinxext/gen_cli.py
+++ b/doc/sphinxext/gen_cli.py
@@ -43,14 +43,14 @@ Here we list the MNE-BIDS tools that you can use from the command line.
 
 command_rst = """
 
-.. _gen_%s:
+.. _gen_{0}:
 
-%s
-%s
+{1}
+{2}
 
 .. rst-class:: callout
 
-%s
+{3}
 
 """
 
@@ -104,8 +104,7 @@ def generate_cli_rst(app=None):
                 output.insert(ii + 4, "")
             output = "\n".join(output)
             f.write(
-                command_rst
-                % (
+                command_rst.format(
                     cmd_name,
                     cmd_name.replace("mne_bids_", "mne_bids "),
                     "=" * len(cmd_name),

--- a/mne_bids/sidecar_updates.py
+++ b/mne_bids/sidecar_updates.py
@@ -225,7 +225,7 @@ def update_anat_landmarks(
 
     if bids_path_mri.suffix is None:
         raise ValueError(
-            'Please specify the "suffix" entity of the provided ' "bids_path."
+            'Please specify the "suffix" entity of the provided bids_path.'
         )
     elif bids_path_mri.suffix not in ("T1w", "FLASH"):
         raise ValueError(

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -117,10 +117,10 @@ def test_not_implemented(tmp_path):
 def test_read_correct_inputs():
     """Test that inputs of read functions are correct."""
     bids_path = "sub-01_ses-01_meg.fif"
-    with pytest.raises(RuntimeError, match='"bids_path" must be a ' "BIDSPath object"):
+    with pytest.raises(RuntimeError, match='"bids_path" must be a BIDSPath object'):
         read_raw_bids(bids_path)
 
-    with pytest.raises(RuntimeError, match='"bids_path" must be a ' "BIDSPath object"):
+    with pytest.raises(RuntimeError, match='"bids_path" must be a BIDSPath object'):
         get_head_mri_trans(bids_path)
 
 

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -320,7 +320,7 @@ def test_write_correct_inputs():
     raw = _read_raw_fif(raw_fname)
 
     bids_path_str = "sub-01_ses-01_meg.fif"
-    with pytest.raises(RuntimeError, match='"bids_path" must be a ' "BIDSPath object"):
+    with pytest.raises(RuntimeError, match='"bids_path" must be a BIDSPath object'):
         write_raw_bids(raw, bids_path_str)
 
     bids_path = _bids_path.copy()
@@ -377,7 +377,7 @@ def test_make_dataset_description(tmp_path, monkeypatch):
 
     # Check we raise warnings and errors where appropriate
     with pytest.raises(
-        ValueError, match='`dataset_type` must be either "raw" ' 'or "derivative."'
+        ValueError, match='`dataset_type` must be either "raw" or "derivative."'
     ):
         make_dataset_description(path=tmp_path, name="tst", dataset_type="src")
 
@@ -1450,7 +1450,6 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate, tmp_path):
         overwrite=True,
         dataset_type="raw",
         ethics_approvals=["approved by S."],
-        hed_version="No HED used (just testing)",
     )
     dataset_description_fpath = op.join(bids_root, "dataset_description.json")
     with open(dataset_description_fpath, encoding="utf-8") as f:
@@ -1755,7 +1754,7 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate, tmp_path):
         elif dir_name == "CNT":
             with pytest.warns(
                 RuntimeWarning,
-                match='Encountered data in "int" format. ' "Converting to float32.",
+                match='Encountered data in "int" format. Converting to float32.',
             ):
                 write_raw_bids(**kwargs)
                 output_path = _test_anonymize(tmp_path / "c", raw, bids_path)
@@ -1765,7 +1764,7 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate, tmp_path):
         elif dir_name == "curry":
             with pytest.warns(
                 RuntimeWarning,
-                match='Encountered data in "int" format. ' "Converting to float32.",
+                match='Encountered data in "int" format. Converting to float32.',
             ):
                 write_raw_bids(**kwargs)
                 output_path = _test_anonymize(tmp_path / "d", raw, bids_path)
@@ -3352,13 +3351,13 @@ def test_convert_eeg_formats(dir_name, format, fname, reader, tmp_path):
         elif dir_name == "CNT":
             with pytest.warns(
                 RuntimeWarning,
-                match='Encountered data in "int" format. ' "Converting to float32.",
+                match='Encountered data in "int" format. Converting to float32.',
             ):
                 bids_output_path = write_raw_bids(**kwargs)
         elif dir_name == "curry":
             with pytest.warns(
                 RuntimeWarning,
-                match='Encountered data in "int" format. ' "Converting to float32.",
+                match='Encountered data in "int" format. Converting to float32.',
             ):
                 bids_output_path = write_raw_bids(**kwargs)
         else:

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -222,7 +222,7 @@ def _write_json(fname, dictionary, overwrite=False):
     """Write JSON to a file."""
     if op.exists(fname) and not overwrite:
         raise FileExistsError(
-            f'"{fname}" already exists. ' "Please set overwrite to True."
+            f'"{fname}" already exists. Please set overwrite to True.'
         )
 
     json_output = json.dumps(dictionary, indent=4)
@@ -238,7 +238,7 @@ def _write_tsv(fname, dictionary, overwrite=False, verbose=None):
     """Write an ordered dictionary to a .tsv file."""
     if op.exists(fname) and not overwrite:
         raise FileExistsError(
-            f'"{fname}" already exists. ' "Please set overwrite to True."
+            f'"{fname}" already exists. Please set overwrite to True.'
         )
     _to_tsv(dictionary, fname)
 
@@ -249,7 +249,7 @@ def _write_text(fname, text, overwrite=False):
     """Write text to a file."""
     if op.exists(fname) and not overwrite:
         raise FileExistsError(
-            f'"{fname}" already exists. ' "Please set overwrite to True."
+            f'"{fname}" already exists. Please set overwrite to True.'
         )
     with open(fname, "w", encoding="utf-8-sig") as fid:
         fid.write(text)

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1341,8 +1341,6 @@ def make_dataset_description(
         ]
     )
 
-    # remove HED
-
     # Handle potentially existing file contents
     if op.isfile(fname):
         with open(fname, encoding="utf-8-sig") as fin:

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1282,7 +1282,7 @@ def make_dataset_description(
 
     # Perform input checks
     if dataset_type not in ["raw", "derivative"]:
-        raise ValueError('`dataset_type` must be either "raw" or ' '"derivative."')
+        raise ValueError('`dataset_type` must be either "raw" or "derivative."')
     if isinstance(doi, str):
         if not doi.startswith("doi:"):
             warn(
@@ -1301,7 +1301,7 @@ def make_dataset_description(
         for i in generated_by:
             if "Name" not in i:
                 raise ValueError(
-                    '"Name" is a required field for each dict in ' "generated_by"
+                    '"Name" is a required field for each dict in generated_by'
                 )
             if not set(i.keys()).issubset(generated_by_keys):
                 raise ValueError(msg_key.format(i.keys() - generated_by_keys))
@@ -1340,6 +1340,8 @@ def make_dataset_description(
             ("SourceDatasets", source_datasets),
         ]
     )
+
+    # remove HED
 
     # Handle potentially existing file contents
     if op.isfile(fname):
@@ -1832,7 +1834,7 @@ def write_raw_bids(
         del er_bids_path, er_date, er_session
     elif isinstance(empty_room, BIDSPath):
         if bids_path.datatype != "meg":
-            raise ValueError('"empty_room" is only supported for ' "MEG data.")
+            raise ValueError('"empty_room" is only supported for MEG data.')
         if data_is_emptyroom:
             raise ValueError(
                 "You cannot write empty-room data and pass "
@@ -2543,7 +2545,7 @@ def mark_channels(bids_path, *, ch_names, status, descriptions=None, verbose=Non
 
     if not all(status in ["good", "bad"] for status in status):
         raise ValueError(
-            "Setting the status of a channel must only be " '"good", or "bad".'
+            'Setting the status of a channel must only be "good", or "bad".'
         )
 
     # Read sidecar and create required columns if they do not exist.
@@ -2552,7 +2554,7 @@ def mark_channels(bids_path, *, ch_names, status, descriptions=None, verbose=Non
         tsv_data["status"] = ["good"] * len(tsv_data["name"])
 
     if "status_description" not in tsv_data:
-        logger.info('No "status_description" column found in input file. ' "Creating.")
+        logger.info('No "status_description" column found in input file. Creating.')
         tsv_data["status_description"] = ["n/a"] * len(tsv_data["name"])
 
     # Now actually mark the user-requested channels as bad.


### PR DESCRIPTION
Intended to solve current CI failures (and some more fixed on the side).

I think the current failures may have to do with: 

- https://github.com/bids-standard/bids-validator/pull/2014#issuecomment-2223687024

and we used to write something like:

```Python
hed_version="No HED used (just testing)",
```
