### PR TITLE
Add event metadata handling

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -187,6 +187,10 @@ authors:
       family-names: Benitez
       affiliation: 'Magnetoencephalography Core, National Institutes of Health, Bethesda, Maryland, USA'
       orcid: 'https://orcid.org/0000-0001-6364-7272'
+    - given-names: Thomas
+      family-names: Hartmann
+      affiliation: 'Paris-Lodron-University Salzburg, Centre for Cogntitive Neuroscience, Department of Psychology, Salzburg, Austria'
+      orcid: 'https://orcid.org/0000-0002-8298-8125'
     - given-names: Alexandre
       family-names: Gramfort
       affiliation: 'Université Paris-Saclay, Inria, CEA, Palaiseau, France'

--- a/doc/authors.rst
+++ b/doc/authors.rst
@@ -48,3 +48,4 @@
 .. _Julius Welzel: https://github.com/JuliusWelzel
 .. _Kaare Mikkelsen: https://github.com/kaare-mikkelsen
 .. _Amaia Benitez: https://github.com/AmaiaBA
+.. _Thomas Hartmann: https://github.com/thht

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -19,6 +19,7 @@ The following authors contributed for the first time. Thank you so much! 🤩
 
 * `Kaare Mikkelsen`_
 * `Amaia Benitez`_
+* `Thomas Hartmann`_
 
 The following authors had contributed before. Thank you for sticking around! 🤘
 
@@ -33,6 +34,7 @@ Detailed list of changes
 ^^^^^^^^^^^^^^^
 
 - :meth:`mne_bids.BIDSPath.match()` and :func:`mne_bids.find_matching_paths` now have additional parameters ``ignore_json`` and ``ignore_nosub``, to give users more control over which type of files are matched, by `Kaare Mikkelsen`_ (:gh:`1281`)
+- :func:`mne_bids.write_raw_bids()` can now handle event metadata as a pandas DataFrame, by `Thomas Hartmann`_ (:gh:`1285`)
 
 🧐 API and behavior changes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -4151,7 +4151,12 @@ def test_write_evt_metadata(_bids_validate, tmp_path):
 
     bids_path = _bids_path.copy().update(root=bids_root, datatype="meg")
     write_raw_bids(
-        raw, bids_path=bids_path, events=events, event_metadata=event_metadata, overwrite=True
+        raw, bids_path=bids_path, events=events, event_metadata=event_metadata, overwrite=True,
+        extra_columns_descriptions={
+            'direction': 'The direction of the stimulus',
+            'event_type': 'The type of the event',
+            'stimulus_kind': 'The stimulus modality'
+        }
     )
     _bids_validate(bids_root)
     events_tsv_path = bids_path.copy().update(suffix="events", extension=".tsv")

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -4154,3 +4154,14 @@ def test_write_evt_metadata(_bids_validate, tmp_path):
         raw, bids_path=bids_path, events=events, event_metadata=event_metadata, overwrite=True
     )
     _bids_validate(bids_root)
+    events_tsv_path = bids_path.copy().update(suffix="events", extension=".tsv")
+    events_json_path = events_tsv_path.copy().update(extension=".json")
+
+    assert events_tsv_path.fpath.exists()
+    assert events_json_path.fpath.exists()
+
+    events_json = json.loads(events_json_path.fpath.read_text())
+    events_tsv = _from_tsv(events_tsv_path)
+    for cur_col in event_metadata.columns:
+        assert cur_col in events_tsv
+        assert cur_col in events_json

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -4162,6 +4162,10 @@ def test_write_evt_metadata(_bids_validate, tmp_path):
 
     events_json = json.loads(events_json_path.fpath.read_text())
     events_tsv = _from_tsv(events_tsv_path)
+
+    assert 'trial_type' not in events_tsv
+    assert 'trial_type' not in events_json
+
     for cur_col in event_metadata.columns:
         assert cur_col in events_tsv
         assert cur_col in events_json

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -4123,40 +4123,45 @@ def test_write_evt_metadata(_bids_validate, tmp_path):
     raw_fname = data_path / "MEG" / "sample" / "sample_audvis_trunc_raw.fif"
     raw = _read_raw_fif(raw_fname)
     events = mne.find_events(raw, initial_event=True)
-    event_id = {"auditory/left": 1, "auditory/right": 2}
     df_list = []
     for idx, event in enumerate(events):
         direction = None
         if event[2] in (1, 3):
-            direction = 'left'
+            direction = "left"
         elif event[2] in (2, 4):
-            direction = 'right'
+            direction = "right"
 
-        event_type = 'button_press' if event[2] == 32 else 'stimulus'
+        event_type = "button_press" if event[2] == 32 else "stimulus"
         stimulus_kind = None
         if event[2] == 5:
-            stimulus_kind = 'smiley'
+            stimulus_kind = "smiley"
         elif event[2] in (1, 2):
-            stimulus_kind = 'auditory'
+            stimulus_kind = "auditory"
         elif event[2] in (3, 4):
-            stimulus_kind = 'visual'
+            stimulus_kind = "visual"
 
-        df_list.append({
-            'direction': direction,
-            'event_type': event_type,
-            'stimulus_kind': stimulus_kind
-        })
+        df_list.append(
+            {
+                "direction": direction,
+                "event_type": event_type,
+                "stimulus_kind": stimulus_kind,
+            }
+        )
 
     event_metadata = pd.DataFrame(df_list)
 
     bids_path = _bids_path.copy().update(root=bids_root, datatype="meg")
     write_raw_bids(
-        raw, bids_path=bids_path, events=events, event_metadata=event_metadata, overwrite=True,
+        raw,
+        bids_path=bids_path,
+        events=events,
+        event_metadata=event_metadata,
+        overwrite=True,
         extra_columns_descriptions={
-            'direction': 'The direction of the stimulus',
-            'event_type': 'The type of the event',
-            'stimulus_kind': 'The stimulus modality'
-        }
+            "direction": "The direction of the stimulus",
+            "event_type": "The type of the event",
+            "stimulus_kind": "The stimulus modality",
+        },
     )
     _bids_validate(bids_root)
     events_tsv_path = bids_path.copy().update(suffix="events", extension=".tsv")
@@ -4168,8 +4173,8 @@ def test_write_evt_metadata(_bids_validate, tmp_path):
     events_json = json.loads(events_json_path.fpath.read_text())
     events_tsv = _from_tsv(events_tsv_path)
 
-    assert 'trial_type' not in events_tsv
-    assert 'trial_type' not in events_json
+    assert "trial_type" not in events_tsv
+    assert "trial_type" not in events_json
 
     for cur_col in event_metadata.columns:
         assert cur_col in events_tsv

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -266,7 +266,9 @@ def _get_fid_coords(dig_points, raise_error=True):
     return fid_coords, coord_frame
 
 
-def _events_tsv(events, durations, raw, fname, trial_type, event_metadata=None, overwrite=False):
+def _events_tsv(
+    events, durations, raw, fname, trial_type, event_metadata=None, overwrite=False
+):
     """Create an events.tsv file and save it.
 
     This function will write the mandatory 'onset', and 'duration' columns as
@@ -371,10 +373,12 @@ def _events_json(fname, extra_columns=None, has_trial_type=True, overwrite=False
     }
 
     if has_trial_type:
-        new_data["trial_type"] = {"Description": "The type, category, or name of the event."}
+        new_data["trial_type"] = {
+            "Description": "The type, category, or name of the event."
+        }
 
     for key, value in extra_columns.items():
-        new_data[key] = {'Description': value}
+        new_data[key] = {"Description": value}
 
     # make sure to append any JSON fields added by the user
     fname = Path(fname)
@@ -1694,15 +1698,23 @@ def write_raw_bids(
         )
 
     if events is not None and event_id is None and event_metadata is None:
-        raise ValueError("You passed events, but no event_id dictionary or event_metadata.")
+        raise ValueError(
+            "You passed events, but no event_id dictionary " "or event_metadata."
+        )
 
     if event_metadata is not None and extra_columns_descriptions is None:
-        raise ValueError("You passed event_metadata, but no extra_columns_descriptions dictionary.")
+        raise ValueError(
+            "You passed event_metadata, but no "
+            "extra_columns_descriptions dictionary."
+        )
 
     if event_metadata is not None:
         for column in event_metadata.columns:
             if column not in extra_columns_descriptions:
-                raise ValueError(f"Extra column {column} in event_metadata is not described in extra_columns_descriptions.")
+                raise ValueError(
+                    f"Extra column {column} in event_metadata "
+                    f"is not described in extra_columns_descriptions."
+                )
 
     _validate_type(
         item=empty_room, item_name="empty_room", types=(mne.io.BaseRaw, BIDSPath, None)
@@ -1997,7 +2009,10 @@ def write_raw_bids(
     # Write events.
     if not data_is_emptyroom:
         events_array, event_dur, event_desc_id_map = _read_events(
-            events, event_id, raw, bids_path=bids_path,
+            events,
+            event_id,
+            raw,
+            bids_path=bids_path,
         )
 
         if event_metadata is not None:
@@ -2015,8 +2030,12 @@ def write_raw_bids(
             )
             has_trial_type = event_desc_id_map is not None
 
-            _events_json(fname=events_json_path.fpath, extra_columns=extra_columns_descriptions,
-                         has_trial_type=has_trial_type, overwrite=overwrite)
+            _events_json(
+                fname=events_json_path.fpath,
+                extra_columns=extra_columns_descriptions,
+                has_trial_type=has_trial_type,
+                overwrite=overwrite,
+            )
         # Kepp events_array around for BrainVision writing below.
         del event_desc_id_map, events, event_id, event_dur
 

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -292,6 +292,9 @@ def _events_tsv(
     trial_type : dict | None
         Dictionary mapping a brief description key to an event id (value). For
         example {'Go': 1, 'No Go': 2}.
+    event_metadata : pd.DataFrame | None
+        Additional metadata to be stored in the events.tsv file. Must have one
+        row per event.
     overwrite : bool
         Whether to overwrite the existing file.
         Defaults to False.
@@ -335,6 +338,10 @@ def _events_json(fname, extra_columns=None, has_trial_type=True, overwrite=False
     ----------
     fname : str | mne_bids.BIDSPath
         Output filename.
+    extra_columns : dict | None
+        Dictionary with additional columns to be added to the events.json file.
+    has_trial_type : bool
+        Whether the events.tsv file should contain a 'trial_type' column.
     overwrite : bool
         Whether to overwrite the output file if it exists.
     """
@@ -1494,6 +1501,11 @@ def write_raw_bids(
         contains :class:`~mne.Annotations`, you can use this parameter to
         assign event codes to each unique annotation description (mapping from
         description to event code).
+    event_metadata : pd.DataFrame | None
+        Metadata for each event in ``events``. Each row corresponds to an event.
+    extra_columns_descriptions : dict | None
+        A dictionary that maps column names of the ``event_metadata`` to descriptions.
+        Each column of ``event_metadata`` must have a corresponding entry in this.
     anonymize : dict | None
         If `None` (default), no anonymization is performed.
         If a dictionary, data will be anonymized depending on the dictionary

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -319,6 +319,10 @@ def _events_tsv(events, durations, raw, fname, trial_type, event_metadata=None, 
     else:
         del data["trial_type"]
 
+    if event_metadata is not None:
+        for key, values in event_metadata.items():
+            data[key] = values
+
     _write_tsv(fname, data, overwrite)
 
 
@@ -1978,6 +1982,10 @@ def write_raw_bids(
         events_array, event_dur, event_desc_id_map = _read_events(
             events, event_id, raw, bids_path=bids_path,
         )
+
+        if event_metadata is not None:
+            event_desc_id_map = None
+
         if events_array.size != 0:
             _events_tsv(
                 events=events_array,

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -292,7 +292,7 @@ def _events_tsv(
     trial_type : dict | None
         Dictionary mapping a brief description key to an event id (value). For
         example {'Go': 1, 'No Go': 2}.
-    event_metadata : pd.DataFrame | None
+    event_metadata : pandas.DataFrame | None
         Additional metadata to be stored in the events.tsv file. Must have one
         row per event.
     overwrite : bool
@@ -1501,7 +1501,7 @@ def write_raw_bids(
         contains :class:`~mne.Annotations`, you can use this parameter to
         assign event codes to each unique annotation description (mapping from
         description to event code).
-    event_metadata : pd.DataFrame | None
+    event_metadata : pandas.DataFrame | None
         Metadata for each event in ``events``. Each row corresponds to an event.
     extra_columns_descriptions : dict | None
         A dictionary that maps column names of the ``event_metadata`` to descriptions.


### PR DESCRIPTION
<!--
Thanks for contributing this pull request (PR).
If this is your first time, make sure to read
[CONTRIBUTING.md](https://github.com/mne-tools/mne-bids/blob/main/CONTRIBUTING.md)
-->

PR Description
--------------

So far, mne-bids only uses `event_id` to handle events. However, we really like and use the event metadata functionality of MNE Python. So, here is an update that you can also use event metadata as an alternative.

Merge checklist
---------------

Maintainer, please confirm the following before merging.
If applicable:

- [ ] All comments are resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] New contributors have been added to [CITATION.cff](https://github.com/mne-tools/mne-bids/blob/main/CITATION.cff)
- [ ] PR description includes phrase "closes <#issue-number>"
