### PR TITLE
MAINT: Bump to 3.10 min req

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -113,8 +113,8 @@ jobs:
   test:
     # For GitHub "required" CI checks, add in branch protection:
     #
-    # 6 checks:
-    # for each OS (ubuntu, macos, macos-13, windows):
+    # 8 checks:
+    # for each machine type (ubuntu, macos, macos-13, windows):
     # (NOTE: macos-13=x86_64, macos>13=arm64)
     # 3.10 / mne-stable / full / validator-stable
     # 3.12 / mne-stable / full / validator-stable

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -114,11 +114,12 @@ jobs:
     # For GitHub "required" CI checks, add in branch protection:
     #
     # 6 checks:
-    # for each OS (ubuntu, macos, windows):
+    # for each OS (ubuntu, macos, macos-13, windows):
+    # (NOTE: macos-13=x86_64, macos>13=arm64)
     # 3.10 / mne-stable / full / validator-stable
     # 3.12 / mne-stable / full / validator-stable
     #
-    # 5 additional checks with alternative MNE-Python and BIDS validator versions:
+    # 3 additional checks with alternative MNE-Python and BIDS validator versions:
     # ubuntu / 3.12 / mne-main / full / validator-main
     # ubuntu / 3.10 / mne-prev / full / validator-stable
     # ubuntu / 3.12 / mne-stable / minimal / validator-stable

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -47,7 +47,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.9", "3.12"]  # Oldest and newest supported versions
+        python-version: ["3.10", "3.12"]  # Oldest and newest supported versions
     steps:
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
@@ -115,38 +115,26 @@ jobs:
     #
     # 6 checks:
     # for each OS (ubuntu, macos, windows):
-    # 3.9 / mne-stable / full / validator-stable
-    # 3.12 / mne-stable / full / validator-stable
-    #
-    # 1 additional check for Apple Silicon (doesn't support Python 3.9):
+    # 3.10 / mne-stable / full / validator-stable
     # 3.12 / mne-stable / full / validator-stable
     #
     # 5 additional checks with alternative MNE-Python and BIDS validator versions:
     # ubuntu / 3.12 / mne-main / full / validator-main
-    # ubuntu / 3.9 / mne-prev / full / validator-stable
+    # ubuntu / 3.10 / mne-prev / full / validator-stable
     # ubuntu / 3.12 / mne-stable / minimal / validator-stable
     timeout-minutes: 60
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.9", "3.12"]  # Oldest and newest supported versions
+        os: [ubuntu-latest, macos-latest, macos-13, windows-latest]
+        python-version: ["3.10", "3.12"]  # Oldest and newest supported versions
         mne-version: [mne-stable]
         mne-bids-install: [full]
         bids-validator-version: [validator-stable]
 
         include:
           # special test runs running only on single CI systems to save resources
-          #
-          # macOS-14 (Apple Silicon) only works with Python 3.10+
-          # Once we drop support for Python 3.9, move it to the "proper" matrix above.
-          - os: macos-14
-            python-version: "3.12"
-            mne-version: mne-stable
-            mne-bids-install: full
-            bids-validator-version: validator-stable
-
           # Test development versions
           - os: ubuntu-latest
             python-version: "3.12"
@@ -155,7 +143,7 @@ jobs:
             bids-validator-version: validator-main
           # Test previous MNE stable version
           - os: ubuntu-latest
-            python-version: "3.9"
+            python-version: "3.10"
             mne-version: mne-prev-stable
             mne-bids-install: full
             bids-validator-version: validator-stable
@@ -198,13 +186,13 @@ jobs:
     - name: Install MNE (stable)
       if: matrix.mne-version == 'mne-stable'
       run: |
-        git clone --single-branch --branch maint/1.6 https://github.com/mne-tools/mne-python.git
+        git clone --single-branch --branch maint/1.8 https://github.com/mne-tools/mne-python.git
         python -m pip install -e ./mne-python
 
     - name: Install MNE (previous stable)
       if: matrix.mne-version == 'mne-prev-stable'
       run: |
-        git clone --single-branch --branch maint/1.6 https://github.com/mne-tools/mne-python.git
+        git clone --single-branch --branch maint/1.7 https://github.com/mne-tools/mne-python.git
         python -m pip install -e ./mne-python
 
     - name: Install MNE (main)

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -191,9 +191,10 @@ jobs:
 
     - name: Install MNE (previous stable)
       if: matrix.mne-version == 'mne-prev-stable'
+      # Have to install NumPy<2.1 here because of a change in positional arg handling + MNE 1.7
       run: |
         git clone --single-branch --branch maint/1.7 https://github.com/mne-tools/mne-python.git
-        python -m pip install -e ./mne-python
+        python -m pip install -e ./mne-python "numpy<2.1"
 
     - name: Install MNE (main)
       if: matrix.mne-version == 'mne-main'

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -45,6 +45,7 @@ Detailed list of changes
 ^^^^^^^^^^^^^^^
 
 - MNE-BIDS now requires MNE-Python 1.6.0 or higher.
+- MNE-BIDS now requires Python 3.10 or higher.
 
 🪲 Bug fixes
 ^^^^^^^^^^^^

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -1473,7 +1473,7 @@ def search_folder_for_text(
 def _check_max_depth(max_depth):
     """Check that max depth is a proper input."""
     msg = "`max_depth` must be a positive integer or None"
-    if not isinstance(max_depth, (int, type(None))):
+    if not isinstance(max_depth, int | type(None)):
         raise ValueError(msg)
     if max_depth is None:
         max_depth = float("inf")
@@ -2217,7 +2217,7 @@ def _infer_datatype(*, root, sub, ses):
 
 def _path_to_str(var):
     """Make sure var is a string or Path, return string representation."""
-    if not isinstance(var, (Path, str)):
+    if not isinstance(var, Path | str):
         raise ValueError(
             f"All path parameters must be either strings or "
             f"pathlib.Path objects. Found type {type(var)}."

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -14,7 +14,6 @@ from io import StringIO
 from os import path as op
 from pathlib import Path
 from textwrap import indent
-from typing import Optional
 
 import numpy as np
 from mne.utils import _check_fname, _validate_type, logger, verbose
@@ -448,7 +447,7 @@ class BIDSPath:
         return Path(data_path)
 
     @property
-    def subject(self) -> Optional[str]:
+    def subject(self) -> str | None:
         """The subject ID."""
         return self._subject
 
@@ -457,7 +456,7 @@ class BIDSPath:
         self.update(subject=value)
 
     @property
-    def session(self) -> Optional[str]:
+    def session(self) -> str | None:
         """The acquisition session."""
         return self._session
 
@@ -466,7 +465,7 @@ class BIDSPath:
         self.update(session=value)
 
     @property
-    def task(self) -> Optional[str]:
+    def task(self) -> str | None:
         """The experimental task."""
         return self._task
 
@@ -475,7 +474,7 @@ class BIDSPath:
         self.update(task=value)
 
     @property
-    def run(self) -> Optional[str]:
+    def run(self) -> str | None:
         """The run number."""
         return self._run
 
@@ -484,7 +483,7 @@ class BIDSPath:
         self.update(run=value)
 
     @property
-    def acquisition(self) -> Optional[str]:
+    def acquisition(self) -> str | None:
         """The acquisition parameters."""
         return self._acquisition
 
@@ -493,7 +492,7 @@ class BIDSPath:
         self.update(acquisition=value)
 
     @property
-    def processing(self) -> Optional[str]:
+    def processing(self) -> str | None:
         """The processing label."""
         return self._processing
 
@@ -502,7 +501,7 @@ class BIDSPath:
         self.update(processing=value)
 
     @property
-    def recording(self) -> Optional[str]:
+    def recording(self) -> str | None:
         """The recording name."""
         return self._recording
 
@@ -511,7 +510,7 @@ class BIDSPath:
         self.update(recording=value)
 
     @property
-    def space(self) -> Optional[str]:
+    def space(self) -> str | None:
         """The coordinate space for an anatomical or sensor position file."""
         return self._space
 
@@ -520,7 +519,7 @@ class BIDSPath:
         self.update(space=value)
 
     @property
-    def description(self) -> Optional[str]:
+    def description(self) -> str | None:
         """The description entity."""
         return self._description
 
@@ -529,7 +528,7 @@ class BIDSPath:
         self.update(description=value)
 
     @property
-    def suffix(self) -> Optional[str]:
+    def suffix(self) -> str | None:
         """The filename suffix."""
         return self._suffix
 
@@ -538,7 +537,7 @@ class BIDSPath:
         self.update(suffix=value)
 
     @property
-    def root(self) -> Optional[Path]:
+    def root(self) -> Path | None:
         """The root directory of the BIDS dataset."""
         return self._root
 
@@ -547,7 +546,7 @@ class BIDSPath:
         self.update(root=value)
 
     @property
-    def datatype(self) -> Optional[str]:
+    def datatype(self) -> str | None:
         """The BIDS data type, e.g. ``'anat'``, ``'meg'``, ``'eeg'``."""
         return self._datatype
 
@@ -556,7 +555,7 @@ class BIDSPath:
         self.update(datatype=value)
 
     @property
-    def split(self) -> Optional[str]:
+    def split(self) -> str | None:
         """The split of the continuous recording file for ``.fif`` data."""
         return self._split
 
@@ -565,7 +564,7 @@ class BIDSPath:
         self.update(split=value)
 
     @property
-    def extension(self) -> Optional[str]:
+    def extension(self) -> str | None:
         """The extension of the filename, including a leading period."""
         return self._extension
 

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -2057,9 +2057,8 @@ def get_entity_vals(
 
     for filename in filenames:
         # Skip ignored directories
-        # XXX In Python 3.9, we can use Path.is_relative_to() here
         if any(
-            [str(filename).startswith(str(ignore_dir)) for ignore_dir in ignore_dirs]
+            [Path(filename).is_relative_to(ignore_dir) for ignore_dir in ignore_dirs]
         ):
             continue
 

--- a/mne_bids/tsv_handler.py
+++ b/mne_bids/tsv_handler.py
@@ -153,7 +153,7 @@ def _from_tsv(fname, dtypes=None):
     data_dict = OrderedDict()
     if dtypes is None:
         dtypes = [str] * info.shape[1]
-    if not isinstance(dtypes, (list, tuple)):
+    if not isinstance(dtypes, list | tuple):
         dtypes = [dtypes] * info.shape[1]
     if not len(dtypes) == info.shape[1]:
         raise ValueError(

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -210,7 +210,7 @@ def _age_on_date(bday, exp_date):
 def _check_types(variables):
     """Make sure all vars are str or None."""
     for var in variables:
-        if not isinstance(var, (str, type(None))):
+        if not isinstance(var, str | type(None)):
             raise ValueError(
                 f"You supplied a value ({var}) of type "
                 f"{type(var)}, where a string or None was "
@@ -271,7 +271,7 @@ def _get_mrk_meas_date(mrk):
     """Find the measurement date from a KIT marker file."""
     info = get_kit_info(mrk, False)[0]
     meas_date = info.get("meas_date", None)
-    if isinstance(meas_date, (tuple, list, np.ndarray)):
+    if isinstance(meas_date, tuple | list | np.ndarray):
         meas_date = meas_date[0]
     if isinstance(meas_date, datetime):
         meas_datetime = meas_date

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -90,7 +90,7 @@ _FIFF_SPLIT_SIZE = "2GB"  # MNE-Python default; can be altered during debugging
 
 
 def _is_numeric(n):
-    return isinstance(n, (np.integer, np.floating, int, float))
+    return isinstance(n, np.integer | np.floating | int | float)
 
 
 def _channels_tsv(raw, fname, overwrite=False):
@@ -459,7 +459,7 @@ def _participants_tsv(raw, subject_id, fname, overwrite=False):
         if isinstance(age, tuple):  # can be removed once MNE >= 1.8 is required
             age = date(*age)
         meas_date = raw.info.get("meas_date", None)
-        if isinstance(meas_date, (tuple, list, np.ndarray)):
+        if isinstance(meas_date, tuple | list | np.ndarray):
             meas_date = meas_date[0]
 
         if meas_date is not None and age is not None:
@@ -2267,7 +2267,7 @@ def _get_t1w_mgh(fs_subject, fs_subjects_dir):
 def _get_landmarks(landmarks, image_nii, kind=""):
     import nibabel as nib
 
-    if isinstance(landmarks, (str, Path)):
+    if isinstance(landmarks, str | Path):
         landmarks, coord_frame = read_fiducials(landmarks)
         landmarks = np.array(
             [landmark["r"] for landmark in landmarks], dtype=float

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ maintainers = [
 ]
 license = { text = "BSD-3-Clause" }
 readme = { file = "README.md", content-type = "text/markdown" }
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 keywords = [
     "meg",
     "eeg",
@@ -151,4 +151,6 @@ filterwarnings = [
     "ignore:datetime\\.datetime\\.utcfromtimestamp.* is deprecated and scheduled for removal in a future version.*:DeprecationWarning",
     # matplotlib
     "ignore:Figure.*is non-interactive.*cannot be shown:UserWarning",
+    # NumPy 2.1 bug (probably)
+    "ignore:__array__ implementation doesn.*:DeprecationWarning",
 ]


### PR DESCRIPTION
Suggested move to require 3.10+. Clean up something that could have been cleaned up once 3.9+ was required. Clean up incorrect installation versions for stable and prev-stable (which used to be the same!).