### PR TITLE
FIX: Workaround header dropdown rendering issue

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -124,11 +124,6 @@ templates_path = ["_templates"]
 html_static_path = ["_static"]
 html_css_files = ["style.css"]
 
-# The number of items that will appear in the header before the dropdown menu kicks in
-html_theme_options = {
-  "header_links_before_dropdown": 6,
-}
-
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
@@ -150,6 +145,7 @@ html_theme_options = {
     "use_edit_page_button": False,
     "navigation_with_keys": False,
     "show_toc_level": 1,
+    "header_links_before_dropdown": 6,
     "navbar_end": ["theme-switcher", "version-switcher", "navbar-icon-links"],
     "analytics": dict(google_analytics_id="G-C8SH9E98QC"),
     "switcher": {

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -124,6 +124,11 @@ templates_path = ["_templates"]
 html_static_path = ["_static"]
 html_css_files = ["style.css"]
 
+# The number of items that will appear in the header before the dropdown menu kicks in
+html_theme_options = {
+  "header_links_before_dropdown": 6,
+}
+
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.


### PR DESCRIPTION
Closes #1295 

On the mne-bids website, this suppresses the dropdown from kicking in the header bar. Instead, this just shows all 6 items in the header bar (before, 5 items were shown in the header, 1 item in the dropdown menu).

If a dropdown is ever introduced again, the issue raised in #1295 may rear its head again.

> [!NOTE]
> - Locally, I'm not seeing this new variable actually change the dropdown behavior. I wanted to open up the PR nonetheless  to see if the change takes effect in the built docs here

Merge checklist
---------------

Maintainer, please confirm the following before merging.
If applicable:

- [ ] All comments are resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] New contributors have been added to [CITATION.cff](https://github.com/mne-tools/mne-bids/blob/main/CITATION.cff)
- [ ] PR description includes phrase "closes <#issue-number>"
