### PR TITLE
deprecate empty list as indicator for marking all channels

### DIFF
--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -2490,7 +2490,7 @@ def test_mark_channels(
     # Mark `existing_ch_names` as bad in raw and sidecar TSV before we
     # begin our actual tests, which should then add additional channels
     # to the list of bads, retaining the ones we're specifying here.
-    mark_channels(ch_names=[], bids_path=bids_path, status="good", verbose=False)
+    mark_channels(ch_names="all", bids_path=bids_path, status="good", verbose=False)
     _bids_validate(bids_root)
     raw = read_raw_bids(bids_path=bids_path, verbose=False)
     # Order is not preserved
@@ -2560,7 +2560,8 @@ def test_mark_channel_roundtrip(tmp_path):
 
     ch_names = raw.ch_names
     # first mark all channels as good
-    mark_channels(bids_path, ch_names=[], status="good", verbose=False)
+    with pytest.warns(FutureWarning, match=r"`mark_channels\(\.\.\., ch_names=\[\]\)`"):
+        mark_channels(bids_path, ch_names=[], status="good", verbose=False)
     tsv_data = _from_tsv(channels_fname)
     assert all(status == "good" for status in tsv_data["status"])
 


### PR DESCRIPTION
PR Description
--------------

paves the way for future change in behavior of `mark_channels(..., ch_names=[])` from marking all channels to marking no channels.

Closes #1294 

Merge checklist
---------------

Maintainer, please confirm the following before merging.
If applicable:

- [ ] All comments are resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] New contributors have been added to [CITATION.cff](https://github.com/mne-tools/mne-bids/blob/main/CITATION.cff)
- [ ] PR description includes phrase "closes <#issue-number>"
