### PR TITLE
Fix participant tsv values when `Info` contains weight and height information as numpy arrays

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -56,6 +56,7 @@ Detailed list of changes
 
 - When anonymizing the date of a recording, MNE-BIDS will no longer error during `~mne_bids.write_raw_bids` if passing a `~mne.io.Raw` instance to ``empty_room``, by `Daniel McCloy`_ (:gh:`1270`)
 - Dealing with alphanumeric ``sub`` entity labels is now fixed for :func:`~mne_bids.write_raw_bids`, by `Aaron Earle-Richardson`_ (:gh:`1291`)
+- When processing subject_info data that MNE Python imports as numpy arrays with only one item, MNE-BIDS now unpacks these, resulting in a correct participants.tsv, by `Thomas Hartmann`_ (:gh:`1310`)
 
 ⚕️ Code health
 ^^^^^^^^^^^^^^

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -4188,7 +4188,7 @@ def test_write_evt_metadata(_bids_validate, tmp_path):
         assert cur_col in events_tsv
         assert cur_col in events_json
 
-
+# XXX: Remove once MNE-Python <1.9 is no longer supported
 @testing.requires_testing_data
 def test_write_bids_with_age_weight_info(tmp_path, monkeypatch):
     """Test writing participant.tsv when using np.arrays for weight and height."""

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -4188,6 +4188,7 @@ def test_write_evt_metadata(_bids_validate, tmp_path):
         assert cur_col in events_tsv
         assert cur_col in events_json
 
+
 # XXX: Remove once MNE-Python <1.9 is no longer supported
 @testing.requires_testing_data
 def test_write_bids_with_age_weight_info(tmp_path, monkeypatch):

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -4187,3 +4187,21 @@ def test_write_evt_metadata(_bids_validate, tmp_path):
     for cur_col in event_metadata.columns:
         assert cur_col in events_tsv
         assert cur_col in events_json
+
+
+@testing.requires_testing_data
+def test_write_bids_with_age_weight_info(tmp_path):
+    """Test writing participant.tsv when using np.arrays for weight and height."""
+    bids_root = tmp_path / "bids"
+    raw_fname = data_path / "MEG" / "sample" / "sample_audvis_trunc_raw.fif"
+    raw = _read_raw_fif(raw_fname)
+    raw.info['subject_info'] = {
+        'weight': np.array([75.]),
+        'height': np.array([180.]),
+    }
+
+    bids_path = _bids_path.copy().update(root=bids_root, datatype="meg", run=1)
+    write_raw_bids(raw, bids_path=bids_path)
+    bids_path = _bids_path.copy().update(root=bids_root, datatype="meg", run=2)
+    write_raw_bids(raw, bids_path=bids_path)
+

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -4195,13 +4195,12 @@ def test_write_bids_with_age_weight_info(tmp_path):
     bids_root = tmp_path / "bids"
     raw_fname = data_path / "MEG" / "sample" / "sample_audvis_trunc_raw.fif"
     raw = _read_raw_fif(raw_fname)
-    raw.info['subject_info'] = {
-        'weight': np.array([75.]),
-        'height': np.array([180.]),
+    raw.info["subject_info"] = {
+        "weight": np.array([75.0]),
+        "height": np.array([180.0]),
     }
 
     bids_path = _bids_path.copy().update(root=bids_root, datatype="meg", run=1)
     write_raw_bids(raw, bids_path=bids_path)
     bids_path = _bids_path.copy().update(root=bids_root, datatype="meg", run=2)
     write_raw_bids(raw, bids_path=bids_path)
-

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -4219,7 +4219,7 @@ def test_write_bids_with_age_weight_info(tmp_path):
         },
     )
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="more than one element"):
         bids_path = _bids_path.copy().update(root=bids_root, datatype="meg", run=3)
         write_raw_bids(raw, bids_path=bids_path)
 

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -4204,3 +4204,23 @@ def test_write_bids_with_age_weight_info(tmp_path):
     write_raw_bids(raw, bids_path=bids_path)
     bids_path = _bids_path.copy().update(root=bids_root, datatype="meg", run=2)
     write_raw_bids(raw, bids_path=bids_path)
+
+    # Test that we get a value error when we have more than one item
+    raw.info["subject_info"] = {
+        "weight": np.array([75.0, 10.2]),
+        "height": np.array([180.0]),
+    }
+
+    with pytest.raises(ValueError):
+        bids_path = _bids_path.copy().update(root=bids_root, datatype="meg", run=3)
+        write_raw_bids(raw, bids_path=bids_path)
+
+    # Test that scalar data is handled correctly
+
+    raw.info["subject_info"] = {
+        "weight": 75.0,
+        "height": np.array([180.0]),
+    }
+
+    bids_path = _bids_path.copy().update(root=bids_root, datatype="meg", run=3)
+    write_raw_bids(raw, bids_path=bids_path)

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -4195,10 +4195,14 @@ def test_write_bids_with_age_weight_info(tmp_path):
     bids_root = tmp_path / "bids"
     raw_fname = data_path / "MEG" / "sample" / "sample_audvis_trunc_raw.fif"
     raw = _read_raw_fif(raw_fname)
-    raw.info["subject_info"] = {
-        "weight": np.array([75.0]),
-        "height": np.array([180.0]),
-    }
+    dict.__setitem__(
+        raw.info,
+        "subject_info",
+        {
+            "weight": np.array([75.0]),
+            "height": np.array([180.0]),
+        },
+    )
 
     bids_path = _bids_path.copy().update(root=bids_root, datatype="meg", run=1)
     write_raw_bids(raw, bids_path=bids_path)
@@ -4206,21 +4210,28 @@ def test_write_bids_with_age_weight_info(tmp_path):
     write_raw_bids(raw, bids_path=bids_path)
 
     # Test that we get a value error when we have more than one item
-    raw.info["subject_info"] = {
-        "weight": np.array([75.0, 10.2]),
-        "height": np.array([180.0]),
-    }
+    dict.__setitem__(
+        raw.info,
+        "subject_info",
+        {
+            "weight": np.array([75.0, 10.2]),
+            "height": np.array([180.0]),
+        },
+    )
 
     with pytest.raises(ValueError):
         bids_path = _bids_path.copy().update(root=bids_root, datatype="meg", run=3)
         write_raw_bids(raw, bids_path=bids_path)
 
     # Test that scalar data is handled correctly
-
-    raw.info["subject_info"] = {
-        "weight": 75.0,
-        "height": np.array([180.0]),
-    }
+    dict.__setitem__(
+        raw.info,
+        "subject_info",
+        {
+            "weight": 75.0,
+            "height": np.array([180.0]),
+        },
+    )
 
     bids_path = _bids_path.copy().update(root=bids_root, datatype="meg", run=3)
     write_raw_bids(raw, bids_path=bids_path)

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -525,8 +525,10 @@ def _participants_tsv(raw, subject_id, fname, overwrite=False):
                 if len(cur_item) == 1:
                     new_value.append(cur_item[0])
                 else:
-                    raise ValueError(f"Value for key {key} is a list with more "
-                                     f"than one element. This is not supported.")
+                    raise ValueError(
+                        f"Value for key {key} is a list with more "
+                        f"than one element. This is not supported."
+                    )
             else:
                 new_value.append(cur_item)
 

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -515,8 +515,6 @@ def _participants_tsv(raw, subject_id, fname, overwrite=False):
     # contain scalars (i.e. not further lists). Fix if possible
     for key in data.keys():
         cur_value = data[key]
-        if not isinstance(cur_value, list):
-            cur_value = [cur_value]
 
         # Check if all values are scalars
         new_value = []

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -525,7 +525,8 @@ def _participants_tsv(raw, subject_id, fname, overwrite=False):
                 else:
                     raise ValueError(
                         f"Value for key {key} is a list with more "
-                        f"than one element. This is not supported."
+                        f"than one element. This is not supported. "
+                        f"Got: {cur_value}."
                     )
             else:
                 new_value.append(cur_item)

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -511,6 +511,27 @@ def _participants_tsv(raw, subject_id, fname, overwrite=False):
         }
     )
 
+    # Make sure that all entries to data are lists that
+    # contain scalars (i.e. not further lists). Fix if possible
+    for key in data.keys():
+        cur_value = data[key]
+        if not isinstance(cur_value, list):
+            cur_value = [cur_value]
+
+        # Check if all values are scalars
+        new_value = []
+        for cur_item in cur_value:
+            if isinstance(cur_item, list | tuple | np.ndarray):
+                if len(cur_item) == 1:
+                    new_value.append(cur_item[0])
+                else:
+                    raise ValueError(f"Value for key {key} is a list with more "
+                                     f"than one element. This is not supported.")
+            else:
+                new_value.append(cur_item)
+
+        data[key] = new_value
+
     if os.path.exists(fname):
         orig_data = _from_tsv(fname)
         # whether the new data exists identically in the previous data

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -511,6 +511,7 @@ def _participants_tsv(raw, subject_id, fname, overwrite=False):
         }
     )
 
+    # XXX: Remove once MNE-Python <1.9 is no longer supported
     # Make sure that all entries to data are lists that
     # contain scalars (i.e. not further lists). Fix if possible
     for key in data.keys():


### PR DESCRIPTION
<!--
Thanks for contributing this pull request (PR).
If this is your first time, make sure to read
[CONTRIBUTING.md](https://github.com/mne-tools/mne-bids/blob/main/CONTRIBUTING.md)
-->

PR Description
--------------

We have raw fiff files at our institution that produce weight and height information as numpy arrays when read with the standard mne functions. These values are not unpacked so they end up as arrays in the participant.tsv. This also leads to wrong behavior when a second run for the same participant and session is written as the detection for already existing rows in participant.tsv then fails. Check the added test for an example and simulation.

This PR adds some sanitation to the handling of participant data, namely making sure that no nested lists/arrays are in there. If it does find a nested list/array and the inner array only has one item, that item gets pulled up. Otherwise, it throws an exception.

Merge checklist
---------------

Maintainer, please confirm the following before merging.
If applicable:

- [ ] All comments are resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] New contributors have been added to [CITATION.cff](https://github.com/mne-tools/mne-bids/blob/main/CITATION.cff)
- [ ] PR description includes phrase "closes <#issue-number>"
