### PR TITLE
adapt bids-validator url

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -213,13 +213,13 @@ jobs:
       if: matrix.bids-validator-version == 'validator-main'
       run: |
         pushd ..
-        git clone --depth 1 https://github.com/bids-standard/bids-validator
+        git clone --depth 1 https://github.com/bids-standard/legacy-validator
         popd
 
     - name: Install BIDS validator (main)
       if: matrix.bids-validator-version == 'validator-main'
       run: |
-        pushd ../bids-validator
+        pushd ../legacy-validator
         # Generate the full development node_modules
         npm install
         # Build & bundle the bids-validator CLI package


### PR DESCRIPTION
See:

- https://github.com/bids-standard/legacy-validator/issues/2179

We should finish:

- #1288 

... and then retire the legacy validator.