### PR TITLE
gh upload artifact: also hidden files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           name: dist
           path: dist
+          include-hidden-files: true
 
   pypi-upload:
     needs: package

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -310,3 +310,4 @@ jobs:
       with:
         name: documentation
         path: doc/_build/html
+        include-hidden-files: true


### PR DESCRIPTION
The default was changed to `false` upstream, but we want to have files like `.nojekyll` uploaded.

https://github.com/actions/upload-artifact?tab=readme-ov-file#v4---whats-new