### PR TITLE
[MRG] Adding eye tracking to ch map

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -198,6 +198,10 @@ authors:
       family-names: Turner
       affiliation: 'Wu Tsai Neurosciences Institute, Stanford University'
       orcid: 'https://orcid.org/0000-0001-8639-9769'
+    - given-names: Christian
+      family-names: O'Reilly
+      affiliation: 'Computer Science and Engineering, University of South Carolina'
+      orcid: 'https://orcid.org/0000-0002-3149-4934'
     - given-names: Alexandre
       family-names: Gramfort
       affiliation: 'Université Paris-Saclay, Inria, CEA, Palaiseau, France'

--- a/doc/authors.rst
+++ b/doc/authors.rst
@@ -51,3 +51,4 @@
 .. _Tom Donoghue: https://github.com/TomDonoghue
 .. _William Turner: https://bootstrapbill.github.io/
 .. _Yorguin Mantilla: https://github.com/yjmantilla
+.. _Christian O'Reilly: https://github.com/christian-oreilly

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -17,7 +17,7 @@ Version 0.17 (unreleased)
 
 The following authors contributed for the first time. Thank you so much! 🤩
 
-* Nobody yet
+* `Christian O'Reilly`_
 
 The following authors had contributed before. Thank you for sticking around! 🤘
 
@@ -29,7 +29,8 @@ Detailed list of changes
 🚀 Enhancements
 ^^^^^^^^^^^^^^^
 
-- Nothing yet
+- :func:`mne_bids.write_raw_bids()` can now handle mne `Raw` objects with `eyegaze` and `pupil` channels, by `Christian O'Reilly`_ (:gh:`1344`)
+
 
 🧐 API and behavior changes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -87,6 +87,9 @@ def _get_ch_type_mapping(fro="mne", to="bids"):
             ias="MEGOTHER",
             syst="MEGOTHER",
             exci="MEGOTHER",
+            # Eye tracking
+            eyegaze="EYEGAZE",
+            pupil="PUPIL",
         )
 
     elif fro == "bids" and to == "mne":
@@ -110,6 +113,9 @@ def _get_ch_type_mapping(fro="mne", to="bids"):
             VEOG="eog",
             HEOG="eog",
             DBS="dbs",
+            # Eye tracking
+            EYEGAZE="eyegaze",
+            PUPIL="pupil",
         )
     else:
         raise ValueError(


### PR DESCRIPTION
<!--
Thanks for contributing this pull request (PR).
If this is your first time, make sure to read
[CONTRIBUTING.md](https://github.com/mne-tools/mne-bids/blob/main/CONTRIBUTING.md)
-->

PR Description
--------------

Very small PR just adding eye-tracking types to the channel mapping. Without this, MNE Raw objects with eye-tracking data cannot be exported to BIDS. Exporting with this change seems to fix the bug. We also had to make sure there were not NaNs in the raw objects using 

```python
def fillna(raw, fill_val=0):
    return mne.io.RawArray(np.nan_to_num(raw.get_data(), nan=fill_val), raw.info)
```

but I did not include this in the PR as it seems like a larger issue.

Related to #1342. Not sure if enough to close that issue. 

Merge checklist
---------------

Maintainer, please confirm the following before merging.
If applicable:

- [x] All comments are resolved
- [ ] This is not your own PR
- [x] All CIs are happy
- [x] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [x] New contributors have been added to [CITATION.cff](https://github.com/mne-tools/mne-bids/blob/main/CITATION.cff)
- [ ] PR description includes phrase "closes <#issue-number>"
