### PR TITLE
optionally return event_id dict from read_raw_bids, and use value column from events file if present

### DIFF
--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -587,7 +587,7 @@ def _handle_events_reading(events_fname, raw):
     # Worst case: all events become `n/a` and all values become `1`
     else:
         descrs = np.full(len(events_dict["onset"]), "n/a")
-        event_id = dict((descrs[0], 1))
+        event_id = {descrs[0]: 1}
     # Deal with "n/a" strings before converting to float
     ons = np.asarray(events_dict["onset"], dtype=float)
     durs = np.array(

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -573,23 +573,31 @@ def _handle_events_reading(events_fname, raw):
                             f"    Renaming event: {trial_type} -> " f"{new_name}"
                         )
                         trial_types[ii] = new_name
+            # for making the event_id dict, we can drop any where `value` is `n/a`
+            events_dict_culled = _drop(events_dict, "n/a", "value")
+            event_id = dict(
+                zip(
+                    events_dict_culled[trial_type_col_name],
+                    np.asarray(events_dict_culled["value"], dtype=int),
+                )
+            )
         else:
-            values = np.arange(len(trial_types))
+            event_id = dict(zip(trial_types, np.arange(len(trial_types))))
         descriptions = np.asarray(trial_types, dtype=str)
     elif "value" in events_dict:
         # If we don't have a proper description of the events, perhaps we have
         # at least an event value?
         # Drop events unrelated to value
         events_dict = _drop(events_dict, "n/a", "value")
-        values = events_dict["value"]
+        values = events_dict["value"].astype(int)
         descriptions = np.asarray(values, dtype=str)
+        event_id = dict(zip(descriptions, values))
 
     # Worst case, we go with 'n/a' for all events
     else:
         descriptions = np.array(["n/a"] * len(events_dict["onset"]), dtype=str)
         values = np.ones_like(descriptions)
-
-    event_id = dict(zip(descriptions, values))
+        event_id = dict(zip(descriptions, values))
     # Deal with "n/a" strings before converting to float
     onsets = np.array(
         [np.nan if on == "n/a" else on for on in events_dict["onset"]], dtype=float

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -534,6 +534,9 @@ def _handle_events_reading(events_fname, raw):
     logger.info(f"Reading events from {events_fname}.")
     events_dict = _from_tsv(events_fname)
 
+    # drop events where onset is n/a
+    events_dict = _drop(events_dict, "n/a", "onset")
+
     # Get the descriptions of the events
     if "trial_type" in events_dict:
         trial_type_col_name = "trial_type"
@@ -605,13 +608,6 @@ def _handle_events_reading(events_fname, raw):
     durations = np.array(
         [0 if du == "n/a" else du for du in events_dict["duration"]], dtype=float
     )
-
-    # Keep only events where onset is known
-    good_events_idx = ~np.isnan(onsets)
-    onsets = onsets[good_events_idx]
-    durations = durations[good_events_idx]
-    descriptions = descriptions[good_events_idx]
-    del good_events_idx
 
     # Add events as Annotations, but keep essential Annotations present in
     # raw file

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -582,27 +582,21 @@ def _handle_events_reading(events_fname, raw):
             )
         else:
             event_id = dict(zip(trial_types, np.arange(len(trial_types))))
-        descriptions = np.asarray(trial_types, dtype=str)
+        descrs = np.asarray(trial_types, dtype=str)
 
     # Worst case: all events become `n/a` and all values become `1`
     else:
-        descriptions = np.array(["n/a"] * len(events_dict["onset"]), dtype=str)
-        event_id = dict((descriptions[0], 1))
+        descrs = np.full(len(events_dict["onset"]), "n/a")
+        event_id = dict((descrs[0], 1))
     # Deal with "n/a" strings before converting to float
-    onsets = np.array(
-        [np.nan if on == "n/a" else on for on in events_dict["onset"]], dtype=float
-    )
-    durations = np.array(
+    ons = np.asarray(events_dict["onset"], dtype=float)
+    durs = np.array(
         [0 if du == "n/a" else du for du in events_dict["duration"]], dtype=float
     )
 
     # Add events as Annotations, but keep essential Annotations present in raw file
     annot_from_raw = raw.annotations.copy()
-
-    annot_from_events = mne.Annotations(
-        onset=onsets, duration=durations, description=descriptions
-    )
-    raw.set_annotations(annot_from_events)
+    annot_from_events = mne.Annotations(onset=ons, duration=durs, description=descrs)
 
     annot_idx_to_keep = [
         idx
@@ -612,8 +606,9 @@ def _handle_events_reading(events_fname, raw):
     annot_to_keep = annot_from_raw[annot_idx_to_keep]
 
     if len(annot_to_keep):
-        raw.set_annotations(raw.annotations + annot_to_keep)
+        annot_from_events += annot_to_keep
 
+    raw.set_annotations(annot_from_events)
     return raw, event_id
 
 

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -597,6 +597,7 @@ def _handle_events_reading(events_fname, raw):
     # Add events as Annotations, but keep essential Annotations present in raw file
     annot_from_raw = raw.annotations.copy()
     annot_from_events = mne.Annotations(onset=ons, duration=durs, description=descrs)
+    raw.set_annotations(annot_from_events)
 
     annot_idx_to_keep = [
         idx
@@ -606,9 +607,8 @@ def _handle_events_reading(events_fname, raw):
     annot_to_keep = annot_from_raw[annot_idx_to_keep]
 
     if len(annot_to_keep):
-        annot_from_events += annot_to_keep
+        raw.set_annotations(raw.annotations + annot_to_keep)
 
-    raw.set_annotations(annot_from_events)
     return raw, event_id
 
 

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -509,7 +509,7 @@ def test_handle_events_reading(tmp_path):
     events_fname.parent.mkdir()
     _to_tsv(events, events_fname)
 
-    raw = _handle_events_reading(events_fname, raw)
+    raw, _ = _handle_events_reading(events_fname, raw)
     events, event_id = mne.events_from_annotations(raw)
 
     # Test with a `stim_type` column instead of `trial_type`.
@@ -523,7 +523,7 @@ def test_handle_events_reading(tmp_path):
     _to_tsv(events, events_fname)
 
     with pytest.warns(RuntimeWarning, match="This column should be renamed"):
-        raw = _handle_events_reading(events_fname, raw)
+        raw, _ = _handle_events_reading(events_fname, raw)
     events, event_id = mne.events_from_annotations(raw)
 
     # Test with same `trial_type` referring to different `value`:
@@ -538,7 +538,7 @@ def test_handle_events_reading(tmp_path):
     events_fname.parent.mkdir()
     _to_tsv(events, events_fname)
 
-    raw = _handle_events_reading(events_fname, raw)
+    raw, _ = _handle_events_reading(events_fname, raw)
     events, event_id = mne.events_from_annotations(raw)
 
     assert len(events) == 5
@@ -555,7 +555,7 @@ def test_handle_events_reading(tmp_path):
     events_fname.parent.mkdir()
     _to_tsv(events, events_fname)
 
-    raw = _handle_events_reading(events_fname, raw)
+    raw, _ = _handle_events_reading(events_fname, raw)
     events, event_id = mne.events_from_annotations(raw)
     ids = list(event_id.keys())
     assert len(ids) == 1

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -509,8 +509,11 @@ def test_handle_events_reading(tmp_path):
     events_fname.parent.mkdir()
     _to_tsv(events, events_fname)
 
-    raw, _ = _handle_events_reading(events_fname, raw)
-    events, event_id = mne.events_from_annotations(raw)
+    raw, event_id = _handle_events_reading(events_fname, raw)
+    ev_arr, ev_dict = mne.events_from_annotations(raw)
+    assert list(ev_dict.values()) == [1, 2]  # auto-assigned
+    want = len(events["onset"]) - 1  # one onset was n/a
+    assert want == len(raw.annotations) == len(ev_arr) == len(ev_dict)
 
     # Test with a `stim_type` column instead of `trial_type`.
     events = {
@@ -526,6 +529,21 @@ def test_handle_events_reading(tmp_path):
         raw, _ = _handle_events_reading(events_fname, raw)
     events, event_id = mne.events_from_annotations(raw)
 
+    # Test with only a `value` column.
+    events = {
+        "onset": [11, 12, 13, 14, 15],
+        "duration": ["n/a", "n/a", 0.1, 0.1, "n/a"],
+        "value": [3, 1, 1, 3, "n/a"],
+    }
+    events_fname = tmp_path / "bids3" / "sub-01_task-test_events.json"
+    events_fname.parent.mkdir()
+    _to_tsv(events, events_fname)
+
+    raw, event_id = _handle_events_reading(events_fname, raw)
+    ev_arr, ev_dict = mne.events_from_annotations(raw, event_id=event_id)
+    assert len(ev_arr) == len(events["value"]) - 1  # one value was n/a
+    assert {"1": 1, "3": 3} == event_id == ev_dict
+
     # Test with same `trial_type` referring to different `value`:
     # The events should be renamed automatically
     events = {
@@ -534,32 +552,32 @@ def test_handle_events_reading(tmp_path):
         "trial_type": ["event1", "event1", "event2", "event3", "event3"],
         "value": [1, 2, 3, 4, "n/a"],
     }
-    events_fname = tmp_path / "bids3" / "sub-01_task-test_events.json"
-    events_fname.parent.mkdir()
-    _to_tsv(events, events_fname)
-
-    raw, _ = _handle_events_reading(events_fname, raw)
-    events, event_id = mne.events_from_annotations(raw)
-
-    assert len(events) == 5
-    assert "event1/1" in event_id
-    assert "event1/2" in event_id
-    assert "event3/4" in event_id
-    assert "event3/na" in event_id  # 'n/a' value should become 'na'
-    # The event with unique value mapping should not be renamed
-    assert "event2" in event_id
-
-    # Test without any kind of event description.
-    events = {"onset": [11, 12, "n/a"], "duration": ["n/a", "n/a", "n/a"]}
     events_fname = tmp_path / "bids4" / "sub-01_task-test_events.json"
     events_fname.parent.mkdir()
     _to_tsv(events, events_fname)
 
-    raw, _ = _handle_events_reading(events_fname, raw)
-    events, event_id = mne.events_from_annotations(raw)
-    ids = list(event_id.keys())
-    assert len(ids) == 1
-    assert ids == ["n/a"]
+    raw, event_id = _handle_events_reading(events_fname, raw)
+    ev_arr, ev_dict = mne.events_from_annotations(raw)
+    # `event_id` will exclude the last event, as its value is `n/a`, but `ev_dict` won't
+    # exclude it (it's made from annotations, which don't know about missing `value`s)
+    assert len(event_id) == len(ev_dict) - 1
+    # check the renaming
+    assert len(ev_arr) == 5
+    assert "event1/1" in ev_dict
+    assert "event1/2" in ev_dict
+    assert "event3/4" in ev_dict
+    assert "event3/na" in ev_dict  # 'n/a' value should become 'na'
+    assert "event2" in ev_dict  # has unique value mapping; should not be renamed
+
+    # Test without any kind of event description.
+    events = {"onset": [11, 12, "n/a"], "duration": ["n/a", "n/a", "n/a"]}
+    events_fname = tmp_path / "bids5" / "sub-01_task-test_events.json"
+    events_fname.parent.mkdir()
+    _to_tsv(events, events_fname)
+
+    raw, event_id = _handle_events_reading(events_fname, raw)
+    ev_arr, ev_dict = mne.events_from_annotations(raw)
+    assert event_id == ev_dict == {"n/a": 1}  # fallback behavior
 
 
 @pytest.mark.filterwarnings(warning_str["channel_unit_changed"])


### PR DESCRIPTION
PR Description
--------------

closes #223 

I opted for @hoechenberger's suggestion in https://github.com/mne-tools/mne-bids/issues/223#issuecomment-964165378, namely, to allow `read_raw_bids` to optionally return an `event_id` dict; when a `values` column is present in `events.tsv` it will use those values for the integer IDs. That dict can then be passed to `mne.events_from_annotations` to recover the original events array.

Merge checklist
---------------

Maintainer, please confirm the following before merging.
If applicable:

- [ ] All comments are resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] New contributors have been added to [CITATION.cff](https://github.com/mne-tools/mne-bids/blob/main/CITATION.cff)
- [x] PR description includes phrase "closes <#issue-number>"
