### PR TITLE
WIP Rework mne bids path match

### DIFF
--- a/doc/authors.rst
+++ b/doc/authors.rst
@@ -5,10 +5,12 @@
 .. _Amaia Benitez: https://github.com/AmaiaBA
 .. _Anand Saini: https://github.com/anandsaini024
 .. _Ariel Rokem: https://github.com/arokem
+.. _Arne Gottwald: https://github.com/waldie11
 .. _Austin Hurst: https://github.com/a-hurst
 .. _Berk Gerçek: https://github.com/berkgercek
 .. _Bruno Hebling Vieira: https://github.com/bhvieira
 .. _Chris Holdgraf: https://bids.berkeley.edu/people/chris-holdgraf
+.. _Christian O'Reilly: https://github.com/christian-oreilly
 .. _Clemens Brunner: https://github.com/cbrnr
 .. _Daniel McCloy: http://dan.mccloy.info
 .. _Denis Engemann: https://github.com/dengemann
@@ -52,4 +54,3 @@
 .. _Tom Donoghue: https://github.com/TomDonoghue
 .. _William Turner: https://bootstrapbill.github.io/
 .. _Yorguin Mantilla: https://github.com/yjmantilla
-.. _Christian O'Reilly: https://github.com/christian-oreilly

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -19,6 +19,7 @@ The following authors contributed for the first time. Thank you so much! 🤩
 
 * `Christian O'Reilly`_
 * `Berk Gerçek`_
+* `Arne Gottwald`_
 
 The following authors had contributed before. Thank you for sticking around! 🤘
 
@@ -35,6 +36,8 @@ Detailed list of changes
 - :func:`mne_bids.write_raw_bids()` can now handle mne `Raw` objects with `eyegaze` and `pupil` channels, by `Christian O'Reilly`_ (:gh:`1344`)
 - :func:`mne_bids.get_entity_vals()` has a new parameter ``ignore_suffixes`` to easily ignore sidecar files, by `Daniel McCloy`_ (:gh:`1362`)
 - Empty-room matching now preferentially finds recordings in the subject directory tagged as `task-noise` before looking in the `sub-emptyroom` directories. This adds support for a part of the BIDS specification for ER recordings, by `Berk Gerçek`_ (:gh:`1364`)
+- Path matching is now implemenented in a more efficient manner within `_return_root_paths`, by `Arne Gottwald` (:gh:`1355`)
+- :func:`mne_bids.get_entity_vals()` has a new parameter ``include_match`` to prefilter item matching and ignore non-matched items from begin of directory scan, by `Arne Gottwald` (:gh:`1355`)
 
 
 🧐 API and behavior changes
@@ -53,6 +56,7 @@ Detailed list of changes
 - :func:`mne_bids.read_raw_bids` can optionally return an ``event_id`` dictionary suitable for use with :func:`mne.events_from_annotations`, and if a ``values`` column is present in ``events.tsv`` it will be used as the source of the integer event ID codes, by `Daniel McCloy`_ (:gh:`1349`)
 - BIDS dictates that the recording entity should be displayed as "_recording-" in the filename. This PR makes :class:`mne_bids.BIDSPath`  correctly display "_recording-" (instead of "_rec-") in BIDSPath.fpath. By `Scott Huberty`_ (:gh:`1348`)
 - :func:`mne_bids.make_dataset_description` now correctly encodes the dataset description as UTF-8 on disk, by `Scott Huberty`_ (:gh:`1357`)
+- Corrects extension match within `_filter_fnames` at end of filename, by `Arne Gottwald` (:gh:`1355`)
 
 ⚕️ Code health
 ^^^^^^^^^^^^^^

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -2474,7 +2474,7 @@ def _return_root_paths(root, datatype=None, ignore_json=True, ignore_nosub=False
     else:
         if datatype is not None:
             datatype = _ensure_tuple(datatype)
-            search_str = f'**/{"|".join(datatype)}/*'
+            search_str = f"**/{'|'.join(datatype)}/*"
 
             # I think this one is more appropriate
             search_str = search_str + ".*"

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -2546,10 +2546,7 @@ def _return_root_paths(root, datatype=None, ignore_json=True, ignore_nosub=False
     else:
         if datatype is not None:
             datatype = _ensure_tuple(datatype)
-            search_str = f"**/{'|'.join(datatype)}/*"
-
-            # I think this one is more appropriate
-            search_str = search_str + ".*"
+            search_str = f"**/{'|'.join(datatype)}/.*"
         else:
             search_str = "**/*.*"
 

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -2580,7 +2580,7 @@ def _return_root_paths(root, datatype=None, ignore_json=True, ignore_nosub=False
             p
             for p in paths
             if p.is_file()
-            # do we really want to do this here
+            # XXX: see above, generalize with private func
             or (p.is_dir() and p.suffix == ".ds")
         ]
 

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -2010,7 +2010,7 @@ def get_entity_vals(
         Directories nested directly within ``root`` to ignore. If ``None``,
         include all directories in the search.
 
-        .. versionadded:: 0.17
+        .. versionadded:: 0.9
     ignore_suffixes : str | array-like of str | None
         Suffixes to ignore. If ``None``, include all suffixes. This can be helpful for
         ignoring non-data sidecars such as `*_scans.tsv` or `*_coordsystem.json`.
@@ -2018,7 +2018,7 @@ def get_entity_vals(
         Apply a starting match pragma following Unix style pattern syntax from
         package glob to prefilter search criterion.
 
-        .. versionadded:: 0.9
+        .. versionadded:: 0.17
     with_key : bool
         If ``True``, returns the full entity with the key and the value. This
         will for example look like ``['sub-001', 'sub-002']``.

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -2487,12 +2487,8 @@ def _return_root_paths(root, datatype=None, ignore_json=True, ignore_nosub=False
         if ignore_nosub:
             search_str = "sub-*/" + search_str
 
-        paths = list(
-            map(
-                lambda fn: Path(root, fn),
-                glob.glob(search_str, root_dir=root, recursive=True),
-            )
-        )
+        paths = [ Path(root, fn) for fn in glob.iglob(search_str, root_dir=root, recursive=True) ]
+
     # Only keep files (not directories), ...
     # and omit the JSON sidecars if `ignore_json` is True.
     if ignore_json:

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -11,10 +11,10 @@ import shutil as sh
 from copy import deepcopy
 from datetime import datetime
 from io import StringIO
+from itertools import chain as iter_chain
 from os import path as op
 from pathlib import Path
 from textwrap import indent
-from itertools import chain as iter_chain
 
 import numpy as np
 from mne.utils import _check_fname, _validate_type, logger, verbose
@@ -2472,7 +2472,6 @@ def _return_root_paths(root, datatype=None, ignore_json=True, ignore_nosub=False
         search_str = "*.*"
         paths = root.rglob(search_str)
     else:
-
         if datatype is not None:
             datatype = _ensure_tuple(datatype)
             search_str = f'**/{"|".join(datatype)}/*'

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -2571,7 +2571,8 @@ def _return_root_paths(root, datatype=None, ignore_json=True, ignore_nosub=False
             p
             for p in paths
             if (p.is_file() and p.suffix != ".json")
-            # do we really want to do this here?
+            # XXX: generalize with a private func that takes
+            # a config of which "data format" are to be expected like .ds
             or (p.is_dir() and p.suffix == ".ds")
         ]
     else:

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -2468,6 +2468,10 @@ def _return_root_paths(root, datatype=None, ignore_json=True, ignore_nosub=False
             search_str = search_str + ".*"
         else:
             search_str = "**/*.*"
+
+        # only browse files which are of the form root/sub-*,
+        # such that we truely only look in 'sub'-folders:
+
         if ignore_nosub:
             search_str = "sub-*/" + search_str
 

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -2430,7 +2430,7 @@ def find_matching_paths(
 
 
 def _return_root_paths(root, datatype=None, ignore_json=True, ignore_nosub=False):
-    """Return all file paths in root.
+    """Return all file paths + .ds paths in root.
 
     Can be filtered by datatype (which is present in the path but not in
     the BIDSPath basename). Can also be list of datatypes.
@@ -2451,7 +2451,7 @@ def _return_root_paths(root, datatype=None, ignore_json=True, ignore_nosub=False
     Returns
     -------
     paths : list of pathlib.Path
-        All paths in `root`, filtered according to the function parameters.
+        All files + .ds paths in `root`, filtered according to the function parameters.
     """
     root = Path(root)  # if root is str
 
@@ -2478,9 +2478,21 @@ def _return_root_paths(root, datatype=None, ignore_json=True, ignore_nosub=False
     # Only keep files (not directories), ...
     # and omit the JSON sidecars if `ignore_json` is True.
     if ignore_json:
-        paths = [p for p in paths if p.is_file() and p.suffix != ".json"]
+        paths = [
+            p
+            for p in paths
+            if (p.is_file() and p.suffix != ".json")
+            # do we really want to do this here?
+            or (p.is_dir() and p.suffix == ".ds")
+        ]
     else:
-        paths = [p for p in paths if p.is_file()]
+        paths = [
+            p
+            for p in paths
+            if p.is_file()
+            # do we really want to do this here
+            or (p.is_dir() and p.suffix == ".ds")
+        ]
 
     return paths
 

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -2464,6 +2464,8 @@ def _return_root_paths(root, datatype=None, ignore_json=True, ignore_nosub=False
             datatype = _ensure_tuple(datatype)
             search_str = f'**/{"|".join(datatype)}/*'
 
+            # I think this one is more appropriate
+            search_str = search_str + ".*"
         else:
             search_str = "**/*.*"
         if ignore_nosub:

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -2286,7 +2286,7 @@ def _filter_fnames(
         r"_desc-(" + "|".join(description) + ")" if description else r"(|_desc-([^_]+))"
     )
     suffix_str = r"_(" + "|".join(suffix) + ")" if suffix else r"_([^_]+)"
-    ext_str = r"(" + "|".join(extension) + ")" if extension else r".([^_]+)"
+    ext_str = r"(" + "|".join(extension) + ")$" if extension else r".([^_]+)"
 
     regexp = (
         leading_path_str

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -2457,6 +2457,7 @@ def _return_root_paths(root, datatype=None, ignore_json=True, ignore_nosub=False
 
     if datatype is None and not ignore_nosub:
         search_str = "*.*"
+        paths = root.rglob(search_str)
     else:
 
         if datatype is not None:

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -222,12 +222,12 @@ def test_path_benchmark(tmp_path_factory):
     timed_all, timed_ignored_nosub = (
         timeit.timeit(
             "mne_bids.find_matching_paths(tmp_bids_root)",
-            setup="import mne_bids\ntmp_bids_root='" + str(tmp_bids_root) + "'",
+            setup="import mne_bids\ntmp_bids_root=r'" + str(tmp_bids_root) + "'",
             number=1,
         ),
         timeit.timeit(
             "mne_bids.find_matching_paths(tmp_bids_root, ignore_nosub=True)",
-            setup="import mne_bids\ntmp_bids_root='" + str(tmp_bids_root) + "'",
+            setup="import mne_bids\ntmp_bids_root=r'" + str(tmp_bids_root) + "'",
             number=10,
         )
         / 10,
@@ -244,12 +244,12 @@ def test_path_benchmark(tmp_path_factory):
     timed_entity, timed_entity_match = (
         timeit.timeit(
             "mne_bids.get_entity_vals(tmp_bids_root, 'session')",
-            setup="import mne_bids\ntmp_bids_root='" + str(tmp_bids_root) + "'",
+            setup="import mne_bids\ntmp_bids_root=r'" + str(tmp_bids_root) + "'",
             number=1,
         ),
         timeit.timeit(
             "mne_bids.get_entity_vals(tmp_bids_root, 'session', include_match='sub-*/')",  # noqa: E501
-            setup="import mne_bids\ntmp_bids_root='" + str(tmp_bids_root) + "'",
+            setup="import mne_bids\ntmp_bids_root=r'" + str(tmp_bids_root) + "'",
             number=10,
         )
         / 10,

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -170,15 +170,20 @@ def test_get_entity_vals(entity, expected_vals, kwargs, return_bids_test_dir):
 
 def test_path_benchmark(tmp_path_factory):
     """Benchmark exploring bids tree."""
-    tmp_bids_root = tmp_path_factory.mktemp("abc")
+    # This benchmark is to verify the speed-up in function call get_entity_vals with
+    # `include_match=sub-*/` in face of a bids tree which hosts derivatives and sourcedata.
+    n_subjects = 20
+    n_sessions = 10
+    n_derivatives = 17
+    tmp_bids_root = tmp_path_factory.mktemp("mnebids_utils_test_bids_ds")
 
-    derivatives = [Path(f"derivatives", f"derivatives" + str(i)) for i in range(17)]
+    derivatives = [Path(f"derivatives", f"derivatives" + str(i)) for i in range(n_derivatives)]
 
     bids_subdirectories = [f"", f"sourcedata", *derivatives]
 
     # Create a BIDS compliant directory tree with high number of branches
-    for i in range(1, 20):
-        for j in range(1, 9):
+    for i in range(1, n_subjects):
+        for j in range(1, n_sessions):
             for subdir in bids_subdirectories:
                 for datatype in [f"eeg", f"meg"]:
                     bids_subdir = BIDSPath(

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -172,7 +172,7 @@ def test_path_benchmark(tmp_path_factory):
     """Benchmark exploring bids tree."""
     tmp_bids_root = tmp_path_factory.mktemp("abc")
 
-    derivatives = ["derivatives/derivatives" + str(i) for i in range(17)]
+    derivatives = [Path("derivatives", "derivatives" + str(i)) for i in range(17)]
 
     bids_subdirectories = ["", "sourcedata", *derivatives]
 

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -171,7 +171,7 @@ def test_get_entity_vals(entity, expected_vals, kwargs, return_bids_test_dir):
 def test_path_benchmark(tmp_path_factory):
     """Benchmark exploring bids tree."""
     # This benchmark is to verify the speed-up in function call get_entity_vals with
-    # `include_match=sub-*/` in face of a bids tree which hosts derivatives and sourcedata.
+    # `include_match=sub-*/` in face of a bids tree hosting derivatives and sourcedata.
     n_subjects = 20
     n_sessions = 10
     n_derivatives = 17

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -177,45 +177,47 @@ def test_path_benchmark(tmp_path_factory):
     n_derivatives = 17
     tmp_bids_root = tmp_path_factory.mktemp("mnebids_utils_test_bids_ds")
 
-    derivatives = [Path(f"derivatives", f"derivatives" + str(i)) for i in range(n_derivatives)]
+    derivatives = [
+        Path("derivatives", "derivatives" + str(i)) for i in range(n_derivatives)
+    ]
 
-    bids_subdirectories = [f"", f"sourcedata", *derivatives]
+    bids_subdirectories = ["", "sourcedata", *derivatives]
 
     # Create a BIDS compliant directory tree with high number of branches
     for i in range(1, n_subjects):
         for j in range(1, n_sessions):
             for subdir in bids_subdirectories:
-                for datatype in [f"eeg", f"meg"]:
+                for datatype in ["eeg", "meg"]:
                     bids_subdir = BIDSPath(
                         subject=str(i),
                         session=str(j),
                         datatype=datatype,
-                        task=f"audvis",
+                        task="audvis",
                         root=str(tmp_bids_root / subdir),
                     )
                     bids_subdir.mkdir(exist_ok=True)
-                    Path(bids_subdir.root / f"participants.tsv").touch()
-                    Path(bids_subdir.root / f"participants.csv").touch()
-                    Path(bids_subdir.root / f"README").touch()
+                    Path(bids_subdir.root / "participants.tsv").touch()
+                    Path(bids_subdir.root / "participants.csv").touch()
+                    Path(bids_subdir.root / "README").touch()
 
                     # os.makedirs(bids_subdir.directory, exist_ok=True)
                     Path(
-                        bids_subdir.directory, bids_subdir.basename + f"_events.tsv"
+                        bids_subdir.directory, bids_subdir.basename + "_events.tsv"
                     ).touch()
                     Path(
-                        bids_subdir.directory, bids_subdir.basename + f"_events.csv"
+                        bids_subdir.directory, bids_subdir.basename + "_events.csv"
                     ).touch()
 
-                    if datatype == f"meg":
+                    if datatype == "meg":
                         ctf_path = Path(
-                            bids_subdir.directory, bids_subdir.basename + f"_meg.ds"
+                            bids_subdir.directory, bids_subdir.basename + "_meg.ds"
                         )
                         ctf_path.mkdir(exist_ok=True)
-                        Path(ctf_path, bids_subdir.basename + f".meg4").touch()
-                        Path(ctf_path, bids_subdir.basename + f".hc").touch()
-                        Path(ctf_path / f"hz.ds").mkdir(exist_ok=True)
-                        Path(ctf_path / f"hz.ds" / f"hz.meg4").touch()
-                        Path(ctf_path / f"hz.ds" / f"hz.hc").touch()
+                        Path(ctf_path, bids_subdir.basename + ".meg4").touch()
+                        Path(ctf_path, bids_subdir.basename + ".hc").touch()
+                        Path(ctf_path / "hz.ds").mkdir(exist_ok=True)
+                        Path(ctf_path / "hz.ds" / "hz.meg4").touch()
+                        Path(ctf_path / "hz.ds" / "hz.hc").touch()
 
     # apply nosub on find_matching_matchs with root level bids directory should
     # yield a performance boost of order of length from bids_subdirectories.

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -172,50 +172,45 @@ def test_path_benchmark(tmp_path_factory):
     """Benchmark exploring bids tree."""
     tmp_bids_root = tmp_path_factory.mktemp("abc")
 
-    derivatives = [Path("derivatives", "derivatives" + str(i)) for i in range(17)]
+    derivatives = [Path(f"derivatives", f"derivatives" + str(i)) for i in range(17)]
 
-    bids_subdirectories = ["", "sourcedata", *derivatives]
-
-    def equal_length_subj_ids(v):
-        assert all(v > 0)
-        n_digits = len(str(np.max(v))) + 1
-        return list(map(lambda i: "0" * (n_digits - len(str(i))) + str(i), v))
+    bids_subdirectories = [f"", f"sourcedata", *derivatives]
 
     # Create a BIDS compliant directory tree with high number of branches
-    for i in equal_length_subj_ids(np.arange(1, 20, dtype=int)):
+    for i in range(1, 20):
         for j in range(1, 9):
             for subdir in bids_subdirectories:
-                for datatype in ["eeg", "meg"]:
+                for datatype in [f"eeg", f"meg"]:
                     bids_subdir = BIDSPath(
-                        subject=i,
-                        session="0" + str(j),
+                        subject=str(i),
+                        session=str(j),
                         datatype=datatype,
-                        task="audvis",
+                        task=f"audvis",
                         root=str(tmp_bids_root / subdir),
                     )
                     bids_subdir.mkdir(exist_ok=True)
-                    Path(bids_subdir.root / "participants.tsv").touch()
-                    Path(bids_subdir.root / "participants.csv").touch()
-                    Path(bids_subdir.root / "README").touch()
+                    Path(bids_subdir.root / f"participants.tsv").touch()
+                    Path(bids_subdir.root / f"participants.csv").touch()
+                    Path(bids_subdir.root / f"README").touch()
 
                     # os.makedirs(bids_subdir.directory, exist_ok=True)
                     Path(
-                        bids_subdir.directory, bids_subdir.basename + "_events.tsv"
+                        bids_subdir.directory, bids_subdir.basename + f"_events.tsv"
                     ).touch()
                     Path(
-                        bids_subdir.directory, bids_subdir.basename + "_events.csv"
+                        bids_subdir.directory, bids_subdir.basename + f"_events.csv"
                     ).touch()
 
-                    if datatype == "meg":
+                    if datatype == f"meg":
                         ctf_path = Path(
-                            bids_subdir.directory, bids_subdir.basename + "_meg.ds"
+                            bids_subdir.directory, bids_subdir.basename + f"_meg.ds"
                         )
                         ctf_path.mkdir(exist_ok=True)
-                        Path(ctf_path, bids_subdir.basename + ".meg4").touch()
-                        Path(ctf_path, bids_subdir.basename + ".hc").touch()
-                        Path(ctf_path / "hz.ds").mkdir(exist_ok=True)
-                        Path(ctf_path / "hz.ds" / "hz.meg4").touch()
-                        Path(ctf_path / "hz.ds" / "hz.hc").touch()
+                        Path(ctf_path, bids_subdir.basename + f".meg4").touch()
+                        Path(ctf_path, bids_subdir.basename + f".hc").touch()
+                        Path(ctf_path / f"hz.ds").mkdir(exist_ok=True)
+                        Path(ctf_path / f"hz.ds" / f"hz.meg4").touch()
+                        Path(ctf_path / f"hz.ds" / f"hz.hc").touch()
 
     # apply nosub on find_matching_matchs with root level bids directory should
     # yield a performance boost of order of length from bids_subdirectories.

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -7,10 +7,12 @@ import os
 import os.path as op
 import shutil
 import shutil as sh
+import timeit
 from datetime import datetime, timezone
 from pathlib import Path
 
 import mne
+import numpy as np
 import pytest
 from mne.datasets import testing
 from mne.io import anonymize_info
@@ -164,6 +166,103 @@ def test_get_entity_vals(entity, expected_vals, kwargs, return_bids_test_dir):
             assert "deriv" in entities
     # Clean up
     shutil.rmtree(deriv_path)
+
+
+def test_path_benchmark(tmp_path_factory):
+    """Benchmark exploring bids tree."""
+    tmp_bids_root = tmp_path_factory.mktemp("abc")
+
+    derivatives = ["derivatives/derivatives" + str(i) for i in range(17)]
+
+    bids_subdirectories = ["", "sourcedata", *derivatives]
+
+    def equal_length_subj_ids(v):
+        assert all(v > 0)
+        n_digits = len(str(np.max(v))) + 1
+        return list(map(lambda i: "0" * (n_digits - len(str(i))) + str(i), v))
+
+    # Create a BIDS compliant directory tree with high number of branches
+    for i in equal_length_subj_ids(np.arange(1, 20, dtype=int)):
+        for j in range(1, 9):
+            for subdir in bids_subdirectories:
+                for datatype in ["eeg", "meg"]:
+                    bids_subdir = BIDSPath(
+                        subject=i,
+                        session="0" + str(j),
+                        datatype=datatype,
+                        task="audvis",
+                        root=str(tmp_bids_root / subdir),
+                    )
+                    bids_subdir.mkdir(exist_ok=True)
+                    Path(bids_subdir.root / "participants.tsv").touch()
+                    Path(bids_subdir.root / "participants.csv").touch()
+                    Path(bids_subdir.root / "README").touch()
+
+                    # os.makedirs(bids_subdir.directory, exist_ok=True)
+                    Path(
+                        bids_subdir.directory, bids_subdir.basename + "_events.tsv"
+                    ).touch()
+                    Path(
+                        bids_subdir.directory, bids_subdir.basename + "_events.csv"
+                    ).touch()
+
+                    if datatype == "meg":
+                        ctf_path = Path(
+                            bids_subdir.directory, bids_subdir.basename + "_meg.ds"
+                        )
+                        ctf_path.mkdir(exist_ok=True)
+                        Path(ctf_path, bids_subdir.basename + ".meg4").touch()
+                        Path(ctf_path, bids_subdir.basename + ".hc").touch()
+                        Path(ctf_path / "hz.ds").mkdir(exist_ok=True)
+                        Path(ctf_path / "hz.ds" / "hz.meg4").touch()
+                        Path(ctf_path / "hz.ds" / "hz.hc").touch()
+
+    # apply nosub on find_matching_matchs with root level bids directory should
+    # yield a performance boost of order of length from bids_subdirectories.
+    timed_all, timed_ignored_nosub = (
+        timeit.timeit(
+            "mne_bids.find_matching_paths(tmp_bids_root)",
+            setup="import mne_bids\ntmp_bids_root='" + str(tmp_bids_root) + "'",
+            number=1,
+        ),
+        timeit.timeit(
+            "mne_bids.find_matching_paths(tmp_bids_root, ignore_nosub=True)",
+            setup="import mne_bids\ntmp_bids_root='" + str(tmp_bids_root) + "'",
+            number=10,
+        )
+        / 10,
+    )
+
+    assert (
+        timed_all / (10 * np.maximum(1, np.floor(len(bids_subdirectories) / 10)))
+        # while this should be of same order, lets give it some space by a factor of 2
+        > 0.5 * timed_ignored_nosub
+    )
+
+    # apply include_match on get_entity_vals with root level bids directory should
+    # yield a performance boost of order of length from bids_subdirectories.
+    timed_entity, timed_entity_match = (
+        timeit.timeit(
+            "mne_bids.get_entity_vals(tmp_bids_root, 'session')",
+            setup="import mne_bids\ntmp_bids_root='" + str(tmp_bids_root) + "'",
+            number=1,
+        ),
+        timeit.timeit(
+            "mne_bids.get_entity_vals(tmp_bids_root, 'session', include_match='sub-*/')",  # noqa: E501
+            setup="import mne_bids\ntmp_bids_root='" + str(tmp_bids_root) + "'",
+            number=10,
+        )
+        / 10,
+    )
+
+    assert (
+        timed_entity / (10 * np.maximum(1, np.floor(len(bids_subdirectories) / 10)))
+        # while this should be of same order, lets give it some space by a factor of 2
+        > 0.5 * timed_entity_match
+    )
+
+    # Clean up
+    shutil.rmtree(tmp_bids_root)
 
 
 def test_search_folder_for_text(capsys):


### PR DESCRIPTION
<!--
Thanks for contributing this pull request (PR).
If this is your first time, make sure to read
[CONTRIBUTING.md](https://github.com/mne-tools/mne-bids/blob/main/CONTRIBUTING.md)
-->

PR Description
--------------

When `_return_root_paths` now uses `ignore_nosub`, it can benefit from from only exploring directories within `root/sub-*` instead of exploring the whole tree and subsequently applying the regex filter on visited files.

 `get_entity_vals` is extended by an argument `include_match` to introduce a prefilter on regex path match. This is a whitelist approach, and extends both functionality and performance compared to a equivalent blacklist approach of existing option `ignore_dirs`.


Merge checklist
---------------

Maintainer, please confirm the following before merging.
If applicable:

- [ ] All comments are resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] New contributors have been added to [CITATION.cff](https://github.com/mne-tools/mne-bids/blob/main/CITATION.cff)
- [ ] PR description includes phrase "closes <#issue-number>"
