### PR TITLE
FIX: Support UTF-8 encoding for JSON files

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -23,6 +23,7 @@ The following authors had contributed before. Thank you for sticking around! �
 
 * `Stefan Appelhoff`_
 * `Daniel McCloy`_
+* `Scott Huberty`_
 
 Detailed list of changes
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -47,6 +48,7 @@ Detailed list of changes
 ^^^^^^^^^^^^
 
 - :func:`mne_bids.read_raw_bids` can optionally return an ``event_id`` dictionary suitable for use with :func:`mne.events_from_annotations`, and if a ``values`` column is present in ``events.tsv`` it will be used as the source of the integer event ID codes, by `Daniel McCloy`_ (:gh:`1349`)
+- :func:`mne_bids.make_dataset_description` now correctly encodes the dataset description as UTF-8 on disk, by `Scott Huberty`_ (:gh:`1357`)
 
 ⚕️ Code health
 ^^^^^^^^^^^^^^

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -387,10 +387,9 @@ def test_make_dataset_description(tmp_path, monkeypatch):
     with open(op.join(tmp_path, "dataset_description.json"), encoding="utf-8") as fid:
         dataset_description_json = json.load(fid)
         assert dataset_description_json["Authors"] == ["MNE B.", "MNE P.", "MNE Ł."]
-
-    # If the text on disk is unicode, json.load will convert it. So let's test that the
-    # text was encoded correctly on disk.
-    with open(op.join(tmp_path, "dataset_description.json"), encoding="utf-8") as fid:
+        # If the text on disk is unicode, json.load will convert it. So let's test that
+        # the text was encoded correctly on disk.
+        fid.seek(0)
         # don't use json.load here, as it will convert unicode to str
         dataset_description_string = fid.read()
         # Check that U+0141 was correctly encoded as Ł on disk

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -376,7 +376,7 @@ def test_make_dataset_description(tmp_path, monkeypatch):
     make_dataset_description(
         path=tmp_path,
         name="tst2",
-        authors="MNE B., MNE P.",
+        authors="MNE B., MNE P., MNE Ł.",
         funding="GSOC2019, GSOC2021",
         references_and_links="https://doi.org/10.21105/joss.01896",
         dataset_type="derivative",
@@ -386,7 +386,15 @@ def test_make_dataset_description(tmp_path, monkeypatch):
 
     with open(op.join(tmp_path, "dataset_description.json"), encoding="utf-8") as fid:
         dataset_description_json = json.load(fid)
-        assert dataset_description_json["Authors"] == ["MNE B.", "MNE P."]
+        assert dataset_description_json["Authors"] == ["MNE B.", "MNE P.", "MNE Ł."]
+
+    # If the text on disk is unicode, json.load will convert it. So let's test that the
+    # text was encoded correctly on disk.
+    with open(op.join(tmp_path, "dataset_description.json"), encoding="utf-8") as fid:
+        # don't use json.load here, as it will convert unicode to str
+        dataset_description_string = fid.read()
+        # Check that U+0141 was correctly encoded as Ł on disk
+        assert "MNE Ł." in dataset_description_string
 
     # Check we raise warnings and errors where appropriate
     with pytest.raises(

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -226,14 +226,14 @@ def _check_types(variables):
             )
 
 
-def _write_json(fname, dictionary, overwrite=False):
+def _write_json(fname, dictionary, overwrite=False, ensure_ascii=False):
     """Write JSON to a file."""
     if op.exists(fname) and not overwrite:
         raise FileExistsError(
             f'"{fname}" already exists. Please set overwrite to True.'
         )
 
-    json_output = json.dumps(dictionary, indent=4)
+    json_output = json.dumps(dictionary, indent=4, ensure_ascii=ensure_ascii)
     with open(fname, "w", encoding="utf-8") as fid:
         fid.write(json_output)
         fid.write("\n")

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -226,14 +226,14 @@ def _check_types(variables):
             )
 
 
-def _write_json(fname, dictionary, overwrite=False, ensure_ascii=False):
+def _write_json(fname, dictionary, overwrite=False):
     """Write JSON to a file."""
     if op.exists(fname) and not overwrite:
         raise FileExistsError(
             f'"{fname}" already exists. Please set overwrite to True.'
         )
 
-    json_output = json.dumps(dictionary, indent=4, ensure_ascii=ensure_ascii)
+    json_output = json.dumps(dictionary, indent=4)
     with open(fname, "w", encoding="utf-8") as fid:
         fid.write(json_output)
         fid.write("\n")

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -233,7 +233,7 @@ def _write_json(fname, dictionary, overwrite=False):
             f'"{fname}" already exists. Please set overwrite to True.'
         )
 
-    json_output = json.dumps(dictionary, indent=4)
+    json_output = json.dumps(dictionary, indent=4, ensure_ascii=False)
     with open(fname, "w", encoding="utf-8") as fid:
         fid.write(json_output)
         fid.write("\n")


### PR DESCRIPTION
fixes #1356 

`_write_json` is used _a lot_ in the MNE-BIDS codebase... I want to get your feedback on whether adding a new parameter `ensure_ascii=False` to `_write_tsv` is the right way to go?

Because I'm not sure if there are cases in MNE-BIDS where we do want to enforce ASCII encoding during JSON writing.. If so, we could change the default to `ensure_ascii=True`, and pass `False` explicitly for the cases where we want to support UTF-8?


cc @sappelhoff @hoechenberger  @larsoner

### TODO

- [x] add test