### PR TITLE
FIX:  Use "recording" for recording entity, not "rec"

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -47,6 +47,7 @@ Detailed list of changes
 ^^^^^^^^^^^^
 
 - :func:`mne_bids.read_raw_bids` can optionally return an ``event_id`` dictionary suitable for use with :func:`mne.events_from_annotations`, and if a ``values`` column is present in ``events.tsv`` it will be used as the source of the integer event ID codes, by `Daniel McCloy`_ (:gh:`1349`)
+- BIDS dictates that the recording entity should be displayed as "_recording-" in the filename. This PR makes :class:`mne_bids.BIDSPath`  correctly display "_recording-" (instead of "_rec-") in BIDSPath.fpath. By `Scott Huberty`_ (:gh:`1348`)
 
 ⚕️ Code health
 ^^^^^^^^^^^^^^

--- a/mne_bids/config.py
+++ b/mne_bids/config.py
@@ -235,7 +235,7 @@ ALLOWED_PATH_ENTITIES_SHORT = {
     "run": "run",
     "proc": "processing",
     "space": "space",
-    "rec": "recording",
+    "recording": "recording",
     "split": "split",
     "desc": "description",
 }

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -2280,9 +2280,11 @@ def _filter_fnames(
         r"_proc-(" + "|".join(processing) + ")" if processing else r"(|_proc-([^_]+))"
     )
     space_str = r"_space-(" + "|".join(space) + ")" if space else r"(|_space-([^_]+))"
-    rec_str = (r"_recording-(" + "|".join(recording) + ")"
-               if recording else r"(|_recording-([^_]+))"
-               )
+    rec_str = (
+        r"_recording-(" + "|".join(recording) + ")"
+        if recording
+        else r"(|_recording-([^_]+))"
+    )
     split_str = r"_split-(" + "|".join(split) + ")" if split else r"(|_split-([^_]+))"
     desc_str = (
         r"_desc-(" + "|".join(description) + ")" if description else r"(|_desc-([^_]+))"

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -2088,7 +2088,7 @@ def get_entity_vals(
         ):
             continue
         if ignore_recordings and any(
-            [f"_rec-{a}_" in filename.stem for a in ignore_recordings]
+            [f"_recording-{a}_" in filename.stem for a in ignore_recordings]
         ):
             continue
         if ignore_splits and any(
@@ -2280,7 +2280,9 @@ def _filter_fnames(
         r"_proc-(" + "|".join(processing) + ")" if processing else r"(|_proc-([^_]+))"
     )
     space_str = r"_space-(" + "|".join(space) + ")" if space else r"(|_space-([^_]+))"
-    rec_str = r"_rec-(" + "|".join(recording) + ")" if recording else r"(|_rec-([^_]+))"
+    rec_str = (r"_recording-(" + "|".join(recording) + ")"
+               if recording else r"(|_recording-([^_]+))"
+               )
     split_str = r"_split-(" + "|".join(split) + ")" if split else r"(|_split-([^_]+))"
     desc_str = (
         r"_desc-(" + "|".join(description) + ")" if description else r"(|_desc-([^_]+))"

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -857,7 +857,7 @@ def test_make_filenames():
         datatype="ieeg",
     )
     expected_str = (
-        "sub-one_ses-two_task-three_acq-four_run-1_proc-six_rec-seven_ieeg.json"
+        "sub-one_ses-two_task-three_acq-four_run-1_proc-six_recording-seven_ieeg.json"
     )
     assert BIDSPath(**prefix_data).basename == expected_str
     assert (
@@ -896,7 +896,7 @@ def test_make_filenames():
     basename = BIDSPath(**prefix_data, check=False)
     assert (
         basename.basename
-        == "sub-one_ses-two_task-three_acq-four_run-1_proc-six_rec-seven_ieeg.h5"
+        == "sub-one_ses-two_task-three_acq-four_run-1_proc-six_recording-seven_ieeg.h5"
     )
 
     # what happens with scans.tsv file


### PR DESCRIPTION
Fixes #1348

See: https://bids-specification.readthedocs.io/en/stable/modality-specific-files/physiological-recordings.html

As @kaare-mikkelsen pointed out, [BEP 020](https://github.com/bids-standard/bids-specification/pull/1128) will make use of the `recording` entity for eyetracking data.  And since I'm working on #1342 , this should be fixed first 🙂 

Merge checklist
---------------

Maintainer, please confirm the following before merging.
If applicable:

- [ ] All comments are resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] New contributors have been added to [CITATION.cff](https://github.com/mne-tools/mne-bids/blob/main/CITATION.cff)
- [x] PR description includes phrase "closes <#issue-number>"
