### PR TITLE
[MRG] Update empty-room matching to look for and prioritize same-session recordings with task "noise" (closes #1354)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,10 +5,6 @@ cff-version: 1.2.0
 title: 'MNE-BIDS: Organizing electrophysiological data into the BIDS format and facilitating their analysis'
 abstract: 'MNE-BIDS is a Python library to facilitate the analysis of MEG, EEG, and iEEG data with MNE-Python for data conforming to the BIDS (Brain Imaging Data Structure) format. More information about BIDS and MNE-Python can be found at <a href="https://bids.neuroimaging.io">bids.neuroimaging.io</a> and <a href="https://mne.tools">mne.tools</a>, respectively.'
 authors:
-    - given-names: Berk
-      family-names: Gerçek
-      affiliation: 'University of Geneva, Department of Fundamental Neuroscience'
-      orcid: 'https://orcid.org/0000-0003-1063-6769'
     - given-names: Stefan
       family-names: Appelhoff
       affiliation: 'Center for Adaptive Rationality, Max Planck Institute for Human Development, Berlin, Germany'
@@ -206,6 +202,10 @@ authors:
       family-names: O'Reilly
       affiliation: 'Computer Science and Engineering, University of South Carolina'
       orcid: 'https://orcid.org/0000-0002-3149-4934'
+    - given-names: Berk
+      family-names: Gerçek
+      affiliation: 'University of Geneva, Department of Fundamental Neuroscience'
+      orcid: 'https://orcid.org/0000-0003-1063-6769'
     - given-names: Alexandre
       family-names: Gramfort
       affiliation: 'Université Paris-Saclay, Inria, CEA, Palaiseau, France'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -243,10 +243,6 @@ preferred-citation:
   start: 1896
   doi: 10.21105/joss.01896
   authors:
-    - given-names: Berk
-      family-names: Gerçek
-      affiliation: 'University of Geneva, Department of Fundamental Neuroscience'
-      orcid: 'https://orcid.org/0000-0003-1063-6769'
     - given-names: Stefan
       family-names: Appelhoff
       affiliation: 'Center for Adaptive Rationality, Max Planck Institute for Human Development, Berlin, Germany'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,6 +5,10 @@ cff-version: 1.2.0
 title: 'MNE-BIDS: Organizing electrophysiological data into the BIDS format and facilitating their analysis'
 abstract: 'MNE-BIDS is a Python library to facilitate the analysis of MEG, EEG, and iEEG data with MNE-Python for data conforming to the BIDS (Brain Imaging Data Structure) format. More information about BIDS and MNE-Python can be found at <a href="https://bids.neuroimaging.io">bids.neuroimaging.io</a> and <a href="https://mne.tools">mne.tools</a>, respectively.'
 authors:
+    - given-names: Berk
+      family-names: Gerçek
+      affiliation: 'University of Geneva, Department of Fundamental Neuroscience'
+      orcid: 'https://orcid.org/0000-0003-1063-6769'
     - given-names: Stefan
       family-names: Appelhoff
       affiliation: 'Center for Adaptive Rationality, Max Planck Institute for Human Development, Berlin, Germany'
@@ -239,6 +243,10 @@ preferred-citation:
   start: 1896
   doi: 10.21105/joss.01896
   authors:
+    - given-names: Berk
+      family-names: Gerçek
+      affiliation: 'University of Geneva, Department of Fundamental Neuroscience'
+      orcid: 'https://orcid.org/0000-0003-1063-6769'
     - given-names: Stefan
       family-names: Appelhoff
       affiliation: 'Center for Adaptive Rationality, Max Planck Institute for Human Development, Berlin, Germany'

--- a/doc/authors.rst
+++ b/doc/authors.rst
@@ -6,7 +6,7 @@
 .. _Anand Saini: https://github.com/anandsaini024
 .. _Ariel Rokem: https://github.com/arokem
 .. _Austin Hurst: https://github.com/a-hurst
-.. _Berk Gercek: https://github.com/berkgercek
+.. _Berk Gerçek: https://github.com/berkgercek
 .. _Bruno Hebling Vieira: https://github.com/bhvieira
 .. _Chris Holdgraf: https://bids.berkeley.edu/people/chris-holdgraf
 .. _Clemens Brunner: https://github.com/cbrnr

--- a/doc/authors.rst
+++ b/doc/authors.rst
@@ -6,6 +6,7 @@
 .. _Anand Saini: https://github.com/anandsaini024
 .. _Ariel Rokem: https://github.com/arokem
 .. _Austin Hurst: https://github.com/a-hurst
+.. _Berk Gercek: https://github.com/berkgercek
 .. _Bruno Hebling Vieira: https://github.com/bhvieira
 .. _Chris Holdgraf: https://bids.berkeley.edu/people/chris-holdgraf
 .. _Clemens Brunner: https://github.com/cbrnr

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -18,6 +18,7 @@ Version 0.17 (unreleased)
 The following authors contributed for the first time. Thank you so much! 🤩
 
 * `Christian O'Reilly`_
+* `Berk Gerçek`_
 
 The following authors had contributed before. Thank you for sticking around! 🤘
 
@@ -33,6 +34,7 @@ Detailed list of changes
 
 - :func:`mne_bids.write_raw_bids()` can now handle mne `Raw` objects with `eyegaze` and `pupil` channels, by `Christian O'Reilly`_ (:gh:`1344`)
 - :func:`mne_bids.get_entity_vals()` has a new parameter ``ignore_suffixes`` to easily ignore sidecar files, by `Daniel McCloy`_ (:gh:`1362`)
+- Empty-room matching now preferentially finds recordings in the subject directory tagged as `task-noise` before looking in the `sub-emptyroom` directories. This adds support for a part of the BIDS specification for ER recordings, by `Berk Gerçek`_ (:gh:`1364`)
 
 
 🧐 API and behavior changes

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -55,32 +55,58 @@ def _find_empty_room_candidates(bids_path):
     datatype = "meg"  # We're only concerned about MEG data here
     bids_fname = bids_path.update(suffix=datatype).fpath
     _, ext = _parse_ext(bids_fname)
+    # Create a path for the empty-room directory to be used for matching.
     emptyroom_dir = BIDSPath(root=bids_root, subject="emptyroom").directory
 
-    if not emptyroom_dir.exists():
-        return list()
-
-    # Find the empty-room recording sessions.
-    emptyroom_session_dirs = [
-        x
-        for x in emptyroom_dir.iterdir()
-        if x.is_dir() and str(x.name).startswith("ses-")
-    ]
-    if not emptyroom_session_dirs:  # No session sub-directories found
-        emptyroom_session_dirs = [emptyroom_dir]
-
-    # Now try to discover all recordings inside the session directories.
+    # Find matching "task-noise" files in the same directory as the recording.
+    noisetask_path = bids_path.update(split=None, task="noise", datatype=datatype, suffix=datatype)
 
     allowed_extensions = list(reader.keys())
     # `.pdf` is just a "virtual" extension for BTi data (which is stored inside
     # a dedicated directory that doesn't have an extension)
     del allowed_extensions[allowed_extensions.index(".pdf")]
 
+    # Get possible noise task files in the same directory as the recording.
+    noisetask_fns = [
+        candidate
+        for candidate in noisetask_path.match()
+        if candidate.extension in allowed_extensions
+    ]
+
+    # If we have more than one noise task file, we need to disambiguate. It might be that it's a
+    # split recording.
+    if len(noisetask_fns) > 1 and any(path.split is not None for path in noisetask_fns):
+        noisetask_path.update(spilt="01")
+        noisetask_fns = [
+            candidate
+            for candidate in noisetask_path.match()
+            if candidate.extension in allowed_extensions
+        ]
+
+    # If it wasn't a split recording, warn the user that something is wonky, then resort to
+    # looking for sub-emptyroom recordings and date-matching.
+    if len(noisetask_fns) > 1:
+        msg = ("Found more than one matching noise task file."
+        " Falling back to looking for sub-emptyroom recordings and date-matching.")
+        warn(msg)
+        noisetask_fns = []
+    else:
+        return noisetask_fns[0]
+
+    if not emptyroom_dir.exists() and not noisetask_fns:
+        return list()
+
+    # Check the 'emptyroom' subject for empty-room recording sessions.
+    emptyroom_session_dirs = [
+        x for x in emptyroom_dir.iterdir() if x.is_dir() and str(x.name).startswith("ses-")
+    ]
+    if not emptyroom_session_dirs:  # No session sub-directories found
+        emptyroom_session_dirs = [emptyroom_dir]
+
+    # Now try to discover all recordings inside the session directories.
     candidate_er_fnames = []
     for session_dir in emptyroom_session_dirs:
-        dir_contents = glob.glob(
-            op.join(session_dir, datatype, f"sub-emptyroom_*_{datatype}*")
-        )
+        dir_contents = glob.glob(op.join(session_dir, datatype, f"sub-emptyroom_*_{datatype}*"))
         for item in dir_contents:
             item = Path(item)
             if (item.suffix in allowed_extensions) or (
@@ -104,6 +130,10 @@ def _find_matched_empty_room(bids_path):
     from mne_bids import read_raw_bids  # avoid circular import.
 
     candidates = _find_empty_room_candidates(bids_path)
+    # If a single candidate is returned, then there's a same-session noise task recording that
+    # takes priority.
+    if not isinstance(candidates, list):
+        return candidates
 
     # Walk through recordings, trying to extract the recording date:
     # First, from the filename; and if that fails, from `info['meas_date']`.

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -69,11 +69,18 @@ def _find_empty_room_candidates(bids_path):
     del allowed_extensions[allowed_extensions.index(".pdf")]
 
     # Get possible noise task files in the same directory as the recording.
-    noisetask_fns = [
+    noisetask_tmp = [
         candidate
         for candidate in noisetask_path.match()
         if candidate.extension in allowed_extensions
     ]
+    # For some reason a single file can produce multiple hits in the match function. Remove dups
+    noisetask_fns = []
+    for i in range(len(noisetask_tmp)):
+        fn = noisetask_tmp.pop()
+        if not any(fn.fpath == f.fpath for f in noisetask_fns):
+            noisetask_fns.append(fn)
+
 
     # If we have more than one noise task file, we need to disambiguate.
     # It might be that it's a
@@ -95,8 +102,9 @@ def _find_empty_room_candidates(bids_path):
         )
         warn(msg)
         noisetask_fns = []
-    else:
+    elif len(noisetask_fns) == 1:
         return noisetask_fns[0]
+
 
     if not emptyroom_dir.exists() and not noisetask_fns:
         return list()

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -59,7 +59,9 @@ def _find_empty_room_candidates(bids_path):
     emptyroom_dir = BIDSPath(root=bids_root, subject="emptyroom").directory
 
     # Find matching "task-noise" files in the same directory as the recording.
-    noisetask_path = bids_path.update(split=None, task="noise", datatype=datatype, suffix=datatype)
+    noisetask_path = bids_path.update(
+        split=None, task="noise", datatype=datatype, suffix=datatype
+    )
 
     allowed_extensions = list(reader.keys())
     # `.pdf` is just a "virtual" extension for BTi data (which is stored inside
@@ -86,8 +88,10 @@ def _find_empty_room_candidates(bids_path):
     # If it wasn't a split recording, warn the user that something is wonky, then resort to
     # looking for sub-emptyroom recordings and date-matching.
     if len(noisetask_fns) > 1:
-        msg = ("Found more than one matching noise task file."
-        " Falling back to looking for sub-emptyroom recordings and date-matching.")
+        msg = (
+            "Found more than one matching noise task file."
+            " Falling back to looking for sub-emptyroom recordings and date-matching."
+        )
         warn(msg)
         noisetask_fns = []
     else:
@@ -98,7 +102,9 @@ def _find_empty_room_candidates(bids_path):
 
     # Check the 'emptyroom' subject for empty-room recording sessions.
     emptyroom_session_dirs = [
-        x for x in emptyroom_dir.iterdir() if x.is_dir() and str(x.name).startswith("ses-")
+        x
+        for x in emptyroom_dir.iterdir()
+        if x.is_dir() and str(x.name).startswith("ses-")
     ]
     if not emptyroom_session_dirs:  # No session sub-directories found
         emptyroom_session_dirs = [emptyroom_dir]
@@ -106,7 +112,9 @@ def _find_empty_room_candidates(bids_path):
     # Now try to discover all recordings inside the session directories.
     candidate_er_fnames = []
     for session_dir in emptyroom_session_dirs:
-        dir_contents = glob.glob(op.join(session_dir, datatype, f"sub-emptyroom_*_{datatype}*"))
+        dir_contents = glob.glob(
+            op.join(session_dir, datatype, f"sub-emptyroom_*_{datatype}*")
+        )
         for item in dir_contents:
             item = Path(item)
             if (item.suffix in allowed_extensions) or (

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -60,7 +60,7 @@ def _find_empty_room_candidates(bids_path):
 
     # Find matching "task-noise" files in the same directory as the recording.
     noisetask_path = bids_path.update(
-        split=None, task="noise", datatype=datatype, suffix=datatype
+        split=None, run=None, task="noise", datatype=datatype, suffix=datatype
     )
 
     allowed_extensions = list(reader.keys())
@@ -74,11 +74,15 @@ def _find_empty_room_candidates(bids_path):
         for candidate in noisetask_path.match()
         if candidate.extension in allowed_extensions
     ]
-    # For some reason a single file can produce multiple hits in the match function. Remove dups
+    print(noisetask_tmp)
+    # For some reason a single file can produce multiple hits in the match function.
+    # Remove dups
     noisetask_fns = []
     for i in range(len(noisetask_tmp)):
         fn = noisetask_tmp.pop()
-        if not any(fn.fpath == f.fpath for f in noisetask_fns):
+        if len(noisetask_tmp) == 0 or not any(
+            fn.fpath == f.fpath for f in noisetask_fns
+        ):
             noisetask_fns.append(fn)
 
     # If we have more than one noise task file, we need to disambiguate.

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -89,7 +89,7 @@ def _find_empty_room_candidates(bids_path):
     # It might be that it's a
     # split recording.
     if len(noisetask_fns) > 1 and any(path.split is not None for path in noisetask_fns):
-        noisetask_path.update(spilt="01")
+        noisetask_path.update(split="01")
         noisetask_fns = [
             candidate
             for candidate in noisetask_path.match()

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -81,7 +81,6 @@ def _find_empty_room_candidates(bids_path):
         if not any(fn.fpath == f.fpath for f in noisetask_fns):
             noisetask_fns.append(fn)
 
-
     # If we have more than one noise task file, we need to disambiguate.
     # It might be that it's a
     # split recording.
@@ -104,7 +103,6 @@ def _find_empty_room_candidates(bids_path):
         noisetask_fns = []
     elif len(noisetask_fns) == 1:
         return noisetask_fns[0]
-
 
     if not emptyroom_dir.exists() and not noisetask_fns:
         return list()

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -74,7 +74,6 @@ def _find_empty_room_candidates(bids_path):
         for candidate in noisetask_path.match()
         if candidate.extension in allowed_extensions
     ]
-    print(noisetask_tmp)
     # For some reason a single file can produce multiple hits in the match function.
     # Remove dups
     noisetask_fns = []

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -75,7 +75,8 @@ def _find_empty_room_candidates(bids_path):
         if candidate.extension in allowed_extensions
     ]
 
-    # If we have more than one noise task file, we need to disambiguate. It might be that it's a
+    # If we have more than one noise task file, we need to disambiguate.
+    # It might be that it's a
     # split recording.
     if len(noisetask_fns) > 1 and any(path.split is not None for path in noisetask_fns):
         noisetask_path.update(spilt="01")
@@ -85,8 +86,8 @@ def _find_empty_room_candidates(bids_path):
             if candidate.extension in allowed_extensions
         ]
 
-    # If it wasn't a split recording, warn the user that something is wonky, then resort to
-    # looking for sub-emptyroom recordings and date-matching.
+    # If it wasn't a split recording, warn the user that something is wonky,
+    # then resort to looking for sub-emptyroom recordings and date-matching.
     if len(noisetask_fns) > 1:
         msg = (
             "Found more than one matching noise task file."
@@ -138,8 +139,8 @@ def _find_matched_empty_room(bids_path):
     from mne_bids import read_raw_bids  # avoid circular import.
 
     candidates = _find_empty_room_candidates(bids_path)
-    # If a single candidate is returned, then there's a same-session noise task recording that
-    # takes priority.
+    # If a single candidate is returned, then there's a same-session noise
+    # task recording that takes priority.
     if not isinstance(candidates, list):
         return candidates
 

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -1170,7 +1170,8 @@ def test_find_empty_room(return_bids_test_dir, tmp_path):
     # precedence over the emptyroom directory file
     os.remove(er_bids_path.fpath)
     er_noise_task_path = bids_path.copy().update(
-        run=None, task="noise",
+        run=None,
+        task="noise",
     )
 
     write_raw_bids(er_raw, er_noise_task_path, overwrite=True, verbose=False)

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -1176,7 +1176,6 @@ def test_find_empty_room(return_bids_test_dir, tmp_path):
 
     # Test that when there is a noise task file in the subject directory it will take
     # precedence over the emptyroom directory file
-    os.remove(er_bids_path.fpath)
     er_noise_task_path = bids_path.copy().update(
         run=None,
         task="noise",
@@ -1185,6 +1184,21 @@ def test_find_empty_room(return_bids_test_dir, tmp_path):
     write_raw_bids(er_raw, er_noise_task_path, overwrite=True, verbose=False)
     recovered_er_bids_path = bids_path.find_empty_room()
     assert er_noise_task_path == recovered_er_bids_path
+    er_noise_task_path.fpath.unlink()
+
+    # When a split empty room file is present, the first split should be returned as the matching
+    # empty room file
+    split_er_bids_path = er_noise_task_path.copy().update(split="01", extension=".fif")
+    split_er_bids_path.fpath.touch()
+    split_er_bids_path2 = split_er_bids_path.copy().update(
+        split="02", extension=".fif"
+    )  # not used
+    split_er_bids_path2.fpath.touch()
+    recovered_er_bids_path = bids_path.find_empty_room()
+    assert split_er_bids_path == recovered_er_bids_path
+    split_er_bids_path.fpath.unlink()
+    split_er_bids_path2.fpath.unlink()
+    write_raw_bids(er_raw, er_noise_task_path, overwrite=True, verbose=False)
 
     # Check that when there are multiple matches that cannot be resolved via assigning
     # split=01 that the sub-emptyroom is the fallback

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -1172,6 +1172,20 @@ def test_find_empty_room(return_bids_test_dir, tmp_path):
     recovered_er_bids_path = bids_path.find_empty_room()
     assert er_noise_task_path == recovered_er_bids_path
 
+    # Test that when there is a split noise task file that the correct one is chosen (split 01)
+    os.remove(er_noise_task_path.fpath)
+    er_noise_task_path.update(split="01")
+    write_raw_bids(er_raw, er_noise_task_path, overwrite=True, verbose=False)
+    recovered_er_bids_path = bids_path.find_empty_room()
+    assert er_noise_task_path == recovered_er_bids_path
+
+    # Check that when there are multiple matches that cannot be resolved via assigning split=01
+    # that the sub-emptyroom is the fallback
+    er_noise_task_path.update(run="100")
+    write_raw_bids(er_raw, er_noise_task_path, overwrite=True, verbose=False)
+    recovered_er_bids_path = bids_path.find_empty_room()
+    assert er_bids_path == recovered_er_bids_path
+
     # assert that we get best emptyroom if there are multiple available
     sh.rmtree(op.join(bids_root, "sub-emptyroom"))
     dates = ["20021204", "20021201", "20021001"]

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -1165,8 +1165,8 @@ def test_find_empty_room(return_bids_test_dir, tmp_path):
     recovered_er_bids_path = bids_path.find_empty_room()
     assert er_bids_path == recovered_er_bids_path
 
-    # Test that when there is a noise task file in the subject directory it will take precedence
-    # over the emptyroom directory file
+    # Test that when there is a noise task file in the subject directory it will take
+    # precedence over the emptyroom directory file
     er_noise_task_path = er_bids_path.copy().update(
         subject="01", session="01", task="noise"
     )
@@ -1174,19 +1174,22 @@ def test_find_empty_room(return_bids_test_dir, tmp_path):
     recovered_er_bids_path = bids_path.find_empty_room()
     assert er_noise_task_path == recovered_er_bids_path
 
-    # Test that when there is a split noise task file that the correct one is chosen (split 01)
+    # Test that when there is a split noise task file that the correct one is
+    # chosen (split 01)
     os.remove(er_noise_task_path.fpath)
     er_noise_task_path.update(split="01")
     write_raw_bids(er_raw, er_noise_task_path, overwrite=True, verbose=False)
     recovered_er_bids_path = bids_path.find_empty_room()
     assert er_noise_task_path == recovered_er_bids_path
 
-    # Check that when there are multiple matches that cannot be resolved via assigning split=01
-    # that the sub-emptyroom is the fallback
+    # Check that when there are multiple matches that cannot be resolved via assigning
+    # split=01 that the sub-emptyroom is the fallback
     er_noise_task_path.update(run="100")
     write_raw_bids(er_raw, er_noise_task_path, overwrite=True, verbose=False)
     recovered_er_bids_path = bids_path.find_empty_room()
     assert er_bids_path == recovered_er_bids_path
+    os.remove(er_noise_task_path.fpath)
+    os.remove(er_noise_task_path.update(split="01").fpath)
 
     # assert that we get best emptyroom if there are multiple available
     sh.rmtree(op.join(bids_root, "sub-emptyroom"))

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -1167,7 +1167,9 @@ def test_find_empty_room(return_bids_test_dir, tmp_path):
 
     # Test that when there is a noise task file in the subject directory it will take precedence
     # over the emptyroom directory file
-    er_noise_task_path = er_bids_path.copy().update(subject="01", session="01", task="noise")
+    er_noise_task_path = er_bids_path.copy().update(
+        subject="01", session="01", task="noise"
+    )
     write_raw_bids(er_raw, er_noise_task_path, overwrite=True, verbose=False)
     recovered_er_bids_path = bids_path.find_empty_room()
     assert er_noise_task_path == recovered_er_bids_path

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -1138,6 +1138,7 @@ def test_find_empty_room(return_bids_test_dir, tmp_path):
         task="audiovisual",
         run="01",
         root=bids_root,
+        datatype="meg",
         suffix="meg",
     )
     write_raw_bids(raw, bids_path, overwrite=True, verbose=False)
@@ -1167,29 +1168,26 @@ def test_find_empty_room(return_bids_test_dir, tmp_path):
 
     # Test that when there is a noise task file in the subject directory it will take
     # precedence over the emptyroom directory file
-    er_noise_task_path = er_bids_path.copy().update(
-        subject="01", session="01", task="noise"
+    os.remove(er_bids_path.fpath)
+    er_noise_task_path = bids_path.copy().update(
+        run=None, task="noise",
     )
-    write_raw_bids(er_raw, er_noise_task_path, overwrite=True, verbose=False)
-    recovered_er_bids_path = bids_path.find_empty_room()
-    assert er_noise_task_path == recovered_er_bids_path
 
-    # Test that when there is a split noise task file that the correct one is
-    # chosen (split 01)
-    os.remove(er_noise_task_path.fpath)
-    er_noise_task_path.update(split="01")
     write_raw_bids(er_raw, er_noise_task_path, overwrite=True, verbose=False)
     recovered_er_bids_path = bids_path.find_empty_room()
     assert er_noise_task_path == recovered_er_bids_path
 
     # Check that when there are multiple matches that cannot be resolved via assigning
     # split=01 that the sub-emptyroom is the fallback
-    er_noise_task_path.update(run="100")
-    write_raw_bids(er_raw, er_noise_task_path, overwrite=True, verbose=False)
-    recovered_er_bids_path = bids_path.find_empty_room()
+    dup_noise_task_path = er_noise_task_path.copy()
+    dup_noise_task_path.update(run="100", split=None)
+    write_raw_bids(er_raw, dup_noise_task_path, overwrite=True, verbose=False)
+    write_raw_bids(er_raw, er_bids_path, overwrite=True, verbose=False)
+    with pytest.warns(RuntimeWarning):
+        recovered_er_bids_path = bids_path.find_empty_room()
     assert er_bids_path == recovered_er_bids_path
     os.remove(er_noise_task_path.fpath)
-    os.remove(er_noise_task_path.update(split="01").fpath)
+    os.remove(dup_noise_task_path.fpath)
 
     # assert that we get best emptyroom if there are multiple available
     sh.rmtree(op.join(bids_root, "sub-emptyroom"))

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -1165,6 +1165,13 @@ def test_find_empty_room(return_bids_test_dir, tmp_path):
     recovered_er_bids_path = bids_path.find_empty_room()
     assert er_bids_path == recovered_er_bids_path
 
+    # Test that when there is a noise task file in the subject directory it will take precedence
+    # over the emptyroom directory file
+    er_noise_task_path = er_bids_path.copy().update(subject="01", session="01", task="noise")
+    write_raw_bids(er_raw, er_noise_task_path, overwrite=True, verbose=False)
+    recovered_er_bids_path = bids_path.find_empty_room()
+    assert er_noise_task_path == recovered_er_bids_path
+
     # assert that we get best emptyroom if there are multiple available
     sh.rmtree(op.join(bids_root, "sub-emptyroom"))
     dates = ["20021204", "20021201", "20021001"]

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -1195,8 +1195,8 @@ def test_find_empty_room(return_bids_test_dir, tmp_path):
     with pytest.warns(RuntimeWarning):
         recovered_er_bids_path = bids_path.find_empty_room()
     assert er_bids_path == recovered_er_bids_path
-    os.remove(er_noise_task_path.fpath)
-    os.remove(dup_noise_task_path.fpath)
+    er_noise_task_path.fpath.unlink()
+    dup_noise_task_path.fpath.unlink()
 
     # assert that we get best emptyroom if there are multiple available
     sh.rmtree(op.join(bids_root, "sub-emptyroom"))

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -1186,8 +1186,8 @@ def test_find_empty_room(return_bids_test_dir, tmp_path):
     assert er_noise_task_path == recovered_er_bids_path
     er_noise_task_path.fpath.unlink()
 
-    # When a split empty room file is present, the first split should be returned as the matching
-    # empty room file
+    # When a split empty room file is present, the first split should be returned as
+    # the matching empty room file
     split_er_bids_path = er_noise_task_path.copy().update(split="01", extension=".fif")
     split_er_bids_path.fpath.touch()
     split_er_bids_path2 = split_er_bids_path.copy().update(

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -1150,6 +1150,9 @@ def test_find_empty_room(return_bids_test_dir, tmp_path):
         suffix="meg",
     )
     write_raw_bids(raw, bids_path, overwrite=True, verbose=False)
+    noroot = bids_path.copy().update(root=None)
+    with pytest.raises(ValueError, match="The root of the"):
+        noroot.find_empty_room()
 
     # No empty-room data present.
     er_basename = bids_path.find_empty_room()


### PR DESCRIPTION
PR Description
--------------

- closes https://github.com/mne-tools/mne-bids/issues/1354

To resolve the lack of "noise" task matching mentioned in #1354 I've implemented logic that prioritizes files found in the same session with `task-noise` over `sub-emptyroom` recordings. See the proposal in the mentioned issue for the details of the logic.

Merge checklist
---------------

Maintainer, please confirm the following before merging.
If applicable:

- [ ] All comments are resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] New contributors have been added to [CITATION.cff](https://github.com/mne-tools/mne-bids/blob/main/CITATION.cff)
- [ ] PR description includes phrase "closes <#issue-number>"
