### PR TITLE
maint: update comment in conf.py

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -115,7 +115,7 @@ release = version
 exclude_patterns = ["auto_examples/index.rst", "_build", "Thumbs.db", ".DS_Store"]
 
 nitpick_ignore_regex = [
-    # needs https://github.com/sphinx-doc/sphinx/issues/13178
+    # TODO can be removed when min. Sphinx version is 8.2
     ("py:class", r".*pathlib\._local\.Path"),
 ]
 


### PR DESCRIPTION
updating a code comment to reflect the fact taht an upstream fix to Sphinx has happened.
So now, reference the relevant Sphinx version rather than the issue.

I'll skip CIs and self-merge, since this only changes code comments.


