### PR TITLE
Refactor _handle_events_reading to allow extracting annotation information stand-alone

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -206,6 +206,10 @@ authors:
       family-names: Gerçek
       affiliation: 'University of Geneva, Department of Fundamental Neuroscience'
       orcid: 'https://orcid.org/0000-0003-1063-6769'
+    - given-names: Matthias
+      family-names: Dold
+      affiliation: 'Donders Institute for Brain, Cognition and Behaviour, Radboud University, Nijmegen, Netherlands'
+      orcid: 'https://orcid.org/0009-0003-1477-4912'
     - given-names: Alexandre
       family-names: Gramfort
       affiliation: 'Université Paris-Saclay, Inria, CEA, Palaiseau, France'

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -27,8 +27,3 @@ view:
 clean:
 	-rm -rf _build auto_examples generated
 
-.PHONY: html-noplot
-html-noplot:
-	$(SPHINXBUILD) -D plot_gallery=0 -b html $(ALLSPHINXOPTS) $(SOURCEDIR) $(BUILDDIR)/html
-	@echo
-	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -26,3 +26,9 @@ view:
 
 clean:
 	-rm -rf _build auto_examples generated
+
+.PHONY: html-noplot
+html-noplot:
+	$(SPHINXBUILD) -D plot_gallery=0 -b html $(ALLSPHINXOPTS) $(SOURCEDIR) $(BUILDDIR)/html
+	@echo
+	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -26,4 +26,3 @@ view:
 
 clean:
 	-rm -rf _build auto_examples generated
-

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -45,6 +45,7 @@ mne_bids
    update_sidecar_json
    anonymize_dataset
    find_matching_paths
+   events_file_to_annotation_kwargs
 
 mne_bids.stats
 --------------

--- a/doc/authors.rst
+++ b/doc/authors.rst
@@ -35,6 +35,7 @@
 .. _Mara Wolter: https://github.com/marakw
 .. _Marijn van Vliet: https://github.com/wmvanvliet
 .. _Mathieu Scheltienne: https://github.com/mscheltienne
+.. _Matthias Dold: https://github.com/matthiasdold
 .. _Matt Sanderson: https://github.com/monkeyman192
 .. _Maximilien Chaumon: https://github.com/dnacombo
 .. _Moritz Gerster: http://moritz-gerster.com

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -40,7 +40,7 @@ Detailed list of changes
 - Empty-room matching now preferentially finds recordings in the subject directory tagged as `task-noise` before looking in the `sub-emptyroom` directories. This adds support for a part of the BIDS specification for ER recordings, by `Berk Gerçek`_ (:gh:`1364`)
 - Path matching is now implemenented in a more efficient manner within :meth:`mne_bids.BIDSPath.match()` and :func:`mne_bids.find_matching_paths()`, by `Arne Gottwald` (:gh:`1355`)
 - :func:`mne_bids.get_entity_vals()` has a new parameter ``include_match`` to prefilter item matching and ignore non-matched items from begin of directory scan, by `Arne Gottwald` (:gh:`1355`)
-- Data from ``events.tsv`` can now be read into an OrderedDict using :func:`mne_bids.events_file_to_annotation_kwargs()`, by `Matthias Dold` (:gh:`1389`)
+- Data from ``events.tsv`` can now be read into an OrderedDict using :func:`mne_bids.events_file_to_annotation_kwargs`, by `Matthias Dold` (:gh:`1389`)
 
 
 🧐 API and behavior changes

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -40,7 +40,7 @@ Detailed list of changes
 - Empty-room matching now preferentially finds recordings in the subject directory tagged as `task-noise` before looking in the `sub-emptyroom` directories. This adds support for a part of the BIDS specification for ER recordings, by `Berk Gerçek`_ (:gh:`1364`)
 - Path matching is now implemenented in a more efficient manner within :meth:`mne_bids.BIDSPath.match()` and :func:`mne_bids.find_matching_paths()`, by `Arne Gottwald` (:gh:`1355`)
 - :func:`mne_bids.get_entity_vals()` has a new parameter ``include_match`` to prefilter item matching and ignore non-matched items from begin of directory scan, by `Arne Gottwald` (:gh:`1355`)
-- `_handle_events_reading()` was refactored to now exposed the filtering of the `events.tsv` data as a separate function :func:`mne_bids.read.events_file_to_annotation_kwargs`, by `Matthias Dold` (:gh:`1389`)
+- :func:`mne_bids.read._handle_events_reading()` was refactored to now exposed the filtering of the `events.tsv` data as a separate function :func:`mne_bids.read._events_file_to_annotation_kwargs`, by `Matthias Dold` (:gh:`1389`)
 
 
 🧐 API and behavior changes

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -40,7 +40,7 @@ Detailed list of changes
 - Empty-room matching now preferentially finds recordings in the subject directory tagged as `task-noise` before looking in the `sub-emptyroom` directories. This adds support for a part of the BIDS specification for ER recordings, by `Berk Gerçek`_ (:gh:`1364`)
 - Path matching is now implemenented in a more efficient manner within :meth:`mne_bids.BIDSPath.match()` and :func:`mne_bids.find_matching_paths()`, by `Arne Gottwald` (:gh:`1355`)
 - :func:`mne_bids.get_entity_vals()` has a new parameter ``include_match`` to prefilter item matching and ignore non-matched items from begin of directory scan, by `Arne Gottwald` (:gh:`1355`)
-- `_handle_events_reading()` was refactored to now exposed the filtering of the `events.tsv` data as a separate function :func:`mne_bids.events_file_to_annotation_kwargs`, by `Matthias Dold` (:gh:`1389`)
+- `_handle_events_reading()` was refactored to now exposed the filtering of the `events.tsv` data as a separate function :func:`mne_bids.read.events_file_to_annotation_kwargs`, by `Matthias Dold` (:gh:`1389`)
 
 
 🧐 API and behavior changes

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -20,6 +20,7 @@ The following authors contributed for the first time. Thank you so much! 🤩
 * `Christian O'Reilly`_
 * `Berk Gerçek`_
 * `Arne Gottwald`_
+* `Matthias Dold`_
 
 The following authors had contributed before. Thank you for sticking around! 🤘
 
@@ -39,6 +40,7 @@ Detailed list of changes
 - Empty-room matching now preferentially finds recordings in the subject directory tagged as `task-noise` before looking in the `sub-emptyroom` directories. This adds support for a part of the BIDS specification for ER recordings, by `Berk Gerçek`_ (:gh:`1364`)
 - Path matching is now implemenented in a more efficient manner within :meth:`mne_bids.BIDSPath.match()` and :func:`mne_bids.find_matching_paths()`, by `Arne Gottwald` (:gh:`1355`)
 - :func:`mne_bids.get_entity_vals()` has a new parameter ``include_match`` to prefilter item matching and ignore non-matched items from begin of directory scan, by `Arne Gottwald` (:gh:`1355`)
+- :func:`mne_bids.read._handle_events_reading()` was refactored to now exposed the filtering of the `events.tsv` data as a separate function :func:`mne_bids.read._events_file_to_annotation_kwargs`, by `Matthias Dold` (:gh:`1389`)
 
 
 🧐 API and behavior changes

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -40,7 +40,7 @@ Detailed list of changes
 - Empty-room matching now preferentially finds recordings in the subject directory tagged as `task-noise` before looking in the `sub-emptyroom` directories. This adds support for a part of the BIDS specification for ER recordings, by `Berk Gerçek`_ (:gh:`1364`)
 - Path matching is now implemenented in a more efficient manner within :meth:`mne_bids.BIDSPath.match()` and :func:`mne_bids.find_matching_paths()`, by `Arne Gottwald` (:gh:`1355`)
 - :func:`mne_bids.get_entity_vals()` has a new parameter ``include_match`` to prefilter item matching and ignore non-matched items from begin of directory scan, by `Arne Gottwald` (:gh:`1355`)
-- :func:`mne_bids.read._handle_events_reading()` was refactored to now exposed the filtering of the `events.tsv` data as a separate function :func:`mne_bids.read._events_file_to_annotation_kwargs`, by `Matthias Dold` (:gh:`1389`)
+- `_handle_events_reading()` was refactored to now exposed the filtering of the `events.tsv` data as a separate function `_events_file_to_annotation_kwargs`, by `Matthias Dold` (:gh:`1389`)
 
 
 🧐 API and behavior changes

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -40,7 +40,7 @@ Detailed list of changes
 - Empty-room matching now preferentially finds recordings in the subject directory tagged as `task-noise` before looking in the `sub-emptyroom` directories. This adds support for a part of the BIDS specification for ER recordings, by `Berk Gerçek`_ (:gh:`1364`)
 - Path matching is now implemenented in a more efficient manner within :meth:`mne_bids.BIDSPath.match()` and :func:`mne_bids.find_matching_paths()`, by `Arne Gottwald` (:gh:`1355`)
 - :func:`mne_bids.get_entity_vals()` has a new parameter ``include_match`` to prefilter item matching and ignore non-matched items from begin of directory scan, by `Arne Gottwald` (:gh:`1355`)
-- :func:`mne_bids.read._handle_events_reading()` was refactored to now exposed the filtering of the `events.tsv` data as a separate function :func:`mne_bids.read._events_file_to_annotation_kwargs`, by `Matthias Dold` (:gh:`1389`)
+- `_handle_events_reading()` was refactored to now exposed the filtering of the `events.tsv` data as a separate function :func:`mne_bids.events_file_to_annotation_kwargs`, by `Matthias Dold` (:gh:`1389`)
 
 
 🧐 API and behavior changes

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -40,7 +40,7 @@ Detailed list of changes
 - Empty-room matching now preferentially finds recordings in the subject directory tagged as `task-noise` before looking in the `sub-emptyroom` directories. This adds support for a part of the BIDS specification for ER recordings, by `Berk Gerçek`_ (:gh:`1364`)
 - Path matching is now implemenented in a more efficient manner within :meth:`mne_bids.BIDSPath.match()` and :func:`mne_bids.find_matching_paths()`, by `Arne Gottwald` (:gh:`1355`)
 - :func:`mne_bids.get_entity_vals()` has a new parameter ``include_match`` to prefilter item matching and ignore non-matched items from begin of directory scan, by `Arne Gottwald` (:gh:`1355`)
-- Data from ``events.tsv`` can now be read into an OrderedDict using :func:`mne_bids.events_file_to_annotation_kwargs`, by `Matthias Dold` (:gh:`1389`)
+- Data from ``events.tsv`` can now be read into an OrderedDict using :func:`mne_bids.events_file_to_annotation_kwargs()`, by `Matthias Dold` (:gh:`1389`)
 
 
 🧐 API and behavior changes

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -40,7 +40,7 @@ Detailed list of changes
 - Empty-room matching now preferentially finds recordings in the subject directory tagged as `task-noise` before looking in the `sub-emptyroom` directories. This adds support for a part of the BIDS specification for ER recordings, by `Berk Gerçek`_ (:gh:`1364`)
 - Path matching is now implemenented in a more efficient manner within :meth:`mne_bids.BIDSPath.match()` and :func:`mne_bids.find_matching_paths()`, by `Arne Gottwald` (:gh:`1355`)
 - :func:`mne_bids.get_entity_vals()` has a new parameter ``include_match`` to prefilter item matching and ignore non-matched items from begin of directory scan, by `Arne Gottwald` (:gh:`1355`)
-- Data from `events.tsv` can now be read into an OrderedDict using :func:`mne_bids.read.events_file_to_annotation_kwargs`, by `Matthias Dold` (:gh:`1389`)
+- Data from `events.tsv` can now be read into an OrderedDict using :func:`mne_bids.events_file_to_annotation_kwargs()`, by `Matthias Dold` (:gh:`1389`)
 
 
 🧐 API and behavior changes

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -40,7 +40,7 @@ Detailed list of changes
 - Empty-room matching now preferentially finds recordings in the subject directory tagged as `task-noise` before looking in the `sub-emptyroom` directories. This adds support for a part of the BIDS specification for ER recordings, by `Berk Gerçek`_ (:gh:`1364`)
 - Path matching is now implemenented in a more efficient manner within :meth:`mne_bids.BIDSPath.match()` and :func:`mne_bids.find_matching_paths()`, by `Arne Gottwald` (:gh:`1355`)
 - :func:`mne_bids.get_entity_vals()` has a new parameter ``include_match`` to prefilter item matching and ignore non-matched items from begin of directory scan, by `Arne Gottwald` (:gh:`1355`)
-- `_handle_events_reading()` was refactored to now exposed the filtering of the `events.tsv` data as a separate function `_events_file_to_annotation_kwargs`, by `Matthias Dold` (:gh:`1389`)
+- Data from `events.tsv` can now be read into an OrderedDict using :func:`mne_bids.read.events_file_to_annotation_kwargs`, by `Matthias Dold` (:gh:`1389`)
 
 
 🧐 API and behavior changes

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -40,7 +40,7 @@ Detailed list of changes
 - Empty-room matching now preferentially finds recordings in the subject directory tagged as `task-noise` before looking in the `sub-emptyroom` directories. This adds support for a part of the BIDS specification for ER recordings, by `Berk Gerçek`_ (:gh:`1364`)
 - Path matching is now implemenented in a more efficient manner within :meth:`mne_bids.BIDSPath.match()` and :func:`mne_bids.find_matching_paths()`, by `Arne Gottwald` (:gh:`1355`)
 - :func:`mne_bids.get_entity_vals()` has a new parameter ``include_match`` to prefilter item matching and ignore non-matched items from begin of directory scan, by `Arne Gottwald` (:gh:`1355`)
-- Data from `events.tsv` can now be read into an OrderedDict using :func:`mne_bids.events_file_to_annotation_kwargs()`, by `Matthias Dold` (:gh:`1389`)
+- Data from ``events.tsv`` can now be read into an OrderedDict using :func:`mne_bids.events_file_to_annotation_kwargs()`, by `Matthias Dold` (:gh:`1389`)
 
 
 🧐 API and behavior changes

--- a/mne_bids/__init__.py
+++ b/mne_bids/__init__.py
@@ -22,7 +22,11 @@ from mne_bids.path import (
     get_bids_path_from_fname,
     find_matching_paths,
 )
-from mne_bids.read import (get_head_mri_trans, read_raw_bids, events_file_to_annotation_kwargs)
+from mne_bids.read import (
+    get_head_mri_trans,
+    read_raw_bids,
+    events_file_to_annotation_kwargs,
+)
 from mne_bids.utils import get_anonymization_daysback
 from mne_bids.write import (
     make_dataset_description,

--- a/mne_bids/__init__.py
+++ b/mne_bids/__init__.py
@@ -22,7 +22,7 @@ from mne_bids.path import (
     get_bids_path_from_fname,
     find_matching_paths,
 )
-from mne_bids.read import get_head_mri_trans, read_raw_bids
+from mne_bids.read import (get_head_mri_trans, read_raw_bids, events_file_to_annotation_kwargs)
 from mne_bids.utils import get_anonymization_daysback
 from mne_bids.write import (
     make_dataset_description,

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -525,20 +525,19 @@ def _handle_info_reading(sidecar_fname, raw):
 
 def events_file_to_annotation_kwargs(events_fname: str | Path) -> dict:
     r"""
-    Read the `events.tsv` file and extract onset, duration, and description.
-
-    This function reads an events file in TSV format and extracts the onset,
-    duration, and description of events.
+    Read the ``events.tsv`` file and extract onset, duration, and description.
 
     Parameters
     ----------
     events_fname : str
-        The file path to the `events.tsv` file.
+        The file path to the ``events.tsv`` file.
 
     Returns
     -------
-    dict
+    kwargs_dict : dict
+
         A dictionary containing the following keys:
+
         - 'onset' : np.ndarray
             The onset times of the events in seconds.
         - 'duration' : np.ndarray
@@ -551,9 +550,10 @@ def events_file_to_annotation_kwargs(events_fname: str | Path) -> dict:
     Notes
     -----
     The function handles the following cases:
-    - If the `trial_type` column is available, it uses it for event descriptions.
-    - If the `stim_type` column is available, it uses it for backward compatibility.
-    - If the `value` column is available, it uses it to create the `event_id`.
+
+    - If the ``trial_type`` column is available, it uses it for event descriptions.
+    - If the ``stim_type`` column is available, it uses it for backward compatibility.
+    - If the ``value`` column is available, it uses it to create the ``event_id``.
     - If none of the above columns are available, it defaults to using 'n/a' for
       descriptions and 1 for event IDs.
 

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -523,8 +523,10 @@ def _handle_info_reading(sidecar_fname, raw):
     return raw
 
 
-def _handle_events_reading(events_fname, raw):
-    """Read associated events.tsv and convert valid events to annotations on Raw."""
+def _events_file_to_annotation_kwargs(events_fname: str) -> dict:
+    """Read the `events.tsv` file and extract onset, duration, and description
+    used to set annotation to an mne.io.BaseRaw."""
+
     logger.info(f"Reading events from {events_fname}.")
     events_dict = _from_tsv(events_fname)
 
@@ -601,9 +603,22 @@ def _handle_events_reading(events_fname, raw):
         [0 if du == "n/a" else du for du in events_dict["duration"]], dtype=float
     )
 
+    return {"onset": ons, "duration": durs, "description": descrs, "event_id": event_id}
+
+
+def _handle_events_reading(events_fname, raw):
+    """Read associated events.tsv and convert valid events to annotations on Raw."""
+
+    annotations_info = _events_file_to_annotation_kwargs(events_fname)
+    event_id = annotations_info["event_id"]
+
     # Add events as Annotations, but keep essential Annotations present in raw file
     annot_from_raw = raw.annotations.copy()
-    annot_from_events = mne.Annotations(onset=ons, duration=durs, description=descrs)
+    annot_from_events = mne.Annotations(
+        onset=annotations_info["onset"],
+        duration=annotations_info["duration"],
+        description=annotations_info["description"],
+    )
     raw.set_annotations(annot_from_events)
 
     annot_idx_to_keep = [

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -523,7 +523,7 @@ def _handle_info_reading(sidecar_fname, raw):
     return raw
 
 
-def events_file_to_annotation_kwargs(events_fname: str) -> dict:
+def _events_file_to_annotation_kwargs(events_fname: str) -> dict:
     """Read the `events.tsv` file and extract onset, duration, and description."""
     logger.info(f"Reading events from {events_fname}.")
     events_dict = _from_tsv(events_fname)
@@ -606,7 +606,7 @@ def events_file_to_annotation_kwargs(events_fname: str) -> dict:
 
 def _handle_events_reading(events_fname, raw):
     """Read associated events.tsv and convert valid events to annotations on Raw."""
-    annotations_info = events_file_to_annotation_kwargs(events_fname)
+    annotations_info = _events_file_to_annotation_kwargs(events_fname)
     event_id = annotations_info["event_id"]
 
     # Add events as Annotations, but keep essential Annotations present in raw file

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -524,9 +524,7 @@ def _handle_info_reading(sidecar_fname, raw):
 
 
 def _events_file_to_annotation_kwargs(events_fname: str) -> dict:
-    """Read the `events.tsv` file and extract onset, duration, and description
-    used to set annotation to an mne.io.BaseRaw."""
-
+    """Read the `events.tsv` file and extract onset, duration, and description."""
     logger.info(f"Reading events from {events_fname}.")
     events_dict = _from_tsv(events_fname)
 
@@ -608,7 +606,6 @@ def _events_file_to_annotation_kwargs(events_fname: str) -> dict:
 
 def _handle_events_reading(events_fname, raw):
     """Read associated events.tsv and convert valid events to annotations on Raw."""
-
     annotations_info = _events_file_to_annotation_kwargs(events_fname)
     event_id = annotations_info["event_id"]
 

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -523,8 +523,49 @@ def _handle_info_reading(sidecar_fname, raw):
     return raw
 
 
-def _events_file_to_annotation_kwargs(events_fname: str) -> dict:
-    """Read the `events.tsv` file and extract onset, duration, and description."""
+def events_file_to_annotation_kwargs(events_fname: str | Path) -> dict:
+    """
+    Read the `events.tsv` file and extract onset, duration, and description.
+
+    This function reads an events file in TSV format and extracts the onset,
+    duration, and description of events.
+
+    Parameters
+    ----------
+    events_fname : str
+        The file path to the `events.tsv` file.
+
+    Returns
+    -------
+    dict
+        A dictionary containing the following keys:
+        - 'onset' : np.ndarray
+            The onset times of the events in seconds.
+        - 'duration' : np.ndarray
+            The durations of the events in seconds.
+        - 'description' : np.ndarray
+            The descriptions of the events.
+        - 'event_id' : dict
+            A dictionary mapping event descriptions to integer event IDs.
+
+    Notes
+    -----
+    The function handles the following cases:
+    - If the `trial_type` column is available, it uses it for event descriptions.
+    - If the `stim_type` column is available, it uses it for backward compatibility.
+    - If the `value` column is available, it uses it to create the `event_id`.
+    - If none of the above columns are available, it defaults to using 'n/a' for
+      descriptions and 1 for event IDs.
+
+    Examples (TBD REWORK THIS)
+    --------
+    >>> events_dict = events_file_to_annotation_kwargs('path/to/events.tsv')
+    >>> print(events_dict['onset'])
+    [0.1, 0.2, 0.3]
+    >>> print(events_dict['event_id'])
+    {'event1': 1, 'event2': 2}
+
+    """
     logger.info(f"Reading events from {events_fname}.")
     events_dict = _from_tsv(events_fname)
 
@@ -606,7 +647,7 @@ def _events_file_to_annotation_kwargs(events_fname: str) -> dict:
 
 def _handle_events_reading(events_fname, raw):
     """Read associated events.tsv and convert valid events to annotations on Raw."""
-    annotations_info = _events_file_to_annotation_kwargs(events_fname)
+    annotations_info = events_file_to_annotation_kwargs(events_fname)
     event_id = annotations_info["event_id"]
 
     # Add events as Annotations, but keep essential Annotations present in raw file

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -524,7 +524,7 @@ def _handle_info_reading(sidecar_fname, raw):
 
 
 def events_file_to_annotation_kwargs(events_fname: str | Path) -> dict:
-    """
+    r"""
     Read the `events.tsv` file and extract onset, duration, and description.
 
     This function reads an events file in TSV format and extracts the onset,
@@ -557,13 +557,34 @@ def events_file_to_annotation_kwargs(events_fname: str | Path) -> dict:
     - If none of the above columns are available, it defaults to using 'n/a' for
       descriptions and 1 for event IDs.
 
-    Examples (TBD REWORK THIS)
+    Examples
     --------
-    >>> events_dict = events_file_to_annotation_kwargs('path/to/events.tsv')
-    >>> print(events_dict['onset'])
-    [0.1, 0.2, 0.3]
-    >>> print(events_dict['event_id'])
-    {'event1': 1, 'event2': 2}
+    >>> import pandas as pd
+    >>> from pathlib import Path
+    >>> import tempfile
+    >>>
+    >>> # Create a sample DataFrame
+    >>> data = {
+    ...     'onset': [0.1, 0.2, 0.3],
+    ...     'duration': [0.1, 0.1, 0.1],
+    ...     'trial_type': ['event1', 'event2', 'event1'],
+    ...     'value': [1, 2, 1],
+    ...     'sample': [10, 20, 30]
+    ... }
+    >>> df = pd.DataFrame(data)
+    >>>
+    >>> # Write the DataFrame to a temporary file
+    >>> temp_dir = tempfile.gettempdir()
+    >>> events_file = Path(temp_dir) / 'events.tsv'
+    >>> df.to_csv(events_file, sep='\t', index=False)
+    >>>
+    >>> # Read the events file using the function
+    >>> events_dict = events_file_to_annotation_kwargs(events_file)
+    >>> events_dict
+    {'onset': array([0.1, 0.2, 0.3]),
+    'duration': array([0.1, 0.1, 0.1]),
+    'description': array(['event1', 'event2', 'event1'], dtype='<U6'),
+    'event_id': {'event1': 1, 'event2': 2}}
 
     """
     logger.info(f"Reading events from {events_fname}.")

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -523,7 +523,7 @@ def _handle_info_reading(sidecar_fname, raw):
     return raw
 
 
-def _events_file_to_annotation_kwargs(events_fname: str) -> dict:
+def events_file_to_annotation_kwargs(events_fname: str) -> dict:
     """Read the `events.tsv` file and extract onset, duration, and description."""
     logger.info(f"Reading events from {events_fname}.")
     events_dict = _from_tsv(events_fname)
@@ -606,7 +606,7 @@ def _events_file_to_annotation_kwargs(events_fname: str) -> dict:
 
 def _handle_events_reading(events_fname, raw):
     """Read associated events.tsv and convert valid events to annotations on Raw."""
-    annotations_info = _events_file_to_annotation_kwargs(events_fname)
+    annotations_info = events_file_to_annotation_kwargs(events_fname)
     event_id = annotations_info["event_id"]
 
     # Add events as Annotations, but keep essential Annotations present in raw file

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 import mne
 import numpy as np
+import pandas as pd
 import pytest
 from mne.datasets import testing
 from mne.io.constants import FIFF
@@ -32,6 +33,7 @@ from mne_bids.read import (
     _handle_events_reading,
     _handle_scans_reading,
     _read_raw,
+    events_file_to_annotation_kwargs,
     get_head_mri_trans,
     read_raw_bids,
 )
@@ -855,9 +857,7 @@ def test_handle_chpi_reading(tmp_path):
     meg_json_data_freq_mismatch["HeadCoilFrequency"][0] = 123
     _write_json(meg_json_path, meg_json_data_freq_mismatch, overwrite=True)
 
-    with (
-        pytest.warns(RuntimeWarning, match="Defaulting to .* mne.Raw object"),
-    ):
+    with (pytest.warns(RuntimeWarning, match="Defaulting to .* mne.Raw object"),):
         raw_read = read_raw_bids(bids_path, extra_params=dict(allow_maxshield="yes"))
 
     # cHPI "off" according to sidecar, but present in the data
@@ -1078,9 +1078,7 @@ def test_handle_ieeg_coords_reading(bids_path, tmp_path):
     _to_tsv(electrodes_dict, electrodes_fname)
     # popping off channels should not result in an error
     # however, a warning will be raised through mne-python
-    with (
-        pytest.warns(RuntimeWarning, match="DigMontage is only a subset of info"),
-    ):
+    with (pytest.warns(RuntimeWarning, match="DigMontage is only a subset of info"),):
         read_raw_bids(bids_path=bids_fname, verbose=False)
 
     # make sure montage is set if there are coordinates w/ 'n/a'
@@ -1096,9 +1094,7 @@ def test_handle_ieeg_coords_reading(bids_path, tmp_path):
     # electrode coordinates should be nan
     # when coordinate is 'n/a'
     nan_chs = [electrodes_dict["name"][i] for i in [0, 3]]
-    with (
-        pytest.warns(RuntimeWarning, match="There are channels without locations"),
-    ):
+    with (pytest.warns(RuntimeWarning, match="There are channels without locations"),):
         raw = read_raw_bids(bids_path=bids_fname, verbose=False)
         for idx, ch in enumerate(raw.info["chs"]):
             if ch["ch_name"] in nan_chs:
@@ -1226,9 +1222,7 @@ def test_handle_non_mne_channel_type(tmp_path):
     channels_data["type"][ch_idx] = "FOOBAR"
     _to_tsv(data=channels_data, fname=channels_tsv_path)
 
-    with (
-        pytest.warns(RuntimeWarning, match='will be set to "misc"'),
-    ):
+    with (pytest.warns(RuntimeWarning, match='will be set to "misc"'),):
         raw = read_raw_bids(bids_path)
 
     # Should be a 'misc' channel.
@@ -1466,3 +1460,75 @@ def test_gsr_and_temp_reading():
     raw = read_raw_bids(bids_path)
     assert raw.get_channel_types(["GSR"]) == ["gsr"]
     assert raw.get_channel_types(["Temperature"]) == ["temperature"]
+
+
+def test_events_file_to_annotation_kwargs(tmp_path):
+    bids_path = BIDSPath(
+        subject="01", session="eeg", task="rest", datatype="eeg", root=tiny_bids_root
+    )
+    events_fname = _find_matching_sidecar(bids_path, suffix="events", extension=".tsv")
+
+    # ---------------- plain read --------------------------------------------
+    df = pd.read_csv(events_fname, sep="\t")
+    ev_kwargs = events_file_to_annotation_kwargs(events_fname=events_fname)
+    assert (ev_kwargs["onset"] == df["onset"].values).all()
+    assert (ev_kwargs["duration"] == df["duration"].values).all()
+    assert (ev_kwargs["description"] == df["trial_type"].values).all()
+
+    # ---------------- filtering out n/a values ------------------------------
+    tmp_tsv_file = tmp_path / "events.tsv"
+    dext = pd.concat(
+        [df.copy().assign(onset=df.onset + i) for i in range(5)]
+    ).reset_index(drop=True)
+
+    dext = dext.assign(
+        ix=range(len(dext)),
+        value=dext.trial_type.map({"start_experiment": 1, "show_stimulus": 2}),
+        duration=1.0,
+    )
+
+    # nan values for `_drop` must be string values, `_drop` is called on
+    # `onset`, `value` and `trial_type`. `duration` n/a should end up as float 0
+    for c in ["onset", "value", "trial_type", "duration"]:
+        dext[c] = dext[c].astype(str)
+
+    dext.loc[0, "onset"] = "n/a"
+    dext.loc[1, "duration"] = "n/a"
+    dext.loc[4, "trial_type"] = "n/a"
+    dext.loc[4, "value"] = (
+        "n/a"  # to check that filtering is also applied when we drop the `trial_type`
+    )
+    dext.to_csv(tmp_tsv_file, sep="\t", index=False)
+
+    ev_kwargs_filtered = events_file_to_annotation_kwargs(events_fname=tmp_tsv_file)
+
+    dext_f = dext[
+        (dext["onset"] != "n/a")
+        & (dext["trial_type"] != "n/a")
+        & (dext["value"] != "n/a")
+    ]
+
+    assert (ev_kwargs_filtered["onset"] == dext_f["onset"].astype(float).values).all()
+    assert (
+        ev_kwargs_filtered["duration"]
+        == dext_f["duration"].replace("n/a", "0.0").astype(float).values
+    ).all()
+    assert (ev_kwargs_filtered["description"] == dext_f["trial_type"].values).all()
+    assert (
+        ev_kwargs_filtered["duration"][0] == 0.0
+    )  # now idx=0, as first row is filtered out
+
+    # ---------------- default if missing trial_type  ------------------------
+    tmp_tsv_file = tmp_path / "events.tsv"
+    dext.drop(columns="trial_type").to_csv(tmp_tsv_file, sep="\t", index=False)
+
+    ev_kwargs_default = events_file_to_annotation_kwargs(events_fname=tmp_tsv_file)
+    assert (ev_kwargs_default["onset"] == dext_f["onset"].astype(float).values).all()
+    assert (
+        ev_kwargs_default["duration"]
+        == dext_f["duration"].replace("n/a", "0.0").astype(float).values
+    ).all()
+    assert (
+        np.sort(np.unique(ev_kwargs_default["description"]))
+        == np.sort(dext_f["value"].unique())
+    ).all()

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -3,7 +3,6 @@
 # Authors: The MNE-BIDS developers
 # SPDX-License-Identifier: BSD-3-Clause
 
-
 import json
 import os
 import os.path as op
@@ -858,7 +857,9 @@ def test_handle_chpi_reading(tmp_path):
     meg_json_data_freq_mismatch["HeadCoilFrequency"][0] = 123
     _write_json(meg_json_path, meg_json_data_freq_mismatch, overwrite=True)
 
-    with (pytest.warns(RuntimeWarning, match="Defaulting to .* mne.Raw object"),):
+    with (
+        pytest.warns(RuntimeWarning, match="Defaulting to .* mne.Raw object"),
+    ):
         raw_read = read_raw_bids(bids_path, extra_params=dict(allow_maxshield="yes"))
 
     # cHPI "off" according to sidecar, but present in the data
@@ -1079,7 +1080,9 @@ def test_handle_ieeg_coords_reading(bids_path, tmp_path):
     _to_tsv(electrodes_dict, electrodes_fname)
     # popping off channels should not result in an error
     # however, a warning will be raised through mne-python
-    with (pytest.warns(RuntimeWarning, match="DigMontage is only a subset of info"),):
+    with (
+        pytest.warns(RuntimeWarning, match="DigMontage is only a subset of info"),
+    ):
         read_raw_bids(bids_path=bids_fname, verbose=False)
 
     # make sure montage is set if there are coordinates w/ 'n/a'
@@ -1095,7 +1098,9 @@ def test_handle_ieeg_coords_reading(bids_path, tmp_path):
     # electrode coordinates should be nan
     # when coordinate is 'n/a'
     nan_chs = [electrodes_dict["name"][i] for i in [0, 3]]
-    with (pytest.warns(RuntimeWarning, match="There are channels without locations"),):
+    with (
+        pytest.warns(RuntimeWarning, match="There are channels without locations"),
+    ):
         raw = read_raw_bids(bids_path=bids_fname, verbose=False)
         for idx, ch in enumerate(raw.info["chs"]):
             if ch["ch_name"] in nan_chs:
@@ -1223,7 +1228,9 @@ def test_handle_non_mne_channel_type(tmp_path):
     channels_data["type"][ch_idx] = "FOOBAR"
     _to_tsv(data=channels_data, fname=channels_tsv_path)
 
-    with (pytest.warns(RuntimeWarning, match='will be set to "misc"'),):
+    with (
+        pytest.warns(RuntimeWarning, match='will be set to "misc"'),
+    ):
         raw = read_raw_bids(bids_path)
 
     # Should be a 'misc' channel.

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -1463,6 +1463,8 @@ def test_gsr_and_temp_reading():
 
 
 def test_events_file_to_annotation_kwargs(tmp_path):
+    """Test that events file is read correctly."""
+
     bids_path = BIDSPath(
         subject="01", session="eeg", task="rest", datatype="eeg", root=tiny_bids_root
     )

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -857,7 +857,9 @@ def test_handle_chpi_reading(tmp_path):
     meg_json_data_freq_mismatch["HeadCoilFrequency"][0] = 123
     _write_json(meg_json_path, meg_json_data_freq_mismatch, overwrite=True)
 
-    with (pytest.warns(RuntimeWarning, match="Defaulting to .* mne.Raw object"),):
+    with (
+        pytest.warns(RuntimeWarning, match="Defaulting to .* mne.Raw object"),
+    ):
         raw_read = read_raw_bids(bids_path, extra_params=dict(allow_maxshield="yes"))
 
     # cHPI "off" according to sidecar, but present in the data
@@ -1078,7 +1080,9 @@ def test_handle_ieeg_coords_reading(bids_path, tmp_path):
     _to_tsv(electrodes_dict, electrodes_fname)
     # popping off channels should not result in an error
     # however, a warning will be raised through mne-python
-    with (pytest.warns(RuntimeWarning, match="DigMontage is only a subset of info"),):
+    with (
+        pytest.warns(RuntimeWarning, match="DigMontage is only a subset of info"),
+    ):
         read_raw_bids(bids_path=bids_fname, verbose=False)
 
     # make sure montage is set if there are coordinates w/ 'n/a'
@@ -1094,7 +1098,9 @@ def test_handle_ieeg_coords_reading(bids_path, tmp_path):
     # electrode coordinates should be nan
     # when coordinate is 'n/a'
     nan_chs = [electrodes_dict["name"][i] for i in [0, 3]]
-    with (pytest.warns(RuntimeWarning, match="There are channels without locations"),):
+    with (
+        pytest.warns(RuntimeWarning, match="There are channels without locations"),
+    ):
         raw = read_raw_bids(bids_path=bids_fname, verbose=False)
         for idx, ch in enumerate(raw.info["chs"]):
             if ch["ch_name"] in nan_chs:
@@ -1222,7 +1228,9 @@ def test_handle_non_mne_channel_type(tmp_path):
     channels_data["type"][ch_idx] = "FOOBAR"
     _to_tsv(data=channels_data, fname=channels_tsv_path)
 
-    with (pytest.warns(RuntimeWarning, match='will be set to "misc"'),):
+    with (
+        pytest.warns(RuntimeWarning, match='will be set to "misc"'),
+    ):
         raw = read_raw_bids(bids_path)
 
     # Should be a 'misc' channel.
@@ -1464,7 +1472,6 @@ def test_gsr_and_temp_reading():
 
 def test_events_file_to_annotation_kwargs(tmp_path):
     """Test that events file is read correctly."""
-
     bids_path = BIDSPath(
         subject="01", session="eeg", task="rest", datatype="eeg", root=tiny_bids_root
     )


### PR DESCRIPTION
<!--
Thanks for contributing this pull request (PR).
If this is your first time, make sure to read
[CONTRIBUTING.md](https://github.com/mne-tools/mne-bids/blob/main/CONTRIBUTING.md)
-->

PR Description
--------------

**Aim**: 
The `_handle_events_reading` in [read.py](https://github.com/matthiasdold/mne-bids/blob/5d4320f0239c5efac25261d123834b1cb0357b1e/mne_bids/read.py#L526) reads onsets, duration and descriptions/event_ids from the `events.tsv`, then filters the columns for n\a values etc. and finally sets annotations to the raw object based on these filtered version of the `events.tsv` data.

```python
    annot_from_raw = raw.annotations.copy()
    annot_from_events = mne.Annotations(onset=ons, duration=durs, description=descrs)
    raw.set_annotations(annot_from_events)
```

On default, this will encode information from three columns within the `events.tsv`.

In order to [extract additional information from BIDS dataset within MOABB](https://github.com/NeuroTechX/moabb/pull/744) it would be necessary to ensure that all annotations that end up in the raw and whatever is extracted from the `events.tsv` are aligned. To allow for this, it would be necessary to have any filtering that happens in [L526-602](https://github.com/matthiasdold/mne-bids/blob/5d4320f0239c5efac25261d123834b1cb0357b1e/mne_bids/read.py#L526C1-L602C1) accessible standalone (without the need to provide a `raw`).

**Proposition**:
Simply have the first part of the [`_handle_events_reading`](https://github.com/matthiasdold/mne-bids/blob/5d4320f0239c5efac25261d123834b1cb0357b1e/mne_bids/read.py#L526) as its own function which returns the filtered version of the onset, description, duration and event_ids. Assuming that these columns would form a primary key within the `events.tsv`, we could always map additional meta info to the annotations in the raw unambiguously.


<!--Describe your PR here-->

Merge checklist
---------------

Maintainer, please confirm the following before merging.
If applicable:

- [ ] All comments are resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] New contributors have been added to [CITATION.cff](https://github.com/mne-tools/mne-bids/blob/main/CITATION.cff)
- [ ] PR description includes phrase "closes <#issue-number>"
