### PR TITLE
Gracefully handle absence of `bids-validator`, and allow running it through `npx`

### DIFF
--- a/mne_bids/tests/conftest.py
+++ b/mne_bids/tests/conftest.py
@@ -21,7 +21,7 @@ def _bids_validate():
         shell = False
 
     # If neither bids-validator nor npx are available, we cannot validate BIDS
-    # datasets, so we skip the tests that require validation.
+    # datasets, so we raise an exception.
     # If both are available, we prefer bids-validator, but we can use npx as a fallback.
 
     has_validator = shutil.which("bids-validator") is not None

--- a/mne_bids/tests/conftest.py
+++ b/mne_bids/tests/conftest.py
@@ -28,8 +28,8 @@ def _bids_validate():
     has_npx = shutil.which("npx") is not None
 
     if not has_validator and not has_npx:
-        pytest.skip(
-            "bids-validator or npx is required to run BIDS validation tests. "
+        raise FileNotFoundError(
+            "⛔️ bids-validator or npx is required to run BIDS validation tests. "
             "Please install the BIDS validator or ensure npx is available."
         )
     elif not has_validator:

--- a/mne_bids/tests/conftest.py
+++ b/mne_bids/tests/conftest.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import platform
+import shutil
 
 import pytest
 from mne.utils import run_subprocess
@@ -19,9 +20,28 @@ def _bids_validate():
     else:
         shell = False
 
-    def _validate(bids_root):
-        cmd = ["bids-validator", bids_root]
-        run_subprocess(cmd, shell=shell)
+    # If neither bids-validator nor npx are available, we cannot validate BIDS
+    # datasets, so we skip the tests that require validation.
+    # If both are available, we prefer bids-validator, but we can use npx as a fallback.
+
+    has_validator = shutil.which("bids-validator") is not None
+    has_npx = shutil.which("npx") is not None
+
+    if not has_validator and not has_npx:
+        pytest.skip(
+            "bids-validator or npx is required to run BIDS validation tests. "
+            "Please install the BIDS validator or ensure npx is available."
+        )
+    elif not has_validator:
+
+        def _validate(bids_root):
+            cmd = ["npx", "bids-validator@latest", bids_root]
+            run_subprocess(cmd, shell=shell)
+    else:
+
+        def _validate(bids_root):
+            cmd = ["bids-validator", bids_root]
+            run_subprocess(cmd, shell=shell)
 
     return _validate
 


### PR DESCRIPTION
@sappelhoff I also made it such that tests are skipped if neither the validator nor `npx` are installed. Is this too lenient? WDYT?

Also wondering if running through `npx` shouldn't be the default, as this would ensure we're always using the latest version of the validator.

Merge checklist
---------------

Maintainer, please confirm the following before merging.
If applicable:

- [ ] All comments are resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] New contributors have been added to [CITATION.cff](https://github.com/mne-tools/mne-bids/blob/main/CITATION.cff)
- [ ] PR description includes phrase "closes <#issue-number>"
