### PR TITLE
[MRG] Ensure check is passed to update function

### DIFF
--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -1369,8 +1369,7 @@ def _get_matching_bidspaths_from_filesystem(bids_path):
         datatype = _infer_datatype(root=bids_root, sub=sub, ses=ses)
 
     data_dir = BIDSPath(
-        subject=sub, session=ses, datatype=datatype, root=bids_root,
-        check=check
+        subject=sub, session=ses, datatype=datatype, root=bids_root, check=check
     ).directory
 
     # For BTi data, just return the directory with a '.pdf' extension

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -1611,6 +1611,7 @@ def test_datasetdescription_with_bidspath(return_bids_test_dir):
         == Path(f"{return_bids_test_dir}/dataset_description.json").as_posix()
     )
 
+
 @testing.requires_testing_data
 def test_update_check(return_bids_test_dir):
     """Test check argument is passed BIDSPath properly."""
@@ -1619,8 +1620,10 @@ def test_update_check(return_bids_test_dir):
         check=False,
     )
     bids_path.update(datatype="eyetrack")
-    assert (bids_path.fpath.as_posix()
-            == Path(f"{return_bids_test_dir}/eyetrack").as_posix())
+    assert (
+        bids_path.fpath.as_posix()
+        == Path(f"{return_bids_test_dir}/eyetrack").as_posix()
+    )
 
 
 def test_update_fail_check_no_change():


### PR DESCRIPTION
<!--
Thanks for contributing this pull request (PR).
If this is your first time, make sure to read
[CONTRIBUTING.md](https://github.com/mne-tools/mne-bids/blob/main/CONTRIBUTING.md)
-->

PR Description
--------------
I noticed that when using the BIDSPath and having passed the argument `check=False`, the value wasn't being passed to the underlying update function.

I noticed this when I was passing the argument datatype='eyetrack' (not supported by BIDS validation) but with the `check=False`. when it came time to use BIDSPath.fpath, it errored

Within the update method, it does a self-assign to `check`, and since the check argument isn't passed, it defaults to True

```
In [1]: bids_path = BIDSPath(root=bids_root, session=None, task=task,
    ...:                      datatype='eyetrack', check=False)

In [2]: bids_path.fpath
...
ValueError: datatype (eyetrack) is not valid. Should be one of ['meg', 'eeg', 'ieeg', 'nirs', 'anat', 'beh']

In [3]: bids_path.check
Out[3]: False
```

<!--Describe your PR here-->

Merge checklist
---------------

Maintainer, please confirm the following before merging.
If applicable:

- [ ] All comments are resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] New contributors have been added to [CITATION.cff](https://github.com/mne-tools/mne-bids/blob/main/CITATION.cff)
- [ ] PR description includes phrase "closes <#issue-number>"
