### PR TITLE
FIX: sphinx-gallery installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ doc = [
   "seaborn",
   "sphinx-copybutton",
   "sphinx>=7.4.7",
-  "sphinx_gallery @ https://github.com/sphinx-gallery/sphinx-gallery/archive/refs/heads/master.zip",
+  "sphinx_gallery @ git+https://github.com/sphinx-gallery/sphinx-gallery.git",
 ]
 # Dependencies for using all mne_bids features
 full = [


### PR DESCRIPTION
We want to install `sphinx-gallery` in a way that ensures `.git` metadata is included, otherwise installation will fail because `setuptools-scm` won't be able to infer the sphinx-gallery package version.

see: https://github.com/mne-tools/mne-bids/issues/1424#issuecomment-3180838806

Let's see if this fixes the doc CI.. and @sappelhoff @hoechenberger let me know either of you still think that this is an upstream packaging bug.