### PR TITLE
Escape period in extension regex

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -214,6 +214,9 @@ authors:
       family-names: Ritz
       affiliation: 'Princeton Neuroscience Institute, Princeton University, Princeton, USA'
       orcid: 'https://orcid.org/0009-0003-1477-4912'
+    - given-names: Nathan
+      family-names: Azrak
+      orcid: 'https://orcid.org/0000-0001-7695-4634'
     - given-names: Alexandre
       family-names: Gramfort
       affiliation: 'Université Paris-Saclay, Inria, CEA, Palaiseau, France'

--- a/doc/authors.rst
+++ b/doc/authors.rst
@@ -40,6 +40,7 @@
 .. _Matthias Dold: https://www.linkedin.com/in/matthiasdold/
 .. _Maximilien Chaumon: https://github.com/dnacombo
 .. _Moritz Gerster: http://moritz-gerster.com
+.. _Nathan Azrak: https://github.com/nathan-az
 .. _Pierre Guetschel: https://github.com/PierreGtch
 .. _Richard Höchenberger: https://github.com/hoechenberger
 .. _Richard Köhler: https://github.com/richardkoehler

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -45,7 +45,7 @@ Detailed list of changes
 - :func:`mne_bids.get_entity_vals()` has a new parameter ``include_match`` to prefilter item matching and ignore non-matched items from begin of directory scan, by `Arne Gottwald` (:gh:`1355`)
 - Data from ``events.tsv`` can now be read into an OrderedDict using :func:`mne_bids.events_file_to_annotation_kwargs()`, by `Matthias Dold` (:gh:`1389`)
 - Read the optionally present extra columns from ``events.tsv`` and pass them to :class:`mne.Annotations`, by `Pierre Guetschel` (:gh:`1401`)
-- :func:`_filter_fnames()` now correctly checks the default extension, correcting suffix filtering, by `Nathan Azrak` (:gh:`1427`)
+- ``_filter_fnames()`` now correctly checks the default extension, correcting suffix filtering, by `Nathan Azrak` (:gh:`1427`)
 
 
 🧐 API and behavior changes

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -22,6 +22,7 @@ The following authors contributed for the first time. Thank you so much! 🤩
 * `Arne Gottwald`_
 * `Matthias Dold`_
 * `Harrison Ritz`_
+* `Nathan Azrak`_
 
 The following authors had contributed before. Thank you for sticking around! 🤘
 
@@ -44,6 +45,7 @@ Detailed list of changes
 - :func:`mne_bids.get_entity_vals()` has a new parameter ``include_match`` to prefilter item matching and ignore non-matched items from begin of directory scan, by `Arne Gottwald` (:gh:`1355`)
 - Data from ``events.tsv`` can now be read into an OrderedDict using :func:`mne_bids.events_file_to_annotation_kwargs()`, by `Matthias Dold` (:gh:`1389`)
 - Read the optionally present extra columns from ``events.tsv`` and pass them to :class:`mne.Annotations`, by `Pierre Guetschel` (:gh:`1401`)
+- :func:`_filter_fnames()` now correctly checks the default extension, correcting suffix filtering, by `Nathan Azrak` (:gh:`1427`)
 
 
 🧐 API and behavior changes

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -2374,7 +2374,7 @@ def _filter_fnames(
         r"_desc-(" + "|".join(description) + ")" if description else r"(|_desc-([^_]+))"
     )
     suffix_str = r"_(" + "|".join(suffix) + ")" if suffix else r"_([^_]+)"
-    ext_str = r"(" + "|".join(extension) + ")$" if extension else r".([^_]+)"
+    ext_str = r"(" + "|".join(extension) + ")$" if extension else r"\.([^_]+)"
 
     regexp = (
         leading_path_str

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -1028,7 +1028,7 @@ def test_filter_fnames(entities, expected_n_matches):
         "sub-Foo_ses-bar_meg.fif",
         "sub-Bar_task-invasive_run-1_ieeg.fif",
         "sub-3_task-fun_proc-sss_meg.fif",
-        "sub-3_task-fun_proc-sss_meg_channels.fif",
+        "sub-3_task-fun_proc-sss_meg_channels.tsv",
         "sub-4_task-pain_acq-lowres_T1w.nii.gz",
         "sub-5_task-test_proc-ica_eeg.vhdr",
         "sub-6_task-test_proc-ica_eeg.vhdr",

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -1028,6 +1028,7 @@ def test_filter_fnames(entities, expected_n_matches):
         "sub-Foo_ses-bar_meg.fif",
         "sub-Bar_task-invasive_run-1_ieeg.fif",
         "sub-3_task-fun_proc-sss_meg.fif",
+        "sub-3_task-fun_proc-sss_meg_channels.fif",
         "sub-4_task-pain_acq-lowres_T1w.nii.gz",
         "sub-5_task-test_proc-ica_eeg.vhdr",
         "sub-6_task-test_proc-ica_eeg.vhdr",


### PR DESCRIPTION
Escapes the period in the extension regex. Caught this because `{suffix}_channels.{extension}` was passing and causing duplicate entries. This should fix that, and the test change should confirm it!

Merge checklist
---------------

Maintainer, please confirm the following before merging.
If applicable:

- [ ] All comments are resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] New contributors have been added to [CITATION.cff](https://github.com/mne-tools/mne-bids/blob/main/CITATION.cff)
- [ ] PR description includes phrase "closes <#issue-number>"
