### PR TITLE
remove duplicated call

### DIFF
--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -2041,15 +2041,6 @@ def write_raw_bids(
             datatype=bids_path.datatype,
             overwrite=overwrite,
         )
-        _write_coordsystem_json(
-            raw=raw,
-            unit=unit,
-            hpi_coord_system=orient,
-            sensor_coord_system=sensor_coord_system,
-            fname=coordsystem_path.fpath,
-            datatype=bids_path.datatype,
-            overwrite=overwrite,
-        )
     elif bids_path.datatype in ["eeg", "ieeg", "nirs"]:
         # We only write electrodes.tsv and accompanying coordsystem.json
         # if we have an available DigMontage


### PR DESCRIPTION
PR Description
--------------

I encountered a case where the same helper function (_write_coordsystem_json) was being called twice in a row in write_raw_bids:

https://github.com/mne-tools/mne-bids/blob/98cb9f5b83c697788a8992733a131eb635f32240/mne_bids/write.py#L2035-L2052

Origin seems to be https://github.com/mne-tools/mne-bids/pull/980

This removes one of the duplicated calls.

Merge checklist
---------------

Maintainer, please confirm the following before merging.
If applicable:

- [ ] All comments are resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] New contributors have been added to [CITATION.cff](https://github.com/mne-tools/mne-bids/blob/main/CITATION.cff)
- [ ] PR description includes phrase "closes <#issue-number>"
