### PR TITLE
alphabetize [ci skip]

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -4,8 +4,8 @@ Alex Rockhill <aprockhill206@gmail.com> <aprock@uw.edu>
 Alex Rockhill <aprockhill206@gmail.com> <aprockhill@mailbox.org>
 Alexandre Gramfort <alexandre.gramfort@m4x.org>
 Alexandre Gramfort <alexandre.gramfort@m4x.org> <agramfort@fb.com>
-Bruno Aristimunha <b.aristimunha@gmail.com>
 Ariel Rokem <arokem@gmail.com>
+Bruno Aristimunha <b.aristimunha@gmail.com>
 Chris Holdgraf <choldgraf@gmail.com>
 Chris Holdgraf <choldgraf@gmail.com> <choldgraf@berkeley.edu>
 Clemens Brunner <clemens.brunner@gmail.com>


### PR DESCRIPTION
fixes alphabetical order error in `.mailmap` introduced in #1449 

