### PR TITLE
DOC: Restore scipy hyperlinking

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -168,20 +168,25 @@ html_context = {
 html_sidebars = {}
 
 # Example configuration for intersphinx: refer to the Python standard library.
-# No SciPy mapping here because docs.scipy.org frequently times out during CI,
-# and our builds treat warnings as errors.
-intersphinx_mapping = get_intersphinx_mapping(
-    packages={
-        "matplotlib",
-        "mne",
-        "nibabel",
-        "nilearn",
-        "numpy",
-        "pandas",
-        "python",
-    }
+# When https://github.com/scipy/docs.scipy.org/issues/102 is resolved, we can
+# remove the scipy entry below and rely on intersphinx_registry.
+intersphinx_mapping = {
+    "scipy": ("https://scipy.github.io/devdocs/", None),
+    "mne-gui-addons": ("https://mne.tools/mne-gui-addons", None),
+}
+intersphinx_mapping.update(
+    get_intersphinx_mapping(
+        packages={
+            "matplotlib",
+            "mne",
+            "nibabel",
+            "nilearn",
+            "numpy",
+            "pandas",
+            "python",
+        }
+    )
 )
-intersphinx_mapping["mne-gui-addons"] = ("https://mne.tools/mne-gui-addons", None)
 intersphinx_timeout = 30
 
 sphinx_gallery_conf = {


### PR DESCRIPTION
<!--
Thanks for contributing this pull request (PR).
If this is your first time, make sure to read
[CONTRIBUTING.md](https://github.com/mne-tools/mne-bids/blob/main/CONTRIBUTING.md)
-->

PR Description
--------------

Workaround for #1456 (but let's keep that issue open until we can rely on Scipy's stable docs once again).

I don't think we need to disable Scipy's intersphinx registry completely, we can configure `intersphinx_mapping` to point to SciPy's development documentation site.

<!--Describe your PR here-->

Merge checklist
---------------

Maintainer, please confirm the following before merging.
If applicable:

- [ ] All comments are resolved
- [ ] This is not your own PR
- [x] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] New contributors have been added to [CITATION.cff](https://github.com/mne-tools/mne-bids/blob/main/CITATION.cff)
- [ ] PR description includes phrase "closes <#issue-number>"
