### PR TITLE
MAINT: Update to macos-15-intel

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -175,6 +175,7 @@ jobs:
             mne-version: mne-stable
             mne-bids-install: full
             bids-validator-version: validator-main-schema
+          # Test macos on x86_64 architecture
           - os: macos-15-intel
             python-version: "3.13"
             mne-version: mne-stable


### PR DESCRIPTION
`macos-13` is deprecated, so update to `macos-15-intel` for the x86_64 runner.

Since MNE-BIDS doesn't do any heavy `linalg` work or anything, I'd actually prefer just to drop `macos-15-intel` and assume upstream libs (MNE, SciPy, etc.) properly test support generalization on those archs. Thoughts?

Merge reqs will need to be updated, I'm happy to do that and merge once the above is discussed :point_up: 