### PR TITLE
MAINT: Sort in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,3 +37,10 @@ repos:
     hooks:
       - id: toml-sort-fix
         files: pyproject.toml
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: file-contents-sorter
+        files: ^doc/authors.rst|^.mailmap
+        args: ["--ignore-case"]

--- a/doc/authors.rst
+++ b/doc/authors.rst
@@ -60,4 +60,3 @@
 .. _waldie11: https://github.com/waldie11
 .. _William Turner: https://bootstrapbill.github.io/
 .. _Yorguin Mantilla: https://github.com/yjmantilla
-.. _Julius Welzel: https://github.com/JuliusWelzel


### PR DESCRIPTION
A comment over in #1466 made me realize we should add this sorter. We use it in MNE-Python. Nice it doesn't catch anything new here! (I deleted the duplicate entry same is in #1466, though.)