### PR TITLE
DOC: Remove repeated words

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -95,7 +95,7 @@ other packages in your existing ``conda`` environment.
 Alternatively, you may wish to take advantage of the fact that the
 ``mne-bids`` package on ``conda-forge`` in fact depends on ``mne``,
 meaning that a "full" installation of ``mne-bids`` (i.e., including its
-dependencies) will provide you with a working copy of of both ``mne`` and
+dependencies) will provide you with a working copy of both ``mne`` and
 ``mne-bids`` at once:
 
 .. code-block:: bash

--- a/examples/anonymize_dataset.py
+++ b/examples/anonymize_dataset.py
@@ -207,7 +207,7 @@ print_dir_tree(bids_root_anon)
 # culture, like "42", or "1337". To obtain a truly random seed, you can paste
 # the following into your console:
 # ``python -c "import secrets; print(secrets.randbits(31))"``
-# Here, 31 bits correspond to the maximum seed "size" that the the legacy
+# Here, 31 bits correspond to the maximum seed "size" that the legacy
 # ``RandomState`` by NumPy, which many scientific libraries still rely on,
 # can accept. For more information, see also this blog post on
 # `NumPy RNG best practices <https://blog.scientific-python.org/numpy/numpy-rng/>`_.

--- a/examples/convert_group_studies.py
+++ b/examples/convert_group_studies.py
@@ -38,7 +38,7 @@ from mne_bids.stats import count_events
 subject_ids = [1, 2]
 
 # The run numbers in the eegbci are not consecutive ... we follow the online
-# documentation to get the 1st, 2nd, and 3rd run of one of the the motor
+# documentation to get the 1st, 2nd, and 3rd run of one of the motor
 # imagery task
 runs = [
     4,  # This is run #1 of imagining to open/close left or right fist

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -327,7 +327,7 @@ def _handle_participants_reading(participants_fname, raw, subject):
             raw.info["subject_info"][key] = value
 
     if bad_key_vals:
-        warn_str = "Unable to map the following column(s) to to MNE:"
+        warn_str = "Unable to map the following column(s) to MNE:"
         for col_name, orig_value, info_str in bad_key_vals:
             warn_str += f"\n{col_name}"
             if info_str is not None:


### PR DESCRIPTION
Noticed the repeated "to" in the warning. Had a look for instances with other words where this often happens, but grep didn't give anything apart for from "of" and "the".