### PR TITLE
Fix small inconsistency in onset description of _events_json in write.py

### DIFF
--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -419,7 +419,7 @@ def _events_json(fname, extra_columns=None, has_trial_type=True, overwrite=False
     new_data = {
         "onset": {
             "Description": (
-                "Onset (in seconds) of the event from the beginning of the first data"
+                "Onset (in seconds) of the event from the beginning of the first data "
                 "point. Negative onsets account for events before the first stored "
                 "data point."
             ),


### PR DESCRIPTION
See the PR Description below.

<!--
Thanks for contributing this pull request (PR).
If this is your first time, make sure to read
[CONTRIBUTING.md](https://github.com/mne-tools/mne-bids/blob/main/CONTRIBUTING.md)
-->

PR Description
--------------

The function _events_json in write.py provides a description for "onset" where both "datapoint" (first) and "data point" (second) are used. This is an inconistency. Both have been changed to "data point".

Merge checklist
---------------

Maintainer, please confirm the following before merging.
If applicable:

- [ ] All comments are resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] New contributors have been added to [CITATION.cff](https://github.com/mne-tools/mne-bids/blob/main/CITATION.cff)
- [ ] PR description includes phrase "closes <#issue-number>"
