### PR TITLE
Allow task=None in read_raw_bids for BIDS paths without task entity

### DIFF
--- a/doc/authors.rst
+++ b/doc/authors.rst
@@ -3,6 +3,7 @@
 .. _Alex Lopez Marquez: https://github.com/alm180
 .. _Alex Rockhill: https://github.com/alexrockhill
 .. _Alexandre Gramfort: http://alexandre.gramfort.net
+.. _Aman Jaiswal: https://github.com/AmanJaiswal1503
 .. _Amaia Benitez: https://github.com/AmaiaBA
 .. _Anand Saini: https://github.com/anandsaini024
 .. _Ariel Rokem: https://github.com/arokem

--- a/doc/authors.rst
+++ b/doc/authors.rst
@@ -3,8 +3,8 @@
 .. _Alex Lopez Marquez: https://github.com/alm180
 .. _Alex Rockhill: https://github.com/alexrockhill
 .. _Alexandre Gramfort: http://alexandre.gramfort.net
-.. _Aman Jaiswal: https://github.com/AmanJaiswal1503
 .. _Amaia Benitez: https://github.com/AmaiaBA
+.. _Aman Jaiswal: https://github.com/AmanJaiswal1503
 .. _Anand Saini: https://github.com/anandsaini024
 .. _Ariel Rokem: https://github.com/arokem
 .. _Arne Gottwald: https://github.com/waldie11

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -56,6 +56,7 @@ Detailed list of changes
 - Reinstate the requirement for ``coordsystem.json`` whenever ``electrodes.tsv`` is present (including EMG), by `Bruno Aristimunha`_ (:gh:`1508`)
 - Fix :func:`read_raw_bids` ignoring ``electrodes.tsv`` when ``EEGCoordinateUnits`` is ``"n/a"`` by inferring the unit from coordinate magnitudes, and synthesize approximate fiducials for ``ctf_head`` montages to enable the coordinate transform to ``head`` frame, by `Bruno Aristimunha`_ (:gh:`1506`)
 - Improve :func:`mne_bids.read_raw_bids` handling when ``electrodes.tsv`` exists without ``coordsystem.json``: keep strict failure for iEEG, and for EEG/MEG emit a warning and continue without applying a montage, by `Bruno Aristimunha`_
+- Allow ``task=None`` in :func:`mne_bids.read_raw_bids` for BIDS paths without a task entity (e.g. datasets that omit task in the path), by `Aman Jaiswal`_
 
 ⚕️ Code health
 ^^^^^^^^^^^^^^

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -1051,6 +1051,14 @@ def read_raw_bids(
                 f"attributes but it's missing `{required}`."
             )
 
+    if bids_path.task is None:
+        warn(
+            "bids_path has no task entity. The BIDS specification requires "
+            "the task entity for M/EEG data; this path may refer to a "
+            "legacy or non-compliant dataset.",
+            UserWarning,
+        )
+
     bids_path = bids_path.copy()
     sub = bids_path.subject
     ses = bids_path.session

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -1164,12 +1164,10 @@ def read_raw_bids(
 
     # Try to find an associated events.tsv to get information about the
     # events in the recorded data
-    if (bids_path.subject == "emptyroom" and bids_path.task == "noise") or (
-        bids_path.task is not None and bids_path.task.startswith("rest")
-    ):
-        on_error = "ignore"
-    else:
-        on_error = "warn"
+    is_emptyroom = bids_path.subject == "emptyroom" and bids_path.task == "noise"
+    is_rest = bids_path.task is not None and bids_path.task.startswith("rest")
+
+    on_error = "ignore" if is_emptyroom or is_rest else "warn"
 
     events_fname = _find_matching_sidecar(
         bids_path, suffix="events", extension=".tsv", on_error=on_error

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -977,11 +977,10 @@ def read_raw_bids(
     ----------
     bids_path : BIDSPath
         The file to read. The :class:`mne_bids.BIDSPath` instance passed here
-        **must** have the ``.root`` and ``.subject`` attributes set. The
-        ``.task`` attribute is optional (e.g. for datasets without a task
-        entity). The ``.datatype`` attribute **may** be set. If ``.datatype``
-        is not set and only one data type (e.g., only EEG or MEG data) is
-        present in the dataset, it will be selected automatically.
+        **must** have the ``.root`` attribute set. The ``.datatype`` attribute
+        **may** be set. If ``.datatype`` is not set and only one data type
+        (e.g., only EEG or MEG data) is present in the dataset, it will be
+        selected automatically.
 
         .. note::
            If ``bids_path`` points to a symbolic link of a ``.fif`` file

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -977,10 +977,11 @@ def read_raw_bids(
     ----------
     bids_path : BIDSPath
         The file to read. The :class:`mne_bids.BIDSPath` instance passed here
-        **must** have the ``.root`` attribute set. The ``.datatype`` attribute
-        **may** be set. If ``.datatype`` is not set and only one data type
-        (e.g., only EEG or MEG data) is present in the dataset, it will be
-        selected automatically.
+        **must** have the ``.root`` and ``.subject`` attributes set. The
+        ``.task`` attribute is optional (e.g. for datasets without a task
+        entity). The ``.datatype`` attribute **may** be set. If ``.datatype``
+        is not set and only one data type (e.g., only EEG or MEG data) is
+        present in the dataset, it will be selected automatically.
 
         .. note::
            If ``bids_path`` points to a symbolic link of a ``.fif`` file
@@ -1043,10 +1044,10 @@ def read_raw_bids(
             '"bids_path" must be a BIDSPath object. Please '
             "instantiate using mne_bids.BIDSPath()."
         )
-    for required in ["root", "subject", "task"]:
+    for required in ["root", "subject"]:
         if not getattr(bids_path, required):
             raise RuntimeError(
-                '"bids_path" must contain `root`, `subject`, and `task` '
+                '"bids_path" must contain `root` and `subject` '
                 f"attributes but it's missing `{required}`."
             )
 
@@ -1156,9 +1157,9 @@ def read_raw_bids(
 
     # Try to find an associated events.tsv to get information about the
     # events in the recorded data
-    if (
-        bids_path.subject == "emptyroom" and bids_path.task == "noise"
-    ) or bids_path.task.startswith("rest"):
+    if (bids_path.subject == "emptyroom" and bids_path.task == "noise") or (
+        bids_path.task is not None and bids_path.task.startswith("rest")
+    ):
         on_error = "ignore"
     else:
         on_error = "warn"

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -215,6 +215,25 @@ def test_read_correct_inputs():
     "ignore:No events found or provided:RuntimeWarning",
     "ignore:Found no extension for raw file.*:RuntimeWarning",
 )
+def test_read_raw_bids_task_none_warns(tmp_path):
+    """Test that read_raw_bids emits UserWarning when bids_path has no task entity."""
+    _write_parallel_dataset(str(tmp_path), subject="01", run="01")
+    bids_path_with_task = BIDSPath(
+        subject="01", task="rest", run="01", datatype="meg", root=tmp_path
+    )
+    bids_path_no_task = BIDSPath(
+        subject="01", task=None, run="01", datatype="meg", root=tmp_path
+    )
+    sh.copy(bids_path_with_task.fpath, bids_path_no_task.fpath)
+    with pytest.warns(UserWarning, match="bids_path has no task entity"):
+        raw = read_raw_bids(bids_path_no_task, verbose=False)
+    assert raw is not None
+
+
+@pytest.mark.filterwarnings(
+    "ignore:No events found or provided:RuntimeWarning",
+    "ignore:Found no extension for raw file.*:RuntimeWarning",
+)
 def test_parallel_participants_multiprocess(tmp_path):
     """Ensure parallel reads keep all participants entries visible."""
     bids_root = tmp_path / "parallel_multiprocess"

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -211,10 +211,7 @@ def test_read_correct_inputs():
         read_raw_bids(bids_path)
 
 
-@pytest.mark.filterwarnings(
-    "ignore:No events found or provided:RuntimeWarning",
-    "ignore:Found no extension for raw file.*:RuntimeWarning",
-)
+@pytest.mark.filterwarnings("ignore::RuntimeWarning")
 def test_read_raw_bids_task_none_warns(tmp_path):
     """Test that read_raw_bids emits UserWarning when bids_path has no task entity."""
     bids_path = BIDSPath(

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -211,24 +211,60 @@ def test_read_correct_inputs():
         read_raw_bids(bids_path)
 
 
-@pytest.mark.filterwarnings("ignore::RuntimeWarning")
 def test_read_raw_bids_task_none_warns(tmp_path):
-    """Test that read_raw_bids emits UserWarning when bids_path has no task entity."""
-    bids_path = BIDSPath(
+    """Test that write rejects task=None and read warns when reading legacy paths."""
+    raw = _make_parallel_raw("01")
+    bids_path_invalid = BIDSPath(
         subject="01",
         run="01",
         datatype="meg",
         suffix="meg",
         extension=".fif",
         root=tmp_path,
+        task=None,
     )
-    bids_path.fpath.parent.mkdir(parents=True, exist_ok=True)
-    raw = _make_parallel_raw("01")
-    raw.save(bids_path.fpath)
+    with pytest.raises(ValueError, match="task"):
+        write_raw_bids(
+            raw, bids_path_invalid, allow_preload=True, format="FIF", verbose=False
+        )
 
+    bids_path_valid = BIDSPath(
+        subject="01",
+        task="rest",
+        run="01",
+        datatype="meg",
+        suffix="meg",
+        extension=".fif",
+        root=tmp_path,
+    )
+    write_raw_bids(
+        raw, bids_path_valid, allow_preload=True, format="FIF", verbose=False
+    )
+
+    meg_dir = tmp_path / "sub-01" / "meg"
+    for fpath in meg_dir.iterdir():
+        if "_task-rest" in fpath.name:
+            new_name = fpath.name.replace("_task-rest", "")
+            fpath.rename(meg_dir / new_name)
+
+    scans_path = tmp_path / "sub-01" / "sub-01_scans.tsv"
+    if scans_path.exists():
+        scans = _from_tsv(scans_path)
+        scans["filename"] = [fn.replace("_task-rest", "") for fn in scans["filename"]]
+        _to_tsv(scans, scans_path)
+
+    bids_path_no_task = BIDSPath(
+        subject="01",
+        run="01",
+        task=None,
+        datatype="meg",
+        suffix="meg",
+        extension=".fif",
+        root=tmp_path,
+    )
     with pytest.warns(UserWarning, match="bids_path has no task entity"):
-        raw = read_raw_bids(bids_path, verbose=False)
-    assert raw is not None
+        raw_read = read_raw_bids(bids_path_no_task, verbose=False)
+    assert raw_read is not None
 
 
 @pytest.mark.filterwarnings(

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -217,28 +217,20 @@ def test_read_correct_inputs():
 )
 def test_read_raw_bids_task_none_warns(tmp_path):
     """Test that read_raw_bids emits UserWarning when bids_path has no task entity."""
-    _write_parallel_dataset(str(tmp_path), subject="01", run="01")
-    bids_path_with_task = BIDSPath(
+    bids_path = BIDSPath(
         subject="01",
-        task="rest",
         run="01",
         datatype="meg",
         suffix="meg",
         extension=".fif",
         root=tmp_path,
     )
-    bids_path_no_task = BIDSPath(
-        subject="01",
-        task=None,
-        run="01",
-        datatype="meg",
-        suffix="meg",
-        extension=".fif",
-        root=tmp_path,
-    )
-    sh.copy(bids_path_with_task.fpath, bids_path_no_task.fpath)
+    bids_path.fpath.parent.mkdir(parents=True, exist_ok=True)
+    raw = _make_parallel_raw("01")
+    raw.save(bids_path.fpath)
+
     with pytest.warns(UserWarning, match="bids_path has no task entity"):
-        raw = read_raw_bids(bids_path_no_task, verbose=False)
+        raw = read_raw_bids(bids_path, verbose=False)
     assert raw is not None
 
 

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -219,10 +219,22 @@ def test_read_raw_bids_task_none_warns(tmp_path):
     """Test that read_raw_bids emits UserWarning when bids_path has no task entity."""
     _write_parallel_dataset(str(tmp_path), subject="01", run="01")
     bids_path_with_task = BIDSPath(
-        subject="01", task="rest", run="01", datatype="meg", root=tmp_path
+        subject="01",
+        task="rest",
+        run="01",
+        datatype="meg",
+        suffix="meg",
+        extension=".fif",
+        root=tmp_path,
     )
     bids_path_no_task = BIDSPath(
-        subject="01", task=None, run="01", datatype="meg", root=tmp_path
+        subject="01",
+        task=None,
+        run="01",
+        datatype="meg",
+        suffix="meg",
+        extension=".fif",
+        root=tmp_path,
     )
     sh.copy(bids_path_with_task.fpath, bids_path_no_task.fpath)
     with pytest.warns(UserWarning, match="bids_path has no task entity"):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,8 +121,6 @@ filterwarnings = [
   # numba with NumPy dev
   "ignore:`np.MachAr` is deprecated.*:DeprecationWarning",
   "ignore:`product` is deprecated as of NumPy.*:DeprecationWarning",
-  # read_raw_bids with task=None (legacy / non-compliant BIDS)
-  "ignore:bids_path has no task entity.*:UserWarning",
   "ignore:Converting data files to BrainVision format:RuntimeWarning",
   "ignore:Converting to BV for anonymization:RuntimeWarning",
   "ignore:Converting to FIF for anonymization:RuntimeWarning",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,6 +131,8 @@ filterwarnings = [
   "ignore:Estimation of line frequency only supports.*:RuntimeWarning",
   # matplotlib
   "ignore:Figure.*is non-interactive.*cannot be shown:UserWarning",
+  # read_raw_bids with task=None (legacy / non-compliant BIDS)
+  "ignore:bids_path has no task entity.*:UserWarning",
   "ignore:MEG ref channel RMSP did not.*:RuntimeWarning",
   "ignore:No events found or provided.*:RuntimeWarning",
   "ignore:numpy.ufunc size changed.*:RuntimeWarning",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,8 @@ filterwarnings = [
   # numba with NumPy dev
   "ignore:`np.MachAr` is deprecated.*:DeprecationWarning",
   "ignore:`product` is deprecated as of NumPy.*:DeprecationWarning",
+  # read_raw_bids with task=None (legacy / non-compliant BIDS)
+  "ignore:bids_path has no task entity.*:UserWarning",
   "ignore:Converting data files to BrainVision format:RuntimeWarning",
   "ignore:Converting to BV for anonymization:RuntimeWarning",
   "ignore:Converting to FIF for anonymization:RuntimeWarning",
@@ -131,8 +133,6 @@ filterwarnings = [
   "ignore:Estimation of line frequency only supports.*:RuntimeWarning",
   # matplotlib
   "ignore:Figure.*is non-interactive.*cannot be shown:UserWarning",
-  # read_raw_bids with task=None (legacy / non-compliant BIDS)
-  "ignore:bids_path has no task entity.*:UserWarning",
   "ignore:MEG ref channel RMSP did not.*:RuntimeWarning",
   "ignore:No events found or provided.*:RuntimeWarning",
   "ignore:numpy.ufunc size changed.*:RuntimeWarning",


### PR DESCRIPTION
<!--
Thanks for contributing this pull request (PR).
If this is your first time, make sure to read
[CONTRIBUTING.md](https://github.com/mne-tools/mne-bids/blob/main/CONTRIBUTING.md)
-->

PR Description
--------------

## Summary
Allow `read_raw_bids` to accept BIDSPath instances with `task=None`, supporting BIDS datasets that omit the task entity in the path (e.g. some anatomical or non-task recordings).

## Changes
- **mne_bids/read.py**
  - Require only `root` and `subject` on `bids_path` (removed `task` from required attributes).
  - When deciding whether to ignore missing events, guard `bids_path.task.startswith("rest")` with `bids_path.task is not None` to avoid AttributeError when task is None.

## Datasets this fixes
OpenNeuro datasets that previously failed with `RuntimeError: BIDSPath missing task` and are fixed by this change:
- ds002791
- ds003420
- ds003498
- ds004017

## Minimal self-contained example

This example downloads one subject from the ds002791 OpenNeuro dataset, then reads the data using a `BIDSPath` that does **not** set the `task` entity (only `subject`, `session="spelling"`, `run=1`, and `datatype="eeg"` are set). On **main**, this results in `RuntimeError: "bids_path" must contain 'root', 'subject', and 'task'`; with this PR it runs successfully.

```python
# Minimal example: read without setting task (fails on main, passes with this PR)
import warnings
warnings.filterwarnings("ignore")

import tempfile
from pathlib import Path

import openneuro
from mne_bids import BIDSPath, read_raw_bids

# Download one subject from a dataset that can be read without task in the path
dataset = "ds002791"
target = Path(tempfile.mkdtemp(prefix="bids_")) / dataset
openneuro.download(dataset=dataset, target_dir=str(target), include="sub-01")

bids_root = target
bids_path = BIDSPath(
    root=bids_root, subject="01", session="spelling", run=1, task=None, datatype="eeg"
)

raw = read_raw_bids(bids_path, verbose=False)
print(f"Read {raw.filenames} successfully with task=None.")
```

Merge checklist
---------------

Maintainer, please confirm the following before merging.
If applicable:

- [ ] All comments are resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] New contributors have been added to [CITATION.cff](https://github.com/mne-tools/mne-bids/blob/main/CITATION.cff)
- [ ] PR description includes phrase "closes <#issue-number>"
