### PR TITLE
FIX: Warn instead of crash on malformed scans.tsv timestamps

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -56,6 +56,7 @@ Detailed list of changes
 - Reinstate the requirement for ``coordsystem.json`` whenever ``electrodes.tsv`` is present (including EMG), by `Bruno Aristimunha`_ (:gh:`1508`)
 - Fix :func:`read_raw_bids` ignoring ``electrodes.tsv`` when ``EEGCoordinateUnits`` is ``"n/a"`` by inferring the unit from coordinate magnitudes, and synthesize approximate fiducials for ``ctf_head`` montages to enable the coordinate transform to ``head`` frame, by `Bruno Aristimunha`_ (:gh:`1506`)
 - Improve :func:`mne_bids.read_raw_bids` handling when ``electrodes.tsv`` exists without ``coordsystem.json``: keep strict failure for iEEG, and for EEG/MEG emit a warning and continue without applying a montage, by `Bruno Aristimunha`_
+- :func:`mne_bids.read_raw_bids` no longer crashes on malformed ``acq_time`` values in ``scans.tsv``. Instead, a warning is emitted and the measurement date is left unchanged, by `Bruno Aristimunha`_ (:gh:`XXXX`)
 
 ⚕️ Code health
 ^^^^^^^^^^^^^^

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -440,7 +440,14 @@ def _handle_scans_reading(scans_fname, raw, bids_path):
         if acq_time_is_utc:
             date_format += "Z"
 
-        acq_time = datetime.strptime(acq_time, date_format)
+        try:
+            acq_time = datetime.strptime(acq_time, date_format)
+        except ValueError:
+            warn(
+                f"Could not parse acquisition time {acq_time!r} in "
+                f"{scans_fname}. Setting acquisition time to None."
+            )
+            return raw
 
         if acq_time_is_utc:
             # Enforce setting timezone to UTC without additonal conversion

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -881,6 +881,15 @@ def test_handle_scans_reading(tmp_path):
     if raw_pre_epoch.annotations.orig_time is not None:
         assert raw_pre_epoch.annotations.orig_time == expected_pre_epoch
 
+    # Regression: malformed timestamps should warn and leave meas_date unchanged,
+    # not crash (GH-XXXX)
+    for bad_time in ["not-a-date", "2020-01-01T25:61:61", "2020-13-01T00:00:00"]:
+        scans_tsv["acq_time"][0] = bad_time
+        _to_tsv(scans_tsv, scans_path)
+        with pytest.warns(RuntimeWarning, match="Could not parse acquisition time"):
+            raw_bad = read_raw_bids(bids_path)
+        assert raw_bad.info["meas_date"] is not None  # unchanged from file
+
 
 @pytest.mark.filterwarnings(warning_str["channel_unit_changed"])
 def test_handle_scans_reading_brainvision(tmp_path):


### PR DESCRIPTION
## Summary

- `_handle_scans_reading` in `read.py` calls `datetime.strptime(acq_time, date_format)` without error handling. Malformed timestamps (seconds >= 60, truncated strings, non-ISO formats) cause an unhandled `ValueError` that crashes `read_raw_bids()`.
- Since mne_bids already handles `"n/a"` gracefully (skipping `meas_date` assignment), a malformed timestamp should degrade the same way rather than crash.
- Wraps `datetime.strptime` in `try/except ValueError`, emits a warning, and returns `raw` with its measurement date unchanged.
- Discovered processing OpenNeuro datasets during batch ingestion with [eegdash](https://github.com/bruAristimunha/eegdash).

## Test plan

- [ ] Added test cases with `"not-a-date"`, `"2020-01-01T25:61:61"`, and `"2020-13-01T00:00:00"` timestamps
- [ ] Verify warning is emitted and `meas_date` is unchanged
- [ ] Run `make pep` to confirm style compliance
- [ ] Run `make test` for full test suite