### PR TITLE
FIX: scans.tsv: resolve the timestamp timezone from the historical date if you can

### DIFF
--- a/mne_bids/conftest.py
+++ b/mne_bids/conftest.py
@@ -2,6 +2,7 @@
 
 # Authors: The MNE-BIDS developers
 # SPDX-License-Identifier: BSD-3-Clause
+from datetime import datetime
 
 import mne
 import pytest
@@ -29,3 +30,19 @@ def monkeypatch_mne():
         "mne",
         "mne_bids",
     )
+
+
+class WindowsDatetime(datetime):
+    """Datetime obj that will raise on tz inference of pre-epoch naive timestamp."""
+
+    def astimezone(self, tz=None):
+        """Convert to specified timezone."""
+        if self.year < 1970 and self.tzinfo is None:
+            raise OSError("simulated Windows pre-epoch failure")
+        return super().astimezone(tz)
+
+
+@pytest.fixture(scope="session")
+def windows_datetime():
+    """Return WindowsDatime."""
+    return WindowsDatetime

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -35,7 +35,13 @@ from mne_bids.path import (
     get_bids_path_from_fname,
 )
 from mne_bids.tsv_handler import _drop, _from_tsv
-from mne_bids.utils import _get_ch_type_mapping, _import_nibabel, verbose, warn
+from mne_bids.utils import (
+    _convert_dt_to_utc,
+    _get_ch_type_mapping,
+    _import_nibabel,
+    verbose,
+    warn,
+)
 
 
 @verbose
@@ -446,12 +452,7 @@ def _handle_scans_reading(scans_fname, raw, bids_path):
             # Enforce setting timezone to UTC without additonal conversion
             acq_time = acq_time.replace(tzinfo=UTC)
         else:
-            # Convert time offset to UTC
-            if acq_time.tzinfo is None:
-                # Windows needs an explicit local tz for naive, pre-epoch times.
-                local_tz = datetime.now().astimezone().tzinfo or UTC
-                acq_time = acq_time.replace(tzinfo=local_tz)
-            acq_time = acq_time.astimezone(UTC)
+            acq_time = _convert_dt_to_utc(acq_time)
 
         logger.debug(f"Loaded {scans_fname} scans file to set acq_time as {acq_time}.")
         # First set measurement date to None and then call call anonymize() to

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -13,7 +13,8 @@ import re
 import shutil as sh
 from collections import OrderedDict
 from contextlib import nullcontext
-from datetime import UTC, date, datetime
+from datetime import UTC, date, datetime, timedelta, timezone
+from functools import partial
 from pathlib import Path
 
 import mne
@@ -25,6 +26,7 @@ from mne.io.constants import FIFF
 from mne.utils import assert_dig_allclose, check_version, object_diff
 from numpy.testing import assert_almost_equal
 
+import mne_bids.utils
 import mne_bids.write
 from mne_bids import BIDSPath
 from mne_bids.config import (
@@ -100,6 +102,21 @@ def _wrap_read_raw(read_raw):
 _read_raw_fif = _wrap_read_raw(mne.io.read_raw_fif)
 _read_raw_ctf = _wrap_read_raw(mne.io.read_raw_ctf)
 _read_raw_edf = _wrap_read_raw(mne.io.read_raw_edf)
+
+
+def _get_scans_info(tmp_path):
+    """Write sample raw data to BIDS and return the scans.tsv data."""
+    raw = _read_raw_fif(raw_fname).pick(["meg", "stim"])
+    bids_path = _bids_path.copy().update(root=tmp_path, run=None, acquisition=None)
+    bids_path = write_raw_bids(raw, bids_path, overwrite=True)
+    # FIXME: find_matching_sidecar should *just* be able to find this scans.tsv?
+    scans_path = (
+        bids_path.copy()
+        .update(datatype=None)
+        .find_matching_sidecar(suffix="scans", extension=".tsv")
+    )
+    scans_data = _from_tsv(scans_path)
+    return raw, bids_path, scans_path, scans_data
 
 
 def _make_parallel_raw(subject, *, seed=None):
@@ -863,39 +880,14 @@ def test_adding_essential_annotations_to_dict(tmp_path):
 @testing.requires_testing_data
 def test_handle_scans_reading(tmp_path):
     """Test reading data from a BIDS scans.tsv file."""
-    raw = _read_raw_fif(raw_fname)
-    suffix = "meg"
-
-    # write copy of raw with line freq of 60
-    # bids basename and fname
-    bids_path = BIDSPath(
-        subject="01",
-        session="01",
-        task="audiovisual",
-        run="01",
-        datatype=suffix,
-        root=tmp_path,
-    )
-    bids_path = write_raw_bids(raw, bids_path, overwrite=True)
-    raw_01 = read_raw_bids(bids_path)
-
-    # find sidecar scans.tsv file and alter the
-    # acquisition time to not have the optional microseconds
-    scans_path = BIDSPath(
-        subject=bids_path.subject,
-        session=bids_path.session,
-        root=tmp_path,
-        suffix="scans",
-        extension=".tsv",
-    )
-    scans_tsv = _from_tsv(scans_path)
-    acq_time_str = scans_tsv["acq_time"][0]
+    raw, bids_path, scans_path, scans_data = _get_scans_info(tmp_path)
+    acq_time_str = scans_data["acq_time"][0]
     acq_time = datetime.strptime(acq_time_str, "%Y-%m-%dT%H:%M:%S.%fZ")
     acq_time = acq_time.replace(tzinfo=UTC)
     new_acq_time = acq_time_str.split(".")[0] + "Z"
-    assert acq_time == raw_01.info["meas_date"]
-    scans_tsv["acq_time"][0] = new_acq_time
-    _to_tsv(scans_tsv, scans_path)
+    assert acq_time == raw.info["meas_date"]
+    scans_data["acq_time"][0] = new_acq_time
+    _to_tsv(scans_data, scans_path)
 
     # now re-load the data and it should be different
     # from the original date and the same as the newly altered date
@@ -904,7 +896,7 @@ def test_handle_scans_reading(tmp_path):
     new_acq_time = datetime.strptime(new_acq_time, "%Y-%m-%dT%H:%M:%S.%fZ")
     new_acq_time = new_acq_time.replace(tzinfo=UTC)
     assert raw_02.info["meas_date"] == new_acq_time
-    assert new_acq_time != raw_01.info["meas_date"]
+    assert new_acq_time != raw.info["meas_date"]
 
     # Test without optional zero-offset UTC time-zone indicator (i.e., without trailing
     # "Z")
@@ -915,8 +907,8 @@ def test_handle_scans_reading(tmp_path):
             new_acq_time_str += ".0"
             date_format += ".%f"
 
-        scans_tsv["acq_time"][0] = new_acq_time_str
-        _to_tsv(scans_tsv, scans_path)
+        scans_data["acq_time"][0] = new_acq_time_str
+        _to_tsv(scans_data, scans_path)
 
         # now re-load the data and it should be different
         # from the original date and the same as the newly altered date
@@ -924,18 +916,29 @@ def test_handle_scans_reading(tmp_path):
         new_acq_time = datetime.strptime(new_acq_time_str, date_format)
         assert raw_03.info["meas_date"] == new_acq_time.astimezone(UTC)
 
-    # Regression for naive, pre-epoch acquisition times (Windows bug GH-1399)
-    pre_epoch_str = "1950-06-15T13:45:30"
-    scans_tsv["acq_time"][0] = pre_epoch_str
-    _to_tsv(scans_tsv, scans_path)
 
-    raw_pre_epoch = read_raw_bids(bids_path)
-    pre_epoch_naive = datetime.strptime(pre_epoch_str, "%Y-%m-%dT%H:%M:%S")
-    local_tz = datetime.now().astimezone().tzinfo or UTC
-    expected_pre_epoch = pre_epoch_naive.replace(tzinfo=local_tz).astimezone(UTC)
-    assert raw_pre_epoch.info["meas_date"] == expected_pre_epoch
-    if raw_pre_epoch.annotations.orig_time is not None:
-        assert raw_pre_epoch.annotations.orig_time == expected_pre_epoch
+@testing.requires_testing_data
+def test_very_old_scan_date(tmp_path, windows_datetime, monkeypatch):
+    """Test Regression for naive, pre-epoch acquisition times on Windows (GH-1399)."""
+    _, bids_path, scans_path, scans_data = _get_scans_info(tmp_path)
+
+    ts = "1950-06-15T13:00:00"
+    scans_data["acq_time"][0] = ts
+    _to_tsv(scans_data, scans_path)
+
+    # Explicitly set a timezone to avoid relying on the computers timezone
+    naive = datetime.strptime(ts, "%Y-%m-%dT%H:%M:%S")
+    local_tz = timezone(timedelta(hours=-5), name="EST")
+    expected = naive.replace(tzinfo=local_tz).astimezone(UTC)
+
+    func = partial(mne_bids.utils._convert_dt_to_utc, local_tz=local_tz)
+    monkeypatch.setattr("mne_bids.read._convert_dt_to_utc", func)
+    monkeypatch.setattr("mne_bids.read.datetime", windows_datetime)
+
+    raw = read_raw_bids(bids_path)
+    assert raw.info["meas_date"] == expected
+    if raw.annotations.orig_time is not None:
+        assert raw.annotations.orig_time == expected
 
 
 @pytest.mark.filterwarnings(warning_str["channel_unit_changed"])

--- a/mne_bids/tests/test_utils.py
+++ b/mne_bids/tests/test_utils.py
@@ -3,7 +3,7 @@
 # Authors: The MNE-BIDS developers
 # SPDX-License-Identifier: BSD-3-Clause
 
-from datetime import datetime
+from datetime import UTC, datetime, timedelta, timezone
 from pathlib import Path
 
 import mne
@@ -16,6 +16,7 @@ from mne_bids.utils import (
     _age_on_date,
     _check_datatype,
     _check_types,
+    _convert_dt_to_utc,
     _get_ch_type_mapping,
     _handle_datatype,
     _infer_eeg_placement_scheme,
@@ -205,3 +206,13 @@ def test_check_datatype():
             ValueError, match=f"The specified datatype {datatype} was not found"
         ):
             _check_datatype(raw, datatype)
+
+
+def test_convert_naive_datetime_fallback(windows_datetime):
+    """Test Windows platform pre-epoch failure fallback."""
+    naive = windows_datetime(1950, 6, 15, 13, 45, 30)
+    fallback_tz = timezone(timedelta(hours=-5), name="EST")
+
+    # Note that June would be EDT i.e. UTC-4, so this is (expectedly) incorrect.
+    expected = naive.replace(tzinfo=fallback_tz).astimezone(UTC)
+    assert _convert_dt_to_utc(naive, local_tz=fallback_tz) == expected

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -149,6 +149,8 @@ def _wrap_read_raw(read_raw):
     def fn(fname, *args, **kwargs):
         if Path(fname).suffix == ".mff":
             kwargs["events_as_annotations"] = True
+        if Path(fname).suffix.lower() == ".cnt":
+            kwargs.setdefault("data_format", "int16")
         raw = read_raw(fname, *args, **kwargs)
         raw.info["line_freq"] = 60
         return raw

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -567,3 +567,22 @@ def warn(
 
 # Some of the defaults here will be wrong but it should be close enough
 warn.__doc__ = getattr(_warn, "__doc__", None)
+
+
+def _convert_dt_to_utc(dt, *, local_tz=None):
+    """Convert a naive datetime to UTC.
+
+    Fallsback to the computers *current* tz if needed (e.g. Windows pre-epoch failures).
+
+    This is in a helper in order to make unit testing this behavior easier.
+    The local_tz parameter exists so that tests can make the fallback path deterministic
+    """
+    try:
+        return dt.astimezone(UTC)
+    except OSError as e:
+        # Windows needs an explicit local tz for naive, pre-epoch datetimes.
+        # https://bugs.python.org/issue36759
+        logger.debug("Using the current local tz for %s, due to: %s", dt, e)
+        if local_tz is None:
+            local_tz = datetime.now().astimezone().tzinfo or UTC
+        return dt.replace(tzinfo=local_tz).astimezone(UTC)


### PR DESCRIPTION
Fixes #1555 

- When parsing a timezone-naive timestamp from a `scans.tsv` file, by default we try to attach the computers local timezone, but using the timezone rules for ~that date~ the date of the timestamp (this was the behavior prior to https://github.com/mne-tools/mne-bids/commit/9c550e1252353f1f693b6e7ecb9021f591001714 )

- But if we hit this Windows platform pre-epoch timestamp error, then we fallback to just attaching the computers *current* timezone to the timestamp (even though this might be incorrect sometimes).

@larsoner @drammock once the CI's are green can I ask one of you to take a close look at this?

This one was tricky because the pre-epoch datetime test had the same problematic behavior as the function we were patching (i.e., it queried the computer to get the current local timezone information). In order to make the test more deterministic I had to do some monkey patching...