### PR TITLE
Add option physical_range in write_raw_bids: only used for format='EDF'

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -229,6 +229,10 @@ authors:
       family-names: Mäkelä
       affiliation: 'University of Helsinki, Helsinki, Finland'
       orcid: 'https://orcid.org/0009-0005-5706-0842'
+    - given-names: Flore
+      family-names: Boscher
+      affiliation: 'Laboratoire de Psychologie et Neurocognition, Grenoble, France'
+      orcid: 'https://orcid.org/0009-0005-1615-1369'
     - given-names: Alexandre
       family-names: Gramfort
       affiliation: 'Université Paris-Saclay, Inria, CEA, Palaiseau, France'

--- a/doc/authors.rst
+++ b/doc/authors.rst
@@ -24,6 +24,7 @@
 .. _Ethan Knights: https://github.com/ethanknights
 .. _Evgenii Kalenkovich: https://github.com/kalenkovich
 .. _Ezequiel Mikulan: https://github.com/ezemikulan
+.. _Flore Boscher: https://github.com/boscherf
 .. _Ford McDonald: https://github.com/fordmcdonald
 .. _Franziska von Albedyll: https://www.researchgate.net/profile/Franziska-Von-Albedyll
 .. _Fu-Te Wong: https://github.com/zuxfoucault

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1841,10 +1841,10 @@ def write_raw_bids(
         to BrainVision, EDF, or EEGLAB for iEEG, to BDF or EDF for EMG,
         and to FIF for MEG data.
     physical_range : str | tuple
-        If 'auto' (default), the physical range is inferred from the data, 
-        taking the minimum and maximum values per channel type. 
-        If 'channelwise', the range will be defined per channel. 
-        If a tuple of minimum and maximum, this manual physical range will be used. 
+        If 'auto' (default), the physical range is inferred from the data,
+        taking the minimum and maximum values per channel type.
+        If 'channelwise', the range will be defined per channel.
+        If a tuple of minimum and maximum, this manual physical range will be used.
         Only used for exporting EDF files.
     symlink : bool
         Instead of copying the source files, only create symbolic links to
@@ -2539,7 +2539,9 @@ def write_raw_bids(
             )
         elif write_format in ("BDF", "EDF"):
             warn(f"Converting data files to {write_format} format")
-            _write_raw_edf_bdf(raw, bids_path.fpath, physical_range = physical_range, overwrite=overwrite)
+            _write_raw_edf_bdf(
+                raw, bids_path.fpath, physical_range=physical_range, overwrite=overwrite
+            )
         elif write_format == "EEGLAB":
             warn("Converting data files to EEGLAB format")
             _write_raw_eeglab(raw, bids_path.fpath, overwrite=overwrite)

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1850,7 +1850,7 @@ def write_raw_bids(
         If ``'channelwise'``, the range will be defined per channel.
         If a tuple of minimum and maximum, this manual physical range will be used.
         Only used for exporting EDF files.
-        
+
         .. versionadded:: 0.19
     symlink : bool
         Instead of copying the source files, only create symbolic links to

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1446,7 +1446,7 @@ def _write_raw_brainvision(raw, bids_fname, events, overwrite):
     )
 
 
-def _write_raw_edf_bdf(raw, bids_fname, physical_range, overwrite):
+def _write_raw_edf_bdf(raw, bids_fname, overwrite, *, physical_range="auto"):
     """Store data as EDF.
 
     Parameters
@@ -1457,6 +1457,10 @@ def _write_raw_edf_bdf(raw, bids_fname, physical_range, overwrite):
         The output filename.
     physical_range : str | tuple
         How to get the physical minimal and maximal values from the data.
+        If ``'auto'`` (default), the physical range is inferred from the data,
+        taking the minimum and maximum values per channel type.
+        If ``'channelwise'``, the range will be defined per channel.
+        If a tuple of minimum and maximum, this manual physical range will be used.
     overwrite : bool
         Whether to overwrite an existing file or not.
     """
@@ -1841,9 +1845,9 @@ def write_raw_bids(
         to BrainVision, EDF, or EEGLAB for iEEG, to BDF or EDF for EMG,
         and to FIF for MEG data.
     physical_range : str | tuple
-        If 'auto' (default), the physical range is inferred from the data,
+        If ``'auto'`` (default), the physical range is inferred from the data,
         taking the minimum and maximum values per channel type.
-        If 'channelwise', the range will be defined per channel.
+        If ``'channelwise'``, the range will be defined per channel.
         If a tuple of minimum and maximum, this manual physical range will be used.
         Only used for exporting EDF files.
     symlink : bool

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1850,6 +1850,8 @@ def write_raw_bids(
         If ``'channelwise'``, the range will be defined per channel.
         If a tuple of minimum and maximum, this manual physical range will be used.
         Only used for exporting EDF files.
+        
+        .. versionadded:: 0.19
     symlink : bool
         Instead of copying the source files, only create symbolic links to
         preserve storage space. This is only allowed when not anonymizing the

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1446,7 +1446,7 @@ def _write_raw_brainvision(raw, bids_fname, events, overwrite):
     )
 
 
-def _write_raw_edf_bdf(raw, bids_fname, overwrite):
+def _write_raw_edf_bdf(raw, bids_fname, physical_range, overwrite):
     """Store data as EDF.
 
     Parameters
@@ -1455,6 +1455,8 @@ def _write_raw_edf_bdf(raw, bids_fname, overwrite):
         Raw data to save.
     bids_fname : str
         The output filename.
+    physical_range : str | tuple
+        How to get the physical minimal and maximal values from the data.
     overwrite : bool
         Whether to overwrite an existing file or not.
     """
@@ -1475,7 +1477,7 @@ def _write_raw_edf_bdf(raw, bids_fname, overwrite):
                 year=1985, month=1, day=1, hour=0, minute=0, second=0, microsecond=0
             )
         )
-    raw.export(bids_fname, overwrite=overwrite)
+    raw.export(bids_fname, physical_range=physical_range, overwrite=overwrite)
 
 
 def _write_raw_eeglab(raw, bids_fname, overwrite):
@@ -1703,6 +1705,7 @@ def write_raw_bids(
     *,
     anonymize=None,
     format="auto",
+    physical_range="auto",
     symlink=False,
     empty_room=None,
     allow_preload=False,
@@ -1837,6 +1840,12 @@ def write_raw_bids(
         Conversion may be forced to BrainVision, BDF, EDF, or EEGLAB for EEG,
         to BrainVision, EDF, or EEGLAB for iEEG, to BDF or EDF for EMG,
         and to FIF for MEG data.
+    physical_range : str | tuple
+        If 'auto' (default), the physical range is inferred from the data, 
+        taking the minimum and maximum values per channel type. 
+        If 'channelwise', the range will be defined per channel. 
+        If a tuple of minimum and maximum, this manual physical range will be used. 
+        Only used for exporting EDF files.
     symlink : bool
         Instead of copying the source files, only create symbolic links to
         preserve storage space. This is only allowed when not anonymizing the
@@ -2530,7 +2539,7 @@ def write_raw_bids(
             )
         elif write_format in ("BDF", "EDF"):
             warn(f"Converting data files to {write_format} format")
-            _write_raw_edf_bdf(raw, bids_path.fpath, overwrite=overwrite)
+            _write_raw_edf_bdf(raw, bids_path.fpath, physical_range = physical_range, overwrite=overwrite)
         elif write_format == "EEGLAB":
             warn("Converting data files to EEGLAB format")
             _write_raw_eeglab(raw, bids_path.fpath, overwrite=overwrite)


### PR DESCRIPTION
<!--
Thanks for contributing this pull request (PR).
If this is your first time, make sure to read
[CONTRIBUTING.md](https://github.com/mne-tools/mne-bids/blob/main/CONTRIBUTING.md)
-->

PR Description
--------------

Saving edf files with physical_range='channel_wise' reduces the difference between the original data and the data saved in the edf file. However, write_raw_bids function did not contain the physical_range argument. I therefore added this argument, similarly to the same argument in the mne export_raw function: by default, physical_range='auto'. The physical_range argument is only used if format='edf'. 

Merge checklist
---------------

Maintainer, please confirm the following before merging.
If applicable:

- [ ] All comments are resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] New contributors have been added to [CITATION.cff](https://github.com/mne-tools/mne-bids/blob/main/CITATION.cff)
- [ ] PR description includes phrase "closes <#issue-number>"
