### PR TITLE
MAINT: DRY BIDSPath.match and find_matching_paths

### DIFF
--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -2063,6 +2063,15 @@ def get_datatypes(root, verbose=None):
     return datatypes
 
 
+# Helpers for testing glob accesses
+def _root_glob(root, pattern):
+    return root.glob(pattern)
+
+
+def _root_rglob(root, pattern):
+    return root.rglob(pattern)
+
+
 @verbose
 def get_entity_vals(
     root,
@@ -2253,9 +2262,11 @@ def get_entity_vals(
     search_str = f"**/*{entity_long_abbr_map[entity_key]}-*_*"
     if include_match is not None:
         include_match = _ensure_tuple(include_match)
-        filenames = [f for im in include_match for f in root.glob(im + search_str)]
+        filenames = [
+            f for im in include_match for f in _root_glob(root, im + search_str)
+        ]
     else:
-        filenames = root.glob(search_str)
+        filenames = _root_glob(root, search_str)
 
     for filename in filenames:
         # Skip ignored directories
@@ -2638,8 +2649,23 @@ def find_matching_paths(
         The matching paths.
 
     """
+    entities_opt = dict()
+    if subjects is not None:
+        if isinstance(subjects, str):
+            entities_opt["subject"] = subjects
+        elif len(subjects) == 1:
+            entities_opt["subject"] = subjects[0]
+    if sessions is not None:
+        if isinstance(sessions, str):
+            entities_opt["session"] = sessions
+        elif len(sessions) == 1:
+            entities_opt["session"] = sessions[0]
     fpaths = _return_root_paths(
-        root, datatype=datatypes, ignore_json=ignore_json, ignore_nosub=ignore_nosub
+        root,
+        datatype=datatypes,
+        ignore_json=ignore_json,
+        ignore_nosub=ignore_nosub,
+        entities=entities_opt,
     )
 
     fpaths_filtered = _filter_fnames(
@@ -2692,6 +2718,8 @@ def _return_root_paths(
     paths : list of pathlib.Path
         All files + .ds paths in `root`, filtered according to the function parameters.
     """
+    # Everything in this should route through glob.iglob so our tests can detect
+    # regressions in performance!
     root = Path(root)  # if root is str
 
     # OPTIMIZATION: Use entity-aware path construction when entities available
@@ -2740,7 +2768,7 @@ def _return_root_paths(
         # FALLBACK: Original implementation when entities not available
         # or subject unknown
         if datatype is None and not ignore_nosub:
-            paths = root.rglob("*.*")
+            paths = _root_rglob(root, "*.*")
         else:
             if datatype is not None:
                 datatype = _ensure_tuple(datatype)

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -1115,21 +1115,6 @@ class BIDSPath:
                 "BIDS root directory path to `root` via "
                 "BIDSPath.update()."
             )
-
-        paths = _return_root_paths(
-            self.root,
-            datatype=self.datatype,
-            ignore_json=ignore_json,
-            ignore_nosub=ignore_nosub,
-            entities=self.entities,
-        )
-
-        fnames = _filter_fnames(
-            paths, suffix=self.suffix, extension=self.extension, **self.entities
-        )
-
-        bids_paths = _fnames_to_bidspaths(fnames, self.root, check=check)
-
         kwargs = {
             f"{key}s": [val] if val is not None else val
             for key, val in self.entities.items()
@@ -1143,9 +1128,7 @@ class BIDSPath:
             suffixes=[self.suffix] if self.suffix is not None else None,
             extensions=[self.extension] if self.extension is not None else None,
         )
-        x = find_matching_paths(**kwargs)
-        assert bids_paths == x
-        return bids_paths
+        return find_matching_paths(**kwargs)
 
     def _check(self):
         """Deep check or not of the instance."""

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -2064,11 +2064,11 @@ def get_datatypes(root, verbose=None):
 
 
 # Helpers for testing glob accesses
-def _root_glob(root, pattern):
+def _path_glob(root, pattern):
     return root.glob(pattern)
 
 
-def _root_rglob(root, pattern):
+def _path_rglob(root, pattern):
     return root.rglob(pattern)
 
 
@@ -2263,10 +2263,10 @@ def get_entity_vals(
     if include_match is not None:
         include_match = _ensure_tuple(include_match)
         filenames = [
-            f for im in include_match for f in _root_glob(root, im + search_str)
+            f for im in include_match for f in _path_glob(root, im + search_str)
         ]
     else:
-        filenames = _root_glob(root, search_str)
+        filenames = _path_glob(root, search_str)
 
     for filename in filenames:
         # Skip ignored directories
@@ -2718,8 +2718,6 @@ def _return_root_paths(
     paths : list of pathlib.Path
         All files + .ds paths in `root`, filtered according to the function parameters.
     """
-    # Everything in this should route through glob.iglob so our tests can detect
-    # regressions in performance!
     root = Path(root)  # if root is str
 
     # OPTIMIZATION: Use entity-aware path construction when entities available
@@ -2768,7 +2766,7 @@ def _return_root_paths(
         # FALLBACK: Original implementation when entities not available
         # or subject unknown
         if datatype is None and not ignore_nosub:
-            paths = _root_rglob(root, "*.*")
+            paths = _path_rglob(root, "*.*")
         else:
             if datatype is not None:
                 datatype = _ensure_tuple(datatype)

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -1129,6 +1129,22 @@ class BIDSPath:
         )
 
         bids_paths = _fnames_to_bidspaths(fnames, self.root, check=check)
+
+        kwargs = {
+            f"{key}s": [val] if val is not None else val
+            for key, val in self.entities.items()
+        }
+        kwargs.update(
+            root=self.root,
+            check=check,
+            ignore_json=ignore_json,
+            ignore_nosub=ignore_nosub,
+            datatypes=[self.datatype] if self.datatype is not None else None,
+            suffixes=[self.suffix] if self.suffix is not None else None,
+            extensions=[self.extension] if self.extension is not None else None,
+        )
+        x = find_matching_paths(**kwargs)
+        assert bids_paths == x
         return bids_paths
 
     def _check(self):
@@ -2556,11 +2572,12 @@ def find_matching_paths(
     spaces=None,
     splits=None,
     descriptions=None,
+    *,
+    tracking_systems=None,
     suffixes=None,
     extensions=None,
     datatypes=None,
     check=False,
-    *,
     ignore_json=False,
     ignore_nosub=False,
 ):
@@ -2604,6 +2621,10 @@ def find_matching_paths(
         may be assigned ``description='cleaned'``.
 
         .. versionadded:: 0.11
+    tracking_systems : str | array-like of str | None
+        The tracking system used for digitization.
+
+        .. versionadded:: 0.19
     suffixes : str | array-like of str | None
         The filename suffix. This is the entity after the
         last ``_`` before the extension. E.g., ``'channels'``.
@@ -2650,6 +2671,7 @@ def find_matching_paths(
         space=spaces,
         split=splits,
         description=descriptions,
+        tracking_system=tracking_systems,
         suffix=suffixes,
         extension=extensions,
     )

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -3,6 +3,7 @@
 # Authors: The MNE-BIDS developers
 # SPDX-License-Identifier: BSD-3-Clause
 
+import glob
 import os
 import os.path as op
 import shutil
@@ -17,6 +18,8 @@ from mne.datasets import testing
 from mne.io import anonymize_info
 from test_read import _read_raw_fif, warning_str
 
+import mne_bids
+import mne_bids.path
 from mne_bids import (
     BIDSPath,
     get_datatypes,
@@ -173,12 +176,12 @@ def test_get_entity_vals(entity, expected_vals, kwargs, return_bids_test_dir):
     shutil.rmtree(deriv_path)
 
 
-def test_path_benchmark(tmp_path_factory):
+def test_path_benchmark(tmp_path_factory, monkeypatch):
     """Benchmark exploring bids tree."""
     # This benchmark is to verify the speed-up in function call get_entity_vals with
     # `include_match=sub-*/` in face of a bids tree hosting derivatives and sourcedata.
-    n_subjects = 10
-    n_sessions = 5
+    n_subjects = 9
+    n_sessions = 4
     n_derivatives = 17
     tmp_bids_root = tmp_path_factory.mktemp("mnebids_utils_test_bids_ds")
 
@@ -189,8 +192,8 @@ def test_path_benchmark(tmp_path_factory):
     bids_subdirectories = ["", "sourcedata", *derivatives]
 
     # Create a BIDS compliant directory tree with high number of branches
-    for i in range(1, n_subjects):
-        for j in range(1, n_sessions):
+    for i in range(1, n_subjects + 1):
+        for j in range(1, n_sessions + 1):
             for subdir in bids_subdirectories:
                 for datatype in ["eeg", "meg"]:
                     bids_subdir = BIDSPath(
@@ -224,17 +227,58 @@ def test_path_benchmark(tmp_path_factory):
                         Path(ctf_path / "hz.ds" / "hz.meg4").touch()
                         Path(ctf_path / "hz.ds" / "hz.hc").touch()
 
+    # count number of accesses
+    count = 0
+    orig_iglob = glob.iglob
+
+    def iglob_count(*args, **kwargs):
+        for fn in orig_iglob(*args, **kwargs):
+            nonlocal count
+            count += 1
+            yield fn
+
+    def _return_root_paths_count(*args, **kwargs):
+        nonlocal count
+        count = 0
+        return _return_root_paths(*args, **kwargs)
+
+    def get_entity_vals_count(*args, **kwargs):
+        nonlocal count
+        count = 0
+        return get_entity_vals(*args, **kwargs)
+
+    def _root_glob_iglob(root, pattern):
+        # Reroute Path.glob through iglob to count accesses
+        return [root / f for f in glob.iglob(pattern, root_dir=root, recursive=True)]
+
+    def _root_rglob_iglob(root, pattern):
+        # Reroute Path.rglob through iglob to count accesses
+        return [
+            root / f for f in glob.iglob(f"**/{pattern}", root_dir=root, recursive=True)
+        ]
+
+    monkeypatch.setattr(glob, "iglob", iglob_count)
+    monkeypatch.setattr(mne_bids.path, "_root_glob", _root_glob_iglob)
+    monkeypatch.setattr(mne_bids.path, "_root_rglob", _root_rglob_iglob)
+    monkeypatch.setattr(mne_bids.path, "_return_root_paths", _return_root_paths_count)
+    monkeypatch.setattr(mne_bids, "get_entity_vals", get_entity_vals_count)
+    fnames = _return_root_paths_count(tmp_bids_root)
+    assert len(fnames) == 6878
+    assert count == 6878
+
     # apply nosub on find_matching_matchs with root level bids directory should
     # yield a performance boost of order of length from bids_subdirectories.
     setup = "import mne_bids\ntmp_bids_root=r'" + str(tmp_bids_root) + "'"
     timed_all = timeit.timeit(
         "mne_bids.find_matching_paths(tmp_bids_root)", setup=setup, number=1
     )
+    assert count == 6878
     timed_ignored_nosub = timeit.timeit(
         "mne_bids.find_matching_paths(tmp_bids_root, ignore_nosub=True)",
         setup=setup,
         number=1,
     )
+    assert count == 360
 
     # while this should be of same order, lets give it some space by a factor of 3
     target = 3 * timed_all / len(bids_subdirectories)
@@ -247,24 +291,54 @@ def test_path_benchmark(tmp_path_factory):
         setup=setup,
         number=1,
     )
+    assert count == 4788
     timed_entity_match = timeit.timeit(
         "mne_bids.get_entity_vals(tmp_bids_root, 'session', include_match='sub-*/')",  # noqa: E501
         setup=setup,
         number=1,
     )
+    assert count == 252
 
     # while this should be of same order, lets give it some space by a factor of 3
     target = 3 * timed_entity / len(bids_subdirectories)
     assert timed_entity_match < target
 
     # and these should be equivalent
-    out_1 = get_entity_vals(tmp_bids_root, "session")
-    out_2 = get_entity_vals(tmp_bids_root, "session", include_match="**/")
+    out_1 = mne_bids.get_entity_vals(tmp_bids_root, "session")
+    assert count == 4788
+    out_2 = mne_bids.get_entity_vals(tmp_bids_root, "session", include_match="**/")
+    assert count == 29340
     assert out_1 == out_2
-    out_3 = get_entity_vals(tmp_bids_root, "session", include_match="sub-*/")
+    out_3 = mne_bids.get_entity_vals(tmp_bids_root, "session", include_match="sub-*/")
+    assert count == 252
     assert out_2 == out_3  # all are sub-* vals
-    out_4 = get_entity_vals(tmp_bids_root, "session", include_match="none/")
+    out_4 = mne_bids.get_entity_vals(tmp_bids_root, "session", include_match="none/")
+    assert count == 0
     assert out_4 == []
+
+    # BIDSPath.match optimizations as well
+    path = BIDSPath(
+        datatype="meg",
+        extension=".ds",
+        root=tmp_bids_root,
+    )
+    paths = path.match()
+    # TODO: We *should* have n_subjects * n_sessions of these, but we get way more:
+    assert len(paths) == 684
+    # This is because we have duplicate files here with BIDS entities, like:
+    # bids_root/derivatives/derivatives0/sub-1/ses-1/meg/sub-1_ses-1_task-audvis_meg.ds
+    # bids_root/derivatives/derivatives1/sub-1/ses-1/meg/sub-1_ses-1_task-audvis_meg.ds
+    # And _fnames_to_bidspaths converts these to the same names!
+    assert paths[0] == paths[n_subjects * n_sessions]
+    assert count == 2052
+    path.subject = "1"  # add subject
+    paths = path.match()
+    assert len(paths) == n_sessions
+    assert count == 12
+    path.session = "2"  # add session
+    paths = path.match()
+    assert len(paths) == 1, paths
+    assert count == 3
 
 
 def _scan_targeted_meg(root, entities=None):

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -247,19 +247,19 @@ def test_path_benchmark(tmp_path_factory, monkeypatch):
         count = 0
         return get_entity_vals(*args, **kwargs)
 
-    def _root_glob_iglob(root, pattern):
+    def _path_glob_iglob(root, pattern):
         # Reroute Path.glob through iglob to count accesses
         return [root / f for f in glob.iglob(pattern, root_dir=root, recursive=True)]
 
-    def _root_rglob_iglob(root, pattern):
+    def _path_rglob_iglob(root, pattern):
         # Reroute Path.rglob through iglob to count accesses
         return [
             root / f for f in glob.iglob(f"**/{pattern}", root_dir=root, recursive=True)
         ]
 
     monkeypatch.setattr(glob, "iglob", iglob_count)
-    monkeypatch.setattr(mne_bids.path, "_root_glob", _root_glob_iglob)
-    monkeypatch.setattr(mne_bids.path, "_root_rglob", _root_rglob_iglob)
+    monkeypatch.setattr(mne_bids.path, "_path_glob", _path_glob_iglob)
+    monkeypatch.setattr(mne_bids.path, "_path_rglob", _path_rglob_iglob)
     monkeypatch.setattr(mne_bids.path, "_return_root_paths", _return_root_paths_count)
     monkeypatch.setattr(mne_bids, "get_entity_vals", get_entity_vals_count)
     fnames = _return_root_paths_count(tmp_bids_root)


### PR DESCRIPTION
A small start toward #1559: make `BIDSPath.match` use `find_matching_files`. These had almost the same code in them, so route one through the other.

First commit (just pushed) uses the alternate code path, and asserts the two give the same files. (It also exposes that `tracking_systems` was missing from `find_matching_paths`!) Once this comes back green, I'll remove the old code path in favor of the new one.