### PR TITLE
Make BIDSPath hashable

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -38,6 +38,7 @@ Detailed list of changes
 - Save ``Annotations.extras`` fields in events.tsv files when writing events, by `Pierre Guetschel`_ (:gh:`1502`)
 - Added support for ``EEGLAB`` and ``EEGLAB-HJ`` coordinate systems as defined in the BIDS specification. Both use ALS orientation (identical to CTF) and map to MNE's ``ctf_head`` coordinate frame, by `Bruno Aristimunha`_ (:gh:`1514`)
 - :func:`mne_bids.read_raw_bids` now reads channel units from ``channels.tsv`` and sets them on the raw object. This includes support for units like ``rad`` (radians), ``V``, ``µV``, ``mV``, ``T``, ``T/m``, ``S``, ``oC``, ``M``, and ``px``. The write path was also updated to correctly write ``rad`` units to ``channels.tsv``, by `Alexandre Gramfort`_ (:gh:`1509`)
+- Added support for hashing ``BIDSPath`` objects so they can be used in caching and other contexts that require hashable objects, by `Eric Larson`_ (:gh:`1563`)
 
 🧐 API and behavior changes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -57,6 +58,7 @@ Detailed list of changes
 - Fix :func:`read_raw_bids` ignoring ``electrodes.tsv`` when ``EEGCoordinateUnits`` is ``"n/a"`` by inferring the unit from coordinate magnitudes, and synthesize approximate fiducials for ``ctf_head`` montages to enable the coordinate transform to ``head`` frame, by `Bruno Aristimunha`_ (:gh:`1506`)
 - Improve :func:`mne_bids.read_raw_bids` handling when ``electrodes.tsv`` exists without ``coordsystem.json``: keep strict failure for iEEG, and for EEG/MEG emit a warning and continue without applying a montage, by `Bruno Aristimunha`_
 - Allow ``task=None`` in :func:`mne_bids.read_raw_bids` for BIDS paths without a task entity (e.g. datasets that omit task in the path), by `Aman Jaiswal`_
+- Fix bug with equality check for BIDSPath objects, by `Eric Larson`_ (:gh:`1563`)
 
 ⚕️ Code health
 ^^^^^^^^^^^^^^

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -58,7 +58,6 @@ Detailed list of changes
 - Fix :func:`read_raw_bids` ignoring ``electrodes.tsv`` when ``EEGCoordinateUnits`` is ``"n/a"`` by inferring the unit from coordinate magnitudes, and synthesize approximate fiducials for ``ctf_head`` montages to enable the coordinate transform to ``head`` frame, by `Bruno Aristimunha`_ (:gh:`1506`)
 - Improve :func:`mne_bids.read_raw_bids` handling when ``electrodes.tsv`` exists without ``coordsystem.json``: keep strict failure for iEEG, and for EEG/MEG emit a warning and continue without applying a montage, by `Bruno Aristimunha`_
 - Allow ``task=None`` in :func:`mne_bids.read_raw_bids` for BIDS paths without a task entity (e.g. datasets that omit task in the path), by `Aman Jaiswal`_
-- Fix bug with equality check for BIDSPath objects, by `Eric Larson`_ (:gh:`1563`)
 
 ⚕️ Code health
 ^^^^^^^^^^^^^^

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -460,6 +460,21 @@ class BIDSPath:
             "tracking_system": self.tracking_system,
         }
 
+    def __getstate__(self):
+        """Get the object state."""
+        state = self.entities
+        for key in ("root", "suffix", "extension", "datatype", "check"):
+            state[key] = getattr(self, key)
+        return state
+
+    def __setstate__(self, state):
+        """Set the object state."""
+        self.update(**state)
+
+    def __hash__(self):
+        """Compute the object hash."""
+        return hash(self.__getstate__().items())
+
     @property
     def basename(self):
         """Path basename."""

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -681,11 +681,11 @@ class BIDSPath:
         """Return the string representation for any fs functions."""
         return str(self.fpath)
 
+    # TODO: This allows some of the attributes to differ between objects (like one can
+    # have .extension None and the other .fif for example) but maybe okay
     def __eq__(self, other):
-        """Compute object equality."""
-        if not isinstance(other, BIDSPath):
-            return NotImplemented
-        return self.__getstate__() == other.__getstate__()
+        """Compare str representations."""
+        return str(self) == str(other)
 
     def copy(self):
         """Copy the instance.

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -473,7 +473,9 @@ class BIDSPath:
 
     def __hash__(self):
         """Compute the object hash."""
-        return hash(frozenset(self.__getstate__().items()))
+        state = self.__getstate__()
+        state["__class__"] = "BIDSPath"
+        return hash(frozenset(state.items()))
 
     @property
     def basename(self):

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -473,7 +473,7 @@ class BIDSPath:
 
     def __hash__(self):
         """Compute the object hash."""
-        return hash(self.__getstate__().items())
+        return hash(frozenset(self.__getstate__().items()))
 
     @property
     def basename(self):
@@ -680,12 +680,10 @@ class BIDSPath:
         return str(self.fpath)
 
     def __eq__(self, other):
-        """Compare str representations."""
-        return str(self) == str(other)
-
-    def __ne__(self, other):
-        """Compare str representations."""
-        return str(self) != str(other)
+        """Compute object equality."""
+        if not isinstance(other, BIDSPath):
+            return NotImplemented
+        return self.__getstate__() == other.__getstate__()
 
     def copy(self):
         """Copy the instance.

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -1311,7 +1311,7 @@ def test_make_filenames():
     )
     assert BIDSPath(**prefix_data).basename == expected_str
     assert (
-        BIDSPath(**prefix_data).fpath.as_posix()
+        BIDSPath(**prefix_data)
         == (Path("sub-one") / "ses-two" / "ieeg" / expected_str).as_posix()
     )
 
@@ -2102,7 +2102,10 @@ def test_hash():
     assert hash(bp1) == hash(bp3)
     # equality and pickling
     assert bp1.__dict__ != bp_other.__dict__  # different content
-    assert bp1 != bp_other  # equality should be false for different content
+    assert bp1.fpath == bp_other.fpath  # okay, I guess
+    assert bp1 == bp_other
+    bp_other.datatype = "meg"
+    assert bp1 != bp_other
     assert bp1 != "foo"  # other type
     # make sure everything in our entities plus properties is in __getstate__
     slim_dict = {k: v for k, v in bp1.__dict__.items() if not k.startswith("_")}
@@ -2112,3 +2115,9 @@ def test_hash():
     )
     assert bp1.__getstate__() == slim_dict
     functools.lru_cache(lambda x, y: x)(bp1, "whatever")  # test cachable
+    # TODO: One more oddity about our equality that we maybe want to fix someday
+    bp3 = BIDSPath(subject="01", datatype="eeg", root=Path("foo"), extension=".fif")
+    bp4 = BIDSPath(subject="01", datatype="eeg", root=Path("foo"), extension=".bdf")
+    # equality is true even though extension differs because .fpath omits it here
+    assert bp3 == bp4
+    assert "." not in str(bp3.fpath)

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -1311,7 +1311,7 @@ def test_make_filenames():
     )
     assert BIDSPath(**prefix_data).basename == expected_str
     assert (
-        BIDSPath(**prefix_data)
+        BIDSPath(**prefix_data).fpath.as_posix()
         == (Path("sub-one") / "ses-two" / "ieeg" / expected_str).as_posix()
     )
 

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -3,9 +3,11 @@
 # Authors: The MNE-BIDS developers
 # SPDX-License-Identifier: BSD-3-Clause
 
+import functools
 import glob
 import os
 import os.path as op
+import pickle
 import shutil
 import shutil as sh
 import timeit
@@ -2080,3 +2082,33 @@ def test_fpath_common_prefix(tmp_path):
         BIDSPath(root=tmp_path, subject="1", run="2").fpath
         == sub_dir / "sub-1_run-2.edf"
     )
+
+
+def test_hash():
+    """Test that BIDSPath is hashable."""
+    bp1 = BIDSPath(subject="01", datatype="eeg", root=Path("foo"))
+    bp2 = BIDSPath(subject="01", datatype="eeg", root=Path("foo"))
+    assert hash(bp1) == hash(bp2)
+    # test standard hash properties:
+    assert hash(bp1) == hash(bp1)  # same object
+    assert hash(bp1) == hash(bp2)  # different objects, same content
+    bp_other = bp1.copy().update(extension=".fif")
+    assert bp1.extension != bp_other.extension
+    assert hash(bp1) != hash(bp_other)  # different content
+    assert hash(bp1) != hash("not a BIDSPath")  # different type
+    assert bp1 == bp2  # equality should be true for same content
+    bp3 = pickle.loads(pickle.dumps(bp1))  # test pickling
+    assert bp1 == bp3
+    assert hash(bp1) == hash(bp3)
+    # equality and pickling
+    assert bp1.__dict__ != bp_other.__dict__  # different content
+    assert bp1 != bp_other  # equality should be false for different content
+    assert bp1 != "foo"  # other type
+    # make sure everything in our entities plus properties is in __getstate__
+    slim_dict = {k: v for k, v in bp1.__dict__.items() if not k.startswith("_")}
+    slim_dict.update(bp1.entities)
+    slim_dict.update(
+        {k: getattr(bp1, k) for k in ("datatype", "extension", "suffix", "root")}
+    )
+    assert bp1.__getstate__() == slim_dict
+    functools.lru_cache(lambda x, y: x)(bp1, "whatever")  # test cachable

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -2088,7 +2088,6 @@ def test_hash():
     """Test that BIDSPath is hashable."""
     bp1 = BIDSPath(subject="01", datatype="eeg", root=Path("foo"))
     bp2 = BIDSPath(subject="01", datatype="eeg", root=Path("foo"))
-    assert hash(bp1) == hash(bp2)
     # test standard hash properties:
     assert hash(bp1) == hash(bp1)  # same object
     assert hash(bp1) == hash(bp2)  # different objects, same content


### PR DESCRIPTION
As part of optimizing MNE-BIDS-Pipeline, I'd like to make BIDSPath objects hashable so they can be used with `@functools.cache`, for example:
```
@functools.cache
def _find_matching_sidecar(
    bp: BIDSPath,
    ...
):
    return bp.find_matching_sidecar(...)
```
This isn't 100% correct but gets the idea across. Need to double check Python `__hash__` reqs, add class name hash, tests, etc. but wanted to get the ball rolling at least.

cc @dnacombo in case this might help you as well