### PR TITLE
updates to handling of sex metadata

### DIFF
--- a/mne_bids/tests/data/tiny_bids/participants.json
+++ b/mne_bids/tests/data/tiny_bids/participants.json
@@ -7,10 +7,11 @@
         "Units": "years"
     },
     "sex": {
-        "Description": "Biological sex of the participant",
+        "Description": "Sex of the participant",
         "Levels": {
             "F": "female",
-            "M": "male"
+            "M": "male",
+            "O": "other"
         }
     },
     "hand": {

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -768,8 +768,8 @@ def _participants_json(fname, overwrite=False):
             "Units": "years",
         },
         "sex": {
-            "Description": "Biological sex of the participant",
-            "Levels": {"F": "female", "M": "male"},
+            "Description": "Sex of the participant",
+            "Levels": {"F": "female", "M": "male", "O": "other"},
         },
         "hand": {
             "Description": "Handedness of the participant",


### PR DESCRIPTION
closes #1566 

PR Description
--------------

does 2 things:

- strikes "biological" from definition of the metadata item "sex"
- adds "other" as a valid value of the "sex" metadata item (BIDS standard supports this)

Merge checklist
---------------

Maintainer, please confirm the following before merging.
If applicable:

- [ ] All comments are resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] New contributors have been added to [CITATION.cff](https://github.com/mne-tools/mne-bids/blob/main/CITATION.cff)
- [ ] PR description includes phrase "closes <#issue-number>"
