### PR TITLE
Speedup get_entity_vals

### DIFF
--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -2272,6 +2272,7 @@ def get_entity_vals(
         filenames = [
             f for im in include_match for f in _path_glob(root, im + search_str)
             if not any(f.is_relative_to(d) for d in ignore_dirs_set)
+            and not (ignore_hidden and any(p.startswith(".") for p in f.parts))
         ]
     else:
         filenames = []

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -2194,7 +2194,7 @@ def get_entity_vals(
         If ``False`` (default), just returns the entity values. This
         will for example look like ``['001', '002']``.
     ignore_hidden : bool
-        If ``True``, ignore hidden files and directories (those starting 
+        If ``True``, ignore hidden files and directories (those starting
         with a period ``.``).
     %(verbose)s
 
@@ -2293,7 +2293,9 @@ def get_entity_vals(
     if include_match is not None:
         include_match = _ensure_tuple(include_match)
         filenames = [
-            f for im in include_match for f in _path_glob(root, im + search_str)
+            f
+            for im in include_match
+            for f in _path_glob(root, im + search_str)
             if not any(f.is_relative_to(d) for d in ignore_dirs_set)
             and not (ignore_hidden and any(p.startswith(".") for p in f.parts))
         ]
@@ -2310,7 +2312,6 @@ def get_entity_vals(
                     filenames.append(dp / f)
 
     for filename in filenames:
-
         if ignore_suffixes and any(
             [filename.stem.endswith(s) for s in ignore_suffixes]
         ):

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -2093,6 +2093,7 @@ def get_entity_vals(
     ignore_suffixes=None,
     include_match=None,
     with_key=False,
+    ignore_hidden=True,
     verbose=None,
 ):
     """Get list of values associated with an `entity_key` in a BIDS dataset.
@@ -2169,6 +2170,9 @@ def get_entity_vals(
         will for example look like ``['sub-001', 'sub-002']``.
         If ``False`` (default), just returns the entity values. This
         will for example look like ``['001', '002']``.
+    ignore_hidden : bool
+        If ``True``, ignore hidden files and directories (those starting 
+        with a period ``.``).
     %(verbose)s
 
     Returns
@@ -2259,21 +2263,29 @@ def get_entity_vals(
 
     p = re.compile(rf"{entity_long_abbr_map[entity_key]}-(.*?)_")
     values = list()
-    search_str = f"**/*{entity_long_abbr_map[entity_key]}-*_*"
+    entity_abbr = entity_long_abbr_map[entity_key]
+    search_str = f"**/*{entity_abbr}-*_*"
+    ignore_dirs_set = set(ignore_dirs)  # resolved absolute Paths, for fast lookup
+
     if include_match is not None:
         include_match = _ensure_tuple(include_match)
         filenames = [
             f for im in include_match for f in _path_glob(root, im + search_str)
+            if not any(f.is_relative_to(d) for d in ignore_dirs_set)
         ]
     else:
-        filenames = _path_glob(root, search_str)
+        filenames = []
+        for dirpath, dirs, files in os.walk(root, topdown=True):
+            dp = Path(dirpath)
+            # Prevent os.walk from descending into ignored dirs
+            dirs[:] = [d for d in dirs if dp / d not in ignore_dirs_set]
+            if ignore_hidden:
+                dirs[:] = [d for d in dirs if not d.startswith(".")]
+            for f in files:
+                if f"{entity_abbr}-" in f and "_" in f:
+                    filenames.append(dp / f)
 
     for filename in filenames:
-        # Skip ignored directories
-        if any(
-            [Path(filename).is_relative_to(ignore_dir) for ignore_dir in ignore_dirs]
-        ):
-            continue
 
         if ignore_suffixes and any(
             [filename.stem.endswith(s) for s in ignore_suffixes]

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -176,6 +176,55 @@ def test_get_entity_vals(entity, expected_vals, kwargs, return_bids_test_dir):
     shutil.rmtree(deriv_path)
 
 
+@testing.requires_testing_data
+def test_get_entity_vals_ignore_hidden(return_bids_test_dir):
+    """Test that hidden directories are skipped by default and included when opted in."""
+    bids_root = return_bids_test_dir
+    hidden_meg_dir = (
+        Path(bids_root) / ".hidden_data" / "sub-hid" / "ses-hid" / "meg"
+    )
+    hidden_meg_dir.mkdir(parents=True)
+    (hidden_meg_dir / "sub-hid_ses-hid_task-hid_meg.fif").touch()
+
+    # Default (ignore_hidden=True): hidden dir must not contribute any values
+    for entity_key in ("subject", "session", "task"):
+        vals = get_entity_vals(root=bids_root, entity_key=entity_key)
+        assert "hid" not in vals, (
+            f"entity '{entity_key}' leaked from hidden dir: {vals}"
+        )
+
+    # ignore_hidden=False + ignore_dirs=None: hidden dir must be included
+    for entity_key in ("subject", "session", "task"):
+        vals = get_entity_vals(
+            root=bids_root,
+            entity_key=entity_key,
+            ignore_hidden=False,
+            ignore_dirs=None,
+        )
+        assert "hid" in vals, (
+            f"entity '{entity_key}' not found in hidden dir when ignore_hidden=False: {vals}"
+        )
+
+    # include_match branch: hidden dir must also be excluded by default
+    vals_include = get_entity_vals(
+        root=bids_root, entity_key="subject", include_match="**/"
+    )
+    assert "hid" not in vals_include
+
+    # include_match branch: hidden dir included when ignore_hidden=False
+    vals_include_hidden = get_entity_vals(
+        root=bids_root,
+        entity_key="subject",
+        include_match="**/",
+        ignore_hidden=False,
+        ignore_dirs=None,
+    )
+    assert "hid" in vals_include_hidden
+
+    # Clean up
+    shutil.rmtree(Path(bids_root) / ".hidden_data")
+
+
 def test_path_benchmark(tmp_path_factory, monkeypatch):
     """Benchmark exploring bids tree."""
     # This benchmark is to verify the speed-up in function call get_entity_vals with

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -187,9 +187,7 @@ def test_get_entity_vals(entity, expected_vals, kwargs, bids_test_dir):
 def test_get_entity_vals_ignore_hidden(return_bids_test_dir):
     """Test that hidden directories are skipped by default and included when opted in."""
     bids_root = return_bids_test_dir
-    hidden_meg_dir = (
-        Path(bids_root) / ".hidden_data" / "sub-hid" / "ses-hid" / "meg"
-    )
+    hidden_meg_dir = Path(bids_root) / ".hidden_data" / "sub-hid" / "ses-hid" / "meg"
     hidden_meg_dir.mkdir(parents=True)
     (hidden_meg_dir / "sub-hid_ses-hid_task-hid_meg.fif").touch()
 

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -185,8 +185,8 @@ def test_get_entity_vals(entity, expected_vals, kwargs, bids_test_dir):
 
 @testing.requires_testing_data
 def test_get_entity_vals_ignore_hidden(bids_test_dir):
-    """Test that hidden directories are skipped by default and included when opted in."""
-    bids_root = return_bids_test_dir
+    """Test hidden directories are skipped by default and included when opted in."""
+    bids_root = bids_test_dir
     hidden_meg_dir = Path(bids_root) / ".hidden_data" / "sub-hid" / "ses-hid" / "meg"
     hidden_meg_dir.mkdir(parents=True)
     (hidden_meg_dir / "sub-hid_ses-hid_task-hid_meg.fif").touch()
@@ -207,7 +207,8 @@ def test_get_entity_vals_ignore_hidden(bids_test_dir):
             ignore_dirs=None,
         )
         assert "hid" in vals, (
-            f"entity '{entity_key}' not found in hidden dir when ignore_hidden=False: {vals}"
+            f"entity '{entity_key}' not found in hidden dir when "
+            f"ignore_hidden=False: {vals}"
         )
 
     # include_match branch: hidden dir must also be excluded by default
@@ -240,6 +241,7 @@ def path_counter(monkeypatch):
     """Count number of files traversed using iglob."""
     out = _PathAccessCounter()
     orig_iglob = glob.iglob
+    orig_walk = os.walk
 
     def iglob_count(*args, **kwargs):
         for fn in orig_iglob(*args, **kwargs):
@@ -268,12 +270,19 @@ def path_counter(monkeypatch):
             root / f for f in glob.iglob(f"**/{pattern}", root_dir=root, recursive=True)
         ]
 
+    def _os_walk_count(*args, **kwargs):
+        out.count = 0
+        for dirpath, dirs, files in orig_walk(*args, **kwargs):
+            out.count += len(files) + len(dirs)
+            yield dirpath, dirs, files
+
     monkeypatch.setattr(glob, "iglob", iglob_count)
     monkeypatch.setattr(mne_bids.path, "_path_glob", _path_glob_iglob)
     monkeypatch.setattr(mne_bids.path, "_path_rglob", _path_rglob_iglob)
     monkeypatch.setattr(mne_bids.path, "_return_root_paths", _return_root_paths_count)
     monkeypatch.setattr(mne_bids, "get_entity_vals", get_entity_vals_count)
     monkeypatch.setattr(mne_bids, "get_datatypes", get_datatypes_count)
+    monkeypatch.setattr(os, "walk", _os_walk_count)
     yield out
 
 
@@ -365,28 +374,9 @@ def test_path_benchmark(bids_test_dir_dense, monkeypatch, path_counter):
     target = 3 * timed_all / len(bids_test_dir_dense.bids_subdirectories)
     assert timed_ignored_nosub < target
 
-    # apply include_match on get_entity_vals with root level bids directory should
-    # yield a performance boost of order of length from bids_subdirectories.
-    timed_entity = timeit.timeit(
-        "mne_bids.get_entity_vals(tmp_bids_root, 'session')",
-        setup=setup,
-        number=1,
-    )
-    assert path_counter.count == 4788
-    timed_entity_match = timeit.timeit(
-        "mne_bids.get_entity_vals(tmp_bids_root, 'session', include_match='sub-*/')",  # noqa: E501
-        setup=setup,
-        number=1,
-    )
-    assert path_counter.count == 252
-
-    # while this should be of same order, lets give it some space by a factor of 3
-    target = 3 * timed_entity / len(bids_test_dir_dense.bids_subdirectories)
-    assert timed_entity_match < target
-
-    # and these should be equivalent
+    # these should be equivalent
     out_1 = mne_bids.get_entity_vals(tmp_bids_root, "session")
-    assert path_counter.count == 4788
+    assert path_counter.count == 482
     out_2 = mne_bids.get_entity_vals(tmp_bids_root, "session", include_match="**/")
     assert path_counter.count == 29340
     assert out_1 == out_2
@@ -1121,26 +1111,27 @@ def test_bids_path_inference(bids_test_dir):
     channels_fname.fpath
 
     # create an extra file under 'eeg'
-    extra_file = op.join(
-        bids_root,
-        f"sub-{subject_id}",
-        f"ses-{session_id}",
-        "eeg",
-        channels_fname.basename + ".tsv",
+    extra_file = (
+        bids_root
+        / f"sub-{subject_id}"
+        / f"ses-{session_id}"
+        / "eeg"
+        / f"{channels_fname.basename}.tsv"
     )
-    Path(extra_file).parent.mkdir(exist_ok=True, parents=True)
-    # Creates a new file and because of this new file, there is now
-    # ambiguity
-    with open(extra_file, "w", encoding="utf-8"):
-        pass
-    with pytest.raises(RuntimeError, match="Found data of more than one"):
-        channels_fname.fpath
+    try:
+        extra_file.parent.mkdir(exist_ok=True, parents=True)
+        # Creates a new file and because of this new file, there is now
+        # ambiguity
+        with open(extra_file, "w", encoding="utf-8"):
+            pass
+        with pytest.raises(RuntimeError, match="Found data of more than one"):
+            channels_fname.fpath
 
-    # if you set datatype, now there is no ambiguity
-    channels_fname.update(datatype="eeg")
-    assert str(channels_fname.fpath) == extra_file
-    # set state back to original
-    shutil.rmtree(Path(extra_file).parent)
+        # if you set datatype, now there is no ambiguity
+        channels_fname.update(datatype="eeg")
+        assert str(channels_fname.fpath) == str(extra_file)
+    finally:
+        shutil.rmtree(extra_file.parent)
 
 
 @testing.requires_testing_data

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -184,7 +184,7 @@ def test_get_entity_vals(entity, expected_vals, kwargs, bids_test_dir):
 
 
 @testing.requires_testing_data
-def test_get_entity_vals_ignore_hidden(return_bids_test_dir):
+def test_get_entity_vals_ignore_hidden(bids_test_dir):
     """Test that hidden directories are skipped by default and included when opted in."""
     bids_root = return_bids_test_dir
     hidden_meg_dir = Path(bids_root) / ".hidden_data" / "sub-hid" / "ses-hid" / "meg"


### PR DESCRIPTION
PR Description
--------------

Scanning for entity values has ignore_dirs option that is applied _after_ listing all files. This is suboptimal.

- Changed scanning strategy to prevent globing into unwanted directories. Using os.walk and discarding unwanted dirs during scanning.
- Add ignore_hidden bool option to prevent descending in .git and other hidden dirs.

Merge checklist
---------------

Maintainer, please confirm the following before merging.
If applicable:

- [ ] All comments are resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] New contributors have been added to [CITATION.cff](https://github.com/mne-tools/mne-bids/blob/main/CITATION.cff)
- [ ] PR description includes phrase "closes <#issue-number>"
