### PR TITLE
DOC: Fix bad links from default_role="autolink"

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -84,3 +84,4 @@ mne_bids.copyfiles
    copyfile_ctf
    copyfile_bti
    copyfile_kit
+   copyfile_mef

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -74,7 +74,12 @@ numpydoc_validate = True
 # generate autosummary even if no references
 autosummary_generate = True
 autodoc_default_options = {"inherited-members": None}
-default_role = "autolink"  # XXX silently allows bad syntax, someone should fix
+
+default_role = "py:obj"
+
+rst_prolog = """
+.. currentmodule:: mne_bids
+"""
 
 # configure linkcheck
 # https://sphinx-doc.org/en/master/usage/configuration.html?#options-for-the-linkcheck-builder

--- a/doc/whats_new_previous_releases.rst
+++ b/doc/whats_new_previous_releases.rst
@@ -36,10 +36,10 @@ Detailed list of changes
 🚀 Enhancements
 ^^^^^^^^^^^^^^^
 
-- :func:`mne_bids.write_raw_bids()` has a new parameter `electrodes_tsv_task` which allows adding the `task` entity to the `electrodes.tsv` filepath, by `Alex Lopez Marquez`_ (:gh:`1424`)
-- Extended the configuration to recognise `motion` as a valid BIDS datatype by `Julius Welzel`_ (:gh:`1430`)
+- :func:`mne_bids.write_raw_bids()` has a new parameter ```electrodes_tsv_task`` which allows adding the ``task`` entity to the ``electrodes.tsv`` filepath, by `Alex Lopez Marquez`_ (:gh:`1424`)
+- Extended the configuration to recognise ``motion`` as a valid BIDS datatype by `Julius Welzel`_ (:gh:`1430`)
 - Better control of verbosity in several functions, by `Bruno Aristimunha`_ (:gh:`1449`)
-- Added parallel reading and writing in all the `open` operations using `_open_lock` mechanism from mne, creating a small wrapper to manage the locks by `Bruno Aristimunha`_ (:gh:`1451`)
+- Added parallel reading and writing in all the ``open`` operations using ``_open_lock`` mechanism from mne, creating a small wrapper to manage the locks by `Bruno Aristimunha`_ (:gh:`1451`)
 - :meth:`mne_bids.BIDSPath.match()` now short-circuits root directory scans when ``subject``, ``session``, or ``datatype`` entities are known, reducing lookup time on large datasets, by `Bruno Aristimunha`_ and `Maximilien Chaumon`_ (:gh:`1450`)
 
 🧐 API and behavior changes
@@ -108,14 +108,14 @@ Detailed list of changes
 🚀 Enhancements
 ^^^^^^^^^^^^^^^
 
-- :func:`mne_bids.write_raw_bids()` can now handle mne `Raw` objects with `eyegaze` and `pupil` channels, by `Christian O'Reilly`_ (:gh:`1344`)
+- :func:`mne_bids.write_raw_bids()` can now handle mne :class:`~mne.io.Raw` objects with ``eyegaze`` and ``pupil`` channels, by `Christian O'Reilly`_ (:gh:`1344`)
 - :func:`mne_bids.get_entity_vals()` has a new parameter ``ignore_suffixes`` to easily ignore sidecar files, by `Daniel McCloy`_ (:gh:`1362`)
-- Empty-room matching now preferentially finds recordings in the subject directory tagged as `task-noise` before looking in the `sub-emptyroom` directories. This adds support for a part of the BIDS specification for ER recordings, by `Berk Gerçek`_ (:gh:`1364`)
-- Path matching is now implemenented in a more efficient manner within :meth:`mne_bids.BIDSPath.match()` and :func:`mne_bids.find_matching_paths()`, by `Arne Gottwald` (:gh:`1355`)
-- :func:`mne_bids.get_entity_vals()` has a new parameter ``include_match`` to prefilter item matching and ignore non-matched items from begin of directory scan, by `Arne Gottwald` (:gh:`1355`)
-- Data from ``events.tsv`` can now be read into an OrderedDict using :func:`mne_bids.events_file_to_annotation_kwargs()`, by `Matthias Dold` (:gh:`1389`)
-- Read the optionally present extra columns from ``events.tsv`` and pass them to :class:`mne.Annotations`, by `Pierre Guetschel` (:gh:`1401`)
-- ``_filter_fnames()`` now correctly checks the default extension, correcting suffix filtering, by `Nathan Azrak` (:gh:`1427`)
+- Empty-room matching now preferentially finds recordings in the subject directory tagged as ``task-noise`` before looking in the ``sub-emptyroom`` directories. This adds support for a part of the BIDS specification for ER recordings, by `Berk Gerçek`_ (:gh:`1364`)
+- Path matching is now implemenented in a more efficient manner within :meth:`mne_bids.BIDSPath.match()` and :func:`mne_bids.find_matching_paths()`, by `Arne Gottwald`_ (:gh:`1355`)
+- :func:`mne_bids.get_entity_vals()` has a new parameter ``include_match`` to prefilter item matching and ignore non-matched items from begin of directory scan, by `Arne Gottwald`_ (:gh:`1355`)
+- Data from ``events.tsv`` can now be read into an OrderedDict using :func:`mne_bids.events_file_to_annotation_kwargs()`, by `Matthias Dold`_ (:gh:`1389`)
+- Read the optionally present extra columns from ``events.tsv`` and pass them to :class:`mne.Annotations`, by `Pierre Guetschel`_ (:gh:`1401`)
+- ``_filter_fnames()`` now correctly checks the default extension, correcting suffix filtering, by `Nathan Azrak`_ (:gh:`1427`)
 
 
 🧐 API and behavior changes
@@ -135,10 +135,10 @@ Detailed list of changes
 - :func:`mne_bids.read_raw_bids` can optionally return an ``event_id`` dictionary suitable for use with :func:`mne.events_from_annotations`, and if a ``values`` column is present in ``events.tsv`` it will be used as the source of the integer event ID codes, by `Daniel McCloy`_ (:gh:`1349`)
 - BIDS dictates that the recording entity should be displayed as "_recording-" in the filename. This PR makes :class:`mne_bids.BIDSPath`  correctly display "_recording-" (instead of "_rec-") in BIDSPath.fpath. By `Scott Huberty`_ (:gh:`1348`)
 - :func:`mne_bids.make_dataset_description` now correctly encodes the dataset description as UTF-8 on disk, by `Scott Huberty`_ (:gh:`1357`)
-- Corrects extension when filtering filenames in :meth:`mne_bids.BIDSPath.match()` and :func:`mne_bids.find_matching_paths()`, by `Arne Gottwald` (:gh:`1355`)
-- Fix :class:`mne_bids.BIDSPath` partially matching a value, by `Pierre Guetschel` (:gh:`1388`)
+- Corrects extension when filtering filenames in :meth:`mne_bids.BIDSPath.match()` and :func:`mne_bids.find_matching_paths()`, by `Arne Gottwald`_ (:gh:`1355`)
+- Fix :class:`mne_bids.BIDSPath` partially matching a value, by `Pierre Guetschel`_ (:gh:`1388`)
 - Ensures that ``check`` parameter in :meth:`mne_bids.BIDSPath.update()` is passed to :class:`mne_bids.BIDSPath`, by `Teon Brooks`_ (:gh:`1411`)
-- minor: added `T2w` to the suffix allowlist, by `Harrison Ritz`_ (:gh:`1420`)
+- minor: added ``T2w`` to the suffix allowlist, by `Harrison Ritz`_ (:gh:`1420`)
 
 ⚕️ Code health
 ^^^^^^^^^^^^^^
@@ -201,8 +201,8 @@ Detailed list of changes
 🪲 Bug fixes
 ^^^^^^^^^^^^
 
-- Writing MEGIN data with MNE channel types `chpi` will now map to BIDS type HLU by `Simon Kern`_ (:gh:`1325`)
-- When anonymizing the date of a recording, MNE-BIDS will no longer error during `~mne_bids.write_raw_bids` if passing a `~mne.io.Raw` instance to ``empty_room``, by `Daniel McCloy`_ (:gh:`1270`)
+- Writing MEGIN data with MNE channel types ``chpi`` will now map to BIDS type HLU by `Simon Kern`_ (:gh:`1325`)
+- When anonymizing the date of a recording, MNE-BIDS will no longer error during `~mne_bids.write_raw_bids` if passing a :class:`~mne.io.Raw` instance to ``empty_room``, by `Daniel McCloy`_ (:gh:`1270`)
 - Dealing with alphanumeric ``sub`` entity labels is now fixed for :func:`~mne_bids.write_raw_bids`, by `Aaron Earle-Richardson`_ (:gh:`1291`)
 - When processing subject_info data that MNE Python imports as numpy arrays with only one item, MNE-BIDS now unpacks these, resulting in a correct participants.tsv, by `Thomas Hartmann`_ (:gh:`1310`)
 - Fixed broken links in examples 7 and 8, by `William Turner`_ (:gh:`1316`)
@@ -419,7 +419,7 @@ Detailed list of changes
 - Add :meth:`mne_bids.BIDSPath.find_matching_sidecar` to find the sidecar file associated with a given file path by `Eric Larson`_ (:gh:`1093`)
 - When writing data via :func:`~mne_bids.write_raw_bids`, it is now possible to specify a custom mapping of :class:`mne.Annotations` descriptions to event codes via the ``event_id`` parameter. Previously, passing this parameter would always require to also pass ``events``, and using a custom event code mapping for annotations was impossible, by `Richard Höchenberger`_ (:gh:`1084`)
 - Improve error message when :obj:`~mne_bids.BIDSPath.fpath` cannot be uniquely resolved by `Eric Larson`_ (:gh:`1097`)
-- Add :func:`mne_bids.find_matching_paths` to retrieve all `BIDSPaths` matching user-specified entities. The functionality partially overlaps with what's offered through :meth:`mne_bids.BIDSPath.match()`, but is more versatile, by `Moritz Gerster`_ (:gh:`1103`)
+- Add :func:`mne_bids.find_matching_paths` to retrieve all :class:`~mne_bids.BIDSPath` instances matching user-specified entities. The functionality partially overlaps with what's offered through :meth:`mne_bids.BIDSPath.match()`, but is more versatile, by `Moritz Gerster`_ (:gh:`1103`)
 
 🧐 API and behavior changes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -639,7 +639,7 @@ Detailed list of changes
 
 - :func:`mne_bids.update_anat_landmarks` will now by default raise an exception if the requested MRI landmarks do not already exist. Use the new ``on_missing`` parameter to control this behavior, by `Richard Höchenberger`_ (:gh:`957`)
 
-- :func:`mne_bids.get_head_mri_trans` now raises a warning if ``datatype`` or ``suffix`` of the provided electrophysiological :class:`mne_bids.BIDSPath` are not set. In the future, this will raise an exception, by `Richard Höchenberger`_(:gh:`969`)
+- :func:`mne_bids.get_head_mri_trans` now raises a warning if ``datatype`` or ``suffix`` of the provided electrophysiological :class:`mne_bids.BIDSPath` are not set. In the future, this will raise an exception, by `Richard Höchenberger`_ (:gh:`969`)
 
 - Passing ``fs_subject=None`` to :func:`get_head_mri_trans` has been deprecated. Please pass the FreeSurfer subject name explicitly, by Richard Höchenberger`_ (:gh:`977`)
 
@@ -873,10 +873,10 @@ Bug fixes
 
 - :func:`mne_bids.make_report` now (1) detects male/female sex and left/right handedness irrespective of letter case, (2) will parse a ``gender`` column if no ``sex`` column is found in ``participants.tsv``, and (3) reports sex as male/female instead of man/woman, by `Alex Rockhill`_ (:gh:`755`)
 - The :class:`mne.Annotations` ``BAD_ACQ_SKIP`` – added by the acquisition system to ``FIFF`` files – will now be preserved when reading raw data, even if these time periods are **not** explicitly included in ``*_events.tsv``, by `Richard Höchenberger`_ and `Alexandre Gramfort`_ (:gh:`754` and :gh:`762`)
-- :func:`mne_bids.write_raw_bids` will handle different cased extensions for EDF files, such as `.edf` and `.EDF` by `Adam Li`_ (:gh:`765`)
+- :func:`mne_bids.write_raw_bids` will handle different cased extensions for EDF files, such as ``.edf`` and ``.EDF`` by `Adam Li`_ (:gh:`765`)
 - :func:`mne_bids.inspect_dataset` didn't handle certain filenames correctly on some systems, by `Richard Höchenberger`_ (:gh:`769`)
 - :func:`mne_bids.write_raw_bids` now works across data types with ``overwrite=True``, by `Alexandre Gramfort`_ (:gh:`791`)
-- :func:`mne_bids.read_raw_bids` didn't always replace all traces of the measurement date and time stored in the raw data with the date found in `*_scans.tsv`, by `Richard Höchenberger`_ (:gh:`812`, :gh:`815`)
+- :func:`mne_bids.read_raw_bids` didn't always replace all traces of the measurement date and time stored in the raw data with the date found in ``*_scans.tsv``, by `Richard Höchenberger`_ (:gh:`812`, :gh:`815`)
 - :func:`mne_bids.read_raw_bids` crashed when the (optional) ``acq_time`` column was missing in ``*_scans.tsv``, by `Alexandre Gramfort`_ (:gh:`814`)
 - :func:`mne_bids.write_raw_bids` doesn't crash anymore if the designated output directory contains the string ``"tsv"``, by `Richard Höchenberger`_ (:gh:`833`)
 - :func:`mne_bids.get_head_mri_trans` gave incorrect results when the T1 image was not in LIA format, now all formats function properly, by `Alex Rockhill`_ and `Alexandre Gramfort`_ (:gh:`827`)
@@ -898,7 +898,7 @@ Notable changes
   take precedence over the names stored in the raw files.
 - When reading data where the same trial type refers to different trigger
   values, we will now automatically create hierarchical event names in the
-  form of ``trial_type/value1``, `trial_type/value2`` etc.
+  form of ``trial_type/value1``, ``trial_type/value2`` etc.
 - :func:`mne_bids.write_raw_bids` now allows users to specify a format
   conversion via the new ``format`` parameter.
 - Various improvements to data reading and :class:`mne_bids.BIDSPath` make
@@ -932,7 +932,7 @@ Enhancements
 - More detailed error messages when trying to write modified data via :func:`mne_bids.write_raw_bids`, by `Richard Höchenberger`_ (:gh:`719`)
 - If ``check=True``, :class:`mne_bids.BIDSPath` now checks the ``space`` entity to be valid according to BIDS specification Appendix VIII, by `Stefan Appelhoff`_ (:gh:`724`)
 - Data types that are currently unsupported by MNE-BIDS (e.g. ``dwi``, ``func``) can now be used in :class:`mne_bids.BIDSPath` by setting ``check=False``, by `Adam Li`_ (:gh:`744`)
-- Arbitrary file names can now be represented as a `BIDSPath`` by passing the entire name as ``suffix`` and setting ``check=False``, by `Adam Li`_ (:gh:`729`)
+- Arbitrary file names can now be represented as a :class:`~mne_bids.BIDSPath` by passing the entire name as ``suffix`` and setting ``check=False``, by `Adam Li`_ (:gh:`729`)
 - Add support for MNE's flux excitation channel (``exci``), by `Maximilien Chaumon`_ (:gh:`728`)
 - :meth:`mne_bids.BIDSPath.match` gained a new parameter ``check``; when setting ``check=True``, ``match()`` will only return paths that conform to BIDS, by `Richard Höchenberger`_ (:gh:`726`)
 - ``BIDSPath.root`` now automatically expands ``~`` to the user's home directory, by `Richard Höchenberger`_ (:gh:`725`)
@@ -1032,7 +1032,7 @@ Enhancements
 API changes
 ^^^^^^^^^^^
 
-- When passing event IDs to :func:`mne_bids.write_raw_bids` via ``events_data`` without an accompanying event description in ``event_id``, we will now raise a `ValueError`. This ensures that accidentally un-described events won't get written unnoticed, by `Richard Höchenberger`_ (:gh:`603`)
+- When passing event IDs to :func:`mne_bids.write_raw_bids` via ``events_data`` without an accompanying event description in ``event_id``, we will now raise a :py:exc:`python:ValueError`. This ensures that accidentally un-described events won't get written unnoticed, by `Richard Höchenberger`_ (:gh:`603`)
 - The :func:`mne_bids.get_head_mri_trans` now has a parameter ``extra_params`` to allow passing arguments specific to a file format, by `Mainak Jas`_ (:gh:`638`)
 - The first parameter of :func:`mne_bids.write_anat` is now called ``image`` and not ``t1w``, by `Alexandre Gramfort`_ (:gh:`641`)
 
@@ -1051,7 +1051,7 @@ Bug fixes
 - Fix a bug in :func:`mne_bids.write_raw_bids` when passing raw MEG data with Internal Active Shielding (IAS) from Triux system, by `Alexandre Gramfort`_ (:gh:`616`)
 - Fix a bug in :func:`mne_bids.write_raw_bids`, where original format of data was not kept when writing to FIFF, by `Alexandre Gramfort`_, `Stefan Appelhoff`_, and `Richard Höchenberger`_ (:gh:`610`)
 - Fix a bug where conversion to BrainVision format was done even when non-Volt channel types were present in the data (BrainVision conversion is done by ``pybv``, which currently only supports Volt channel types), by `Stefan Appelhoff`_ (:gh:`619`)
-- Ensure sidecar files (`.tsv` and `.json`) are always read and written in UTF-8, by `Richard Höchenberger`_ (:gh:`625`)
+- Ensure sidecar files (``.tsv`` and ``.json``) are always read and written in UTF-8, by `Richard Höchenberger`_ (:gh:`625`)
 - Fix a bug where ``participants.tsv`` was not being appended to correctly when it contained a subset of ``hand``, ``age`` and ``sex``, by `Adam Li`_ (:gh:`648`)
 - :func:`mne_bids.copyfiles.copyfile_eeglab` didn't handle certain EEGLAB files correctly, by `Richard Höchenberger`_ (:gh:`653`)
 - Fix bug where images with different orientations than the T1 used to define the landmarks were defaced improperly, by `Alex Rockhill`_ (:gh:`651`)
@@ -1197,15 +1197,15 @@ Changelog
 ~~~~~~~~~
 
 - Added automatic conversion of FIF to BrainVision format with warning for EEG only data and conversion to FIF for meg non-FIF data, by `Alex Rockhill`_ (:gh:`237`)
-- Add possibility to pass raw readers parameters (e.g. `allow_maxshield`) to :func:`read_raw_bids` to allow reading BIDS-formatted data before applying maxfilter, by  `Sophie Herbst`_
+- Add possibility to pass raw readers parameters (e.g. ``allow_maxshield``) to :func:`read_raw_bids` to allow reading BIDS-formatted data before applying maxfilter, by  `Sophie Herbst`_
 - New feature in :code:`mne_bids.write.write_anat` for shear deface of mri, by `Alex Rockhill`_ (:gh:`271`)
-- Added option to anonymize by shifting measurement date with `anonymize` parameter, in accordance with BIDS specifications, by `Alex Rockhill`_ (:gh:`280`)
+- Added option to anonymize by shifting measurement date with ``anonymize`` parameter, in accordance with BIDS specifications, by `Alex Rockhill`_ (:gh:`280`)
 - Added ``mne_bids.get_matched_empty_room`` to get empty room filename matching a data file, by `Mainak Jas`_ (:gh:`290`)
 - Add ability for :func:`mne_bids.get_head_mri_trans` to read fiducial points from fif data without applying maxfilter, by `Maximilien Chaumon`_ (:gh:`291`)
 - Added landmark argument to :func:`write_anat` to pass landmark location directly for deface, by `Alex Rockhill`_ (:gh:`292`)
-- Standardized `bids_root` and `output_path` arguments in :func:`read_raw_bids`, :func:`write_raw_bids`, and ``make_bids_folders`` to just `bids_root`, by `Adam Li`_ (:gh:`303`)
+- Standardized ``bids_root`` and ``output_path`` arguments in :func:`read_raw_bids`, :func:`write_raw_bids`, and ``make_bids_folders`` to just ``bids_root``, by `Adam Li`_ (:gh:`303`)
 - Add existence check for :func:`write_raw_bids` before :func:`make_dataset_description` is called, by `Adam Li`_ (:gh:`331`)
-- Update scans.tsv writer to adhere to MNE-Python v0.20+ where `meas_date` is stored as a `datetime` object, by `Adam Li`_ (:gh:`344`)
+- Update scans.tsv writer to adhere to MNE-Python v0.20+ where ``meas_date`` is stored as a :class:`python:datetime.datetime` object, by `Adam Li`_ (:gh:`344`)
 - :func:`read_raw_bids` now reads in sidecar json files to set, or estimate Power Line Frequency, by `Adam Li`_ (:gh:`341`)
 - Allow FIF files with multiple parts to be read using :func:`read_raw_bids`, by `Teon Brooks`_ (:gh:`346`)
 - Added handedness to participant files, by `Dominik Welke`_ (:gh:`354`)
@@ -1221,7 +1221,7 @@ Bug
 - Fix writing to scans.tsv file when anonymization is turned on, by `Adam Li`_ (:gh:`352`)
 - Fix :func:`read_raw_bids` to properly read in sidecar json even if a similarly named copy lives inside "derivatives/" sub-folder, by `Adam Li`_  (:gh:`350`)
 - Fix :func:`read_raw_bids` to properly read in events.tsv sidecar if the 'trial_type' description has a "#" character in it, by `Adam Li`_ (:gh:`355`)
-- Avoid cases in which NumPy would raise a `FutureWarning` when populating TSV files, by `Richard Höchenberger`_ (:gh:`372`)
+- Avoid cases in which NumPy would raise a :py:exc:`python:FutureWarning` when populating TSV files, by `Richard Höchenberger`_ (:gh:`372`)
 - Remove events with an unknown onset, and assume unknown event durations to be zero, when reading BIDS data via :func:`read_raw_bids`, by `Richard Höchenberger`_ (:gh:`375`)
 
 Authors
@@ -1309,13 +1309,13 @@ Bug
 - Fix the file naming for FIF files to only expose the part key-value pair when files are split, by `Teon Brooks`_ (:gh:`137`)
 - Allow files with no stim channel, which could be the case for example in resting state data, by `Mainak Jas`_ (:gh:`167`)
 - Better handling of unicode strings in TSV files, by `Mainak Jas`_ (:gh:`172`)
-- Fix separator in scans.tsv to always be `/`, by `Matt Sanderson`_ (:gh:`176`)
+- Fix separator in scans.tsv to always be ``/``, by `Matt Sanderson`_ (:gh:`176`)
 - Add seeg to :code:`mne_bids.utils._handle_datatype` when determining the kind of ieeg data, by `Ezequiel Mikulan`_ (:gh:`180`)
 - Fix problem in copying CTF files on Network File System due to a bug upstream in Python, by `Mainak Jas`_ (:gh:`174`)
 - Fix problem in copying BTi files. Now, a utility function ensures that all the related files
   such as config and headshape are copied correctly, by `Mainak Jas`_ (:gh:`135`)
 - Fix name of "sample" and "value" columns on events.tsv files, by `Ezequiel Mikulan`_ (:gh:`185`)
-- Update function to copy KIT files to the `meg` directory, by `Matt Sanderson`_ (:gh:`187`)
+- Update function to copy KIT files to the ``meg`` directory, by `Matt Sanderson`_ (:gh:`187`)
 
 API
 ~~~
@@ -1352,10 +1352,10 @@ Version 0.1 (2018-11-05)
 Changelog
 ~~~~~~~~~
 
-- Add example for how to rename BrainVision file triplets: `rename_brainvision_files.py`, by `Stefan Appelhoff`_ (:gh:`104`)
+- Add example for how to rename BrainVision file triplets: ``rename_brainvision_files.py``, by `Stefan Appelhoff`_ (:gh:`104`)
 - Add function to fetch BrainVision testing data ``mne_bids.datasets.fetch_brainvision_testing_data``, by `Stefan Appelhoff`_ (:gh:`104`)
-- Add support for EEG and a corresponding example: `make_eeg_bids.py`, by `Stefan Appelhoff`_ (:gh:`78`)
-- Update :code:`mne_bids.raw_to_bids` to work for KIT and BTi systems, by `Teon Brooks`_ (:gh:`16`)
+- Add support for EEG and a corresponding example: ``make_eeg_bids.py``, by `Stefan Appelhoff`_ (:gh:`78`)
+- Update ``mne_bids.raw_to_bids`` to work for KIT and BTi systems, by `Teon Brooks`_ (:gh:`16`)
 - Add support for iEEG and add ``mne_bids.make_bids_folders`` and ``mne_bids.make_bids_folders``, by `Chris Holdgraf`_ (:gh:`28` and :gh:`37`)
 - Add command line interface, by `Teon Brooks`_ (:gh:`31`)
 - Add :func:`mne_bids.print_dir_tree` for visualizing directory structures and restructuring package to be more

--- a/examples/bidspath.py
+++ b/examples/bidspath.py
@@ -25,7 +25,7 @@ from mne_bids import BIDSPath
 # naming scheme. The first term we are going to introduce is the **BIDS root**.
 # The BIDS root is simply the root folder of your BIDS dataset. For
 # example, if the BIDS data of one of your studies is stored in
-# `/Users/me/Studies/Study_01`, then this will be the BIDS root.
+# ``/Users/me/Studies/Study_01``, then this will be the BIDS root.
 #
 # Similarly, if you have **no** BIDS dataset to begin with, you need to
 # consider where to store your data upon BIDS conversion. Again, the intended
@@ -95,7 +95,7 @@ print(bids_path)
 # %%
 # As you can see, ``BIDSPath`` automatically arranged all the information we
 # provided such that it creates a valid BIDS folder structure. You can also
-# retrieve a `pathlib.Path` object of this path:
+# retrieve a :class:`pathlib.Path` object of this path:
 
 pathlib_path = bids_path.fpath
 pathlib_path

--- a/examples/convert_fieldtrip_emg.py
+++ b/examples/convert_fieldtrip_emg.py
@@ -43,7 +43,7 @@ for msg, mod in known_warnings.items():
     )
 
 # %%
-# First we'll get the data. We'll use :mod:`pooch` here, but the :mod:`requests` module
+# First we'll get the data. We'll use ``pooch`` here, but the ``requests`` module
 # would work just as well (or you could manually download the data of course).
 
 remote_folder = "https://download.fieldtriptoolbox.org/example/bids_emg/original/"

--- a/examples/convert_ieeg_to_bids.py
+++ b/examples/convert_ieeg_to_bids.py
@@ -129,7 +129,7 @@ convert_montage_to_ras(montage, "sample_seeg", subjects_dir)  # mri->ras
 # Step 2: Formatting as BIDS
 # --------------------------
 #
-# Now, let us format the `Raw` object into BIDS.
+# Now, let us format the :class:`~mne:mne.io.Raw` object into BIDS.
 #
 # With this step, we have everything to start a new BIDS directory using
 # our data. To do that, we can use :func:`write_raw_bids`
@@ -203,13 +203,13 @@ fig.axes["x"].ax.annotate(
 landmarks = get_anat_landmarks(T1_fname, raw.info, trans, "sample_seeg", subjects_dir)
 T1_bids_path = write_anat(T1_fname, bids_path, deface=True, landmarks=landmarks)
 
-# write `raw` to BIDS and anonymize it (converts to BrainVision format)
+# write ``raw`` to BIDS and anonymize it (converts to BrainVision format)
 #
-# we need to pass the `montage` argument for coordinate frames other than
-# "head" which is what MNE uses internally in the `raw` object
+# we need to pass the ``montage`` argument for coordinate frames other than
+# "head" which is what MNE uses internally in the ``raw`` object
 #
-# `acpc_aligned=True` affirms that our MRI is aligned to ACPC
-# if this is not true, convert to `fsaverage` (see below)!
+# ``acpc_aligned=True`` affirms that our MRI is aligned to ACPC
+# if this is not true, convert to ``fsaverage`` (see below)!
 write_raw_bids(
     raw,
     bids_path,
@@ -363,13 +363,13 @@ raw2 = read_raw_bids(bids_path=bids_path)
 # the ``raw`` object and the ``trans`` as in any MNE example
 # (e.g. :ref:`tut-working-with-seeg`).
 
-# use `coord_frame='mri'` to indicate that the montage is in surface RAS
-# and `unit='m'` to indicate that the units are in meters
+# use ``coord_frame='mri'`` to indicate that the montage is in surface RAS
+# and ``unit='m'`` to indicate that the units are in meters
 trans2 = template_to_head(raw2.info, space="fsaverage", coord_frame="mri", unit="m")[1]
 # this a bit confusing since we transformed from mri->mni and now we're
 # saying we're back in 'mri' but that is because we were in the surface RAS
-# coordinate frame of `sample_seeg` and transformed to 'mni_tal', which is the
-# surface RAS coordinate frame for `fsaverage`: since MNE denotes surface RAS
+# coordinate frame of ``sample_seeg`` and transformed to 'mni_tal', which is the
+# surface RAS coordinate frame for ``fsaverage``: since MNE denotes surface RAS
 # as 'mri', both coordinate frames are 'mri', it's just that 'mni_tal' is 'mri'
 # when the subject is 'fsaverage'
 

--- a/examples/convert_mne_sample.py
+++ b/examples/convert_mne_sample.py
@@ -41,11 +41,11 @@ from mne_bids import (
 from mne_bids.stats import count_events
 
 # %%
-# Now we can read the MNE sample data. We define an `event_id` based on our
+# Now we can read the MNE sample data. We define an ``event_id`` based on our
 # knowledge of the data, to give meaning to events in the data.
 #
-# With `raw_fname` and `events`, we determine where to get the sample data
-# from. `output_path` determines where we will write the BIDS conversion to.
+# With ``raw_fname`` and ``events``, we determine where to get the sample data
+# from. ``output_path`` determines where we will write the BIDS conversion to.
 
 data_path = sample.data_path()
 event_id = {

--- a/examples/create_bids_folder.py
+++ b/examples/create_bids_folder.py
@@ -30,7 +30,7 @@ from mne_bids import BIDSPath
 # ----------------------------
 #
 # BIDS requires a specific ordering and structure for metadata fields in
-# file paths, the class `BIDSPath` allows you to specify many such
+# file paths, the class :class:`BIDSPath` allows you to specify many such
 # pieces of metadata, ensuring that they are in the correct order in the
 # final file path. Omitted keys will not be included in the file path.
 

--- a/examples/mark_bad_channels.py
+++ b/examples/mark_bad_channels.py
@@ -87,7 +87,7 @@ write_raw_bids(
 # with the data, a small popup window will allow you to toggle the projectors
 # on and off. If you changed the selection of bad channels, you will be
 # prompted whether you would like to save the changes when closing the main
-# window. Your raw data and the `*_channels.tsv` sidecar file will be updated
+# window. Your raw data and the ``*_channels.tsv`` sidecar file will be updated
 # upon saving.
 
 inspect_dataset(bids_path)
@@ -106,7 +106,7 @@ inspect_dataset(bids_path, l_freq=1.0, h_freq=30.0)
 # the `MNE-Python Annotations tutorial`_ for an introduction to the interactive
 # interface. If you're closing the main window after changing the annotations,
 # you will be prompted whether you wish to save the changes. Your raw data and
-# the `*_events.tsv` sidecar file will be updated upon saving.
+# the ``*_events.tsv`` sidecar file will be updated upon saving.
 #
 # Non-interactive (programmatic) bad channel selection
 # ----------------------------------------------------

--- a/examples/read_bids_datasets.py
+++ b/examples/read_bids_datasets.py
@@ -49,7 +49,7 @@ from mne_bids import (
 # --------------------------------------
 #
 # A downloaded OpenNeuro dataset is stored in a ``target_dir`` directory, which is
-# called the `root` of each BIDS dataset. This example uses this
+# called the ``root`` of each BIDS dataset. This example uses this
 # `EEG dataset <https://openneuro.org/datasets/ds002778>`_ of resting-state recordings
 # of patients with Parkinson's disease.
 #

--- a/examples/update_bids_datasets.py
+++ b/examples/update_bids_datasets.py
@@ -38,7 +38,7 @@ from mne_bids import (
 # ------------------------------------
 #
 # Download the data if it hasn't been downloaded already, and return the path
-# to the download directory. This directory is the so-called `root` of this
+# to the download directory. This directory is the so-called ``root`` of this
 # BIDS dataset.
 bids_root = somato.data_path()
 

--- a/mne_bids/copyfiles.py
+++ b/mne_bids/copyfiles.py
@@ -30,7 +30,7 @@ def _copytree(src, dst, **kwargs):
     try:
         sh.copytree(src, dst, **kwargs)
     except sh.Error as error:
-        # `copytree` throws an error if copying to + from NFS even though
+        # ``copytree`` throws an error if copying to + from NFS even though
         # the copy is successful (see https://bugs.python.org/issue24564)
         if "[Errno 22]" not in str(error) or not op.exists(dst):
             raise
@@ -310,7 +310,7 @@ def _replace_file(fname, pattern, replace):
 
 
 def _anonymize_brainvision(vhdr_file, date):
-    """Anonymize vmrk and vhdr files in place using `date` datetime object."""
+    """Anonymize vmrk and vhdr files in place using ``date`` datetime object."""
     _, vmrk_file = _get_brainvision_paths(vhdr_file)
 
     # Go through VMRK
@@ -331,7 +331,7 @@ def copyfile_brainvision(vhdr_src, vhdr_dest, anonymize=None, *, verbose=None):
     The BrainVision file format consists of three files:
     .vhdr, .eeg/.dat, and .vmrk
     The .eeg/.dat and .vmrk files associated with the .vhdr file will be
-    given names as in `vhdr_dest` with adjusted extensions. Internal file
+    given names as in ``vhdr_dest`` with adjusted extensions. Internal file
     pointers will be fixed.
 
     Parameters
@@ -343,16 +343,16 @@ def copyfile_brainvision(vhdr_src, vhdr_dest, anonymize=None, *, verbose=None):
     anonymize : dict | None
         If None (default), no anonymization is performed.
         If dict, data will be anonymized depending on the keys provided with
-        the dict: `daysback` is a required key, `keep_his` is an optional key.
+        the dict: ``daysback`` is a required key, ``keep_his`` is an optional key.
 
-        `daysback` : int
+        ``daysback`` : int
             Number of days by which to move back the recording date in time.
             In studies with multiple subjects the relative recording date
             differences between subjects can be kept by using the same number
-            of `daysback` for all subject anonymizations. `daysback` should be
+            of ``daysback`` for all subject anonymizations. ``daysback`` should be
             great enough to shift the date prior to 1925 to conform with BIDS
             anonymization rules.
-        `keep_his` : bool
+        ``keep_his`` : bool
             By default (False), all subject information next to the recording
             date will be overwritten as well. If True, keep subject information
             apart from the recording date.
@@ -473,13 +473,13 @@ def copyfile_edf(src, dest, anonymize=None, *, verbose=None):
     anonymize : dict | None
         If None (default), no anonymization is performed.
         If dict, data will be anonymized depending on the keys provided with
-        the dict: `daysback` is a required key, `keep_his` is an optional key.
+        the dict: ``daysback`` is a required key, ``keep_his`` is an optional key.
 
-        `daysback` : int
+        ``daysback`` : int
             Number of days by which to move back the recording date in time.
             In studies with multiple subjects the relative recording date
             differences between subjects can be kept by using the same number
-            of `daysback` for all subject anonymizations. `daysback` should be
+            of ``daysback`` for all subject anonymizations. ``daysback`` should be
             great enough to shift the date prior to 1925 to conform with BIDS
             anonymization rules. Due to limitations of the EDF/BDF format, the
             year of the anonymized date will always be set to 1985 in the
@@ -487,7 +487,7 @@ def copyfile_edf(src, dest, anonymize=None, *, verbose=None):
             written to the 'local recording identification' region of the
             file header, which may not be parsed by all EDF/EDF+/BDF reader
             software.
-        `keep_his` : bool
+        ``keep_his`` : bool
             By default (False), all subject information next to the recording
             date will be overwritten as well. If True, keep subject information
             apart from the recording date. Participant names and birthdates

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -244,7 +244,7 @@ class BIDSPath:
     the file name.
 
     BIDSPath allows dynamic updating of its entities in place, and operates
-    similar to `pathlib.Path`. In addition, it can query multiple paths
+    similar to :class:`python:pathlib.Path`. In addition, it can query multiple paths
     with matching BIDS entities via the ``match`` method.
 
     Note that not all parameters are applicable to each suffix of data. For
@@ -314,7 +314,7 @@ class BIDSPath:
         The data type, i.e., one of ``'meg'``, ``'eeg'``, ``'ieeg'``,
         ``'anat'``.
     basename : str
-        The basename of the file path. Similar to `os.path.basename(fpath)`.
+        The basename of the file path. Similar to ``os.path.basename(fpath)``.
     root : pathlib.Path
         The root of the BIDS path.
     directory : pathlib.Path
@@ -362,12 +362,12 @@ class BIDSPath:
     >>> print(new_bids_path.basename)
     sub-test2_ses-one_task-mytask_ieeg.edf
 
-    Printing a BIDSPath will show a relative path when `root` is not set
+    Printing a BIDSPath will show a relative path when ``root`` is not set
 
     >>> print(new_bids_path)
     sub-test2/ses-one/ieeg/sub-test2_ses-one_task-mytask_ieeg.edf
 
-    Setting `suffix` without an identifiable datatype will make
+    Setting ``suffix`` without an identifiable datatype will make
     BIDSPath try to guess the datatype
 
     >>> new_bids_path = new_bids_path.update(suffix='channels',
@@ -676,7 +676,7 @@ class BIDSPath:
         return str(self.fpath.as_posix())
 
     def __repr__(self):
-        """Representation in the style of `pathlib.Path`."""
+        """Representation in the style of :class:`python:pathlib.Path`."""
         root = self.root.as_posix() if self.root is not None else None
 
         return (
@@ -1026,7 +1026,7 @@ class BIDSPath:
         ...                      extension='.tsv')
         >>> print(bids_path.basename)
         sub-test_ses-two_task-mytask_channels.tsv
-        >>> # Then, one can update this `BIDSPath` object in place
+        >>> # Then, one can update this ``BIDSPath`` object in place
         >>> bids_path.update(acquisition='test', suffix='ieeg',
         ...                  datatype='ieeg',
         ...                  extension='.vhdr', task=None)
@@ -1112,7 +1112,7 @@ class BIDSPath:
         """Get a list of all matching paths in the root directory.
 
         Performs a recursive search, starting in ``.root`` (if set), based on
-        `BIDSPath.entities` object. Ignores ``.json`` files.
+        ``BIDSPath.entities`` object. Ignores ``.json`` files.
 
         Parameters
         ----------
@@ -1489,7 +1489,7 @@ def _print_lines_with_entry(file, entry, folder, is_tsv, line_numbers, outfile):
     line_numbers : bool
         Whether to include line numbers in the printout.
     outfile : io.StringIO | None
-        The argument to pass to `print` for `file`. If ``None``,
+        The argument to pass to :func:`python:print` for ``file``. If ``None``,
         prints to the console, else a string is printed to.
     """
     entry_lines = list()
@@ -1558,7 +1558,7 @@ def search_folder_for_text(
     Returns
     -------
     str | None
-        If `return_str` is ``True``, the fields are returned as a
+        If ``return_str`` is ``True``, the fields are returned as a
         string. Else, ``None`` is returned and the fields are printed.
     """
     _validate_type(entry, str, "entry")
@@ -1613,7 +1613,7 @@ def print_dir_tree(folder, max_depth=None, return_str=False):
     Returns
     -------
     str | None
-        If `return_str` is ``True``, the directory tree is returned as a
+        If ``return_str`` is ``True``, the directory tree is returned as a
         string. Else, ``None`` is returned and the directory tree is printed.
     """
     folder = _check_fname(
@@ -1700,10 +1700,10 @@ def get_bids_path_from_fname(fname, check=True, *, verbose=None):
     Parameters
     ----------
     fname : path-like
-        The path to parse a `BIDSPath` from.
+        The path to parse a :class:`~mne_bids.BIDSPath` from.
     check : bool
-        Whether to check if the generated `BIDSPath` complies with the BIDS
-        specification, i.e., whether all included entities and the suffix are
+        Whether to check if the generated :class:`~mne_bids.BIDSPath` complies with the
+        BIDS specification, i.e., whether all included entities and the suffix are
         valid.
     %(verbose)s
 
@@ -2197,7 +2197,7 @@ def get_datatypes(root, *, verbose=None):
     -------
     modalities : list of str
         List of the data types present in the BIDS dataset pointed to by
-        `root`.
+        ``root``.
     """
     datatypes = list()
     for sub_dir in glob.iglob(os.path.join(root, "sub-*/*/"), recursive=True):
@@ -2249,7 +2249,7 @@ def get_entity_vals(
     ignore_hidden=True,
     verbose=None,
 ):
-    """Get list of values associated with an `entity_key` in a BIDS dataset.
+    """Get list of values associated with an ``entity_key`` in a BIDS dataset.
 
     BIDS file names are organized by key-value pairs called "entities" [1]_.
     With this function, you can get all values for an entity indexed by its
@@ -2308,7 +2308,7 @@ def get_entity_vals(
         .. versionadded:: 0.9
     ignore_suffixes : str | array-like of str | None
         Suffixes to ignore. If ``None``, include all suffixes. This can be helpful for
-        ignoring non-data sidecars such as `*_scans.tsv` or `*_coordsystem.json`.
+        ignoring non-data sidecars such as ``*_scans.tsv`` or ``*_coordsystem.json``.
 
         .. versionadded:: 0.17
     include_match : str | array-like of str | None
@@ -2330,8 +2330,8 @@ def get_entity_vals(
     Returns
     -------
     entity_vals : list of str
-        List of the values associated with an `entity_key` in the BIDS dataset
-        pointed to by `root`.
+        List of the values associated with an ``entity_key`` in the BIDS dataset
+        pointed to by ``root``.
 
     Notes
     -----
@@ -2525,9 +2525,9 @@ def _find_best_candidates(params, candidate_list):
     """Return the best candidate, based on the number of param matches.
 
     Assign each candidate a score, based on how many entities are shared with
-    the ones supplied in the `params` parameter. The candidate with the highest
+    the ones supplied in the ``params`` parameter. The candidate with the highest
     score wins. Candidates with entities that conflict with the supplied
-    `params` are disqualified.
+    ``params`` are disqualified.
 
     Parameters
     ----------
@@ -2743,7 +2743,7 @@ def find_matching_paths(
     Input can be str or list of str. None matches all found values.
 
     Performs a recursive search, starting in ``.root`` (if set), based on
-    `BIDSPath.entities` object.
+    ``BIDSPath.entities`` object.
 
     Parameters
     ----------
@@ -2878,7 +2878,8 @@ def _return_root_paths(
     Returns
     -------
     paths : list of pathlib.Path
-        All files + .ds paths in `root`, filtered according to the function parameters.
+        All files + .ds paths in ``root``, filtered according to the function
+        parameters.
     """
     root = Path(root)  # if root is str
 

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -40,16 +40,16 @@ def _get_ch_type_mapping(fro="mne", to="bids"):
     Parameters
     ----------
     fro : str
-        Mapping from nomenclature of `fro`. Can be 'mne', 'bids'
+        Mapping from nomenclature of ``fro``. Can be 'mne', 'bids'
     to : str
-        Mapping to nomenclature of `to`. Can be 'mne', 'bids'
+        Mapping to nomenclature of ``to``. Can be 'mne', 'bids'
 
     Returns
     -------
     mapping : dict
         Dictionary mapping from one nomenclature of channel types to another.
         If a key is not present, a default value will be returned that depends
-        on the `fro` and `to` parameters.
+        on the ``fro`` and ``to`` parameters.
 
     Notes
     -----
@@ -136,7 +136,7 @@ def _handle_datatype(raw, datatype):
         Raw object.
     datatype : str | None
         Can be one of either ``'meg'``, ``'eeg'``, ``'emg'`` or ``'ieeg'``. If ``None``,
-        `mne.utils._handle_datatype()` will attempt to infer the datatype from
+        ``mne.utils._handle_datatype()`` will attempt to infer the datatype from
         the ``raw`` object. In case of multiple data types in the ``raw``
         object, ``datatype`` must not be ``None``.
 
@@ -353,7 +353,7 @@ def _check_empty_room_basename(bids_path):
 
 
 def _check_anonymize(anonymize, raw, ext):
-    """Check the `anonymize` dict."""
+    """Check the ``anonymize`` dict."""
     # if info['meas_date'] None, then the dates are not stored
     if raw.info["meas_date"] is None:
         daysback = None
@@ -417,8 +417,8 @@ def get_anonymization_daysback(raws, *, verbose=None):
 
     BIDS requires that anonymized dates be before 1925. In order to
     preserve the longitudinal structure and ensure anonymization, the
-    user is asked to provide the same `daysback` argument to each call
-    of `write_raw_bids`. To determine the minimum number of daysback
+    user is asked to provide the same ``daysback`` argument to each call
+    of :func:`~mne_bids.write_raw_bids`. To determine the minimum number of daysback
     necessary, this function will calculate the minimum number based on
     the most recent measurement date of raw objects.
 
@@ -485,10 +485,6 @@ def _check_datatype(raw, datatype):
         Raw object.
     datatype : str
         Can be one of either ``'meg'``, ``'eeg'``, or ``'ieeg'``.
-
-    Returns
-    -------
-    None
     """
     supported_types = ("eeg", "emg", "ieeg", "meg", "nirs")
     if datatype not in supported_types:

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -595,7 +595,7 @@ def _readme(datatype, fname, overwrite=False):
 
     This will write a README file containing an MNE-BIDS citation.
     If a README already exists, the behavior depends on the
-    `overwrite` parameter, as described below.
+    ``overwrite`` parameter, as described below.
 
     Parameters
     ----------
@@ -647,7 +647,7 @@ def _participants_tsv(raw, subject_id, fname, overwrite=False):
     overwrite : bool
         Whether to overwrite the existing file.
         Defaults to False.
-        If there is already data for the given `subject_id` and overwrite is
+        If there is already data for the given ``subject_id`` and overwrite is
         False, an error will be raised.
 
     """
@@ -800,7 +800,7 @@ def _participants_json(fname, overwrite=False):
     overwrite : bool
         Defaults to False.
         Whether to overwrite the existing data in the file.
-        If there is already data for the given `fname` and overwrite is False,
+        If there is already data for the given ``fname`` and overwrite is False,
         an error will be raised.
 
     """
@@ -894,7 +894,7 @@ def _scans_tsv(raw, raw_fname, fname, keep_source, overwrite=False):
     overwrite : bool
         Defaults to False.
         Whether to overwrite the existing data in the file.
-        If there is already data for the given `fname` and overwrite is False,
+        If there is already data for the given ``fname`` and overwrite is False,
         an error will be raised.
 
     """
@@ -1781,7 +1781,7 @@ def write_raw_bids(
     Parameters
     ----------
     raw : mne.io.Raw
-        The raw data. It must be an instance of `mne.io.Raw` that is not
+        The raw data. It must be an instance of :class:`mne:mne.io.Raw` that is not
         already loaded from disk unless ``allow_preload`` is explicitly set
         to ``True``. See warning for the ``allow_preload`` parameter.
     bids_path : BIDSPath
@@ -1856,7 +1856,7 @@ def write_raw_bids(
         A dictionary that maps column names of the ``event_metadata`` to descriptions.
         Each column of ``event_metadata`` must have a corresponding entry in this.
     anonymize : dict | None
-        If `None` (default), no anonymization is performed.
+        If ``None`` (default), no anonymization is performed.
         If a dictionary, data will be anonymized depending on the dictionary
         keys: ``daysback`` is a required key, ``keep_his`` is optional.
 
@@ -1988,7 +1988,7 @@ def write_raw_bids(
     for the correct computation of each participant's age when creating
     ``*_participants.tsv``.
 
-    This function will convert existing `mne.Annotations` from
+    This function will convert existing :class:`mne:mne.Annotations` from
     ``raw.annotations`` to events. Additionally, any events supplied via
     ``events`` will be written too. To avoid writing of annotations,
     remove them from the raw file via ``raw.set_annotations(None)`` before
@@ -2841,7 +2841,7 @@ def write_anat(
     landmarks : mne.channels.DigMontage | path-like | dict | None
         The montage or path to a montage with landmarks that can be
         passed to provide information for defacing. Landmarks can be determined
-        from the head model using `mne coreg` GUI, or they can be determined
+        from the head model using :ref:`mne:mne coreg` GUI, or they can be determined
         from the MRI using ``freeview``.  If a dictionary is passed, then the
         values must be instances of :class:`~mne.channels.DigMontage` or
         path-like objects pointing to a :class:`~mne.channels.DigMontage`
@@ -2857,18 +2857,18 @@ def write_anat(
         suffix exist, will use the first ones in the ``landmarks`` dictionary.
         If dict, accepts the following keys:
 
-        - `inset`: how far back in voxels to start defacing
+        - ``inset``: how far back in voxels to start defacing
           relative to the nasion (default 5)
 
-        - `theta`: is the angle of the defacing shear in degrees relative
+        - ``theta``: is the angle of the defacing shear in degrees relative
           to vertical (default 15).
 
     overwrite : bool
         Whether to overwrite existing files or data in files.
         Defaults to False.
         If overwrite is True, any existing files with the same BIDS parameters
-        will be overwritten with the exception of the `participants.tsv` and
-        `scans.tsv` files. For these files, parts of pre-existing data that
+        will be overwritten with the exception of the ``participants.tsv`` and
+        ``scans.tsv`` files. For these files, parts of pre-existing data that
         match the current data will be replaced.
         If overwrite is False, no existing data will be overwritten or
         replaced.
@@ -3239,7 +3239,7 @@ def _get_daysback(
         The BIDSPath instances to consider. Will be filtered down in this
         function to reduce run time (only one file run per session).
     rng
-        The RNG to use for selecting a `daysback` from the valid range.
+        The RNG to use for selecting a ``daysback`` from the valid range.
     show_progress_thresh
         After narrowing down the files to query for their measurement date,
         show a progress bar if >= this number of files remain.


### PR DESCRIPTION
As suggested by the warning comment in `doc/conf.py`, there were indeed many little errors in doc liking etc. due to `default_role = 'autolink'`. Switch it to `py:obj` but prefer explicit syntax anyway.

FYI this regex find/replace in VSCode helped me get 95% of them (not perfect but good enough, put here for future reference):
```
([^\w\):`]`)([^_:`]+)(`[^`_\w])
$1`$2`$3
```