### PR TITLE
MAINT: Make testing data read-only

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -320,9 +320,13 @@ jobs:
     - run: |
         ./tools/github_actions_download.sh
         PATH=$(python -c "import mne; print(mne.datasets.testing.data_path(verbose=False))")
+        echo "Testing data path: $PATH"
+        ls /usr/bin/chmod
+        echo $PATH
+        which chmod
         chmod -R a-w "$PATH"
       working-directory: mne-python
-      name: Get testing data and set it read-only
+      name: 'Get testing data and set it read-only'
 
     - name: Run pytest
       run: make test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -179,8 +179,7 @@ jobs:
             python-version: "3.13"
             mne-version: mne-stable
             mne-bids-install: full
-            bids-validator-version: validator-stable
-
+            bids-validator-version: stable
     defaults:
       run:
         shell: bash -el {0}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -186,6 +186,9 @@ jobs:
       TZ: Europe/Berlin
       FORCE_COLOR: true
       MNE_BIDS_FILELOCK_TIMEOUT: 5  # be more stringent than it would be for end-users
+    defaults:
+      run:
+        shell: bash -el {0}
     steps:
     - uses: actions/checkout@v6
       with:
@@ -279,7 +282,6 @@ jobs:
         popd
 
     - name: Display versions and environment information
-      shell: bash
       run: |
         echo $TZ
         date
@@ -307,7 +309,6 @@ jobs:
     # Get testing data
     - run: ./tools/get_testing_version.sh
       working-directory: mne-python
-      shell: bash
       name: 'Get testing version'
 
     - uses: actions/cache@v5
@@ -316,12 +317,14 @@ jobs:
         path: ~/mne_data
       name: 'Cache testing data'
 
-    - run: ./tools/github_actions_download.sh
-      shell: bash
+    - run: |
+        ./tools/github_actions_download.sh
+        PATH=$(python -c "import mne; print(mne.datasets.testing.data_path(verbose=False))")
+        chmod -R a-w "$PATH"
       working-directory: mne-python
+      name: Get testing data and set it read-only
 
     - name: Run pytest
-      shell: bash
       run: make test
 
     - name: Upload coverage stats to codecov

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -319,12 +319,9 @@ jobs:
 
     - run: |
         ./tools/github_actions_download.sh
-        PATH=$(python -c "import mne; print(mne.datasets.testing.data_path(verbose=False))")
-        echo "Testing data path: $PATH"
-        ls /usr/bin/chmod
-        echo $PATH
-        which chmod
-        chmod -R a-w "$PATH"
+        TEST_PATH=$(python -c "import mne; print(mne.datasets.testing.data_path(verbose=False))")
+        echo "Testing data path: $TEST_PATH"
+        chmod -R a-w "$TEST_PATH"
       working-directory: mne-python
       name: 'Get testing data and set it read-only'
 

--- a/examples/rename_brainvision_files.py
+++ b/examples/rename_brainvision_files.py
@@ -34,6 +34,8 @@ for the :ref:`Python Command Line Interface <python_cli>`.
 
 # %%
 # We are importing everything we need for this example:
+from pathlib import Path
+
 import mne
 
 from mne_bids.copyfiles import copyfile_brainvision
@@ -71,7 +73,7 @@ examples_dir = data_path / "Brainvision"
 
 # Rename the file
 vhdr_file = examples_dir / "Analyzer_nV_Export.vhdr"
-vhdr_file_renamed = examples_dir / "test_renamed.vhdr"
+vhdr_file_renamed = Path.cwd() / "test_renamed.vhdr"
 copyfile_brainvision(vhdr_file, vhdr_file_renamed, verbose=True)
 
 # Check that MNE-Python can read in both, the original as well as the renamed

--- a/mne_bids/_fileio.py
+++ b/mne_bids/_fileio.py
@@ -168,6 +168,8 @@ def _open_lock(path, *args, lock_timeout=None, lock=True, **kwargs):
 
 
 def _chmod_rw_R(path):
+    assert os.path.isdir(path), f"Expected a directory, got {path}"
+    os.chmod(path, os.stat(path).st_mode | 0o770)
     for root, dirs, files in os.walk(path):
         for name in files:
             os.chmod(os.path.join(root, name), 0o660)

--- a/mne_bids/_fileio.py
+++ b/mne_bids/_fileio.py
@@ -165,3 +165,11 @@ def _open_lock(path, *args, lock_timeout=None, lock=True, **kwargs):
                 yield fid
             else:
                 yield None
+
+
+def _chmod_rw_R(path):
+    for root, dirs, files in os.walk(path):
+        for name in files:
+            os.chmod(os.path.join(root, name), 0o660)
+        for name in dirs:
+            os.chmod(os.path.join(root, name), 0o770)

--- a/mne_bids/copyfiles.py
+++ b/mne_bids/copyfiles.py
@@ -22,13 +22,13 @@ from scipy.io import loadmat, savemat
 
 from mne_bids._fileio import _open_lock
 from mne_bids.path import BIDSPath, _mkdir_p, _parse_ext
-from mne_bids.utils import _check_anonymize, _get_mrk_meas_date, warn
+from mne_bids.utils import _check_anonymize, _chmod_rw_R, _get_mrk_meas_date, warn
 
 
 def _copytree(src, dst, **kwargs):
     """See: https://github.com/jupyterlab/jupyterlab/pull/5150."""
     try:
-        sh.copytree(src, dst, copy_function=sh.copy, **kwargs)
+        sh.copytree(src, dst, **kwargs)
     except sh.Error as error:
         # ``copytree`` throws an error if copying to + from NFS even though
         # the copy is successful (see https://bugs.python.org/issue24564)
@@ -36,11 +36,7 @@ def _copytree(src, dst, **kwargs):
             raise
     # set reasonable perms for new files (writeable by user at least)
     try:
-        os.chmod(dst, os.stat(dst).st_mode | 0o700)
-        for root, dirs, _ in os.walk(dst):
-            for name in dirs:
-                dir_path = os.path.join(root, name)
-                os.chmod(dir_path, os.stat(dir_path).st_mode | 0o700)
+        _chmod_rw_R(dst)
     except Exception:  # pragma: no cover
         warn(
             f"Could not set write permissions for {dst} and its subdirectories, "

--- a/mne_bids/copyfiles.py
+++ b/mne_bids/copyfiles.py
@@ -20,9 +20,9 @@ from mne.io import anonymize_info, read_raw_bdf, read_raw_brainvision, read_raw_
 from mne.utils import logger, verbose
 from scipy.io import loadmat, savemat
 
-from mne_bids._fileio import _open_lock
+from mne_bids._fileio import _chmod_rw_R, _open_lock
 from mne_bids.path import BIDSPath, _mkdir_p, _parse_ext
-from mne_bids.utils import _check_anonymize, _chmod_rw_R, _get_mrk_meas_date, warn
+from mne_bids.utils import _check_anonymize, _get_mrk_meas_date, warn
 
 
 def _copytree(src, dst, **kwargs):

--- a/mne_bids/copyfiles.py
+++ b/mne_bids/copyfiles.py
@@ -28,12 +28,24 @@ from mne_bids.utils import _check_anonymize, _get_mrk_meas_date, warn
 def _copytree(src, dst, **kwargs):
     """See: https://github.com/jupyterlab/jupyterlab/pull/5150."""
     try:
-        sh.copytree(src, dst, **kwargs)
+        sh.copytree(src, dst, copy_function=sh.copy, **kwargs)
     except sh.Error as error:
         # ``copytree`` throws an error if copying to + from NFS even though
         # the copy is successful (see https://bugs.python.org/issue24564)
         if "[Errno 22]" not in str(error) or not op.exists(dst):
             raise
+    # set reasonable perms for new files (writeable by user at least)
+    try:
+        os.chmod(dst, os.stat(dst).st_mode | 0o700)
+        for root, dirs, _ in os.walk(dst):
+            for name in dirs:
+                dir_path = os.path.join(root, name)
+                os.chmod(dir_path, os.stat(dir_path).st_mode | 0o700)
+    except Exception:  # pragma: no cover
+        warn(
+            f"Could not set write permissions for {dst} and its subdirectories, "
+            "please check the permissions of the copied files."
+        )
 
 
 def _kit_marker_acq_label(run, acquisition_label):
@@ -63,7 +75,7 @@ def _get_brainvision_encoding(vhdr_file):
         either 'UTF-8' (default) or whatever encoding scheme is specified
         in the header.
     """
-    with _open_lock(vhdr_file, "rb") as ef:
+    with open(vhdr_file, "rb") as ef:
         enc = ef.read()
         if enc.find(b"Codepage=") != -1:
             enc = enc[enc.find(b"Codepage=") + 9 :]
@@ -100,7 +112,7 @@ def _get_brainvision_paths(vhdr_path):
     enc = _get_brainvision_encoding(vhdr_path)
 
     # ..and read it
-    with _open_lock(vhdr_path, encoding=enc) as f:
+    with open(vhdr_path, encoding=enc) as f:
         lines = f.readlines()
 
     # Try to find data file .eeg/.dat
@@ -187,6 +199,7 @@ def copyfile_ctf(src, dest):
     bids_folder_name = op.splitext(op.split(dest)[-1])[0]
     for fname in fnames:
         ext = op.splitext(fname)[-1]
+        # ensure it's writeable before trying to rename it
         os.replace(op.join(dest, fname), op.join(dest, bids_folder_name + ext))
 
 
@@ -417,14 +430,14 @@ def copyfile_brainvision(vhdr_src, vhdr_dest, anonymize=None, *, verbose=None):
         f"MarkerFile={basename_src}.vmrk",
     ]
 
-    with _open_lock(vhdr_src, encoding=enc) as fin:
+    with open(vhdr_src, encoding=enc) as fin:
         with _open_lock(vhdr_dest, "w", encoding=enc) as fout:
             for line in fin.readlines():
                 if line.strip() in search_lines:
                     line = line.replace(basename_src, basename_dest)
                 fout.write(line)
 
-    with _open_lock(vmrk_file_path, encoding=enc) as fin:
+    with open(vmrk_file_path, encoding=enc) as fin:
         with _open_lock(fname_dest + ".vmrk", "w", encoding=enc) as fout:
             for line in fin.readlines():
                 if line.strip() in search_lines:

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -2036,9 +2036,7 @@ def test_find_emptyroom_ties(tmp_path):
 
     raw = _read_raw_fif(raw_fname)
 
-    er_raw_fname = data_path / "MEG" / "sample" / "ernoise_raw.fif"
-    raw.copy().crop(0, 10).save(er_raw_fname, overwrite=True)
-    er_raw = _read_raw_fif(er_raw_fname)
+    er_raw = raw.copy().crop(0, 10)
     raw.set_meas_date(meas_date)
     er_raw.set_meas_date(meas_date)
 
@@ -2077,9 +2075,7 @@ def test_find_emptyroom_no_meas_date(tmp_path):
     er_basename = er_bids_path.basename
     raw = _read_raw_fif(raw_fname)
 
-    er_raw_fname = data_path / "MEG" / "sample" / "ernoise_raw.fif"
-    raw.copy().crop(0, 10).save(er_raw_fname, overwrite=True)
-    er_raw = _read_raw_fif(er_raw_fname)
+    er_raw = raw.copy().crop(0, 10)
     er_raw.set_meas_date(er_meas_date)
     er_raw.save(op.join(er_dir, f"{er_basename}_meg.fif"), overwrite=True)
 

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -977,7 +977,7 @@ def test_handle_scans_reading_brainvision(tmp_path):
     for test_scan in [test_scan_eeg, test_scan_vmrk]:
         _handle_scans_reading(tmp_path / test_scan["filename"][0], raw, bids_path)
 
-    with pytest.raises(ValueError, match="is not in list"):
+    with pytest.raises(ValueError, match="not in list"):
         _handle_scans_reading(tmp_path / test_scan_edf["filename"][0], raw, bids_path)
 
 

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -45,6 +45,7 @@ from mne_bids import (
     write_meg_crosstalk,
     write_raw_bids,
 )
+from mne_bids._fileio import _chmod_rw_R
 from mne_bids.config import (
     BIDS_COORD_FRAME_DESCRIPTIONS,
     CURRYREADER_VERSION,
@@ -3719,18 +3720,17 @@ def test_write_extension_case_insensitive(_bids_validate, tmp_path, datatype):
     dir_name, fname, reader = "EDF", "test_reduced.edf", _read_raw_edf
 
     bids_root = tmp_path / "bids1"
-    source_path = Path(bids_root) / "sourcedata"
-    dir_path = data_path / dir_name
-    sh.copytree(dir_path, source_path)
-    dir_path = source_path
+    dir_path = Path(bids_root) / "sourcedata"
+    sh.copytree(data_path / dir_name, dir_path)
+    _chmod_rw_R(bids_root)
 
     # rename extension to upper-case
     _fname, ext = _parse_ext(fname)
     new_fname = _fname + ext.upper()
 
     # rename the file's extension
-    raw_fname = op.join(dir_path, fname)
-    new_raw_fname = op.join(dir_path, new_fname)
+    raw_fname = dir_path / fname
+    new_raw_fname = dir_path / new_fname
     os.rename(raw_fname, new_raw_fname)
 
     # the BIDSPath for test datasets to get written to

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -3722,7 +3722,7 @@ def test_write_extension_case_insensitive(_bids_validate, tmp_path, datatype):
     bids_root = tmp_path / "bids1"
     dir_path = Path(bids_root) / "sourcedata"
     sh.copytree(data_path / dir_name, dir_path)
-    _chmod_rw_R(bids_root)
+    _chmod_rw_R(dir_path)
 
     # rename extension to upper-case
     _fname, ext = _parse_ext(fname)


### PR DESCRIPTION
One little step toward #1582

1. Make `mne-testing-data` read-only. We were writing a few files there, which isn't great (I always wondered why sometimes I had an `ernoise_raw.fif` show up locally!)
2. rename `unit_tests` to `tests` for GHA (match MNE)
3. set default shell for all test commands on GHA for uniformity and DRY