### PR TITLE
Fix dependency spec for filelock

### DIFF
--- a/mne_bids/_fileio.py
+++ b/mne_bids/_fileio.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import contextlib
 import inspect
 import os
-import sys
 from contextlib import contextmanager
 from pathlib import Path
 
@@ -69,7 +68,7 @@ def _get_lock_context(path, *, timeout=None, lock=True):
         "filelock",
         purpose="parallel file I/O locking",
         strict=False,
-        min_version="3.20.4" if sys.platform == "darwin" else None,
+        min_version="3.20.4",
     )
 
     lock_path = canonical_path.with_name(f"{canonical_path.name}.lock")

--- a/mne_bids/_fileio.py
+++ b/mne_bids/_fileio.py
@@ -65,7 +65,10 @@ def _get_lock_context(path, *, timeout=None, lock=True):
     canonical_path = _canonical_lock_path(path)
 
     filelock = _soft_import(
-        "filelock", purpose="parallel file I/O locking", strict=False
+        "filelock",
+        purpose="parallel file I/O locking",
+        strict=False,
+        min_version="3.20.4",
     )
 
     lock_path = canonical_path.with_name(f"{canonical_path.name}.lock")

--- a/mne_bids/_fileio.py
+++ b/mne_bids/_fileio.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import contextlib
 import inspect
 import os
+import sys
 from contextlib import contextmanager
 from pathlib import Path
 
@@ -68,7 +69,7 @@ def _get_lock_context(path, *, timeout=None, lock=True):
         "filelock",
         purpose="parallel file I/O locking",
         strict=False,
-        min_version="3.20.4",
+        min_version="3.20.4" if sys.platform == "darwin" else None,
     )
 
     lock_path = canonical_path.with_name(f"{canonical_path.name}.lock")

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -68,7 +68,7 @@ def test_datatypes_alphabetical():
 )
 def bids_root(tmp_path):
     """Return path to a written test BIDS dir."""
-    bids_root = tmp_path / "mnebids_utils_test_bids_ds"
+    bids_root = tmp_path / "mb_ds"
     bids_root.mkdir()
     raw_fname = data_path / "MEG" / "sample" / "sample_audvis_trunc_raw.fif"
 
@@ -358,7 +358,7 @@ class _BIDSDirDense:
 @pytest.fixture
 def bids_root_dense(tmp_path):
     """Create a dense BIDS directory tree."""
-    tmp_bids_root = tmp_path / "mnebids_utils_test_bids_ds"
+    tmp_bids_root = tmp_path / "mb_dense_ds"
     tmp_bids_root.mkdir()
     out = _BIDSDirDense(root=tmp_bids_root, bids_subdirectories=[])
 
@@ -420,11 +420,11 @@ def bids_root_dense(tmp_path):
 
 
 @pytest.mark.slow  # ~5s
-def test_path_benchmark(bids_test_dir_dense, monkeypatch, path_counter):
+def test_path_benchmark(bids_root_dense, monkeypatch, path_counter):
     """Benchmark exploring bids tree."""
-    tmp_bids_root = bids_test_dir_dense.root
-    n_subjects = bids_test_dir_dense.n_subjects
-    n_sessions = bids_test_dir_dense.n_sessions
+    tmp_bids_root = bids_root_dense.root
+    n_subjects = bids_root_dense.n_subjects
+    n_sessions = bids_root_dense.n_sessions
     # This benchmark is to verify the speed-up in function call get_entity_vals with
     # `include_match=sub-*/` in face of a bids tree hosting derivatives and sourcedata.
     fnames = mne_bids.path._return_root_paths(tmp_bids_root)
@@ -668,7 +668,7 @@ def test_rm(bids_root, capsys, tmp_path, path_counter, fast_sidecar):
 
     # Delete one run:
     deleted_paths = bids_path.match(ignore_json=False)
-    assert len(path_counter.calls) == 0
+    assert len(path_counter.calls) == 2
     want_path = (
         bids_path.directory
         / f"sub-{bids_path.subject}_ses-{bids_path.session}_scans.tsv"
@@ -684,13 +684,13 @@ def test_rm(bids_root, capsys, tmp_path, path_counter, fast_sidecar):
     ]
     assert updated_paths[0] == want_path
     want_count = 0 if fast_sidecar else 1
-    assert len(path_counter.calls) == 1
+    assert len(path_counter.calls) == want_count
     assert path_counter.count == want_count
     expected = ["Executing the following operations:", "Delete:", "Update:", ""]
     expected += [str(p) for p in deleted_paths + updated_paths]
-    assert len(path_counter.calls) == 1
+    assert len(path_counter.calls) == 3
     bids_path.rm(safe_remove=False, verbose="INFO")
-    assert len(path_counter.calls) == 6
+    assert len(path_counter.calls) == 10
     captured = capsys.readouterr().out
     assert set(captured.splitlines()) == set(expected)
 
@@ -707,7 +707,7 @@ def test_rm(bids_root, capsys, tmp_path, path_counter, fast_sidecar):
             subject=bids_path.subject,
         ).directory
     ]
-    assert len(path_counter.calls) == 6
+    assert len(path_counter.calls) == 12
     updated_paths = [
         bids_path.copy()
         .update(datatype=None)
@@ -718,7 +718,7 @@ def test_rm(bids_root, capsys, tmp_path, path_counter, fast_sidecar):
         ),
         bids_path.root / "participants.tsv",
     ]
-    assert len(path_counter.calls) == 7
+    assert len(path_counter.calls) == 13
     assert path_counter.count == want_count
     expected = ["Executing the following operations:", "Delete:", "Update:", ""]
     expected += [str(p) for p in deleted_paths + updated_paths]
@@ -1823,8 +1823,6 @@ def test_return_root_paths_entity_aware(tmp_path):
     This validates the entity-aware optimization added to reduce filesystem
     scanning when the subject (and optionally session) is known.
     """
-    from mne_bids.path import _return_root_paths
-
     root = tmp_path / "bids"
     # Create two subjects each with meg and eeg directories and a file
     for subj in ("subjA", "subjB"):
@@ -1841,11 +1839,13 @@ def test_return_root_paths_entity_aware(tmp_path):
     root_str = str(root)
     # ensure directories exist
     assert (root / "sub-subjA").exists()
-    all_paths = _return_root_paths(root_str, datatype=("meg", "eeg"), ignore_json=True)
+    all_paths = mne_bids.path._return_root_paths(
+        root_str, datatype=("meg", "eeg"), ignore_json=True
+    )
     assert len(all_paths) >= 2
 
     # Entity-aware scan for subjA should only return files under sub-subjA
-    subj_paths = _return_root_paths(
+    subj_paths = mne_bids.path._return_root_paths(
         root_str,
         datatype=("meg", "eeg"),
         ignore_json=True,

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -269,7 +269,9 @@ def path_counter(monkeypatch):
     orig_walk = os.walk
 
     def iglob_count(*args, **kwargs):
-        path_counter.calls.append("iglob")
+        # We might want this someday... but for now let's just limit "calls"
+        # to the ones that MBP defines...
+        # path_counter.calls.append("iglob")
         for fn in orig_iglob(*args, **kwargs):
             path_counter.count += 1
             path_counter.files.append(fn)
@@ -668,7 +670,7 @@ def test_rm(bids_root, capsys, tmp_path, path_counter, fast_sidecar):
 
     # Delete one run:
     deleted_paths = bids_path.match(ignore_json=False)
-    assert len(path_counter.calls) == 2
+    assert path_counter.calls == ["_return_root_paths"]
     want_path = (
         bids_path.directory
         / f"sub-{bids_path.subject}_ses-{bids_path.session}_scans.tsv"
@@ -683,14 +685,14 @@ def test_rm(bids_root, capsys, tmp_path, path_counter, fast_sidecar):
         )
     ]
     assert updated_paths[0] == want_path
+    assert path_counter.calls == ["_return_root_paths", "_find_matching_sidecar"]
     want_count = 0 if fast_sidecar else 1
-    assert len(path_counter.calls) == want_count
     assert path_counter.count == want_count
     expected = ["Executing the following operations:", "Delete:", "Update:", ""]
     expected += [str(p) for p in deleted_paths + updated_paths]
-    assert len(path_counter.calls) == 3
+    assert len(path_counter.calls) == 2
     bids_path.rm(safe_remove=False, verbose="INFO")
-    assert len(path_counter.calls) == 10
+    assert len(path_counter.calls) == 8
     captured = capsys.readouterr().out
     assert set(captured.splitlines()) == set(expected)
 
@@ -707,7 +709,7 @@ def test_rm(bids_root, capsys, tmp_path, path_counter, fast_sidecar):
             subject=bids_path.subject,
         ).directory
     ]
-    assert len(path_counter.calls) == 12
+    assert len(path_counter.calls) == 9
     updated_paths = [
         bids_path.copy()
         .update(datatype=None)
@@ -718,7 +720,7 @@ def test_rm(bids_root, capsys, tmp_path, path_counter, fast_sidecar):
         ),
         bids_path.root / "participants.tsv",
     ]
-    assert len(path_counter.calls) == 13
+    assert len(path_counter.calls) == 10
     assert path_counter.count == want_count
     expected = ["Executing the following operations:", "Delete:", "Update:", ""]
     expected += [str(p) for p in deleted_paths + updated_paths]

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -113,12 +113,12 @@ def test_get_datatypes(bids_root_dense, bids_root, path_counter):
 
 
 @pytest.mark.parametrize(
-    "entity, expected_vals, kwargs",
+    "entity, expected_vals, kwargs, count",
     [
-        ("bogus", None, None),
-        ("subject", [subject_id], None),
-        ("session", [session_id], None),
-        (
+        pytest.param("bogus", None, None, 0, id="bogus"),
+        pytest.param("subject", [subject_id], None, 9, id="subject"),
+        pytest.param("session", [session_id], None, 9, id="session"),
+        pytest.param(
             "session",
             [],
             dict(
@@ -126,23 +126,51 @@ def test_get_datatypes(bids_root_dense, bids_root, path_counter):
                 ignore_acquisitions=("calibration", "crosstalk"),
                 ignore_suffixes=("scans", "coordsystem"),
             ),
+            9,
+            id="session_ignore_kinds",
         ),
-        ("run", [run, "02"], None),
-        ("acquisition", ["calibration", "crosstalk"], None),
-        ("task", [task], None),
-        ("subject", [], dict(ignore_subjects=[subject_id])),
-        ("subject", [], dict(ignore_subjects=subject_id)),
-        ("session", [], dict(ignore_sessions=[session_id])),
-        ("session", [], dict(ignore_sessions=session_id)),
-        ("run", [run], dict(ignore_runs=["02"])),
-        ("run", [run], dict(ignore_runs="02")),
-        ("task", [], dict(ignore_tasks=[task])),
-        ("task", [], dict(ignore_tasks=task)),
-        ("run", [run, "02"], dict(ignore_runs=["bogus"])),
-        ("run", [], dict(ignore_datatypes=["meg"])),
+        pytest.param("run", [run, "02"], None, 22, id="run"),
+        pytest.param(
+            "acquisition", ["calibration", "crosstalk"], None, 22, id="acquisition"
+        ),
+        pytest.param("task", [task], None, 22, id="task"),
+        pytest.param(
+            "subject", [], dict(ignore_subjects=[subject_id]), 9, id="subject_ignore"
+        ),
+        pytest.param(
+            "subject",
+            [],
+            dict(ignore_subjects=subject_id),
+            9,
+            id="subject_ignore_single",
+        ),
+        pytest.param(
+            "session",
+            [],
+            dict(ignore_sessions=[session_id]),
+            9,
+            id="session_ignore_sessions",
+        ),
+        pytest.param(
+            "session",
+            [],
+            dict(ignore_sessions=session_id),
+            9,
+            id="session_ignore_single",
+        ),
+        pytest.param("run", [run], dict(ignore_runs=["02"]), 22, id="run_ignore"),
+        pytest.param("run", [run], dict(ignore_runs="02"), 22, id="run_ignore_single"),
+        pytest.param("task", [], dict(ignore_tasks=[task]), 22, id="task_ignore"),
+        pytest.param("task", [], dict(ignore_tasks=task), 22, id="task_ignore_single"),
+        pytest.param(
+            "run", [run, "02"], dict(ignore_runs=["bogus"]), 22, id="run_ignore_bogus"
+        ),
+        pytest.param(
+            "run", [], dict(ignore_datatypes=["meg"]), 22, id="ignore_datatypes"
+        ),
     ],
 )
-def test_get_entity_vals(entity, expected_vals, kwargs, bids_root):
+def test_get_entity_vals(entity, expected_vals, kwargs, count, bids_root, path_counter):
     """Test getting a list of entities."""
     # Add some derivative data that should be ignored by get_entity_vals()
     deriv_path = Path(bids_root) / "derivatives"
@@ -158,7 +186,9 @@ def test_get_entity_vals(entity, expected_vals, kwargs, bids_root):
         with pytest.raises(ValueError, match="`key` must be one of"):
             get_entity_vals(root=bids_root, entity_key=entity, **kwargs)
         return
+    assert path_counter.count == 0
     vals = get_entity_vals(root=bids_root, entity_key=entity, **kwargs)
+    assert path_counter.count == count
     assert vals == expected_vals
 
     # test using ``with_key`` kwarg

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -189,8 +189,6 @@ def test_get_entity_vals(entity, expected_vals, kwargs, count, bids_root, path_c
     assert path_counter.count == 0
     vals = get_entity_vals(root=bids_root, entity_key=entity, **kwargs)
     assert path_counter.count == count
-    if entity == "subject":
-        1 / 0
     assert vals == expected_vals
 
     # test using ``with_key`` kwarg

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -8,7 +8,6 @@ import glob
 import os
 import os.path as op
 import pickle
-import shutil
 import shutil as sh
 import timeit
 from dataclasses import dataclass
@@ -65,12 +64,12 @@ def test_datatypes_alphabetical():
 
 
 @pytest.fixture(
-    scope="session",
     params=[pytest.param("testing", marks=mne.datasets.testing._pytest_mark())],
 )
-def bids_test_dir(tmp_path_factory):
+def bids_root(tmp_path):
     """Return path to a written test BIDS dir."""
-    bids_root = tmp_path_factory.mktemp("mnebids_utils_test_bids_ds")
+    bids_root = tmp_path / "mnebids_utils_test_bids_ds"
+    bids_root.mkdir()
     raw_fname = data_path / "MEG" / "sample" / "sample_audvis_trunc_raw.fif"
 
     event_id = {
@@ -103,12 +102,12 @@ def bids_test_dir(tmp_path_factory):
     return bids_root
 
 
-def test_get_datatypes(bids_test_dir_dense, bids_test_dir, path_counter):
+def test_get_datatypes(bids_root_dense, bids_root, path_counter):
     """Test getting the datatypes (=modalities) of a dir."""
-    modalities = mne_bids.get_datatypes(bids_test_dir)
+    modalities = mne_bids.get_datatypes(bids_root)
     assert modalities == ["meg"]
     assert path_counter.count == 2
-    modalities = mne_bids.get_datatypes(bids_test_dir_dense.root)
+    modalities = mne_bids.get_datatypes(bids_root_dense.root)
     assert modalities == ["eeg", "meg"]
     assert path_counter.count == 108
 
@@ -143,9 +142,8 @@ def test_get_datatypes(bids_test_dir_dense, bids_test_dir, path_counter):
         ("run", [], dict(ignore_datatypes=["meg"])),
     ],
 )
-def test_get_entity_vals(entity, expected_vals, kwargs, bids_test_dir):
+def test_get_entity_vals(entity, expected_vals, kwargs, bids_root):
     """Test getting a list of entities."""
-    bids_root = bids_test_dir
     # Add some derivative data that should be ignored by get_entity_vals()
     deriv_path = Path(bids_root) / "derivatives"
     deriv_meg_dir = deriv_path / "pipeline" / "sub-deriv" / "ses-deriv" / "meg"
@@ -159,35 +157,32 @@ def test_get_entity_vals(entity, expected_vals, kwargs, bids_test_dir):
     if entity == "bogus":
         with pytest.raises(ValueError, match="`key` must be one of"):
             get_entity_vals(root=bids_root, entity_key=entity, **kwargs)
-    else:
-        vals = get_entity_vals(root=bids_root, entity_key=entity, **kwargs)
-        assert vals == expected_vals
+        return
+    vals = get_entity_vals(root=bids_root, entity_key=entity, **kwargs)
+    assert vals == expected_vals
 
-        # test using ``with_key`` kwarg
-        entities = get_entity_vals(
-            root=bids_root, entity_key=entity, with_key=True, **kwargs
-        )
-        entity_long_to_short = {
-            val: key for key, val in ALLOWED_PATH_ENTITIES_SHORT.items()
-        }
-        assert entities == [
-            f"{entity_long_to_short[entity]}-{val}" for val in expected_vals
-        ]
+    # test using ``with_key`` kwarg
+    entities = get_entity_vals(
+        root=bids_root, entity_key=entity, with_key=True, **kwargs
+    )
+    entity_long_to_short = {
+        val: key for key, val in ALLOWED_PATH_ENTITIES_SHORT.items()
+    }
+    assert entities == [
+        f"{entity_long_to_short[entity]}-{val}" for val in expected_vals
+    ]
 
-        # Test without ignoring the derivatives dir
-        entities = get_entity_vals(
-            root=bids_root, entity_key=entity, **kwargs, ignore_dirs=None
-        )
-        if entity not in ("acquisition", "run"):
-            assert "deriv" in entities
-    # Clean up
-    shutil.rmtree(deriv_path)
+    # Test without ignoring the derivatives dir
+    entities = get_entity_vals(
+        root=bids_root, entity_key=entity, **kwargs, ignore_dirs=None
+    )
+    if entity not in ("acquisition", "run"):
+        assert "deriv" in entities
 
 
 @testing.requires_testing_data
-def test_get_entity_vals_ignore_hidden(bids_test_dir):
+def test_get_entity_vals_ignore_hidden(bids_root):
     """Test hidden directories are skipped by default and included when opted in."""
-    bids_root = bids_test_dir
     hidden_meg_dir = Path(bids_root) / ".hidden_data" / "sub-hid" / "ses-hid" / "meg"
     hidden_meg_dir.mkdir(parents=True)
     (hidden_meg_dir / "sub-hid_ses-hid_task-hid_meg.fif").touch()
@@ -227,9 +222,6 @@ def test_get_entity_vals_ignore_hidden(bids_test_dir):
         ignore_dirs=None,
     )
     assert "hid" in vals_include_hidden
-
-    # Clean up
-    shutil.rmtree(Path(bids_root) / ".hidden_data")
 
 
 @dataclass
@@ -310,9 +302,10 @@ class _BIDSDirDense:
 
 
 @pytest.fixture
-def bids_test_dir_dense(tmp_path_factory):
+def bids_root_dense(tmp_path):
     """Create a dense BIDS directory tree."""
-    tmp_bids_root = tmp_path_factory.mktemp("mnebids_utils_test_bids_ds")
+    tmp_bids_root = tmp_path / "mnebids_utils_test_bids_ds"
+    tmp_bids_root.mkdir()
     out = _BIDSDirDense(root=tmp_bids_root, bids_subdirectories=[])
 
     derivatives = [
@@ -401,7 +394,7 @@ def test_path_benchmark(bids_test_dir_dense, monkeypatch, path_counter):
     assert path_counter.count == 621
 
     # while this should be of same order, lets give it some space by a factor of 3
-    target = 3 * timed_all / len(bids_test_dir_dense.bids_subdirectories)
+    target = 3 * timed_all / len(bids_root_dense.bids_subdirectories)
     assert timed_ignored_nosub < target
 
     # these should be equivalent
@@ -605,11 +598,9 @@ def test_make_folders(tmp_path):
     os.chdir(curr_dir)
 
 
-def test_rm(bids_test_dir, capsys, tmp_path, path_counter, fast_sidecar):
+def test_rm(bids_root, capsys, tmp_path, path_counter, fast_sidecar):
     """Test BIDSPath's rm method to remove files."""
     # for some reason, mne's logger can't be captured by caplog....
-    bids_root = tmp_path / "mnebids_utils_test_bids_ds"
-    shutil.copytree(bids_test_dir, bids_root)
 
     # without providing all the entities, ambiguous when trying to use fpath
     bids_path = BIDSPath(
@@ -993,12 +984,8 @@ def test_find_best_candidates(candidate_list, best_candidates):
     assert _find_best_candidates(params, candidate_list) == best_candidates
 
 
-def test_find_matching_sidecar_basic(
-    bids_test_dir, tmp_path, path_counter, fast_sidecar
-):
+def test_find_matching_sidecar_basic(bids_root, tmp_path, path_counter, fast_sidecar):
     """Test finding a sidecar file from a BIDS dir."""
-    bids_root = bids_test_dir
-
     bids_path = _bids_path.copy().update(root=bids_root)
 
     # Now find a sidecar
@@ -1101,7 +1088,7 @@ def fast_sidecar(request, monkeypatch):
 
 @pytest.mark.parametrize("dataset", ("basic", "dense"))
 def test_find_matching_sidecar_fast(
-    bids_test_dir, bids_test_dir_dense, path_counter, fast_sidecar, dataset
+    bids_root, bids_root_dense, path_counter, fast_sidecar, dataset
 ):
     """Test that we can find sidecars with the fast shortcut method."""
     if dataset == "basic":
@@ -1110,7 +1097,7 @@ def test_find_matching_sidecar_fast(
             session="01",
             run="01",
             task="testing",
-            root=bids_test_dir,
+            root=bids_root,
         )
         datatype = "meg"
         call_count = 2
@@ -1119,10 +1106,11 @@ def test_find_matching_sidecar_fast(
             subject="1",
             session="1",
             task="audvis",
-            root=bids_test_dir_dense.root,
+            root=bids_root_dense.root,
         )
         datatype = "eeg"
         call_count = 1
+    del bids_root, bids_root_dense
     path.update(datatype=datatype)
     assert path.fpath.is_file()
 
@@ -1205,10 +1193,8 @@ def test_find_matching_sidecar_at_root(tmp_path, path_counter, fast_sidecar):
     assert path_counter.count == 2
 
 
-def test_bids_path_inference(bids_test_dir):
+def test_bids_path_inference(bids_root):
     """Test usage of BIDSPath object and fpath."""
-    bids_root = bids_test_dir
-
     # without providing all the entities, ambiguous when trying
     # to use fpath
     bids_path = BIDSPath(
@@ -1241,26 +1227,21 @@ def test_bids_path_inference(bids_test_dir):
         / "eeg"
         / f"{channels_fname.basename}.tsv"
     )
-    try:
-        extra_file.parent.mkdir(exist_ok=True, parents=True)
-        # Creates a new file and because of this new file, there is now
-        # ambiguity
-        with open(extra_file, "w", encoding="utf-8"):
-            pass
-        with pytest.raises(RuntimeError, match="Found data of more than one"):
-            channels_fname.fpath
+    extra_file.parent.mkdir(exist_ok=True, parents=True)
+    # Creates a new file and because of this new file, there is now
+    # ambiguity
+    with open(extra_file, "w", encoding="utf-8"):
+        pass
+    with pytest.raises(RuntimeError, match="Found data of more than one"):
+        channels_fname.fpath
 
-        # if you set datatype, now there is no ambiguity
-        channels_fname.update(datatype="eeg")
-        assert str(channels_fname.fpath) == str(extra_file)
-    finally:
-        shutil.rmtree(extra_file.parent)
+    # if you set datatype, now there is no ambiguity
+    channels_fname.update(datatype="eeg")
+    assert str(channels_fname.fpath) == str(extra_file)
 
 
-def test_bids_path(bids_test_dir):
+def test_bids_path(bids_root):
     """Test usage of BIDSPath object."""
-    bids_root = bids_test_dir
-
     bids_path = BIDSPath(
         subject=subject_id,
         session=session_id,
@@ -1588,10 +1569,8 @@ def test_filter_fnames(entities, expected_n_matches):
     assert len(output) == expected_n_matches
 
 
-def test_match_basic(bids_test_dir):
+def test_match_basic(bids_root):
     """Test retrieval of matching basenames."""
-    bids_root = bids_test_dir
-
     bids_path_01 = BIDSPath(root=bids_root)
     paths = bids_path_01.match()
     assert len(paths) == 9
@@ -1703,13 +1682,11 @@ def test_match_advanced(tmp_path):
     assert len(matches) == len(fnames), path
 
 
-def test_find_matching_paths(bids_test_dir):
+def test_find_matching_paths(bids_root):
     """We test by yielding the same results as BIDSPath.match().
 
     BIDSPath.match() is extensively tested above.
     """
-    bids_root = bids_test_dir
-
     # Check a few exemplary entities
     bids_path_01 = BIDSPath(root=bids_root)
     paths_match = bids_path_01.match(ignore_json=False)
@@ -1826,7 +1803,7 @@ def test_return_root_paths_entity_aware(tmp_path):
 
 @pytest.mark.filterwarnings(warning_str["meas_date_set_to_none"])
 @pytest.mark.filterwarnings(warning_str["channel_unit_changed"])
-def test_find_empty_room_basic(bids_test_dir, tmp_path):
+def test_find_empty_room_basic(tmp_path):
     """Test reading of empty room data."""
     raw_fname = data_path / "MEG" / "sample" / "sample_audvis_trunc_raw.fif"
     bids_root = tmp_path / "bids"
@@ -2111,10 +2088,8 @@ def test_bids_path_label_vs_index_entity():
     BIDSPath(subject="01", split=1)  # ok as <index> entity
 
 
-def test_meg_calibration_fpath(bids_test_dir, tmp_path):
+def test_meg_calibration_fpath(bids_root, tmp_path):
     """Test BIDSPath.meg_calibration_fpath."""
-    bids_root = bids_test_dir
-
     # File exists, so BIDSPath.meg_calibration_fpath should return a non-None
     # value.
     bids_path_ = _bids_path.copy().update(subject="01", root=bids_root)
@@ -2145,10 +2120,8 @@ def test_meg_calibration_fpath(bids_test_dir, tmp_path):
     assert bids_path_.meg_calibration_fpath is not None
 
 
-def test_meg_crosstalk_fpath(bids_test_dir, tmp_path):
+def test_meg_crosstalk_fpath(bids_root, tmp_path):
     """Test BIDSPath.meg_crosstalk_fpath."""
-    bids_root = bids_test_dir
-
     # File exists, so BIDSPath.crosstalk_fpath should return a non-None
     # value.
     bids_path = _bids_path.copy().update(subject="01", root=bids_root)
@@ -2179,39 +2152,39 @@ def test_meg_crosstalk_fpath(bids_test_dir, tmp_path):
     assert bids_path.meg_crosstalk_fpath is not None
 
 
-def test_datasetdescription_with_bidspath(bids_test_dir):
+def test_datasetdescription_with_bidspath(bids_root):
     """Test a BIDSPath can generate a valid path to dataset_description.json."""
     with pytest.raises(ValueError, match="Unallowed"):
         bids_path = BIDSPath(
-            root=bids_test_dir, suffix="dataset_description", extension=".json"
+            root=bids_root, suffix="dataset_description", extension=".json"
         )
 
     # initialization should work
     bids_path = BIDSPath(
-        root=bids_test_dir,
+        root=bids_root,
         suffix="dataset_description",
         extension=".json",
         check=False,
     )
     assert (
         bids_path.fpath.as_posix()
-        == Path(f"{bids_test_dir}/dataset_description.json").as_posix()
+        == Path(f"{bids_root}/dataset_description.json").as_posix()
     )
 
     # setting it via update should work
-    bids_path = BIDSPath(root=bids_test_dir, extension=".json", check=True)
+    bids_path = BIDSPath(root=bids_root, extension=".json", check=True)
     bids_path.update(suffix="dataset_description", check=False)
     assert (
         bids_path.fpath.as_posix()
-        == Path(f"{bids_test_dir}/dataset_description.json").as_posix()
+        == Path(f"{bids_root}/dataset_description.json").as_posix()
     )
 
 
-def test_update_check(bids_test_dir):
+def test_update_check(bids_root):
     """Test check argument is passed BIDSPath properly."""
-    bids_path = BIDSPath(root=bids_test_dir, check=False)
+    bids_path = BIDSPath(root=bids_root, check=False)
     bids_path.update(datatype="eyetrack")
-    assert bids_path.fpath.as_posix() == (bids_test_dir / "eyetrack").as_posix()
+    assert bids_path.fpath.as_posix() == (bids_root / "eyetrack").as_posix()
 
 
 def test_update_fail_check_no_change():

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -257,41 +257,53 @@ def test_get_entity_vals_ignore_hidden(bids_root):
 @dataclass
 class _PathAccessCounter:
     calls: list[str]
+    files: list[str]
     count: int = 0
 
 
 @pytest.fixture
 def path_counter(monkeypatch):
     """Count number of files traversed using iglob."""
-    out = _PathAccessCounter(calls=list())
+    path_counter = _PathAccessCounter(calls=list(), files=list())
     orig_iglob = glob.iglob
     orig_walk = os.walk
 
     def iglob_count(*args, **kwargs):
+        path_counter.calls.append("iglob")
         for fn in orig_iglob(*args, **kwargs):
-            out.count += 1
+            path_counter.count += 1
+            path_counter.files.append(fn)
             yield fn
 
     def _return_root_paths_count(*args, **kwargs):
-        out.count = 0
-        return _return_root_paths(*args, **kwargs)
+        path_counter.calls.append("_return_root_paths")
+        path_counter.count = 0
+        out = _return_root_paths(*args, **kwargs)
+        path_counter.files.extend(out)
+        return out
 
     def get_entity_vals_count(*args, **kwargs):
-        out.calls.append("get_entity_vals")
-        out.count = 0
-        return get_entity_vals(*args, **kwargs)
+        path_counter.calls.append("get_entity_vals")
+        path_counter.count = 0
+        out = get_entity_vals(*args, **kwargs)
+        path_counter.files.extend(out)
+        return out
 
     def get_datatypes_count(*args, **kwargs):
-        out.calls.append("get_datatypes")
-        out.count = 0
-        return get_datatypes(*args, **kwargs)
+        path_counter.calls.append("get_datatypes")
+        path_counter.count = 0
+        out = get_datatypes(*args, **kwargs)
+        path_counter.files.extend(out)
+        return out
 
     orig_find = mne_bids.path._find_matching_sidecar
 
     def _find_matching_sidecar_count(*args, **kwargs):
-        out.calls.append("_find_matching_sidecar")
-        out.count = 0
-        return orig_find(*args, **kwargs)
+        path_counter.calls.append("_find_matching_sidecar")
+        path_counter.count = 0
+        out = orig_find(*args, **kwargs)
+        path_counter.files.extend(out)
+        return out
 
     def _path_glob_iglob(root, pattern):
         # Reroute Path.glob through iglob to count accesses
@@ -304,10 +316,13 @@ def path_counter(monkeypatch):
         ]
 
     def _os_walk_count(*args, **kwargs):
-        out.count = 0
+        path_counter.count = 0
+        path_counter.calls.append("os.walk")
         for dirpath, dirs, files in orig_walk(*args, **kwargs):
-            out.count += len(files) + len(dirs)
-            yield dirpath, dirs, files
+            path_counter.count += len(files) + len(dirs)
+            out = dirpath, dirs, files
+            path_counter.files.extend(files)
+            yield out
 
     monkeypatch.setattr(glob, "iglob", iglob_count)
     monkeypatch.setattr(mne_bids.path, "_path_glob", _path_glob_iglob)
@@ -319,7 +334,7 @@ def path_counter(monkeypatch):
         mne_bids.path, "_find_matching_sidecar", _find_matching_sidecar_count
     )
     monkeypatch.setattr(os, "walk", _os_walk_count)
-    yield out
+    yield path_counter
 
 
 @dataclass

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -112,12 +112,16 @@ def test_get_datatypes(bids_root_dense, bids_root, path_counter):
     assert path_counter.count == 108
 
 
+_ROOT_NUM = 9
+_SUB_NUM = 22
+
+
 @pytest.mark.parametrize(
     "entity, expected_vals, kwargs, count",
     [
         pytest.param("bogus", None, None, 0, id="bogus"),
-        pytest.param("subject", [subject_id], None, 9, id="subject"),
-        pytest.param("session", [session_id], None, 9, id="session"),
+        pytest.param("subject", [subject_id], None, _ROOT_NUM, id="subject"),
+        pytest.param("session", [session_id], None, _ROOT_NUM, id="session"),
         pytest.param(
             "session",
             [],
@@ -126,47 +130,63 @@ def test_get_datatypes(bids_root_dense, bids_root, path_counter):
                 ignore_acquisitions=("calibration", "crosstalk"),
                 ignore_suffixes=("scans", "coordsystem"),
             ),
-            9,
+            _ROOT_NUM,
             id="session_ignore_kinds",
         ),
-        pytest.param("run", [run, "02"], None, 22, id="run"),
+        pytest.param("run", [run, "02"], None, _SUB_NUM, id="run"),
         pytest.param(
-            "acquisition", ["calibration", "crosstalk"], None, 22, id="acquisition"
+            "acquisition",
+            ["calibration", "crosstalk"],
+            None,
+            _SUB_NUM,
+            id="acquisition",
         ),
-        pytest.param("task", [task], None, 22, id="task"),
+        pytest.param("task", [task], None, _SUB_NUM, id="task"),
         pytest.param(
-            "subject", [], dict(ignore_subjects=[subject_id]), 9, id="subject_ignore"
+            "subject",
+            [],
+            dict(ignore_subjects=[subject_id]),
+            _ROOT_NUM,
+            id="subject_ignore",
         ),
         pytest.param(
             "subject",
             [],
             dict(ignore_subjects=subject_id),
-            9,
+            _ROOT_NUM,
             id="subject_ignore_single",
         ),
         pytest.param(
             "session",
             [],
             dict(ignore_sessions=[session_id]),
-            9,
+            _ROOT_NUM,
             id="session_ignore_sessions",
         ),
         pytest.param(
             "session",
             [],
             dict(ignore_sessions=session_id),
-            9,
+            _ROOT_NUM,
             id="session_ignore_single",
         ),
-        pytest.param("run", [run], dict(ignore_runs=["02"]), 22, id="run_ignore"),
-        pytest.param("run", [run], dict(ignore_runs="02"), 22, id="run_ignore_single"),
-        pytest.param("task", [], dict(ignore_tasks=[task]), 22, id="task_ignore"),
-        pytest.param("task", [], dict(ignore_tasks=task), 22, id="task_ignore_single"),
+        pytest.param("run", [run], dict(ignore_runs=["02"]), _SUB_NUM, id="run_ignore"),
         pytest.param(
-            "run", [run, "02"], dict(ignore_runs=["bogus"]), 22, id="run_ignore_bogus"
+            "run", [run], dict(ignore_runs="02"), _SUB_NUM, id="run_ignore_single"
+        ),
+        pytest.param("task", [], dict(ignore_tasks=[task]), _SUB_NUM, id="task_ignore"),
+        pytest.param(
+            "task", [], dict(ignore_tasks=task), _SUB_NUM, id="task_ignore_single"
         ),
         pytest.param(
-            "run", [], dict(ignore_datatypes=["meg"]), 22, id="ignore_datatypes"
+            "run",
+            [run, "02"],
+            dict(ignore_runs=["bogus"]),
+            _SUB_NUM,
+            id="run_ignore_bogus",
+        ),
+        pytest.param(
+            "run", [], dict(ignore_datatypes=["meg"]), _SUB_NUM, id="ignore_datatypes"
         ),
     ],
 )
@@ -268,14 +288,8 @@ def path_counter(monkeypatch):
     orig_iglob = glob.iglob
     orig_walk = os.walk
 
-    def iglob_count(*args, **kwargs):
-        # We might want this someday... but for now let's just limit "calls"
-        # to the ones that MBP defines...
-        # path_counter.calls.append("iglob")
-        for fn in orig_iglob(*args, **kwargs):
-            path_counter.count += 1
-            path_counter.files.append(fn)
-            yield fn
+    # Internal MBP functions should set .count=0 and .files=[] and append themselves
+    # to .calls. Builtin Python functions should increment .count and extend .files.
 
     def _return_root_paths_count(*args, **kwargs):
         path_counter.calls.append("_return_root_paths")
@@ -321,9 +335,13 @@ def path_counter(monkeypatch):
             root / f for f in glob.iglob(f"**/{pattern}", root_dir=root, recursive=True)
         ]
 
+    def _iglob_count(*args, **kwargs):
+        for fn in orig_iglob(*args, **kwargs):
+            path_counter.count += 1
+            path_counter.files.append(fn)
+            yield fn
+
     def _os_walk_count(top, **kwargs):
-        path_counter.count = 0
-        path_counter.calls.append("os.walk")
         for dirpath, dirs, files in orig_walk(top, **kwargs):
             path_counter.count += len(files) + len(dirs)
             out = dirpath, dirs, files
@@ -335,7 +353,7 @@ def path_counter(monkeypatch):
             )
             yield out
 
-    monkeypatch.setattr(glob, "iglob", iglob_count)
+    monkeypatch.setattr(glob, "iglob", _iglob_count)
     monkeypatch.setattr(mne_bids.path, "_path_glob", _path_glob_iglob)
     monkeypatch.setattr(mne_bids.path, "_path_rglob", _path_rglob_iglob)
     monkeypatch.setattr(mne_bids.path, "_return_root_paths", _return_root_paths_count)

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -302,7 +302,11 @@ def path_counter(monkeypatch):
         path_counter.calls.append("_find_matching_sidecar")
         path_counter.count = 0
         out = orig_find(*args, **kwargs)
-        path_counter.files.extend(out)
+        func = getattr(
+            path_counter.files, "extend" if isinstance(out, list) else "append"
+        )
+        func(out)
+        path_counter.files.append(out)
         return out
 
     def _path_glob_iglob(root, pattern):

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -189,6 +189,8 @@ def test_get_entity_vals(entity, expected_vals, kwargs, count, bids_root, path_c
     assert path_counter.count == 0
     vals = get_entity_vals(root=bids_root, entity_key=entity, **kwargs)
     assert path_counter.count == count
+    if entity == "subject":
+        1 / 0
     assert vals == expected_vals
 
     # test using ``with_key`` kwarg
@@ -315,13 +317,18 @@ def path_counter(monkeypatch):
             root / f for f in glob.iglob(f"**/{pattern}", root_dir=root, recursive=True)
         ]
 
-    def _os_walk_count(*args, **kwargs):
+    def _os_walk_count(top, **kwargs):
         path_counter.count = 0
         path_counter.calls.append("os.walk")
-        for dirpath, dirs, files in orig_walk(*args, **kwargs):
+        for dirpath, dirs, files in orig_walk(top, **kwargs):
             path_counter.count += len(files) + len(dirs)
             out = dirpath, dirs, files
-            path_counter.files.extend(files)
+            path_counter.files.extend(
+                os.path.join(os.path.relpath(dirpath, top), d) for d in dirs
+            )
+            path_counter.files.extend(
+                os.path.join(os.path.relpath(dirpath, top), f) for f in files
+            )
             yield out
 
     monkeypatch.setattr(glob, "iglob", iglob_count)

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -1875,6 +1875,7 @@ def test_return_root_paths_entity_aware(tmp_path):
     assert all("sub-subjA" in str(p) for p in subj_paths)
 
 
+@testing.requires_testing_data
 @pytest.mark.filterwarnings(warning_str["meas_date_set_to_none"])
 @pytest.mark.filterwarnings(warning_str["channel_unit_changed"])
 def test_find_empty_room_basic(tmp_path):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,8 +64,7 @@ full = [
   "defusedxml",  # For reading EGI MFF data and BrainVision montages
   "edfio >= 0.4.10",
   "eeglabio >= 0.1.0",
-  "filelock >= 3.20.4; sys_platform == 'darwin'",
-  "filelock; sys_platform != 'darwin'",
+  "filelock >= 3.20.4",
   "h5py!=3.15.0",  # temporary fix until h5py 3.15.1 is released
   "hedtools",  # For HED (Hierarchical Event Descriptors) annotation support
   "matplotlib >= 3.6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ full = [
   "defusedxml",  # For reading EGI MFF data and BrainVision montages
   "edfio >= 0.4.10",
   "eeglabio >= 0.1.0",
-  "filelock",
+  "filelock >= 3.20.4",
   "h5py!=3.15.0",  # temporary fix until h5py 3.15.1 is released
   "hedtools",  # For HED (Hierarchical Event Descriptors) annotation support
   "matplotlib >= 3.6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,8 @@ full = [
   "defusedxml",  # For reading EGI MFF data and BrainVision montages
   "edfio >= 0.4.10",
   "eeglabio >= 0.1.0",
-  "filelock >= 3.20.4",
+  "filelock >= 3.20.4; sys_platform == 'darwin'",
+  "filelock; sys_platform != 'darwin'",
   "h5py!=3.15.0",  # temporary fix until h5py 3.15.1 is released
   "hedtools",  # For HED (Hierarchical Event Descriptors) annotation support
   "matplotlib >= 3.6",


### PR DESCRIPTION
Closes #1582

@scott-huberty it turns out FileLock was the problem. When upgrading to `>=3.20.4` things are fine. Unfortunately this was released Feb 16 of this year :sweat: , but I guess it's what we need for this advanced functionality.

Discovered this by improving the `path_counter` to list the files it has looped over, and noticed a bunch of `.lock` files still on the filesystem. This motivated me to clean up our testing infrastructure to better isolate each test by making `bids_test_dir->bids_root` fixture (DRY renaming) be function- rather than session-specific. Then we don't need `shutil.rmtree` calls, which all should have been in `try/finally`s anyway.