### PR TITLE
FIX: more generous events.tsv reading

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -65,7 +65,7 @@ Detailed list of changes
 - Fix :func:`mne_bids.read_raw_bids` and related read paths failing with ``PermissionError`` on datalad/git-annex datasets by keeping the file lock next to the symlink instead of its (read-only) target, and gracefully continuing without a lock when one cannot be created, by `Bruno Aristimunha`_ (:gh:`1569`)
 - Avoid modifying calibration files by making :func:`mne_bids.write_meg_calibration` copy instead of parsing and rewriting, by `Marijn van Vliet`_ (:gh:`1576`)
 - Fix bug with :meth:`mne_bids.BIDSPath.find_matching_sidecar` not searching parent directories properly, by `Eric Larson`_ (:gh:`1565`)
-- Fix :func:`mne_bids.read.events_file_to_annotation_kwargs` to drop rows with invalid ``onset`` values (``n/a``, ``nan``, ``NaN``, empty string) before float conversion. This makes reading real-world OpenNeuro datasets (e.g. ``ds004841``, ``ds004842``, ``ds004843``) succeed instead of either raising or returning ``NaN`` onsets, by `Bruno Aristimunha`_ (:gh:`1547`)
+- Fix :func:`mne_bids.events_file_to_annotation_kwargs` to drop rows with invalid ``onset`` values (``n/a``, ``nan``, ``NaN``, empty string) before float conversion. This makes reading real-world OpenNeuro datasets (e.g. ``ds004841``, ``ds004842``, ``ds004843``) succeed instead of either raising or returning ``NaN`` onsets, by `Bruno Aristimunha`_ (:gh:`1547`)
 - Fix :func:`mne_bids.read.events_file_to_annotation_kwargs` to fall back to the ``value`` column when ``trial_type`` is entirely ``n/a`` but ``value`` contains trigger codes, instead of dropping all events, by `Bruno Aristimunha`_ (:gh:`947`)
 
 ⚕️ Code health

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -65,6 +65,8 @@ Detailed list of changes
 - Fix :func:`mne_bids.read_raw_bids` and related read paths failing with ``PermissionError`` on datalad/git-annex datasets by keeping the file lock next to the symlink instead of its (read-only) target, and gracefully continuing without a lock when one cannot be created, by `Bruno Aristimunha`_ (:gh:`1569`)
 - Avoid modifying calibration files by making :func:`mne_bids.write_meg_calibration` copy instead of parsing and rewriting, by `Marijn van Vliet`_ (:gh:`1576`)
 - Fix bug with :meth:`mne_bids.BIDSPath.find_matching_sidecar` not searching parent directories properly, by `Eric Larson`_ (:gh:`1565`)
+- Fix :func:`mne_bids.read.events_file_to_annotation_kwargs` to drop rows with invalid ``onset`` values (``n/a``, ``nan``, ``NaN``, empty string) before float conversion. This makes reading real-world OpenNeuro datasets (e.g. ``ds004841``, ``ds004842``, ``ds004843``) succeed instead of either raising or returning ``NaN`` onsets, by `Bruno Aristimunha`_ (:gh:`1547`)
+- Fix :func:`mne_bids.read.events_file_to_annotation_kwargs` to fall back to the ``value`` column when ``trial_type`` is entirely ``n/a`` but ``value`` contains trigger codes, instead of dropping all events, by `Bruno Aristimunha`_ (:gh:`947`)
 
 ⚕️ Code health
 ^^^^^^^^^^^^^^

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -660,9 +660,8 @@ def _make_annotation_kwargs(events_dict, events_fname=None):
         The filtered events dict (n/a rows dropped), suitable for reuse
         by ``_assemble_hed_from_sidecar``.
     """
-    # drop events where onset is n/a; we can't annotate them and thus don't need entries
-    # for them in event_id either
-    events_dict = _drop(events_dict, "n/a", "onset")
+    # drop events with invalid onsets so float() doesn't choke (#1547)
+    events_dict = _drop(events_dict, ["n/a", "nan", "NaN", ""], "onset")
 
     # Get event descriptions. Use `trial_type` column if available.
     if "trial_type" in events_dict:
@@ -682,6 +681,16 @@ def _make_annotation_kwargs(events_dict, events_fname=None):
         trial_type_col_name = None
         descrs = np.full(len(events_dict["onset"]), "n/a")
         event_id = {descrs[0]: 1}
+
+    # trial_type all "n/a" but value has codes -> fall back to value (#947)
+    if (
+        trial_type_col_name in ("trial_type", "stim_type")
+        and "value" in events_dict
+        and all(v == "n/a" for v in events_dict[trial_type_col_name])
+        and any(v != "n/a" for v in events_dict["value"])
+    ):
+        logger.info(f'"{trial_type_col_name}" all "n/a"; using "value" instead.')
+        trial_type_col_name = "value"
 
     if trial_type_col_name is not None:
         # Drop events unrelated to a trial type

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -2134,6 +2134,40 @@ def test_events_file_to_annotation_kwargs(tmp_path):
         assert "HED" not in extra
 
 
+@pytest.mark.parametrize("marker", ["n/a", "nan", "NaN", ""])
+def test_events_file_to_annotation_kwargs_invalid_onsets(tmp_path, marker):
+    """Rows with invalid onset markers are dropped (#1547)."""
+    events = {
+        "onset": ["0.1", marker, "0.3"],
+        "duration": ["0.0"] * 3,
+        "trial_type": ["a", "drop", "b"],
+    }
+    events_fname = tmp_path / "events.tsv"
+    _to_tsv(events, events_fname)
+
+    ev = events_file_to_annotation_kwargs(events_fname=events_fname)
+
+    np.testing.assert_array_equal(ev["onset"], [0.1, 0.3])
+    np.testing.assert_array_equal(ev["description"], ["a", "b"])
+
+
+def test_events_file_to_annotation_kwargs_trial_type_fallback_to_value(tmp_path):
+    """All-n/a ``trial_type`` falls back to ``value`` for descriptions (#947)."""
+    events = {
+        "onset": ["0.1", "0.2", "0.3"],
+        "duration": ["0.0"] * 3,
+        "trial_type": ["n/a"] * 3,
+        "value": ["1040", "2049", "1040"],
+    }
+    events_fname = tmp_path / "events.tsv"
+    _to_tsv(events, events_fname)
+
+    ev = events_file_to_annotation_kwargs(events_fname=events_fname)
+
+    np.testing.assert_array_equal(ev["description"], ["1040", "2049", "1040"])
+    assert ev["event_id"] == {"1040": 1040, "2049": 2049}
+
+
 @pytest.fixture
 def _hed_tiny_bids(tmp_path):
     """Copy the tiny_bids fixture and return paths + a fresh Raw for HED tests."""


### PR DESCRIPTION
Closes #1547, closes #947.

Two small fixes in `events_file_to_annotation_kwargs`:

1. Drop rows with invalid onset markers (`n/a`, `nan`, `NaN`, `""`) before float conversion. Previously `nan`/`NaN` leaked through as `float("nan")` and `""` raised `ValueError`.
2. When `trial_type` is entirely `n/a` but `value` has trigger codes, fall back to `value` instead of dropping every row.

## Reproducer (end-to-end `read_raw_bids`)

```python
import openneuro
from mne_bids import BIDSPath, read_raw_bids

openneuro.download(
    dataset="ds004843",
    target_dir="/tmp/ds004843",
    include=["sub-001/eeg/sub-001_task-VisualSituationalAwareness_run-2_*",
             "dataset_description.json", "participants.tsv"],
)
bp = BIDSPath(subject="001", task="VisualSituationalAwareness", run="2",
              datatype="eeg", suffix="eeg", extension=".set",
              root="/tmp/ds004843")
raw = read_raw_bids(bp)
print(len(raw.annotations), "annotations")
```

| | result |
|--|--|
| `main` | `ValueError: cannot convert float NaN to integer` (in `mne/annotations.py:crop`) |
| this PR | 4048 annotations, all onsets finite |

Other affected datasets: `ds004841`, `ds004842`.