### PR TITLE
[MRG] ENH: Demote format-conversion warnings to log messages

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -47,7 +47,7 @@ Detailed list of changes
 🧐 API and behavior changes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-- Format-conversion notices in :func:`mne_bids.write_raw_bids` no longer emit ``RuntimeWarning``\s when conversion is expected. ``Converting data files to <FORMAT> format`` is now logged at INFO level, and the internal ``Encountered data in "<FMT>" format`` notice is logged at DEBUG level. Adjust visibility with :func:`mne.set_log_level`, by `Bruno Aristimunha`_ (:gh:`1589`)
+- Format-conversion notices in :func:`mne_bids.write_raw_bids` no longer emit ``RuntimeWarning``\s when conversion is expected. Both ``Converting data files to <FORMAT> format`` and ``Encountered data in "<FMT>" format`` are now logged at INFO level. Adjust visibility with :func:`mne.set_log_level`, by `Bruno Aristimunha`_ (:gh:`1589`)
 
 🛠 Requirements
 ^^^^^^^^^^^^^^^

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -47,7 +47,7 @@ Detailed list of changes
 🧐 API and behavior changes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-- Format-conversion notices in :func:`mne_bids.write_raw_bids` no longer emit ``RuntimeWarning``\s when conversion is expected. Both ``Converting data files to <FORMAT> format`` and ``Encountered data in "<FMT>" format`` are now logged at INFO level. Adjust visibility with :func:`mne.set_log_level`, by `Bruno Aristimunha`_ (:gh:`1589`)
+- Expected format conversions notices are now logged at ``info`` instead of ``warn`` level, by `Bruno Aristimunha`_ (:gh:`1589`)
 
 🛠 Requirements
 ^^^^^^^^^^^^^^^

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -47,7 +47,7 @@ Detailed list of changes
 🧐 API and behavior changes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-- None yet
+- Format-conversion notices in :func:`mne_bids.write_raw_bids` no longer emit ``RuntimeWarning``\s when conversion is expected. ``Converting data files to <FORMAT> format`` is now logged at INFO level, and the internal ``Encountered data in "<FMT>" format`` notice is logged at DEBUG level. Adjust visibility with :func:`mne.set_log_level`, by `Bruno Aristimunha`_ (:gh:`1589`)
 
 🛠 Requirements
 ^^^^^^^^^^^^^^^

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -2019,8 +2019,7 @@ def test_channel_units_from_tsv(tmp_path):
     bids_path = _bids_path.copy().update(
         root=bids_root, datatype="eeg", suffix="eeg", extension=".edf"
     )
-    with pytest.warns(RuntimeWarning, match="Converting data files to EDF format"):
-        write_raw_bids(raw, bids_path, overwrite=True, allow_preload=True, format="EDF")
+    write_raw_bids(raw, bids_path, overwrite=True, allow_preload=True, format="EDF")
 
     # Check that channels.tsv contains "rad" for the misc channel
     channels_fname = _find_matching_sidecar(

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -646,17 +646,14 @@ def test_fif(_bids_validate, tmp_path):
         raw2, events, event_id=event_id, tmin=-0.2, tmax=0.5, preload=True
     )
     bids_path = bids_path.update(datatype="eeg")
-    with pytest.warns(
-        RuntimeWarning, match="Converting data files to BrainVision format"
-    ):
-        write_raw_bids(
-            raw2,
-            bids_path,
-            events=events,
-            event_id=event_id,
-            verbose=True,
-            overwrite=False,
-        )
+    write_raw_bids(
+        raw2,
+        bids_path,
+        events=events,
+        event_id=event_id,
+        verbose=True,
+        overwrite=False,
+    )
     bids_dir = op.join(bids_root, f"sub-{subject_id}", f"ses-{session_id}", "eeg")
     sidecar_basename = bids_path.copy()
     for sidecar in [
@@ -1471,18 +1468,15 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate, tmp_path):
 
     warning_to_catch = {
         "EDF": None,
-        "curry": 'Encountered data in "int" format. Converting to float32.',
-        "NihonKohden": 'Encountered data in "short" format',
-        "CNT": 'Encountered data in "int" format. Converting to float32.',
+        "curry": None,
+        "NihonKohden": None,
+        "CNT": None,
         "EGI": None,
-        "Persyst": 'Encountered data in "double" format',
+        "Persyst": None,
     }
 
     if warning_to_catch[dir_name] is None:
         bids_output_path = write_raw_bids(**kwargs)
-    else:
-        with pytest.warns(RuntimeWarning, match=warning_to_catch[dir_name]):
-            bids_output_path = write_raw_bids(**kwargs)
 
     with pytest.raises(ValueError, match="You passed events, but no event_id "):
         write_raw_bids(raw, bids_path, events=events)
@@ -1509,9 +1503,6 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate, tmp_path):
     kwargs = dict(raw=raw, bids_path=bids_path, overwrite=True)
     if warning_to_catch[dir_name] is None:
         bids_output_path = write_raw_bids(**kwargs)
-    else:
-        with pytest.warns(RuntimeWarning, match=warning_to_catch[dir_name]):
-            bids_output_path = write_raw_bids(**kwargs)
 
     make_dataset_description(
         path=bids_root,
@@ -1531,9 +1522,6 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate, tmp_path):
     kwargs = dict(raw=raw, bids_path=bids_path, overwrite=True)
     if warning_to_catch[dir_name] is None:
         bids_output_path = write_raw_bids(**kwargs)
-    else:
-        with pytest.warns(RuntimeWarning, match=warning_to_catch[dir_name]):
-            bids_output_path = write_raw_bids(**kwargs)
 
     # dataset_description.json files should not be overwritten inside
     # write_raw_bids calls
@@ -1593,9 +1581,6 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate, tmp_path):
     kwargs = dict(raw=raw, bids_path=bids_path, overwrite=True)
     if warning_to_catch[dir_name] is None:
         bids_output_path = write_raw_bids(**kwargs)
-    else:
-        with pytest.warns(RuntimeWarning, match=warning_to_catch[dir_name]):
-            bids_output_path = write_raw_bids(**kwargs)
 
     electrodes_fpath = _find_matching_sidecar(
         bids_path, suffix="electrodes", extension=".tsv"
@@ -1650,9 +1635,6 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate, tmp_path):
                 write_raw_bids(**kwargs)
         elif warning_to_catch[dir_name] is None:
             bids_output_path = write_raw_bids(**kwargs)
-        else:
-            with pytest.warns(RuntimeWarning, match=warning_to_catch[dir_name]):
-                bids_output_path = write_raw_bids(**kwargs)
 
         data = _from_tsv(scans_tsv)
         bids_path = bids_path.copy()
@@ -1675,9 +1657,6 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate, tmp_path):
     kwargs = dict(raw=ieeg_raw, bids_path=bids_path, overwrite=True)
     if warning_to_catch[dir_name] is None:
         bids_output_path = write_raw_bids(**kwargs)
-    else:
-        with pytest.warns(RuntimeWarning, match=warning_to_catch[dir_name]):
-            bids_output_path = write_raw_bids(**kwargs)
 
     _bids_validate(bids_root)
 
@@ -1707,9 +1686,6 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate, tmp_path):
     kwargs = dict(raw=ieeg_raw, bids_path=bids_path, overwrite=True)
     if warning_to_catch[dir_name] is None:
         bids_output_path = write_raw_bids(**kwargs)
-    else:
-        with pytest.warns(RuntimeWarning, match=warning_to_catch[dir_name]):
-            bids_output_path = write_raw_bids(**kwargs)
 
     _bids_validate(bids_root)
 
@@ -1763,9 +1739,6 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate, tmp_path):
     kwargs.update(montage=ecog_montage, acpc_aligned=True)
     if warning_to_catch[dir_name] is None:
         bids_output_path = write_raw_bids(**kwargs)
-    else:
-        with pytest.warns(RuntimeWarning, match=warning_to_catch[dir_name]):
-            bids_output_path = write_raw_bids(**kwargs)
 
     _bids_validate(bids_root)
 
@@ -1810,40 +1783,26 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate, tmp_path):
         raw = reader(raw_fname)
         bids_path.update(root=bids_root, datatype="eeg")
         kwargs = dict(raw=raw, bids_path=bids_path, overwrite=True)
-        if dir_name == "NihonKohden":
-            with pytest.warns(
-                RuntimeWarning, match='Encountered data in "short" format'
-            ):
-                write_raw_bids(**kwargs)
-                output_path = _test_anonymize(tmp_path / "a", raw, bids_path)
-        elif dir_name == "EDF":
+        if dir_name == "EDF":
             match = r"^EDF\/EDF\+\/BDF files contain two fields .*"
             with pytest.warns(RuntimeWarning, match=match):
                 write_raw_bids(**kwargs)  # Just copies.
                 output_path = _test_anonymize(tmp_path / "b", raw, bids_path)
+        elif dir_name == "NihonKohden":
+            write_raw_bids(**kwargs)
+            output_path = _test_anonymize(tmp_path / "a", raw, bids_path)
         elif dir_name == "CNT":
-            with pytest.warns(
-                RuntimeWarning,
-                match='Encountered data in "int" format. Converting to float32.',
-            ):
-                write_raw_bids(**kwargs)
-                output_path = _test_anonymize(tmp_path / "c", raw, bids_path)
+            write_raw_bids(**kwargs)
+            output_path = _test_anonymize(tmp_path / "c", raw, bids_path)
         elif dir_name == "EGI":
             write_raw_bids(**kwargs)
             output_path = _test_anonymize(tmp_path / "d", raw, bids_path)
         elif dir_name == "curry":
-            with pytest.warns(
-                RuntimeWarning,
-                match='Encountered data in "int" format. Converting to float32.',
-            ):
-                write_raw_bids(**kwargs)
-                output_path = _test_anonymize(tmp_path / "d", raw, bids_path)
+            write_raw_bids(**kwargs)
+            output_path = _test_anonymize(tmp_path / "d", raw, bids_path)
         else:
-            with pytest.warns(
-                RuntimeWarning, match='Encountered data in "double" format'
-            ):
-                write_raw_bids(**kwargs)  # Converts.
-                output_path = _test_anonymize(tmp_path / "e", raw, bids_path)
+            write_raw_bids(**kwargs)  # Converts.
+            output_path = _test_anonymize(tmp_path / "e", raw, bids_path)
         _bids_validate(output_path)
 
 
@@ -2009,8 +1968,7 @@ def test_set(_bids_validate, tmp_path):
 
     # test anonymize and convert
     if check_version("pybv", PYBV_VERSION):
-        with pytest.warns(RuntimeWarning, match='Encountered data in "double" format'):
-            output_path = _test_anonymize(tmp_path / "tmp", raw, bids_path)
+        output_path = _test_anonymize(tmp_path / "tmp", raw, bids_path)
         _bids_validate(output_path)
 
 
@@ -3387,7 +3345,6 @@ def test_emg_errors_and_warnings(tmp_path):
         write_raw_bids(**good_kwargs, emg_placement="Foo")
     with (
         pytest.warns(RuntimeWarning, match="BDF format requires equal-length data"),
-        pytest.warns(RuntimeWarning, match="Converting data files to BDF format"),
         pytest.warns(RuntimeWarning, match="add `coordsystem.json` file manually"),
     ):
         write_raw_bids(**good_kwargs, emg_placement="Other")
@@ -3462,32 +3419,15 @@ def test_convert_eeg_formats(dir_name, fmt, fname, reader, tmp_path):
     # test formatting to BrainVision, EDF, or auto (BrainVision)
     if fmt in ["BrainVision", "auto"]:
         if dir_name == "NihonKohden":
-            with pytest.warns(RuntimeWarning, match='Encountered data in "short"'):
-                bids_output_path = write_raw_bids(**kwargs)
-        elif dir_name == "CNT":
-            with pytest.warns(
-                RuntimeWarning,
-                match='Encountered data in "int" format. Converting to float32.',
-            ):
-                bids_output_path = write_raw_bids(**kwargs)
-        elif dir_name == "curry":
-            with pytest.warns(
-                RuntimeWarning,
-                match='Encountered data in "int" format. Converting to float32.',
-            ):
-                bids_output_path = write_raw_bids(**kwargs)
-        else:
-            with pytest.warns(
-                RuntimeWarning, match='Encountered data in "double" format'
-            ):
-                bids_output_path = write_raw_bids(**kwargs)
-    else:
-        with pytest.warns(RuntimeWarning) as warn_records:
             bids_output_path = write_raw_bids(**kwargs)
-        warn_messages = [str(w.message) for w in warn_records]
-        assert any(
-            f"Converting data files to {fmt} format" in msg for msg in warn_messages
-        )
+        elif dir_name == "CNT":
+            bids_output_path = write_raw_bids(**kwargs)
+        elif dir_name == "curry":
+            bids_output_path = write_raw_bids(**kwargs)
+        else:
+            bids_output_path = write_raw_bids(**kwargs)
+    else:
+        bids_output_path = write_raw_bids(**kwargs)
 
     # channel units should stay the same
     raw2 = read_raw_bids(bids_output_path, extra_params=dict(preload=True))
@@ -3529,10 +3469,7 @@ def test_anonymize_and_convert_to_edf(tmp_path):
     bids_path = _bids_path.copy().update(root=bids_root, datatype="eeg")
     raw = _read_raw_nihon(raw_fname)
 
-    with (
-        pytest.warns(RuntimeWarning, match="limits `startdate` to dates after 1985"),
-        pytest.warns(RuntimeWarning, match="Converting data files to EDF format"),
-    ):
+    with pytest.warns(RuntimeWarning, match="limits `startdate` to dates after 1985"):
         bids_output_path = write_raw_bids(
             raw=raw,
             format="EDF",

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -1466,17 +1466,7 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate, tmp_path):
     events, _ = mne.events_from_annotations(raw, event_id=None)
     kwargs = dict(raw=raw, bids_path=bids_path, overwrite=True)
 
-    warning_to_catch = {
-        "EDF": None,
-        "curry": None,
-        "NihonKohden": None,
-        "CNT": None,
-        "EGI": None,
-        "Persyst": None,
-    }
-
-    if warning_to_catch[dir_name] is None:
-        bids_output_path = write_raw_bids(**kwargs)
+    bids_output_path = write_raw_bids(**kwargs)
 
     with pytest.raises(ValueError, match="You passed events, but no event_id "):
         write_raw_bids(raw, bids_path, events=events)
@@ -1501,8 +1491,7 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate, tmp_path):
 
     # Test we can overwrite dataset_description.json
     kwargs = dict(raw=raw, bids_path=bids_path, overwrite=True)
-    if warning_to_catch[dir_name] is None:
-        bids_output_path = write_raw_bids(**kwargs)
+    bids_output_path = write_raw_bids(**kwargs)
 
     make_dataset_description(
         path=bids_root,
@@ -1520,8 +1509,7 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate, tmp_path):
     # After writing the entire dataset again, dataset_description.json should
     # contain the default values.
     kwargs = dict(raw=raw, bids_path=bids_path, overwrite=True)
-    if warning_to_catch[dir_name] is None:
-        bids_output_path = write_raw_bids(**kwargs)
+    bids_output_path = write_raw_bids(**kwargs)
 
     # dataset_description.json files should not be overwritten inside
     # write_raw_bids calls
@@ -1579,8 +1567,7 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate, tmp_path):
     )
     raw.set_montage(eeg_montage)
     kwargs = dict(raw=raw, bids_path=bids_path, overwrite=True)
-    if warning_to_catch[dir_name] is None:
-        bids_output_path = write_raw_bids(**kwargs)
+    bids_output_path = write_raw_bids(**kwargs)
 
     electrodes_fpath = _find_matching_sidecar(
         bids_path, suffix="electrodes", extension=".tsv"
@@ -1633,7 +1620,7 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate, tmp_path):
             match = r"^EDF\/EDF\+\/BDF files contain two fields .*"
             with pytest.warns(RuntimeWarning, match=match):
                 write_raw_bids(**kwargs)
-        elif warning_to_catch[dir_name] is None:
+        else:
             bids_output_path = write_raw_bids(**kwargs)
 
         data = _from_tsv(scans_tsv)
@@ -1655,8 +1642,7 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate, tmp_path):
     bids_root = tmp_path / "bids2"
     bids_path.update(root=bids_root, datatype="ieeg")
     kwargs = dict(raw=ieeg_raw, bids_path=bids_path, overwrite=True)
-    if warning_to_catch[dir_name] is None:
-        bids_output_path = write_raw_bids(**kwargs)
+    bids_output_path = write_raw_bids(**kwargs)
 
     _bids_validate(bids_root)
 
@@ -1684,8 +1670,7 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate, tmp_path):
     bids_root = tmp_path / "bids3"
     bids_path.update(root=bids_root, datatype="ieeg")
     kwargs = dict(raw=ieeg_raw, bids_path=bids_path, overwrite=True)
-    if warning_to_catch[dir_name] is None:
-        bids_output_path = write_raw_bids(**kwargs)
+    bids_output_path = write_raw_bids(**kwargs)
 
     _bids_validate(bids_root)
 
@@ -1737,8 +1722,7 @@ def test_eegieeg(dir_name, fname, reader, _bids_validate, tmp_path):
     bids_path.update(root=bids_root, datatype="ieeg")
     # test works if ACPC-aligned is specified
     kwargs.update(montage=ecog_montage, acpc_aligned=True)
-    if warning_to_catch[dir_name] is None:
-        bids_output_path = write_raw_bids(**kwargs)
+    bids_output_path = write_raw_bids(**kwargs)
 
     _bids_validate(bids_root)
 

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1464,9 +1464,8 @@ def _write_raw_brainvision(raw, bids_fname, events, overwrite):
     # function to pybv that maximizes the resolution parameter while
     # ensuring that int16 can represent the data in original units.
     if raw.orig_format != "single":
-        warn(
-            f'Encountered data in "{raw.orig_format}" format. Converting to float32.',
-            RuntimeWarning,
+        logger.debug(
+            f'Encountered data in "{raw.orig_format}" format. Converting to float32.'
         )
 
     # Writing to float32 µV with 0.1 resolution are the pybv defaults,
@@ -2600,15 +2599,15 @@ def write_raw_bids(
                 ),
             )
         elif write_format in ("BDF", "EDF"):
-            warn(f"Converting data files to {write_format} format")
+            logger.info(f"Converting data files to {write_format} format")
             _write_raw_edf_bdf(
                 raw, bids_path.fpath, physical_range=physical_range, overwrite=overwrite
             )
         elif write_format == "EEGLAB":
-            warn("Converting data files to EEGLAB format")
+            logger.info("Converting data files to EEGLAB format")
             _write_raw_eeglab(raw, bids_path.fpath, overwrite=overwrite)
         else:  # BrainVision
-            warn("Converting data files to BrainVision format")
+            logger.info("Converting data files to BrainVision format")
             bids_path.update(suffix=bids_path.datatype)
             # XXX Should we write durations here too?
             _write_raw_brainvision(

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1464,7 +1464,7 @@ def _write_raw_brainvision(raw, bids_fname, events, overwrite):
     # function to pybv that maximizes the resolution parameter while
     # ensuring that int16 can represent the data in original units.
     if raw.orig_format != "single":
-        logger.debug(
+        logger.info(
             f'Encountered data in "{raw.orig_format}" format. Converting to float32.'
         )
 


### PR DESCRIPTION
<!--
Thanks for contributing this pull request (PR).
If this is your first time, make sure to read
[CONTRIBUTING.md](https://github.com/mne-tools/mne-bids/blob/main/CONTRIBUTING.md)
-->

PR Description
--------------

When users explicitly request a target format via `write_raw_bids(format=...)`, two `RuntimeWarning`s were previously emitted that duplicated each other in spirit:

1. `"Converting data files to <FORMAT> format"` (outer notice, before each writer call)
2. `'Encountered data in "<FMT>" format. Converting to float32.'` (inner notice from the BrainVision writer)

These notices are noise when the conversion was explicitly requested by the user, and downstream projects (e.g. [MOABB](https://github.com/NeuroTechX/moabb)) have to suppress them with `warnings.filterwarnings(...)` boilerplate around every `write_raw_bids` call.

This PR demotes both notices to log messages instead of warnings:

- The outer `"Converting data files to <FORMAT> format"` (BDF/EDF, EEGLAB, BrainVision branches) is now `logger.info(...)` — visible at the default MNE log level, so users still see what's happening.
- The inner `'Encountered data in "<FMT>" format. Converting to float32.'` is now `logger.debug(...)` — hidden by default since it's an implementation detail; visible via `mne.set_log_level("debug")`.

Source change is 4 sites in `mne_bids/write.py`. The bulk of the diff is test cleanup: dropping `pytest.warns(...)` matchers for warnings that no longer fire.

Closes #1551.

Merge checklist
---------------

Maintainer, please confirm the following before merging.
If applicable:

- [ ] All comments are resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] New contributors have been added to [CITATION.cff](https://github.com/mne-tools/mne-bids/blob/main/CITATION.cff)
- [x] PR description includes phrase "closes <#issue-number>"