### PR TITLE
FIX: more generous scans.tsv reading

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -66,9 +66,8 @@ Detailed list of changes
 - Avoid modifying calibration files by making :func:`mne_bids.write_meg_calibration` copy instead of parsing and rewriting, by `Marijn van Vliet`_ (:gh:`1576`)
 - Fix bug with :meth:`mne_bids.BIDSPath.find_matching_sidecar` not searching parent directories properly, by `Eric Larson`_ (:gh:`1565`)
 - Fix :func:`mne_bids.events_file_to_annotation_kwargs` to drop rows with invalid ``onset`` values (``n/a``, ``nan``, ``NaN``, empty string) before float conversion. This makes reading real-world OpenNeuro datasets (e.g. ``ds004841``, ``ds004842``, ``ds004843``) succeed instead of either raising or returning ``NaN`` onsets, by `Bruno Aristimunha`_ (:gh:`1547`)
-- Fix :func:`mne_bids.read.events_file_to_annotation_kwargs` to fall back to the ``value`` column when ``trial_type`` is entirely ``n/a`` but ``value`` contains trigger codes, instead of dropping all events, by `Bruno Aristimunha`_ (:gh:`947`)
-- Make :func:`mne_bids.read_raw_bids` tolerant of real-world ``scans.tsv`` quirks: malformed ``acq_time`` values, recordings missing from the filename column, and header-only files now warn instead of crashing, and ISO 8601 variants such as space separators and explicit UTC offsets are accepted, by `Bruno Aristimunha`_ (:gh:`1591`)
 - Fix :func:`mne_bids.events_file_to_annotation_kwargs` to fall back to the ``value`` column when ``trial_type`` is entirely ``n/a`` but ``value`` contains trigger codes, instead of dropping all events, by `Bruno Aristimunha`_ (:gh:`947`)
+- :func:`mne_bids.read_raw_bids` now tolerates malformed ``scans.tsv`` entries and ISO 8601 ``acq_time`` variants, by `Bruno Aristimunha`_ (:gh:`1591`)
 
 ⚕️ Code health
 ^^^^^^^^^^^^^^

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -67,6 +67,7 @@ Detailed list of changes
 - Fix bug with :meth:`mne_bids.BIDSPath.find_matching_sidecar` not searching parent directories properly, by `Eric Larson`_ (:gh:`1565`)
 - Fix :func:`mne_bids.events_file_to_annotation_kwargs` to drop rows with invalid ``onset`` values (``n/a``, ``nan``, ``NaN``, empty string) before float conversion. This makes reading real-world OpenNeuro datasets (e.g. ``ds004841``, ``ds004842``, ``ds004843``) succeed instead of either raising or returning ``NaN`` onsets, by `Bruno Aristimunha`_ (:gh:`1547`)
 - Fix :func:`mne_bids.read.events_file_to_annotation_kwargs` to fall back to the ``value`` column when ``trial_type`` is entirely ``n/a`` but ``value`` contains trigger codes, instead of dropping all events, by `Bruno Aristimunha`_ (:gh:`947`)
+- Make :func:`mne_bids.read_raw_bids` tolerant of real-world ``scans.tsv`` quirks: malformed ``acq_time`` values, recordings missing from the filename column, and header-only files now warn instead of crashing, and ISO 8601 variants such as space separators and explicit UTC offsets are accepted, by `Bruno Aristimunha`_
 
 ⚕️ Code health
 ^^^^^^^^^^^^^^

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -398,19 +398,21 @@ def _handle_scans_reading(scans_fname, raw, bids_path):
         ext = fnames[0].suffix
         data_fname = Path(data_fname).with_suffix(ext)
     try:
-        row_ind = _verbose_list_index(fnames, data_fname)
-    except ValueError as exc:
+        row_ind = fnames.index(data_fname)
+    except ValueError:
         row_ind = None
         if fname.endswith(".pdf"):
             alt_fname = Path(bids_path.datatype) / Path(fname).with_suffix("")
             try:
-                row_ind = _verbose_list_index(fnames, alt_fname)
+                row_ind = fnames.index(alt_fname)
                 data_fname = alt_fname
             except ValueError:
                 pass
         if row_ind is None:
+            matches = get_close_matches(str(data_fname), [str(f) for f in fnames])
+            hint = f" Did you mean one of {matches}?" if matches else ""
             warn(
-                f"{data_fname} is not listed in {scans_fname.name} ({exc}). "
+                f"{data_fname} is not listed in {scans_fname.name}.{hint} "
                 "Leaving raw.info['meas_date'] unchanged."
             )
             return raw

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -381,6 +381,8 @@ def _handle_scans_reading(scans_fname, raw, bids_path):
     data_fname = Path(bids_path.datatype) / fname
     fnames = scans_tsv["filename"]
     fnames = [Path(fname) for fname in fnames]
+    if not fnames:  # header-only scans.tsv
+        return raw
     if "acq_time" in scans_tsv:
         acq_times = scans_tsv["acq_time"]
     else:
@@ -398,12 +400,20 @@ def _handle_scans_reading(scans_fname, raw, bids_path):
     try:
         row_ind = _verbose_list_index(fnames, data_fname)
     except ValueError as exc:
+        row_ind = None
         if fname.endswith(".pdf"):
             alt_fname = Path(bids_path.datatype) / Path(fname).with_suffix("")
-            row_ind = _verbose_list_index(fnames, alt_fname)
-            data_fname = alt_fname
-        else:
-            raise exc
+            try:
+                row_ind = _verbose_list_index(fnames, alt_fname)
+                data_fname = alt_fname
+            except ValueError:
+                pass
+        if row_ind is None:
+            warn(
+                f"{data_fname} is not listed in {scans_fname.name} ({exc}). "
+                "Leaving raw.info['meas_date'] unchanged."
+            )
+            return raw
 
     # check whether all split files have the same acq_time
     # and throw an error if they don't
@@ -432,26 +442,26 @@ def _handle_scans_reading(scans_fname, raw, bids_path):
         # time is represented as "local" time. We have no way to know what the local
         # time zone is at the *acquisition* site; so we simply assume the same time zone
         # as the user's current system (this is what the spec demands anyway).
-        acq_time_is_utc = acq_time.endswith("Z")
+        s = acq_time.strip()
+        parsed = None
+        if s and s.lower() != "nan":
+            try:
+                parsed = datetime.fromisoformat(
+                    s.replace("Z", "+00:00") if s.endswith("Z") else s
+                )
+            except ValueError:
+                pass
+        if parsed is None:
+            warn(
+                f"The scans.tsv file {scans_fname} contains an invalid acq_time "
+                f"value: {acq_time!r}. Leaving raw.info['meas_date'] unchanged."
+            )
+            return raw
 
-        # microseconds part in the acquisition time is optional; add it if missing
-        if "." not in acq_time:
-            if acq_time_is_utc:
-                acq_time = acq_time.replace("Z", ".0Z")
-            else:
-                acq_time += ".0"
-
-        date_format = "%Y-%m-%dT%H:%M:%S.%f"
-        if acq_time_is_utc:
-            date_format += "Z"
-
-        acq_time = datetime.strptime(acq_time, date_format)
-
-        if acq_time_is_utc:
-            # Enforce setting timezone to UTC without additonal conversion
-            acq_time = acq_time.replace(tzinfo=UTC)
+        if parsed.tzinfo is not None:
+            acq_time = parsed.astimezone(UTC)
         else:
-            acq_time = _convert_dt_to_utc(acq_time)
+            acq_time = _convert_dt_to_utc(parsed)
 
         logger.debug(f"Loaded {scans_fname} scans file to set acq_time as {acq_time}.")
         # First set measurement date to None and then call call anonymize() to

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -960,14 +960,8 @@ def test_handle_scans_reading_brainvision(tmp_path):
             ("acq_time", ["2000-01-01T12:00:00.000000Z"]),
         ]
     )
-    test_scan_edf = OrderedDict(
-        [
-            ("filename", [Path("eeg/sub-01_ses-eeg_task-rest_eeg.edf")]),
-            ("acq_time", ["2000-01-01T12:00:00.000000Z"]),
-        ]
-    )
     os.mkdir(tmp_path / "eeg")
-    for test_scan in [test_scan_eeg, test_scan_vmrk, test_scan_edf]:
+    for test_scan in [test_scan_eeg, test_scan_vmrk]:
         _to_tsv(test_scan, tmp_path / test_scan["filename"][0])
 
     bids_path = BIDSPath(
@@ -978,12 +972,6 @@ def test_handle_scans_reading_brainvision(tmp_path):
 
     for test_scan in [test_scan_eeg, test_scan_vmrk]:
         _handle_scans_reading(tmp_path / test_scan["filename"][0], raw, bids_path)
-
-    with pytest.warns(RuntimeWarning, match="is not listed in"):
-        out = _handle_scans_reading(
-            tmp_path / test_scan_edf["filename"][0], raw, bids_path
-        )
-    assert out is raw
 
 
 def _scans_setup(tmp_path):

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -1025,10 +1025,11 @@ def test_handle_scans_reading_filename_not_listed(tmp_path):
     """Recording absent from ``scans.tsv`` warns and leaves ``meas_date`` unchanged."""
     raw, bids_path, scans_path = _scans_setup(tmp_path)
     initial = raw.info["meas_date"]
+    fake_fname = Path("eeg/sub-foo_task-bar_eeg.fif")
     _to_tsv(
         OrderedDict(
             [
-                ("filename", [Path("eeg/sub-99_task-test_eeg.fif")]),
+                ("filename", [fake_fname]),
                 ("acq_time", ["2024-02-04T17:47:18.000000Z"]),
             ]
         ),

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -984,46 +984,11 @@ def test_handle_scans_reading_brainvision(tmp_path):
     assert out is raw
 
 
-@pytest.mark.parametrize(
-    "filename, acq_time, warn_match, expected",
-    [
-        # Malformed acq_time → warn, meas_date unchanged.
-        ("eeg/sub-01_task-test_eeg.fif", "not-a-date", "invalid acq_time", None),
-        ("eeg/sub-01_task-test_eeg.fif", "NaN", "invalid acq_time", None),
-        ("eeg/sub-01_task-test_eeg.fif", "", "invalid acq_time", None),
-        # Recording not in scans.tsv → warn, meas_date unchanged.
-        (
-            "eeg/sub-99_task-test_eeg.fif",
-            "2024-02-04T17:47:18.000000Z",
-            "is not listed in",
-            None,
-        ),
-        # Header-only scans.tsv → upstream warn, meas_date unchanged.
-        (None, None, "TSV file is empty", None),
-        # Generous parser succeeds → no warn, meas_date set.
-        (
-            "eeg/sub-01_task-test_eeg.fif",
-            "2024-02-04 17:47:18",
-            None,
-            datetime(2024, 2, 4, 17, 47, 18).astimezone(UTC),
-        ),
-        (
-            "eeg/sub-01_task-test_eeg.fif",
-            "2024-02-04T17:47:18+02:00",
-            None,
-            datetime(2024, 2, 4, 15, 47, 18, tzinfo=UTC),
-        ),
-    ],
-)
-def test_handle_scans_reading_tolerant(
-    tmp_path, filename, acq_time, warn_match, expected
-):
-    """Warn-and-skip on bad inputs; accept generous ISO 8601 variants."""
+def _scans_setup(tmp_path):
     raw = mne.io.RawArray(
         np.zeros((1, 10)), mne.create_info(["EEG001"], sfreq=100, ch_types="eeg")
     )
-    initial = datetime(2020, 1, 1, tzinfo=UTC)
-    raw.set_meas_date(initial)
+    raw.set_meas_date(datetime(2020, 1, 1, tzinfo=UTC))
     bids_path = BIDSPath(
         subject="01",
         task="test",
@@ -1032,22 +997,84 @@ def test_handle_scans_reading_tolerant(
         extension=".fif",
         root=tmp_path,
     )
-    scans_path = tmp_path / "sub-01_scans.tsv"
-    rows = OrderedDict(
-        [
-            ("filename", [Path(filename)] if filename else []),
-            ("acq_time", [acq_time] if acq_time is not None else []),
-        ]
-    )
-    _to_tsv(rows, scans_path)
+    return raw, bids_path, tmp_path / "sub-01_scans.tsv"
 
-    ctx = (
-        pytest.warns(RuntimeWarning, match=warn_match) if warn_match else nullcontext()
+
+@pytest.mark.parametrize("acq_time", ["not-a-date", "NaN", ""])
+def test_handle_scans_reading_invalid_acq_time(tmp_path, acq_time):
+    """Malformed ``acq_time`` warns and leaves ``meas_date`` unchanged."""
+    raw, bids_path, scans_path = _scans_setup(tmp_path)
+    initial = raw.info["meas_date"]
+    _to_tsv(
+        OrderedDict(
+            [
+                ("filename", [Path("eeg/sub-01_task-test_eeg.fif")]),
+                ("acq_time", [acq_time]),
+            ]
+        ),
+        scans_path,
     )
-    with ctx:
+
+    with pytest.warns(RuntimeWarning, match="invalid acq_time"):
         out = _handle_scans_reading(scans_path, raw, bids_path)
     assert out is raw
-    assert raw.info["meas_date"] == (expected or initial)
+    assert raw.info["meas_date"] == initial
+
+
+def test_handle_scans_reading_filename_not_listed(tmp_path):
+    """Recording absent from ``scans.tsv`` warns and leaves ``meas_date`` unchanged."""
+    raw, bids_path, scans_path = _scans_setup(tmp_path)
+    initial = raw.info["meas_date"]
+    _to_tsv(
+        OrderedDict(
+            [
+                ("filename", [Path("eeg/sub-99_task-test_eeg.fif")]),
+                ("acq_time", ["2024-02-04T17:47:18.000000Z"]),
+            ]
+        ),
+        scans_path,
+    )
+
+    with pytest.warns(RuntimeWarning, match="is not listed in"):
+        out = _handle_scans_reading(scans_path, raw, bids_path)
+    assert out is raw
+    assert raw.info["meas_date"] == initial
+
+
+def test_handle_scans_reading_empty(tmp_path):
+    """Header-only ``scans.tsv`` does not crash on the BrainVision suffix block."""
+    raw, bids_path, scans_path = _scans_setup(tmp_path)
+    initial = raw.info["meas_date"]
+    _to_tsv(OrderedDict([("filename", []), ("acq_time", [])]), scans_path)
+
+    with pytest.warns(RuntimeWarning, match="TSV file is empty"):
+        out = _handle_scans_reading(scans_path, raw, bids_path)
+    assert out is raw
+    assert raw.info["meas_date"] == initial
+
+
+@pytest.mark.parametrize(
+    "acq_time, expected",
+    [
+        ("2024-02-04 17:47:18", datetime(2024, 2, 4, 17, 47, 18).astimezone(UTC)),
+        ("2024-02-04T17:47:18+02:00", datetime(2024, 2, 4, 15, 47, 18, tzinfo=UTC)),
+    ],
+)
+def test_handle_scans_reading_iso8601_variants(tmp_path, acq_time, expected):
+    """``fromisoformat`` accepts space separator and explicit UTC offsets."""
+    raw, bids_path, scans_path = _scans_setup(tmp_path)
+    _to_tsv(
+        OrderedDict(
+            [
+                ("filename", [Path("eeg/sub-01_task-test_eeg.fif")]),
+                ("acq_time", [acq_time]),
+            ]
+        ),
+        scans_path,
+    )
+
+    out = _handle_scans_reading(scans_path, raw, bids_path)
+    assert out.info["meas_date"] == expected
 
 
 @pytest.mark.filterwarnings(warning_str["channel_unit_changed"])

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -977,8 +977,77 @@ def test_handle_scans_reading_brainvision(tmp_path):
     for test_scan in [test_scan_eeg, test_scan_vmrk]:
         _handle_scans_reading(tmp_path / test_scan["filename"][0], raw, bids_path)
 
-    with pytest.raises(ValueError, match="not in list"):
-        _handle_scans_reading(tmp_path / test_scan_edf["filename"][0], raw, bids_path)
+    with pytest.warns(RuntimeWarning, match="is not listed in"):
+        out = _handle_scans_reading(
+            tmp_path / test_scan_edf["filename"][0], raw, bids_path
+        )
+    assert out is raw
+
+
+@pytest.mark.parametrize(
+    "filename, acq_time, warn_match, expected",
+    [
+        # Malformed acq_time → warn, meas_date unchanged.
+        ("eeg/sub-01_task-test_eeg.fif", "not-a-date", "invalid acq_time", None),
+        ("eeg/sub-01_task-test_eeg.fif", "NaN", "invalid acq_time", None),
+        ("eeg/sub-01_task-test_eeg.fif", "", "invalid acq_time", None),
+        # Recording not in scans.tsv → warn, meas_date unchanged.
+        (
+            "eeg/sub-99_task-test_eeg.fif",
+            "2024-02-04T17:47:18.000000Z",
+            "is not listed in",
+            None,
+        ),
+        # Header-only scans.tsv → upstream warn, meas_date unchanged.
+        (None, None, "TSV file is empty", None),
+        # Generous parser succeeds → no warn, meas_date set.
+        (
+            "eeg/sub-01_task-test_eeg.fif",
+            "2024-02-04 17:47:18",
+            None,
+            datetime(2024, 2, 4, 17, 47, 18).astimezone(UTC),
+        ),
+        (
+            "eeg/sub-01_task-test_eeg.fif",
+            "2024-02-04T17:47:18+02:00",
+            None,
+            datetime(2024, 2, 4, 15, 47, 18, tzinfo=UTC),
+        ),
+    ],
+)
+def test_handle_scans_reading_tolerant(
+    tmp_path, filename, acq_time, warn_match, expected
+):
+    """Warn-and-skip on bad inputs; accept generous ISO 8601 variants."""
+    raw = mne.io.RawArray(
+        np.zeros((1, 10)), mne.create_info(["EEG001"], sfreq=100, ch_types="eeg")
+    )
+    initial = datetime(2020, 1, 1, tzinfo=UTC)
+    raw.set_meas_date(initial)
+    bids_path = BIDSPath(
+        subject="01",
+        task="test",
+        datatype="eeg",
+        suffix="eeg",
+        extension=".fif",
+        root=tmp_path,
+    )
+    scans_path = tmp_path / "sub-01_scans.tsv"
+    rows = OrderedDict(
+        [
+            ("filename", [Path(filename)] if filename else []),
+            ("acq_time", [acq_time] if acq_time is not None else []),
+        ]
+    )
+    _to_tsv(rows, scans_path)
+
+    ctx = (
+        pytest.warns(RuntimeWarning, match=warn_match) if warn_match else nullcontext()
+    )
+    with ctx:
+        out = _handle_scans_reading(scans_path, raw, bids_path)
+    assert out is raw
+    assert raw.info["meas_date"] == (expected or initial)
 
 
 @pytest.mark.filterwarnings(warning_str["channel_unit_changed"])


### PR DESCRIPTION
Mirrors #1587 for `scans.tsv`. Three small fixes in `_handle_scans_reading`:

1. Malformed `acq_time` (`""`, `"NaN"`, non-ISO strings) now warns and leaves `meas_date` unchanged instead of crashing on `strptime`.
2. Recording absent from the `filename` column now warns and skips instead of raising. The close-matches diagnostic from `_verbose_list_index` is preserved in the warning text.
3. Header-only `scans.tsv` short-circuits instead of `IndexError` on `fnames[0].suffix`.

Also: parse `acq_time` via `datetime.fromisoformat` to accept ISO 8601 variants (space separator, explicit `+HH:MM` offsets, microsecond precisions other than 6 digits). Naive parses still defer to `_convert_dt_to_utc` (post-#1556); tz-aware parses skip straight to `.astimezone(UTC)`.

## Reproducer (end-to-end `read_raw_bids`)

```python
import openneuro
from mne_bids import BIDSPath, read_raw_bids

openneuro.download(
    dataset="ds006377",
    target_dir="/tmp/ds006377",
    include=["sub-225/sub-225_scans.tsv",
             "sub-225/nirs/sub-225_task-001RestingLH_run-1_nirs*",
             "dataset_description.json", "participants.tsv"],
)
bp = BIDSPath(subject="225", task="001RestingLH", run="1",
              datatype="nirs", suffix="nirs", extension=".snirf",
              root="/tmp/ds006377")
raw = read_raw_bids(bp)
print("meas_date:", raw.info["meas_date"])
```

`sub-225_scans.tsv` has empty `acq_time` cells (`filename\tacq_time\nnirs/...\t\n`).

| | result |
|--|--|
| `main` | `ValueError: time data '.0' does not match format '%Y-%m-%dT%H:%M:%S.%f'` (in `datetime.strptime`) |
| this PR | `RuntimeWarning: ... contains an invalid acq_time value: ''. Leaving raw.info['meas_date'] unchanged.` — read continues, `meas_date` retained from the SNIRF file (`2022-05-17 12:37:15+00:00`) |

Other affected dataset: `ds003844` has `acq_time=1934-09-01T13:42:17.9008789` (7-digit microseconds) — this PR truncates via `fromisoformat` rather than crashing. Discovered ingesting OpenNeuro datasets with [eegdash](https://github.com/bruAristimunha/eegdash). Supersedes #1532 (closed by me as too broad).