### PR TITLE
[MRG] ENH: Preserve enriched dataset_description.json and user-authored README

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -48,7 +48,7 @@ Detailed list of changes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - Expected format conversions notices are now logged at ``info`` instead of ``warn`` level, by `Bruno Aristimunha`_ (:gh:`1589`)
-- :func:`mne_bids.write_raw_bids` no longer appends MNE-BIDS citations to user-authored ``README`` files; existing content is preserved unchanged, by `Bruno Aristimunha`_ (:gh:`1550`)
+- Add ``readme`` parameter to :func:`mne_bids.write_raw_bids`; pass ``readme=False`` to leave any existing ``README`` untouched and skip creating one, by `Bruno Aristimunha`_ (:gh:`1550`)
 - :func:`mne_bids.make_dataset_description` preserves BIDS-spec keys it does not model when merging with an existing ``dataset_description.json``, by `Bruno Aristimunha`_ (:gh:`1548`)
 
 🛠 Requirements

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -47,7 +47,8 @@ Detailed list of changes
 🧐 API and behavior changes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-- None yet
+- :func:`mne_bids.write_raw_bids` no longer appends MNE-BIDS citations to a user-authored ``README``. If the file exists with content other than the auto-generated references section it is preserved unchanged; add the citation manually if you want it included. Boilerplate references are still written when the ``README`` is absent or empty, by `Bruno Aristimunha`_ (:gh:`1550`)
+- :func:`mne_bids.make_dataset_description` (and therefore :func:`mne_bids.write_raw_bids`) now preserves BIDS-spec keys it does not model (e.g. ``Description``, ``DatasetLinks``) when merging with an existing ``dataset_description.json``, by `Bruno Aristimunha`_ (:gh:`1548`)
 
 🛠 Requirements
 ^^^^^^^^^^^^^^^

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -485,34 +485,15 @@ def test_make_dataset_description(tmp_path, monkeypatch):
 
 
 def test_make_dataset_description_preserves_unknown_keys(tmp_path):
-    """Custom BIDS-spec fields not modeled by make_dataset_description survive merges.
-
-    Regression test for https://github.com/mne-tools/mne-bids/issues/1548 — calling
-    write_raw_bids (which invokes make_dataset_description with overwrite=False)
-    used to silently drop any keys the OrderedDict didn't model, e.g. the
-    free-form "Description" field.
-    """
+    """Unmodeled keys in dataset_description.json survive merges (gh:1548)."""
     fname = tmp_path / "dataset_description.json"
-    make_dataset_description(
-        path=tmp_path,
-        name="enriched",
-        authors=["Alice", "Bob"],
-        funding=["NIH grant 12345"],
-        overwrite=True,
-    )
+    make_dataset_description(path=tmp_path, name="enriched", overwrite=True)
     desc = json.loads(fname.read_text())
     desc["Description"] = "Free-form custom field"
-    desc["DatasetLinks"] = {"derivative": "../derivatives"}
-    fname.write_text(json.dumps(desc, indent=2))
-
-    # Subsequent call (mirrors the one inside write_raw_bids).
+    fname.write_text(json.dumps(desc))
     make_dataset_description(path=tmp_path, name="[Unspecified]", overwrite=False)
-
     final = json.loads(fname.read_text())
     assert final["Description"] == "Free-form custom field"
-    assert final["DatasetLinks"] == {"derivative": "../derivatives"}
-    assert final["Authors"] == ["Alice", "Bob"]
-    assert final["Funding"] == ["NIH grant 12345"]
     assert final["Name"] == "enriched"
 
 
@@ -834,15 +815,9 @@ def test_fif(_bids_validate, tmp_path):
         assert REFERENCES["mne-bids"] in text
         assert REFERENCES["meg"] in text
 
-    # readme=False leaves the existing README untouched.
     snapshot = Path(readme).read_bytes()
     write_raw_bids(
-        raw,
-        bids_path2,
-        events=events,
-        event_id=event_id,
-        overwrite=True,
-        readme=False,
+        raw, bids_path2, events=events, event_id=event_id, overwrite=True, readme=False
     )
     assert Path(readme).read_bytes() == snapshot
 

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -64,7 +64,7 @@ from mne_bids.utils import (
     _write_json,
     get_anonymization_daysback,
 )
-from mne_bids.write import _get_fid_coords
+from mne_bids.write import _get_fid_coords, _readme
 
 base_path = Path(mne.__file__).parent / "io"
 subject_id = "01"
@@ -484,6 +484,65 @@ def test_make_dataset_description(tmp_path, monkeypatch):
         make_dataset_description(path=tmp_path, name="tst")
 
 
+def test_make_dataset_description_preserves_unknown_keys(tmp_path):
+    """Custom BIDS-spec fields not modeled by make_dataset_description survive merges.
+
+    Regression test for https://github.com/mne-tools/mne-bids/issues/1548 — calling
+    write_raw_bids (which invokes make_dataset_description with overwrite=False)
+    used to silently drop any keys the OrderedDict didn't model, e.g. the
+    free-form "Description" field.
+    """
+    fname = tmp_path / "dataset_description.json"
+    make_dataset_description(
+        path=tmp_path,
+        name="enriched",
+        authors=["Alice", "Bob"],
+        funding=["NIH grant 12345"],
+        overwrite=True,
+    )
+    desc = json.loads(fname.read_text())
+    desc["Description"] = "Free-form custom field"
+    desc["DatasetLinks"] = {"derivative": "../derivatives"}
+    fname.write_text(json.dumps(desc, indent=2))
+
+    # Subsequent call (mirrors the one inside write_raw_bids).
+    make_dataset_description(path=tmp_path, name="[Unspecified]", overwrite=False)
+
+    final = json.loads(fname.read_text())
+    assert final["Description"] == "Free-form custom field"
+    assert final["DatasetLinks"] == {"derivative": "../derivatives"}
+    assert final["Authors"] == ["Alice", "Bob"]
+    assert final["Funding"] == ["NIH grant 12345"]
+    assert final["Name"] == "enriched"
+
+
+def test_readme_preserves_user_authored_content(tmp_path):
+    """User-authored READMEs are not modified across write_raw_bids.
+
+    Regression test for https://github.com/mne-tools/mne-bids/issues/1550 — the
+    helper used to append MNE-BIDS citations to existing user content.
+    """
+    fname = tmp_path / "README"
+    user_text = "My Project\n==========\n\nUser-authored description.\n"
+    fname.write_text(user_text)
+    _readme("meg", fname, overwrite=False)
+    # _write_text adds a UTF-8 BOM, so read with utf-8-sig to compare semantics.
+    assert fname.read_text(encoding="utf-8-sig") == user_text
+
+    # Empty file falls through to writing the boilerplate references.
+    fname.write_text("")
+    _readme("meg", fname, overwrite=False)
+    written = fname.read_text(encoding="utf-8-sig")
+    assert written.startswith("References\n----------")
+    assert REFERENCES["mne-bids"] in written
+    assert REFERENCES["meg"] in written
+
+    # Re-running on a boilerplate-only file is a no-op.
+    snapshot = fname.read_bytes()
+    _readme("meg", fname, overwrite=False)
+    assert fname.read_bytes() == snapshot
+
+
 def test_stamp_to_dt():
     """Test conversions of meas_date to datetime objects."""
     meas_date = (1346981585, 835782)
@@ -787,23 +846,23 @@ def test_fif(_bids_validate, tmp_path):
             raw, bids_path2, events=events, event_id=event_id, overwrite=False
         )
 
-    # assert README has references in it
+    # User-authored README content is preserved as-is and citations are
+    # not appended. https://github.com/mne-tools/mne-bids/issues/1550
     with open(readme, encoding="utf-8-sig") as fid:
         text = fid.read()
         assert "Welcome to my dataset\n" in text
-        assert REFERENCES["mne-bids"] in text
-        assert REFERENCES["meg"] in text
-        assert REFERENCES["eeg"] not in text
-        assert REFERENCES["ieeg"] not in text
+        assert REFERENCES["mne-bids"] not in text
+        assert REFERENCES["meg"] not in text
 
-    # now force the overwrite
+    # now force the overwrite — README still preserved (write_raw_bids does
+    # not propagate overwrite=True to the README writer).
     write_raw_bids(raw, bids_path2, events=events, event_id=event_id, overwrite=True)
 
     with open(readme, encoding="utf-8-sig") as fid:
         text = fid.read()
         assert "Welcome to my dataset\n" in text
-        assert REFERENCES["mne-bids"] in text
-        assert REFERENCES["meg"] in text
+        assert REFERENCES["mne-bids"] not in text
+        assert REFERENCES["meg"] not in text
 
     with pytest.raises(ValueError, match="raw_file must be"):
         write_raw_bids("blah", bids_path)

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -64,7 +64,7 @@ from mne_bids.utils import (
     _write_json,
     get_anonymization_daysback,
 )
-from mne_bids.write import _get_fid_coords, _readme
+from mne_bids.write import _get_fid_coords
 
 base_path = Path(mne.__file__).parent / "io"
 subject_id = "01"
@@ -516,33 +516,6 @@ def test_make_dataset_description_preserves_unknown_keys(tmp_path):
     assert final["Name"] == "enriched"
 
 
-def test_readme_preserves_user_authored_content(tmp_path):
-    """User-authored READMEs are not modified across write_raw_bids.
-
-    Regression test for https://github.com/mne-tools/mne-bids/issues/1550 — the
-    helper used to append MNE-BIDS citations to existing user content.
-    """
-    fname = tmp_path / "README"
-    user_text = "My Project\n==========\n\nUser-authored description.\n"
-    fname.write_text(user_text)
-    _readme("meg", fname, overwrite=False)
-    # _write_text adds a UTF-8 BOM, so read with utf-8-sig to compare semantics.
-    assert fname.read_text(encoding="utf-8-sig") == user_text
-
-    # Empty file falls through to writing the boilerplate references.
-    fname.write_text("")
-    _readme("meg", fname, overwrite=False)
-    written = fname.read_text(encoding="utf-8-sig")
-    assert written.startswith("References\n----------")
-    assert REFERENCES["mne-bids"] in written
-    assert REFERENCES["meg"] in written
-
-    # Re-running on a boilerplate-only file is a no-op.
-    snapshot = fname.read_bytes()
-    _readme("meg", fname, overwrite=False)
-    assert fname.read_bytes() == snapshot
-
-
 def test_stamp_to_dt():
     """Test conversions of meas_date to datetime objects."""
     meas_date = (1346981585, 835782)
@@ -843,23 +816,35 @@ def test_fif(_bids_validate, tmp_path):
             raw, bids_path2, events=events, event_id=event_id, overwrite=False
         )
 
-    # User-authored README content is preserved as-is and citations are
-    # not appended. https://github.com/mne-tools/mne-bids/issues/1550
+    # assert README has references in it
     with open(readme, encoding="utf-8-sig") as fid:
         text = fid.read()
         assert "Welcome to my dataset\n" in text
-        assert REFERENCES["mne-bids"] not in text
-        assert REFERENCES["meg"] not in text
+        assert REFERENCES["mne-bids"] in text
+        assert REFERENCES["meg"] in text
+        assert REFERENCES["eeg"] not in text
+        assert REFERENCES["ieeg"] not in text
 
-    # now force the overwrite — README still preserved (write_raw_bids does
-    # not propagate overwrite=True to the README writer).
+    # now force the overwrite
     write_raw_bids(raw, bids_path2, events=events, event_id=event_id, overwrite=True)
 
     with open(readme, encoding="utf-8-sig") as fid:
         text = fid.read()
         assert "Welcome to my dataset\n" in text
-        assert REFERENCES["mne-bids"] not in text
-        assert REFERENCES["meg"] not in text
+        assert REFERENCES["mne-bids"] in text
+        assert REFERENCES["meg"] in text
+
+    # readme=False leaves the existing README untouched.
+    snapshot = Path(readme).read_bytes()
+    write_raw_bids(
+        raw,
+        bids_path2,
+        events=events,
+        event_id=event_id,
+        overwrite=True,
+        readme=False,
+    )
+    assert Path(readme).read_bytes() == snapshot
 
     with pytest.raises(ValueError, match="raw_file must be"):
         write_raw_bids("blah", bids_path)

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -257,13 +257,13 @@ def _write_tsv(fname, dictionary, *, overwrite=False, lock=True, verbose=None):
     logger.info(f"Writing '{fname}'...")
 
 
-def _write_text(fname, text, overwrite=False):
+def _write_text(fname, text, overwrite=False, lock=True):
     """Write text to a file."""
     if fname.exists() and not overwrite:
         raise FileExistsError(
             f'"{fname}" already exists. Please set overwrite to True.'
         )
-    with _open_lock(fname, "w", encoding="utf-8-sig") as fid:
+    with _open_lock(fname, "w", encoding="utf-8-sig", lock=lock) as fid:
         fid.write(text)
         fid.write("\n")
 

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -590,12 +590,12 @@ def _events_json(
     _write_json(fname, new_data, overwrite=overwrite)
 
 
-def _readme(datatype, fname, overwrite=False):
+def _readme(datatype, fname):
     """Create a README file and save it.
 
-    This will write a README file containing an MNE-BIDS citation.
-    If a README already exists, the behavior depends on the
-    ``overwrite`` parameter, as described below.
+    If a README already exists, append an MNE-BIDS citation to it
+    unless one is already present. Otherwise, create a new README
+    containing an MNE-BIDS citation.
 
     Parameters
     ----------
@@ -603,17 +603,11 @@ def _readme(datatype, fname, overwrite=False):
         The type of data contained in the raw file ('meg', 'eeg', 'ieeg')
     fname : str | mne_bids.BIDSPath
         Filename to save the README to.
-    overwrite : bool
-        Whether to overwrite the existing file (defaults to False).
-        If overwrite is True, create a new README containing an
-        MNE-BIDS citation. If overwrite is False, append an
-        MNE-BIDS citation to the existing README, unless it
-        already contains that citation.
     """
     # Hold the lock across read and write so concurrent writers cannot
     # observe a partially written file.
     with _open_lock(fname):
-        if fname.is_file() and not overwrite:
+        if fname.is_file():
             with open(fname, encoding="utf-8-sig") as fid:
                 orig_data = fid.read()
             mne_bids_ref = REFERENCES["mne-bids"] in orig_data
@@ -2359,7 +2353,7 @@ def write_raw_bids(
     # XXX: can include README overwrite in future if using a template API
     # XXX: see https://github.com/mne-tools/mne-bids/issues/551
     if readme:
-        _readme(bids_path.datatype, readme_fname, False)
+        _readme(bids_path.datatype, readme_fname)
 
     # save all participants meta data
     _participants_tsv(

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -607,23 +607,20 @@ def _readme(datatype, fname):
     # Hold the lock across read and write so concurrent writers cannot
     # observe a partially written file.
     with _open_lock(fname):
+        orig_data = ""
         if fname.is_file():
             with open(fname, encoding="utf-8-sig") as fid:
                 orig_data = fid.read()
-            mne_bids_ref = REFERENCES["mne-bids"] in orig_data
-            datatype_ref = REFERENCES[datatype] in orig_data
-            if mne_bids_ref and datatype_ref:
-                return
-            text = "{}References\n----------\n{}{}".format(
-                orig_data + "\n\n",
-                "" if mne_bids_ref else REFERENCES["mne-bids"] + "\n\n",
-                "" if datatype_ref else REFERENCES[datatype] + "\n",
-            )
-        else:
-            text = "References\n----------\n{}{}".format(
-                REFERENCES["mne-bids"] + "\n\n", REFERENCES[datatype] + "\n"
-            )
-
+        mne_bids_ref = REFERENCES["mne-bids"] in orig_data
+        datatype_ref = REFERENCES[datatype] in orig_data
+        if mne_bids_ref and datatype_ref:
+            return
+        prefix = f"{orig_data}\n\n" if orig_data else ""
+        text = "{}References\n----------\n{}{}".format(
+            prefix,
+            "" if mne_bids_ref else REFERENCES["mne-bids"] + "\n\n",
+            "" if datatype_ref else REFERENCES[datatype] + "\n",
+        )
         _write_text(fname, text, overwrite=True, lock=False)
 
 

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -607,20 +607,20 @@ def _readme(datatype, fname):
     # Hold the lock across read and write so concurrent writers cannot
     # observe a partially written file.
     with _open_lock(fname):
-        orig_data = ""
         if fname.is_file():
-            with open(fname, encoding="utf-8-sig") as fid:
-                orig_data = fid.read()
-        mne_bids_ref = REFERENCES["mne-bids"] in orig_data
-        datatype_ref = REFERENCES[datatype] in orig_data
+            text = fname.read_text("utf-8-sig")
+        else:
+            text = ""
+        mne_bids_ref = REFERENCES["mne-bids"] in text
+        datatype_ref = REFERENCES[datatype] in text
         if mne_bids_ref and datatype_ref:
             return
-        prefix = f"{orig_data}\n\n" if orig_data else ""
-        text = "{}References\n----------\n{}{}".format(
-            prefix,
-            "" if mne_bids_ref else REFERENCES["mne-bids"] + "\n\n",
-            "" if datatype_ref else REFERENCES[datatype] + "\n",
-        )
+        text += "\n\n" if text else ""
+        text += "References\n----------\n"
+        if not mne_bids_ref:
+            text += REFERENCES["mne-bids"] + "\n\n"
+        if not datatype_ref:
+            text += REFERENCES[datatype] + "\n"
         _write_text(fname, text, overwrite=True, lock=False)
 
 

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1701,13 +1701,14 @@ def make_dataset_description(
 
     # Handle potentially existing file contents
     with _open_lock(fname):
+        orig_cols = {}
         if op.isfile(fname):
             try:
                 with open(fname, encoding="utf-8-sig") as fin:
                     orig_cols = json.load(fin)
             except (json.JSONDecodeError, OSError):
                 # File is empty, corrupted, or being written to by another process
-                orig_cols = {}
+                pass
             if "BIDSVersion" in orig_cols and orig_cols["BIDSVersion"] != BIDS_VERSION:
                 warnings.warn(
                     "Conflicting BIDSVersion found in dataset_description.json! "
@@ -1733,10 +1734,9 @@ def make_dataset_description(
         for key in pop_keys:
             description.pop(key)
 
-        # Preserve unmodeled keys from existing file (gh:1548).
-        if op.isfile(fname):
-            for key, val in orig_cols.items():
-                description.setdefault(key, val)
+        # Preserve BIDS-spec keys we do not model (e.g. Description, DatasetLinks).
+        for key, val in orig_cols.items():
+            description.setdefault(key, val)
 
         _write_json(fname, description, overwrite=True, lock=False)
 

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -91,6 +91,7 @@ from mne_bids.utils import (
     _infer_eeg_placement_scheme,
     _stamp_to_dt,
     _write_json,
+    _write_text,
     _write_tsv,
     warn,
 )
@@ -629,13 +630,7 @@ def _readme(datatype, fname, overwrite=False):
                 REFERENCES["mne-bids"] + "\n\n", REFERENCES[datatype] + "\n"
             )
 
-        # Write inline (don't call _write_text — it would acquire the
-        # same lock again, which is not re-entrant across FileLock
-        # instances).
-        with open(fname, "w", encoding="utf-8-sig") as fid:
-            fid.write(text)
-            fid.write("\n")
-        logger.info(f"Writing '{fname}'...")
+        _write_text(fname, text, overwrite=True, lock=False)
 
 
 def _participants_tsv(raw, subject_id, fname, overwrite=False):
@@ -1715,7 +1710,6 @@ def make_dataset_description(
 
     # Handle potentially existing file contents
     with _open_lock(fname):
-        orig_cols = {}
         if op.isfile(fname):
             try:
                 with open(fname, encoding="utf-8-sig") as fin:
@@ -1748,14 +1742,10 @@ def make_dataset_description(
         for key in pop_keys:
             description.pop(key)
 
-        # Preserve any extra keys present in the existing file that this
-        # function does not model (e.g. user-added BIDS-spec fields like
-        # "Description"), so that calling write_raw_bids does not silently
-        # drop enriched metadata.
-        # https://github.com/mne-tools/mne-bids/issues/1548
-        for key, val in orig_cols.items():
-            if key not in description:
-                description[key] = val
+        # Preserve unmodeled keys from existing file (gh:1548).
+        if op.isfile(fname):
+            for key, val in orig_cols.items():
+                description.setdefault(key, val)
 
         _write_json(fname, description, overwrite=True, lock=False)
 
@@ -1982,11 +1972,8 @@ def write_raw_bids(
         If ``False``, no existing data will be overwritten or
         replaced.
     readme : bool
-        Whether to write or update the dataset-level ``README``.
-        Defaults to ``True``: if no ``README`` exists, write a stub
-        containing the MNE-BIDS citation; if one already exists,
-        append the citation when missing. Pass ``False`` to leave
-        any existing ``README`` untouched and to skip creating one.
+        If ``False``, leave any existing ``README`` untouched and do
+        not create one. Defaults to ``True``.
     %(verbose)s
 
     Returns

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -606,9 +606,10 @@ def _readme(datatype, fname, overwrite=False):
     overwrite : bool
         Whether to overwrite the existing file (defaults to False).
         If overwrite is True, create a new README containing an
-        MNE-BIDS citation. If overwrite is False, append an
-        MNE-BIDS citation to the existing README, unless it
-        already contains that citation.
+        MNE-BIDS citation. If overwrite is False, the existing
+        README is preserved as-is when it appears to contain
+        user-authored content; otherwise the auto-generated
+        references are written or completed.
     """
     if fname.is_file() and not overwrite:
         with _open_lock(fname, encoding="utf-8-sig") as fid:
@@ -617,8 +618,22 @@ def _readme(datatype, fname, overwrite=False):
         datatype_ref = REFERENCES[datatype] in orig_data
         if mne_bids_ref and datatype_ref:
             return
+        # Detect user-authored content: a non-empty file that does not
+        # look like the auto-generated references-only README we write
+        # for new datasets. Preserve such content untouched instead of
+        # appending citations to it.
+        # https://github.com/mne-tools/mne-bids/issues/1550
+        if orig_data.strip() and not orig_data.lstrip().startswith(
+            "References\n----------"
+        ):
+            logger.info(
+                f"README at {fname} contains user-authored content; "
+                "leaving it unchanged. Add the MNE-BIDS citation "
+                "manually if you want it included."
+            )
+            return
         text = "{}References\n----------\n{}{}".format(
-            orig_data + "\n\n",
+            orig_data + "\n\n" if orig_data.strip() else "",
             "" if mne_bids_ref else REFERENCES["mne-bids"] + "\n\n",
             "" if datatype_ref else REFERENCES[datatype] + "\n",
         )
@@ -1708,6 +1723,7 @@ def make_dataset_description(
 
     # Handle potentially existing file contents
     with _open_lock(fname):
+        orig_cols = {}
         if op.isfile(fname):
             try:
                 with open(fname, encoding="utf-8-sig") as fin:
@@ -1739,6 +1755,16 @@ def make_dataset_description(
         pop_keys = [key for key, val in description.items() if val is None]
         for key in pop_keys:
             description.pop(key)
+
+        # Preserve any extra keys present in the existing file that this
+        # function does not model (e.g. user-added BIDS-spec fields like
+        # "Description"), so that calling write_raw_bids does not silently
+        # drop enriched metadata.
+        # https://github.com/mne-tools/mne-bids/issues/1548
+        for key, val in orig_cols.items():
+            if key not in description:
+                description[key] = val
+
         _write_json(fname, description, overwrite=True, lock=False)
 
 
@@ -2013,9 +2039,15 @@ def write_raw_bids(
     ``write_raw_bids`` will generate a ``dataset_description.json`` file
     if it does not already exist. Minimal metadata will be written there.
     If one sets ``overwrite`` to ``True`` here, it will not overwrite an
-    existing ``dataset_description.json`` file.
+    existing ``dataset_description.json`` file. Existing fields, including
+    BIDS-spec keys not modeled by :func:`mne_bids.make_dataset_description`
+    (e.g. ``Description``, ``DatasetLinks``), are preserved.
     If you need to add more data there, or overwrite it, then you should
     call :func:`mne_bids.make_dataset_description` directly.
+
+    A ``README`` file is written only if one does not already exist or the
+    existing one is empty. User-authored README content is preserved
+    untouched; the MNE-BIDS citation is no longer appended in that case.
 
     When writing EDF or BDF files, all file extensions are forced to be
     lower-case, in compliance with the BIDS specification.

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -91,7 +91,6 @@ from mne_bids.utils import (
     _infer_eeg_placement_scheme,
     _stamp_to_dt,
     _write_json,
-    _write_text,
     _write_tsv,
     warn,
 )
@@ -606,43 +605,37 @@ def _readme(datatype, fname, overwrite=False):
     overwrite : bool
         Whether to overwrite the existing file (defaults to False).
         If overwrite is True, create a new README containing an
-        MNE-BIDS citation. If overwrite is False, the existing
-        README is preserved as-is when it appears to contain
-        user-authored content; otherwise the auto-generated
-        references are written or completed.
+        MNE-BIDS citation. If overwrite is False, append an
+        MNE-BIDS citation to the existing README, unless it
+        already contains that citation.
     """
-    if fname.is_file() and not overwrite:
-        with _open_lock(fname, encoding="utf-8-sig") as fid:
-            orig_data = fid.read()
-        mne_bids_ref = REFERENCES["mne-bids"] in orig_data
-        datatype_ref = REFERENCES[datatype] in orig_data
-        if mne_bids_ref and datatype_ref:
-            return
-        # Detect user-authored content: a non-empty file that does not
-        # look like the auto-generated references-only README we write
-        # for new datasets. Preserve such content untouched instead of
-        # appending citations to it.
-        # https://github.com/mne-tools/mne-bids/issues/1550
-        if orig_data.strip() and not orig_data.lstrip().startswith(
-            "References\n----------"
-        ):
-            logger.info(
-                f"README at {fname} contains user-authored content; "
-                "leaving it unchanged. Add the MNE-BIDS citation "
-                "manually if you want it included."
+    # Hold the lock across read and write so concurrent writers cannot
+    # observe a partially written file.
+    with _open_lock(fname):
+        if fname.is_file() and not overwrite:
+            with open(fname, encoding="utf-8-sig") as fid:
+                orig_data = fid.read()
+            mne_bids_ref = REFERENCES["mne-bids"] in orig_data
+            datatype_ref = REFERENCES[datatype] in orig_data
+            if mne_bids_ref and datatype_ref:
+                return
+            text = "{}References\n----------\n{}{}".format(
+                orig_data + "\n\n",
+                "" if mne_bids_ref else REFERENCES["mne-bids"] + "\n\n",
+                "" if datatype_ref else REFERENCES[datatype] + "\n",
             )
-            return
-        text = "{}References\n----------\n{}{}".format(
-            orig_data + "\n\n" if orig_data.strip() else "",
-            "" if mne_bids_ref else REFERENCES["mne-bids"] + "\n\n",
-            "" if datatype_ref else REFERENCES[datatype] + "\n",
-        )
-    else:
-        text = "References\n----------\n{}{}".format(
-            REFERENCES["mne-bids"] + "\n\n", REFERENCES[datatype] + "\n"
-        )
+        else:
+            text = "References\n----------\n{}{}".format(
+                REFERENCES["mne-bids"] + "\n\n", REFERENCES[datatype] + "\n"
+            )
 
-    _write_text(fname, text, overwrite=True)
+        # Write inline (don't call _write_text — it would acquire the
+        # same lock again, which is not re-entrant across FileLock
+        # instances).
+        with open(fname, "w", encoding="utf-8-sig") as fid:
+            fid.write(text)
+            fid.write("\n")
+        logger.info(f"Writing '{fname}'...")
 
 
 def _participants_tsv(raw, subject_id, fname, overwrite=False):
@@ -1787,6 +1780,7 @@ def write_raw_bids(
     electrodes_tsv_task=False,
     emg_placement=None,
     overwrite=False,
+    readme=True,
     verbose=None,
 ):
     """Save raw data to a BIDS-compliant folder structure.
@@ -1987,6 +1981,12 @@ def write_raw_bids(
         and ``participants.tsv`` by a user will be retained.
         If ``False``, no existing data will be overwritten or
         replaced.
+    readme : bool
+        Whether to write or update the dataset-level ``README``.
+        Defaults to ``True``: if no ``README`` exists, write a stub
+        containing the MNE-BIDS citation; if one already exists,
+        append the citation when missing. Pass ``False`` to leave
+        any existing ``README`` untouched and to skip creating one.
     %(verbose)s
 
     Returns
@@ -2038,15 +2038,9 @@ def write_raw_bids(
     ``write_raw_bids`` will generate a ``dataset_description.json`` file
     if it does not already exist. Minimal metadata will be written there.
     If one sets ``overwrite`` to ``True`` here, it will not overwrite an
-    existing ``dataset_description.json`` file. Existing fields, including
-    BIDS-spec keys not modeled by :func:`mne_bids.make_dataset_description`
-    (e.g. ``Description``, ``DatasetLinks``), are preserved.
+    existing ``dataset_description.json`` file.
     If you need to add more data there, or overwrite it, then you should
     call :func:`mne_bids.make_dataset_description` directly.
-
-    A ``README`` file is written only if one does not already exist or the
-    existing one is empty. User-authored README content is preserved
-    untouched; the MNE-BIDS citation is no longer appended in that case.
 
     When writing EDF or BDF files, all file extensions are forced to be
     lower-case, in compliance with the BIDS specification.
@@ -2377,7 +2371,8 @@ def write_raw_bids(
     # save readme file unless it already exists
     # XXX: can include README overwrite in future if using a template API
     # XXX: see https://github.com/mne-tools/mne-bids/issues/551
-    _readme(bids_path.datatype, readme_fname, False)
+    if readme:
+        _readme(bids_path.datatype, readme_fname, False)
 
     # save all participants meta data
     _participants_tsv(

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1965,6 +1965,8 @@ def write_raw_bids(
     readme : bool
         If ``False``, leave any existing ``README`` untouched and do
         not create one. Defaults to ``True``.
+
+        .. versionadded:: 0.19
     %(verbose)s
 
     Returns


### PR DESCRIPTION
PR Description
--------------

Two MOABB-driven friction points in ``write_raw_bids``:

- **README** (#1550): add ``readme=True/False`` parameter; default keeps current append-refs behavior; ``readme=False`` skips creating/modifying the file entirely. Also fix racy ``lock→read→unlock→write`` in ``_readme`` to a single lock for the full read-modify-write.
- **dataset_description.json** (#1548): preserve BIDS-spec keys not modeled by ``make_dataset_description`` (e.g. ``Description``, ``DatasetLinks``) when merging with an existing file.

Closes #1548. Closes #1550.

Merge checklist
---------------

- [ ] All comments are resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-bids/blob/main/doc/whats_new.rst) is updated
- [ ] New contributors have been added to [CITATION.cff](https://github.com/mne-tools/mne-bids/blob/main/CITATION.cff)
- [x] PR description includes phrase "closes <#issue-number>"