### PR TITLE
FIX: detect TSV encoding before reading

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -65,6 +65,7 @@ Detailed list of changes
 - Fix :func:`mne_bids.read_raw_bids` and related read paths failing with ``PermissionError`` on datalad/git-annex datasets by keeping the file lock next to the symlink instead of its (read-only) target, and gracefully continuing without a lock when one cannot be created, by `Bruno Aristimunha`_ (:gh:`1569`)
 - Avoid modifying calibration files by making :func:`mne_bids.write_meg_calibration` copy instead of parsing and rewriting, by `Marijn van Vliet`_ (:gh:`1576`)
 - Fix bug with :meth:`mne_bids.BIDSPath.find_matching_sidecar` not searching parent directories properly, by `Eric Larson`_ (:gh:`1565`)
+- TSV reading now detects the file encoding (UTF-8 with/without BOM, UTF-16, or latin-1) before parsing instead of assuming UTF-8. This fixes ``UnicodeDecodeError`` on real-world OpenNeuro datasets that contain non-ASCII characters such as ``µ`` (micro-sign) in ``channels.tsv``, by `Bruno Aristimunha`_
 - Fix :func:`mne_bids.events_file_to_annotation_kwargs` to drop rows with invalid ``onset`` values (``n/a``, ``nan``, ``NaN``, empty string) before float conversion. This makes reading real-world OpenNeuro datasets (e.g. ``ds004841``, ``ds004842``, ``ds004843``) succeed instead of either raising or returning ``NaN`` onsets, by `Bruno Aristimunha`_ (:gh:`1547`)
 - Fix :func:`mne_bids.events_file_to_annotation_kwargs` to fall back to the ``value`` column when ``trial_type`` is entirely ``n/a`` but ``value`` contains trigger codes, instead of dropping all events, by `Bruno Aristimunha`_ (:gh:`947`)
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -65,7 +65,7 @@ Detailed list of changes
 - Fix :func:`mne_bids.read_raw_bids` and related read paths failing with ``PermissionError`` on datalad/git-annex datasets by keeping the file lock next to the symlink instead of its (read-only) target, and gracefully continuing without a lock when one cannot be created, by `Bruno Aristimunha`_ (:gh:`1569`)
 - Avoid modifying calibration files by making :func:`mne_bids.write_meg_calibration` copy instead of parsing and rewriting, by `Marijn van Vliet`_ (:gh:`1576`)
 - Fix bug with :meth:`mne_bids.BIDSPath.find_matching_sidecar` not searching parent directories properly, by `Eric Larson`_ (:gh:`1565`)
-- TSV reading now detects the file encoding (UTF-8 with/without BOM, UTF-16, or latin-1) before parsing instead of assuming UTF-8. This fixes ``UnicodeDecodeError`` on real-world OpenNeuro datasets that contain non-ASCII characters such as ``µ`` (micro-sign) in ``channels.tsv``, by `Bruno Aristimunha`_
+- Detect TSV file encoding before reading, fixing ``UnicodeDecodeError`` on non-UTF-8 sidecars (e.g. ``channels.tsv`` with ``µV`` in latin-1), by `Bruno Aristimunha`_ (:gh:`1593`)
 - Fix :func:`mne_bids.events_file_to_annotation_kwargs` to drop rows with invalid ``onset`` values (``n/a``, ``nan``, ``NaN``, empty string) before float conversion. This makes reading real-world OpenNeuro datasets (e.g. ``ds004841``, ``ds004842``, ``ds004843``) succeed instead of either raising or returning ``NaN`` onsets, by `Bruno Aristimunha`_ (:gh:`1547`)
 - Fix :func:`mne_bids.events_file_to_annotation_kwargs` to fall back to the ``value`` column when ``trial_type`` is entirely ``n/a`` but ``value`` contains trigger codes, instead of dropping all events, by `Bruno Aristimunha`_ (:gh:`947`)
 

--- a/mne_bids/tests/test_tsv_handler.py
+++ b/mne_bids/tests/test_tsv_handler.py
@@ -3,6 +3,7 @@
 # Authors: The MNE-BIDS developers
 # SPDX-License-Identifier: BSD-3-Clause
 
+import codecs
 from collections import OrderedDict as odict
 
 import pytest
@@ -11,6 +12,7 @@ import mne_bids._fileio as _fileio
 from mne_bids.tsv_handler import (
     _combine_rows,
     _contains_row,
+    _detect_tsv_encoding,
     _drop,
     _from_tsv,
     _to_tsv,
@@ -103,6 +105,33 @@ def test_contains_row_different_types():
     data = odict(age=[20, 30, 40, "n/a"])  # string
     row = dict(age=60)  # int
     _contains_row(data, row)
+
+
+@pytest.mark.parametrize(
+    "payload,expected",
+    [
+        (b"name\tunit\nEEG\tuV\n", "utf-8"),
+        ("name\tunit\nEEG\tµV\n".encode(), "utf-8"),
+        (codecs.BOM_UTF8 + b"name\tunit\nEEG\tuV\n", "utf-8-sig"),
+        ("name\tunit\nEEG\tµV\n".encode("utf-16"), "utf-16"),
+        (b"name\tunit\nEEG\t\xb5V\n", "latin-1"),
+    ],
+    ids=["ascii", "utf8", "utf8-bom", "utf16", "latin1"],
+)
+def test_detect_tsv_encoding(tmp_path, payload, expected):
+    """Encoding is detected deterministically from BOM and UTF-8 validity."""
+    tsv = tmp_path / "test.tsv"
+    tsv.write_bytes(payload)
+    assert _detect_tsv_encoding(tsv) == expected
+
+
+def test_from_tsv_latin1_warns(tmp_path):
+    """``_from_tsv`` reads non-UTF-8 TSV files as latin-1 with a warning."""
+    tsv = tmp_path / "channels.tsv"
+    tsv.write_bytes(b"name\tunit\nEEG\t\xb5V\n")  # 'µV' in latin-1
+    with pytest.warns(RuntimeWarning, match="not UTF-8"):
+        d = _from_tsv(tsv)
+    assert d["unit"] == ["µV"]
 
 
 def test_drop_different_types():

--- a/mne_bids/tests/test_tsv_handler.py
+++ b/mne_bids/tests/test_tsv_handler.py
@@ -12,7 +12,7 @@ import mne_bids._fileio as _fileio
 from mne_bids.tsv_handler import (
     _combine_rows,
     _contains_row,
-    _detect_tsv_encoding,
+    _detect_file_encoding,
     _drop,
     _from_tsv,
     _to_tsv,
@@ -118,11 +118,11 @@ def test_contains_row_different_types():
     ],
     ids=["ascii", "utf8", "utf8-bom", "utf16", "latin1"],
 )
-def test_detect_tsv_encoding(tmp_path, payload, expected):
+def test_detect_file_encoding(tmp_path, payload, expected):
     """Encoding is detected deterministically from BOM and UTF-8 validity."""
-    tsv = tmp_path / "test.tsv"
-    tsv.write_bytes(payload)
-    assert _detect_tsv_encoding(tsv) == expected
+    fpath = tmp_path / "test.tsv"
+    fpath.write_bytes(payload)
+    assert _detect_file_encoding(fpath) == expected
 
 
 def test_from_tsv_latin1_warns(tmp_path):

--- a/mne_bids/tests/test_tsv_handler.py
+++ b/mne_bids/tests/test_tsv_handler.py
@@ -7,6 +7,7 @@ import codecs
 from collections import OrderedDict as odict
 
 import pytest
+from mne.utils import catch_logging
 
 import mne_bids._fileio as _fileio
 from mne_bids.tsv_handler import (
@@ -125,13 +126,14 @@ def test_detect_file_encoding(tmp_path, payload, expected):
     assert _detect_file_encoding(fpath) == expected
 
 
-def test_from_tsv_latin1_warns(tmp_path):
-    """``_from_tsv`` reads non-UTF-8 TSV files as latin-1 with a warning."""
+def test_from_tsv_latin1_logs_info(tmp_path):
+    """``_from_tsv`` reads non-UTF-8 TSV files and emits a soft info message."""
     tsv = tmp_path / "channels.tsv"
     tsv.write_bytes(b"name\tunit\nEEG\t\xb5V\n")  # 'µV' in latin-1
-    with pytest.warns(RuntimeWarning, match="not UTF-8"):
+    with catch_logging(verbose="info") as log:
         d = _from_tsv(tsv)
     assert d["unit"] == ["µV"]
+    assert "non-UTF-8" in log.getvalue()
 
 
 def test_drop_different_types():

--- a/mne_bids/tsv_handler.py
+++ b/mne_bids/tsv_handler.py
@@ -8,6 +8,7 @@ from collections import OrderedDict
 from copy import deepcopy
 
 import numpy as np
+from mne.utils import logger
 
 from mne_bids._fileio import _open_lock
 
@@ -172,7 +173,7 @@ def _from_tsv(fname, dtypes=None):
 
     encoding = _detect_file_encoding(fname)
     if not encoding.startswith("utf-8"):
-        warn(f"TSV file is not UTF-8 encoded, reading as latin-1: '{fname}'")
+        logger.info(f"Reading non-UTF-8 TSV as {encoding}: '{fname}'")
     data = np.loadtxt(
         fname, dtype=str, delimiter="\t", ndmin=2, comments=None, encoding=encoding
     )

--- a/mne_bids/tsv_handler.py
+++ b/mne_bids/tsv_handler.py
@@ -3,12 +3,28 @@
 # Authors: The MNE-BIDS developers
 # SPDX-License-Identifier: BSD-3-Clause
 
+import codecs
 from collections import OrderedDict
 from copy import deepcopy
+from pathlib import Path
 
 import numpy as np
 
 from mne_bids._fileio import _open_lock
+
+
+def _detect_tsv_encoding(fname):
+    """Deterministically detect the encoding of a TSV file."""
+    raw = Path(fname).read_bytes()
+    if raw.startswith(codecs.BOM_UTF8):
+        return "utf-8-sig"
+    if raw.startswith((codecs.BOM_UTF16_LE, codecs.BOM_UTF16_BE)):
+        return "utf-16"
+    try:
+        raw.decode("utf-8")
+        return "utf-8"
+    except UnicodeDecodeError:
+        return "latin-1"
 
 
 def _combine_rows(data1, data2, drop_column=None):
@@ -147,8 +163,11 @@ def _from_tsv(fname, dtypes=None):
     """
     from .utils import warn  # avoid circular import
 
+    encoding = _detect_tsv_encoding(fname)
+    if encoding == "latin-1":
+        warn(f"TSV file is not UTF-8 encoded, reading as latin-1: '{fname}'")
     data = np.loadtxt(
-        fname, dtype=str, delimiter="\t", ndmin=2, comments=None, encoding="utf-8-sig"
+        fname, dtype=str, delimiter="\t", ndmin=2, comments=None, encoding=encoding
     )
     # Handle empty files - data may be empty or only have a header
     if data.size == 0:

--- a/mne_bids/tsv_handler.py
+++ b/mne_bids/tsv_handler.py
@@ -13,15 +13,15 @@ import numpy as np
 from mne_bids._fileio import _open_lock
 
 
-def _detect_tsv_encoding(fname):
-    """Deterministically detect the encoding of a TSV file."""
-    raw = Path(fname).read_bytes()
-    if raw.startswith(codecs.BOM_UTF8):
+def _detect_file_encoding(fname):
+    """Deterministically detect the text encoding of a file."""
+    byte_content = Path(fname).read_bytes()
+    if byte_content.startswith(codecs.BOM_UTF8):
         return "utf-8-sig"
-    if raw.startswith((codecs.BOM_UTF16_LE, codecs.BOM_UTF16_BE)):
+    if byte_content.startswith((codecs.BOM_UTF16_LE, codecs.BOM_UTF16_BE)):
         return "utf-16"
     try:
-        raw.decode("utf-8")
+        byte_content.decode("utf-8")
         return "utf-8"
     except UnicodeDecodeError:
         return "latin-1"
@@ -163,7 +163,7 @@ def _from_tsv(fname, dtypes=None):
     """
     from .utils import warn  # avoid circular import
 
-    encoding = _detect_tsv_encoding(fname)
+    encoding = _detect_file_encoding(fname)
     if encoding == "latin-1":
         warn(f"TSV file is not UTF-8 encoded, reading as latin-1: '{fname}'")
     data = np.loadtxt(

--- a/mne_bids/tsv_handler.py
+++ b/mne_bids/tsv_handler.py
@@ -171,7 +171,7 @@ def _from_tsv(fname, dtypes=None):
     from .utils import warn  # avoid circular import
 
     encoding = _detect_file_encoding(fname)
-    if encoding == "latin-1":
+    if not encoding.startswith("utf-8"):
         warn(f"TSV file is not UTF-8 encoded, reading as latin-1: '{fname}'")
     data = np.loadtxt(
         fname, dtype=str, delimiter="\t", ndmin=2, comments=None, encoding=encoding

--- a/mne_bids/tsv_handler.py
+++ b/mne_bids/tsv_handler.py
@@ -6,22 +6,29 @@
 import codecs
 from collections import OrderedDict
 from copy import deepcopy
-from pathlib import Path
 
 import numpy as np
 
 from mne_bids._fileio import _open_lock
 
 
-def _detect_file_encoding(fname):
-    """Deterministically detect the text encoding of a file."""
-    byte_content = Path(fname).read_bytes()
-    if byte_content.startswith(codecs.BOM_UTF8):
+def _detect_file_encoding(fname, chunk_size=65536):
+    """Detect the text encoding of a file from its first chunk.
+
+    Checks for a BOM and otherwise tests UTF-8 validity on a single chunk
+    (default 64 KiB), falling back to ``latin-1``. Avoids reading the full
+    file: enough to catch non-UTF-8 bytes in typical BIDS TSV files (e.g.
+    ``µV`` in ``channels.tsv``).
+    """
+    with open(fname, "rb") as f:
+        chunk = f.read(chunk_size)
+    if chunk.startswith(codecs.BOM_UTF8):
         return "utf-8-sig"
-    if byte_content.startswith((codecs.BOM_UTF16_LE, codecs.BOM_UTF16_BE)):
+    if chunk.startswith((codecs.BOM_UTF16_LE, codecs.BOM_UTF16_BE)):
         return "utf-16"
+    decoder = codecs.getincrementaldecoder("utf-8")()
     try:
-        byte_content.decode("utf-8")
+        decoder.decode(chunk, final=False)
         return "utf-8"
     except UnicodeDecodeError:
         return "latin-1"


### PR DESCRIPTION
Closes #1594.

Real-world OpenNeuro datasets sometimes ship `channels.tsv` (and friends) in `latin-1` rather than UTF-8 — typically because of the `µ` sign in the `unit` column. `_from_tsv` hardcoded `utf-8-sig` and crashed.

Add a small deterministic encoding detector and feed the result straight into `np.loadtxt`:

```python
def _detect_file_encoding(fname):
    raw = Path(fname).read_bytes()
    if raw.startswith(codecs.BOM_UTF8):
        return "utf-8-sig"
    if raw.startswith((codecs.BOM_UTF16_LE, codecs.BOM_UTF16_BE)):
        return "utf-16"
    try:
        raw.decode("utf-8")
        return "utf-8"
    except UnicodeDecodeError:
        return "latin-1"
```

I think it could potentially be used as complemented of #1531 by @scott-huberty.

## Reproducer (end-to-end `read_raw_bids` on a real OpenNeuro dataset)

```python
import openneuro
from mne_bids import BIDSPath, read_raw_bids

openneuro.download(
    dataset="ds004621",
    target_dir="/tmp/ds004621",
    include=["dataset_description.json", "participants.tsv",
             "sub-13/eeg/sub-13_task-rest_*"],
)
bp = BIDSPath(subject="13", task="rest", datatype="eeg",
              suffix="eeg", extension=".vhdr", root="/tmp/ds004621")
raw = read_raw_bids(bp, on_ch_mismatch="rename")
print(f"OK — {len(raw.ch_names)} channels, {raw.n_times} samples")
```

| | result |
|--|--|
| `main` | `UnicodeDecodeError: 'utf-8' codec can't decode byte 0xb5 in position 25: invalid start byte` (deep in `numpy.loadtxt`) |
| this PR | `OK — 127 channels, 711840 samples` |

The offending bytes are `\xb5V` (`µV`) in the `units` column of `sub-13_task-rest_channels.tsv`. Same pattern affects `ds003620` (160 files), `ds005692` (59 files), `ds004598` (20 files), `ds005691` (8 iEEG files), and more.

Tests cover the 5 encoding cases (ASCII / UTF-8 / UTF-8-BOM / UTF-16 / latin-1) plus an integration test that verifies the warning fires and `µV` is read correctly.