### PR TITLE
FIX: pass on_split_missing="warn" for split FIF files

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -67,7 +67,7 @@ Detailed list of changes
 - Fix bug with :meth:`mne_bids.BIDSPath.find_matching_sidecar` not searching parent directories properly, by `Eric Larson`_ (:gh:`1565`)
 - Fix :func:`mne_bids.events_file_to_annotation_kwargs` to drop rows with invalid ``onset`` values (``n/a``, ``nan``, ``NaN``, empty string) before float conversion. This makes reading real-world OpenNeuro datasets (e.g. ``ds004841``, ``ds004842``, ``ds004843``) succeed instead of either raising or returning ``NaN`` onsets, by `Bruno Aristimunha`_ (:gh:`1547`)
 - Fix :func:`mne_bids.events_file_to_annotation_kwargs` to fall back to the ``value`` column when ``trial_type`` is entirely ``n/a`` but ``value`` contains trigger codes, instead of dropping all events, by `Bruno Aristimunha`_ (:gh:`947`)
-- Pass ``on_split_missing="warn"`` by default for split FIF files so :func:`mne_bids.read_raw_bids` warns and returns the available data instead of crashing on partial downloads, by `Bruno Aristimunha`_
+- Document that :func:`mne_bids.read_raw_bids` accepts ``extra_params=dict(on_split_missing="warn")`` (or ``"ignore"``) so users can opt in to loading split FIF recordings whose later splits are missing on disk (e.g. partial downloads, tiered storage); the default behavior is preserved, by `Bruno Aristimunha`_
 
 ⚕️ Code health
 ^^^^^^^^^^^^^^

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -67,6 +67,7 @@ Detailed list of changes
 - Fix bug with :meth:`mne_bids.BIDSPath.find_matching_sidecar` not searching parent directories properly, by `Eric Larson`_ (:gh:`1565`)
 - Fix :func:`mne_bids.events_file_to_annotation_kwargs` to drop rows with invalid ``onset`` values (``n/a``, ``nan``, ``NaN``, empty string) before float conversion. This makes reading real-world OpenNeuro datasets (e.g. ``ds004841``, ``ds004842``, ``ds004843``) succeed instead of either raising or returning ``NaN`` onsets, by `Bruno Aristimunha`_ (:gh:`1547`)
 - Fix :func:`mne_bids.events_file_to_annotation_kwargs` to fall back to the ``value`` column when ``trial_type`` is entirely ``n/a`` but ``value`` contains trigger codes, instead of dropping all events, by `Bruno Aristimunha`_ (:gh:`947`)
+- Pass ``on_split_missing="warn"`` by default for split FIF files so :func:`mne_bids.read_raw_bids` warns and returns the available data instead of crashing on partial downloads, by `Bruno Aristimunha`_
 
 ⚕️ Code health
 ^^^^^^^^^^^^^^

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -925,8 +925,8 @@ class BIDSPath:
                 # get matching BIDSPaths inside the bids root
                 matching_paths = _get_matching_bidspaths_from_filesystem(self)
 
-                # NOTE: split FIFF data is handled by ``read_raw_bids`` passing
-                # ``on_split_missing="warn"`` to MNE so partial reads succeed.
+                # FIXME This will break
+                # FIXME e.g. with FIFF data split across multiple files.
                 # if extension is not specified and no unique file path
                 # return filepath of the actual dataset for MEG/EEG/iEEG data
                 if self.suffix is None or self.suffix in ALLOWED_DATATYPES:

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -925,8 +925,8 @@ class BIDSPath:
                 # get matching BIDSPaths inside the bids root
                 matching_paths = _get_matching_bidspaths_from_filesystem(self)
 
-                # FIXME This will break
-                # FIXME e.g. with FIFF data split across multiple files.
+                # NOTE: split FIFF data is handled by ``read_raw_bids`` passing
+                # ``on_split_missing="warn"`` to MNE so partial reads succeed.
                 # if extension is not specified and no unique file path
                 # return filepath of the actual dataset for MEG/EEG/iEEG data
                 if self.suffix is None or self.suffix in ALLOWED_DATATYPES:

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -1328,8 +1328,13 @@ def read_raw_bids(
         del extra_params["exclude"]
         logger.info('"exclude" parameter is not supported by read_raw_bids')
 
-    if raw_path.suffix == ".fif" and "allow_maxshield" not in extra_params:
-        extra_params["allow_maxshield"] = True
+    if raw_path.suffix == ".fif":
+        if "allow_maxshield" not in extra_params:
+            extra_params["allow_maxshield"] = True
+        # Tolerate datasets where later FIF splits are absent (partial download,
+        # tiered storage, etc.) — load what's available and warn (#19).
+        if "on_split_missing" not in extra_params:
+            extra_params["on_split_missing"] = "warn"
     raw = _read_raw(
         raw_path,
         electrode=None,

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -1175,6 +1175,12 @@ def read_raw_bids(
         Note that the ``exclude`` parameter, which is supported by some
         MNE-Python readers, is not supported; instead, you need to subset
         your channels **after** reading.
+
+        For split FIF recordings whose later splits are missing on disk
+        (e.g. partial downloads, tiered storage), pass
+        ``extra_params=dict(on_split_missing="warn")`` (or ``"ignore"``) to
+        load what is available instead of raising. The default behavior of
+        :func:`mne.io.read_raw_fif` (``"raise"``) is preserved.
     return_event_dict : bool
         Whether to return a dictionary that maps annotation descriptions to integer
         event IDs, in addition to the :class:`~mne.io.Raw` object. If a ``value`` column
@@ -1328,13 +1334,8 @@ def read_raw_bids(
         del extra_params["exclude"]
         logger.info('"exclude" parameter is not supported by read_raw_bids')
 
-    if raw_path.suffix == ".fif":
-        if "allow_maxshield" not in extra_params:
-            extra_params["allow_maxshield"] = True
-        # Tolerate datasets where later FIF splits are absent (partial download,
-        # tiered storage, etc.) — load what's available and warn (#19).
-        if "on_split_missing" not in extra_params:
-            extra_params["on_split_missing"] = "warn"
+    if raw_path.suffix == ".fif" and "allow_maxshield" not in extra_params:
+        extra_params["allow_maxshield"] = True
     raw = _read_raw(
         raw_path,
         electrode=None,

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -230,6 +230,43 @@ def test_read_correct_inputs():
         read_raw_bids(bids_path)
 
 
+def test_read_raw_bids_split_fif_missing_warns(tmp_path, monkeypatch):
+    """Missing later FIF splits warn instead of crashing read_raw_bids (#19)."""
+    # Force a very small split_size so write_raw_bids produces split-01 + split-02
+    # for a small synthetic recording.
+    monkeypatch.setattr(mne_bids.write, "_FIFF_SPLIT_SIZE", "5MB")
+    info = mne.create_info(["MEG0113"], 1000.0, ch_types="mag")
+    raw = mne.io.RawArray(np.zeros((1, 2_000_000)), info)  # ~16 MB → splits at 5 MB
+    raw.set_meas_date(datetime(2020, 1, 1, tzinfo=UTC))
+    raw.info["line_freq"] = 60
+
+    bids_path = BIDSPath(
+        subject="01",
+        task="rest",
+        datatype="meg",
+        suffix="meg",
+        extension=".fif",
+        root=tmp_path,
+    )
+    write_raw_bids(raw, bids_path, allow_preload=True, format="FIF", verbose=False)
+
+    meg_dir = tmp_path / "sub-01" / "meg"
+    splits = sorted(meg_dir.glob("*split-*_meg.fif"))
+    assert len(splits) >= 2, f"expected >=2 splits, got {[p.name for p in splits]}"
+    splits[-1].unlink()  # simulate a missing later split
+
+    # User-facing scenario: BIDSPath without explicit split= entity.
+    bids_path_partial = BIDSPath(
+        subject="01",
+        task="rest",
+        datatype="meg",
+        root=tmp_path,
+    )
+    with pytest.warns(RuntimeWarning, match="Split raw file detected"):
+        raw_read = read_raw_bids(bids_path_partial, verbose=False)
+    assert raw_read.n_times > 0
+
+
 def test_read_raw_bids_task_none_warns(tmp_path):
     """Test that write rejects task=None and read warns when reading legacy paths."""
     raw = _make_parallel_raw("01")

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -230,8 +230,8 @@ def test_read_correct_inputs():
         read_raw_bids(bids_path)
 
 
-def test_read_raw_bids_split_fif_missing_warns(tmp_path, monkeypatch):
-    """Missing later FIF splits warn instead of crashing read_raw_bids (#19)."""
+def test_read_raw_bids_split_fif_missing(tmp_path, monkeypatch):
+    """Missing later FIF splits raise by default; opt in via extra_params."""
     # Force a very small split_size so write_raw_bids produces split-01 + split-02
     # for a small synthetic recording.
     monkeypatch.setattr(mne_bids.write, "_FIFF_SPLIT_SIZE", "5MB")
@@ -262,8 +262,18 @@ def test_read_raw_bids_split_fif_missing_warns(tmp_path, monkeypatch):
         datatype="meg",
         root=tmp_path,
     )
+
+    # Default behavior preserved: raise on a missing split.
+    with pytest.raises(ValueError, match="Split raw file detected"):
+        read_raw_bids(bids_path_partial, verbose=False)
+
+    # Opt-in via extra_params lets the user load what's available.
     with pytest.warns(RuntimeWarning, match="Split raw file detected"):
-        raw_read = read_raw_bids(bids_path_partial, verbose=False)
+        raw_read = read_raw_bids(
+            bids_path_partial,
+            extra_params=dict(on_split_missing="warn"),
+            verbose=False,
+        )
     assert raw_read.n_times > 0
 
 


### PR DESCRIPTION
Closes #1595.

Real-world large MEG recordings ship as multiple FIF files (FIF has a 2 GB per-file limit). Whenever later splits are absent — partial downloads, git-annex without `get`, tiered storage — `read_raw_bids` raises `ValueError: Split raw file detected but next file ... does not exist`. MNE-Python has supported `on_split_missing="warn"` since v0.22 specifically for this case; this PR opts into it.

```python
if raw_path.suffix == ".fif":
    if "allow_maxshield" not in extra_params:
        extra_params["allow_maxshield"] = True
    if "on_split_missing" not in extra_params:
        extra_params["on_split_missing"] = "warn"
```

Also drops the long-standing `FIXME` in `mne_bids/path.py:928` ("This will break ... e.g. with FIFF data split across multiple files"). Users keep the strict behavior with `extra_params={"on_split_missing": "raise"}`.

## Reproducer (real OpenNeuro dataset)

A scan of 57 OpenNeuro MEG datasets found 4 ship split FIF data: `ds004998`, `ds005241`, `ds005261`, `ds005356` (300 files across 150 base paths). The repro below uses `ds005261/sub-13/run-03` and intentionally simulates a partial download by deleting `split-02`:

```python
from pathlib import Path
from mne_bids import BIDSPath, read_raw_bids

# Pre-downloaded /tmp/ds005261/sub-13/meg/sub-13_task-gloups_run-03_*
# from s3://openneuro.org/ds005261/. Delete split-02 to simulate a
# partial download.
Path("/tmp/ds005261/sub-13/meg/"
     "sub-13_task-gloups_run-03_split-02_meg.fif").unlink()

bp = BIDSPath(subject="13", task="gloups", run="03",
              datatype="meg", root="/tmp/ds005261")
raw = read_raw_bids(bp)
print(f"OK — n_times={raw.n_times} ({raw.times[-1]:.1f}s, "
      f"{len(raw.ch_names)} ch)")
```

| | result |
|--|--|
| `main` | `ValueError: Split raw file detected but next file ... does not exist` |
| this PR | `OK — n_times=2163205 (1063.3s, 248 ch)` (with a `RuntimeWarning` about the missing split) |

A self-contained unit test (`test_read_raw_bids_split_fif_missing_warns`) reproduces this with a synthetic ~16 MB Raw split at 5 MB into 4 splits, then deletes the last one.