### PR TITLE
FIX: write *_electrodes.json with SpatialReference for derivative datasets

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -70,6 +70,7 @@ Detailed list of changes
 - Fix :func:`mne_bids.events_file_to_annotation_kwargs` to drop rows with invalid ``onset`` values (``n/a``, ``nan``, ``NaN``, empty string) before float conversion. This makes reading real-world OpenNeuro datasets (e.g. ``ds004841``, ``ds004842``, ``ds004843``) succeed instead of either raising or returning ``NaN`` onsets, by `Bruno Aristimunha`_ (:gh:`1547`)
 - Fix :func:`mne_bids.events_file_to_annotation_kwargs` to fall back to the ``value`` column when ``trial_type`` is entirely ``n/a`` but ``value`` contains trigger codes, instead of dropping all events, by `Bruno Aristimunha`_ (:gh:`947`)
 - :func:`mne_bids.read_raw_bids` now tolerates malformed ``scans.tsv`` entries and ISO 8601 ``acq_time`` variants, by `Bruno Aristimunha`_ (:gh:`1591`)
+- :func:`mne_bids.write_raw_bids` now writes an ``*_electrodes.json`` sidecar so derivative datasets pass the BIDS validator, by `Bruno Aristimunha`_ (:gh:`1545`)
 
 ⚕️ Code health
 ^^^^^^^^^^^^^^

--- a/mne_bids/dig.py
+++ b/mne_bids/dig.py
@@ -738,6 +738,10 @@ def _write_dig_bids(
         overwrite=overwrite,
     )
     if bids_path.datatype != "nirs":
+        # NIRS uses *_optodes.{tsv,json}; for EEG/iEEG the BIDS spec defines
+        # a *_electrodes.json sidecar whose SpatialReference field the
+        # validator requires for derivative datasets (see #1545):
+        # https://bids-specification.readthedocs.io/en/stable/modality-specific-files/electroencephalography.html#electrodes-description-_electrodestsv
         electrodes_json_path = BIDSPath(
             **electrode_file_entities, suffix="electrodes", extension=".json"
         )

--- a/mne_bids/dig.py
+++ b/mne_bids/dig.py
@@ -25,11 +25,13 @@ from mne_bids.config import (
     ALLOWED_SPACES,
     BIDS_COORD_FRAME_DESCRIPTIONS,
     BIDS_COORDINATE_UNITS,
+    BIDS_IEEG_COORDINATE_FRAMES,
     BIDS_STANDARD_TEMPLATE_COORDINATE_SYSTEMS,
     BIDS_TO_MNE_FRAMES,
     MNE_FRAME_TO_STR,
     MNE_STR_TO_FRAME,
     MNE_TO_BIDS_FRAMES,
+    coordsys_standard_template_deprecated,
 )
 from mne_bids.path import BIDSPath
 from mne_bids.tsv_handler import _from_tsv
@@ -484,6 +486,47 @@ def _write_coordsystem_json(
     _write_json(fname, fid_json, overwrite=True)
 
 
+def _write_electrodes_json(fname, *, spatial_reference, overwrite=False):
+    """Write the ``*_electrodes.json`` sidecar (#1545)."""
+    fid_json = {"SpatialReference": spatial_reference}
+    if Path(fname).exists() and not overwrite:
+        with _open_lock(fname, encoding="utf-8-sig") as fin:
+            existing = json.load(fin)
+        if fid_json != existing:
+            raise RuntimeError(
+                f"Trying to write electrodes.json, but it already exists at "
+                f"{fname} and the contents do not match. You must "
+                f"differentiate this electrodes.json file from the existing "
+                f'one, or set "overwrite" to True.'
+            )
+    _write_json(fname, fid_json, overwrite=True)
+
+
+def _infer_spatial_reference(bids_path, coord_frame):
+    """Infer SpatialReference for the ``*_electrodes.json`` sidecar (#1545)."""
+    if coord_frame in (
+        BIDS_STANDARD_TEMPLATE_COORDINATE_SYSTEMS
+        + coordsys_standard_template_deprecated
+    ):
+        return coord_frame
+    if coord_frame in BIDS_IEEG_COORDINATE_FRAMES:
+        query = bids_path.copy().update(
+            datatype="anat",
+            suffix="T1w",
+            task=None,
+            space=None,
+            acquisition=None,
+            run=None,
+            processing=None,
+        )
+        for ext in (".nii.gz", ".nii"):
+            cand = query.copy().update(extension=ext).fpath
+            if cand.exists():
+                return f"bids::{cand.relative_to(bids_path.root).as_posix()}"
+        logger.info(f"No T1w found for sub-{bids_path.subject}; using 'n/a'.")
+    return "n/a"
+
+
 def _write_empty_ieeg_positions(
     bids_path,
     raw,
@@ -530,6 +573,12 @@ def _write_empty_ieeg_positions(
         fname=coordsystem_path,
         datatype=bids_path.datatype,
         overwrite=overwrite,
+    )
+    electrodes_json_path = BIDSPath(
+        **electrode_entities, suffix="electrodes", extension=".json"
+    )
+    _write_electrodes_json(
+        electrodes_json_path, spatial_reference="n/a", overwrite=overwrite
     )
 
 
@@ -688,6 +737,15 @@ def _write_dig_bids(
         datatype=bids_path.datatype,
         overwrite=overwrite,
     )
+    if bids_path.datatype != "nirs":
+        electrodes_json_path = BIDSPath(
+            **electrode_file_entities, suffix="electrodes", extension=".json"
+        )
+        _write_electrodes_json(
+            electrodes_json_path,
+            spatial_reference=_infer_spatial_reference(bids_path, coord_frame),
+            overwrite=overwrite,
+        )
 
 
 def _read_dig_bids(electrodes_fpath, coordsystem_fpath, datatype, raw):

--- a/mne_bids/tests/test_dig.py
+++ b/mne_bids/tests/test_dig.py
@@ -6,6 +6,7 @@ For each supported coordinate frame, implement a test.
 # Authors: The MNE-BIDS developers
 # SPDX-License-Identifier: BSD-3-Clause
 
+import json
 import warnings
 from pathlib import Path
 
@@ -25,6 +26,7 @@ from mne_bids.config import (
 from mne_bids.dig import (
     _ensure_fiducials_ctf_head,
     _infer_coord_unit,
+    _infer_spatial_reference,
     _read_dig_bids,
     _write_dig_bids,
     convert_montage_to_mri,
@@ -559,3 +561,62 @@ def test_ensure_fiducials_ctf_head():
     montage_head = mne.channels.make_dig_montage(ch_pos=ch_pos, coord_frame="head")
     _ensure_fiducials_ctf_head(montage_head)
     assert montage_head.get_positions()["nasion"] is None
+
+
+@pytest.mark.parametrize(
+    "coord_frame, expected",
+    [
+        # head-based EEG frames (defined by landmarks, no image)
+        ("CapTrak", "n/a"),
+        ("EEGLAB", "n/a"),
+        ("EEGLAB-HJ", "n/a"),
+        # head-based MEG frames (would be n/a if they ever reached the helper)
+        ("CTF", "n/a"),
+        ("ElektaNeuromag", "n/a"),
+        # standard templates -> template name
+        ("fsaverage", "fsaverage"),
+        ("MNI152NLin2009cAsym", "MNI152NLin2009cAsym"),
+        ("Talairach", "Talairach"),
+        # deprecated templates -> template name
+        ("fsaverage5", "fsaverage5"),
+        # wildcard / arbitrary EMG -> n/a
+        ("Other", "n/a"),
+        ("MyCustomEmgSpace", "n/a"),
+    ],
+)
+def test_infer_spatial_reference_branches(tmp_path, coord_frame, expected):
+    """All non-iEEG-MRI BIDS coord frames map to the right SpatialReference (#1545)."""
+    bp = BIDSPath(subject="01", root=tmp_path)
+    assert _infer_spatial_reference(bp, coord_frame) == expected
+
+
+@pytest.mark.parametrize("coord_frame", ["ACPC", "ScanRAS", "Pixels"])
+def test_infer_spatial_reference_subject_mri(tmp_path, coord_frame):
+    """IEEG subject-MRI frames link to the subject T1w when present (#1545)."""
+    bp = BIDSPath(subject="01", session="01", root=tmp_path)
+    assert _infer_spatial_reference(bp, coord_frame) == "n/a"
+    anat_dir = tmp_path / "sub-01" / "ses-01" / "anat"
+    anat_dir.mkdir(parents=True)
+    (anat_dir / "sub-01_ses-01_T1w.nii.gz").touch()
+    assert _infer_spatial_reference(bp, coord_frame) == (
+        "bids::sub-01/ses-01/anat/sub-01_ses-01_T1w.nii.gz"
+    )
+
+
+@testing.requires_testing_data
+def test_electrodes_json_written(tmp_path):
+    """``write_raw_bids`` writes ``*_electrodes.json`` with SpatialReference (#1545)."""
+    bids_root = tmp_path / "bids"
+    (bids_root / "sub-01" / "ses-01" / "eeg").mkdir(parents=True)
+    raw = _load_raw()
+    raw.pick(["eeg"])
+    bids_path = _bids_path.copy().update(root=bids_root, datatype="eeg")
+    _write_dig_bids(bids_path, raw, raw.get_montage(), acpc_aligned=True)
+    elec_json = bids_path.copy().update(
+        task=None,
+        run=None,
+        space="CapTrak",
+        suffix="electrodes",
+        extension=".json",
+    )
+    assert json.loads(elec_json.fpath.read_text())["SpatialReference"] == "n/a"

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -3131,13 +3131,28 @@ def test_coordsystem_json_compliance(
         )
         elecs_tsv = _from_tsv(electrodes_fname)
 
+        # electrodes.json mismatch on rewrite (#1545)
+        electrodes_json_fname = _find_matching_sidecar(
+            bids_output_path, suffix="electrodes", extension=".json"
+        )
+        with open(electrodes_json_fname, encoding="utf-8") as fin:
+            original_electrodes_json = json.load(fin)
+        _write_json(electrodes_json_fname, {"SpatialReference": "blah"}, overwrite=True)
+        kwargs.update(bids_path=bids_path.copy().update(run="04"))
+        with pytest.raises(
+            RuntimeError,
+            match="Trying to write electrodes.json, but it already exists",
+        ):
+            write_raw_bids(**kwargs)
+        _write_json(electrodes_json_fname, original_electrodes_json, overwrite=True)
+
         # electrodes.tsv file, then an error will occur.
         # upon changing electrodes contents, and overwrite not True
         # this will fail
         new_elecs_tsv = elecs_tsv.copy()
         new_elecs_tsv["name"][0] = "blah"
         _to_tsv(new_elecs_tsv, electrodes_fname)
-        kwargs.update(bids_path=bids_path.copy().update(run="04"))
+        kwargs.update(bids_path=bids_path.copy().update(run="05"))
         with pytest.raises(
             RuntimeError,
             match="Trying to write electrodes.tsv, but it already exists",


### PR DESCRIPTION
Closes #1545.

Derivative datasets with a `space` entity fail the BIDS validator because the required `*_electrodes.json` (with `SpatialReference`) isn't written. This adds it and infers the value from the coordinate frame: template name for standard templates, a `bids::` URI to the subject T1w for `ACPC`/`ScanRAS`/`Pixels`, and `"n/a"` for head-based frames.

## Reproducer

```python
from mne_bids import write_raw_bids, BIDSPath, make_dataset_description

bp = BIDSPath(subject="01", task="test", root="/tmp/x", datatype="eeg")
write_raw_bids(raw, bp, overwrite=True)
make_dataset_description(path="/tmp/x", name="x", dataset_type="derivative", overwrite=True)
```

| | `deno -A jsr:@bids/validator /tmp/x` |
|--|--|
| `main` | `[ERROR] SIDECAR_KEY_REQUIRED: SpatialReference` |
| this PR | 0 errors |