### PR TITLE
FIX: strip whitespace and normalize decimal commas in TSV cells

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -71,6 +71,7 @@ Detailed list of changes
 - Fix :func:`mne_bids.events_file_to_annotation_kwargs` to drop rows with invalid ``onset`` values (``n/a``, ``nan``, ``NaN``, empty string) before float conversion. This makes reading real-world OpenNeuro datasets (e.g. ``ds004841``, ``ds004842``, ``ds004843``) succeed instead of either raising or returning ``NaN`` onsets, by `Bruno Aristimunha`_ (:gh:`1547`)
 - Fix :func:`mne_bids.events_file_to_annotation_kwargs` to fall back to the ``value`` column when ``trial_type`` is entirely ``n/a`` but ``value`` contains trigger codes, instead of dropping all events, by `Bruno Aristimunha`_ (:gh:`947`)
 - :func:`mne_bids.read_raw_bids` now tolerates malformed ``scans.tsv`` entries and ISO 8601 ``acq_time`` variants, by `Bruno Aristimunha`_ (:gh:`1591`)
+- :func:`mne_bids.read_raw_bids` now strips whitespace-padded ``n/a`` cells and normalizes European-locale decimal commas in TSV sidecars, by `Bruno Aristimunha`_
 
 ⚕️ Code health
 ^^^^^^^^^^^^^^

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -71,7 +71,7 @@ Detailed list of changes
 - Fix :func:`mne_bids.events_file_to_annotation_kwargs` to drop rows with invalid ``onset`` values (``n/a``, ``nan``, ``NaN``, empty string) before float conversion. This makes reading real-world OpenNeuro datasets (e.g. ``ds004841``, ``ds004842``, ``ds004843``) succeed instead of either raising or returning ``NaN`` onsets, by `Bruno Aristimunha`_ (:gh:`1547`)
 - Fix :func:`mne_bids.events_file_to_annotation_kwargs` to fall back to the ``value`` column when ``trial_type`` is entirely ``n/a`` but ``value`` contains trigger codes, instead of dropping all events, by `Bruno Aristimunha`_ (:gh:`947`)
 - :func:`mne_bids.read_raw_bids` now tolerates malformed ``scans.tsv`` entries and ISO 8601 ``acq_time`` variants, by `Bruno Aristimunha`_ (:gh:`1591`)
-- :func:`mne_bids.read_raw_bids` now strips whitespace-padded ``n/a`` cells and normalizes European-locale decimal commas in TSV sidecars, by `Bruno Aristimunha`_
+- :func:`mne_bids.read_raw_bids` now strips whitespace-padded ``n/a`` cells and normalizes European-locale decimal commas in TSV sidecars, by `Bruno Aristimunha`_ (:gh:`1599`)
 
 ⚕️ Code health
 ^^^^^^^^^^^^^^

--- a/mne_bids/tests/test_tsv_handler.py
+++ b/mne_bids/tests/test_tsv_handler.py
@@ -136,6 +136,22 @@ def test_from_tsv_latin1_logs_info(tmp_path):
     assert "non-UTF-8" in log.getvalue()
 
 
+def test_from_tsv_strips_whitespace_and_normalizes_decimal_commas(tmp_path):
+    """``_from_tsv`` tolerates padded ``n/a`` cells and European decimal commas."""
+    tsv = tmp_path / "events.tsv"
+    tsv.write_text(
+        "onset\tduration\ttrial_type\n"
+        "0,5\t1,25\tstim\n"  # European decimals
+        "n/a    \t  n/a\tstim\n"  # whitespace-padded n/a
+        "1.0\t1\trest, eyes-open\n",  # untouched: dot decimal, comma in string
+        encoding="utf-8",
+    )
+    d = _from_tsv(tsv)
+    assert d["onset"] == ["0.5", "n/a", "1.0"]
+    assert d["duration"] == ["1.25", "n/a", "1"]
+    assert d["trial_type"] == ["stim", "stim", "rest, eyes-open"]
+
+
 def test_drop_different_types():
     """Test that _drop() can handle different dtypes without warning.
 

--- a/mne_bids/tsv_handler.py
+++ b/mne_bids/tsv_handler.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import codecs
+import re
 from collections import OrderedDict
 from copy import deepcopy
 
@@ -11,6 +12,21 @@ import numpy as np
 from mne.utils import logger
 
 from mne_bids._fileio import _open_lock
+
+# Match digit,digit not adjacent to other word chars; rewrites
+# European-locale decimal commas (e.g. "0,5") to "0.5" without touching
+# strings like "EEG, channel 1" or "10,000" inside non-numeric cells.
+_DECIMAL_COMMA_RE = re.compile(r"(?<!\w)(\d+),(\d+)(?!\w)")
+
+
+def _normalize_tsv_cell(value):
+    """Strip whitespace and normalize decimal commas in a TSV cell."""
+    if not isinstance(value, str):
+        return value
+    stripped = value.strip()
+    if "," not in stripped:
+        return stripped
+    return _DECIMAL_COMMA_RE.sub(r"\1.\2", stripped)
 
 
 def _detect_file_encoding(fname, chunk_size=65536):
@@ -199,7 +215,8 @@ def _from_tsv(fname, dtypes=None):
         )
     empty_cols = 0
     for i, name in enumerate(column_names):
-        values = info[:, i].astype(dtypes[i]).tolist()
+        cells = np.array([_normalize_tsv_cell(v) for v in info[:, i].tolist()])
+        values = cells.astype(dtypes[i]).tolist()
         data_dict[name] = values
         if len(values) == 0:
             empty_cols += 1


### PR DESCRIPTION
Two TSV-cell normalizations in `_from_tsv`: strip whitespace (so `"n/a   "` matches `"n/a"`) and rewrite digit,digit decimal commas (`"0,5"` -> `"0.5"`) for European-locale datasets. Both happen before the dtype cast, so downstream `float()` and `_drop()` calls succeed on real-world OpenNeuro TSVs.

Same shape as #1587, #1591, #1593: more generous reading of cell content that the BIDS spec doesn't strictly allow but real datasets contain.

Reproducer:

```python
from mne_bids.tsv_handler import _from_tsv
# events.tsv body: "onset\tduration\n0,5\t1,25\nn/a    \t1.0\n"
d = _from_tsv("events.tsv")
# main:    d["onset"] == ["0,5", "n/a    "]  -> float() raises
# this PR: d["onset"] == ["0.5", "n/a"]
```