### PR TITLE
FIX: allow non-numeric run values in BIDSPath if check=False

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -70,6 +70,7 @@ Detailed list of changes
 - Fix :func:`mne_bids.events_file_to_annotation_kwargs` to drop rows with invalid ``onset`` values (``n/a``, ``nan``, ``NaN``, empty string) before float conversion. This makes reading real-world OpenNeuro datasets (e.g. ``ds004841``, ``ds004842``, ``ds004843``) succeed instead of either raising or returning ``NaN`` onsets, by `Bruno Aristimunha`_ (:gh:`1547`)
 - Fix :func:`mne_bids.events_file_to_annotation_kwargs` to fall back to the ``value`` column when ``trial_type`` is entirely ``n/a`` but ``value`` contains trigger codes, instead of dropping all events, by `Bruno Aristimunha`_ (:gh:`947`)
 - :func:`mne_bids.read_raw_bids` now tolerates malformed ``scans.tsv`` entries and ISO 8601 ``acq_time`` variants, by `Bruno Aristimunha`_ (:gh:`1591`)
+- Allow non-numeric ``run`` entities (e.g. ``run-5H``) in :class:`mne_bids.BIDSPath` when ``check=False``, by `Bruno Aristimunha`_
 
 ⚕️ Code health
 ^^^^^^^^^^^^^^

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -70,7 +70,7 @@ Detailed list of changes
 - Fix :func:`mne_bids.events_file_to_annotation_kwargs` to drop rows with invalid ``onset`` values (``n/a``, ``nan``, ``NaN``, empty string) before float conversion. This makes reading real-world OpenNeuro datasets (e.g. ``ds004841``, ``ds004842``, ``ds004843``) succeed instead of either raising or returning ``NaN`` onsets, by `Bruno Aristimunha`_ (:gh:`1547`)
 - Fix :func:`mne_bids.events_file_to_annotation_kwargs` to fall back to the ``value`` column when ``trial_type`` is entirely ``n/a`` but ``value`` contains trigger codes, instead of dropping all events, by `Bruno Aristimunha`_ (:gh:`947`)
 - :func:`mne_bids.read_raw_bids` now tolerates malformed ``scans.tsv`` entries and ISO 8601 ``acq_time`` variants, by `Bruno Aristimunha`_ (:gh:`1591`)
-- Allow non-numeric ``run`` entities (e.g. ``run-5H``) in :class:`mne_bids.BIDSPath` when ``check=False``, by `Bruno Aristimunha`_
+- Allow non-numeric ``run`` entities (e.g. ``run-5H``) in :class:`mne_bids.BIDSPath` when ``check=False``, by `Bruno Aristimunha`_ (:gh:`1601`)
 
 ⚕️ Code health
 ^^^^^^^^^^^^^^

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -1066,7 +1066,7 @@ class BIDSPath:
             else:
                 assert ENTITY_VALUE_TYPE[key] == "index"
                 _validate_type(val, types=(int, str, None), item_name=key)
-                if isinstance(val, str) and not val.isdigit():
+                if isinstance(val, str) and not val.isdigit() and self.check:
                     raise ValueError(f"{key} is not an index (Got {val})")
                 elif isinstance(val, int):
                     kwargs[key] = f"{val}"

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -1440,6 +1440,13 @@ def test_bids_path(bids_root):
     with pytest.raises(ValueError, match="datatype .* is not valid"):
         bids_path.copy().update(check=True, datatype=error_kind)
 
+    # does not error check on datatype in BIDSPath if check=False
+    # (e.g. a non-spec ``fnirs/`` directory used in some real-world datasets)
+    with pytest.raises(ValueError, match="datatype .* is not valid"):
+        BIDSPath(subject=subject_id, datatype="fnirs")
+    bp_fnirs = BIDSPath(subject=subject_id, datatype="fnirs", check=False)
+    assert bp_fnirs.datatype == "fnirs"
+
     # does not error check on space if check=False ...
     BIDSPath(subject=subject_id, space="foo", suffix="eeg", check=False)
 
@@ -1598,6 +1605,13 @@ def test_make_filenames():
         basename.basename
         == "sub-one_ses-two_task-three_acq-four_run-1_proc-six_recording-seven_ieeg.h5"
     )
+
+    # non-numeric run is rejected by default but accepted with check=False
+    with pytest.raises(ValueError, match="run is not an index"):
+        BIDSPath(subject="01", run="5H")
+    bp = BIDSPath(subject="01", run="5H", check=False)
+    assert bp.run == "5H"
+    assert "run-5H" in bp.basename
 
     # what happens with scans.tsv file
     with pytest.raises(ValueError, match="scans.tsv file name can only contain"):


### PR DESCRIPTION
One-character fix in `mne_bids/path.py`: gate the "run is not an index" check on `self.check`, so `BIDSPath(..., run="5H", check=False)` succeeds while the strict default still rejects.

```diff
-                if isinstance(val, str) and not val.isdigit():
+                if isinstance(val, str) and not val.isdigit() and self.check:
                     raise ValueError(f"{key} is not an index (Got {val})")
```

This matches the existing `check=False` escape hatch already used for `suffix`, `space`, `datatype`, and `extension`.

## Real-world dataset blocked today

[`ds003190`](https://openneuro.org/datasets/ds003190) ships VHDR files with `run-5F` and `run-5H` entities. eegdash hit this and silently dropped 104 files via a workaround ([eegdash#263](https://github.com/eegdash/EEGDash/pull/263), later extended in [eegdash#277](https://github.com/eegdash/EEGDash/pull/277)).

```python
from mne_bids import BIDSPath

BIDSPath(subject="01", run="5H")
# main: ValueError: run is not an index (Got 5H)

bp = BIDSPath(subject="01", run="5H", check=False)
# this PR: bp.basename == "sub-01_run-5H"
```

|        | result                                              |
|--------|-----------------------------------------------------|
| `main` | `ValueError: run is not an index (Got 5H)`          |
| this PR| `BIDSPath(...).basename == "sub-01_run-5H"`         |

## End-to-end `read_raw_bids` works

The fix carries through to `read_raw_bids`. Synthetic dataset with `run-5H` files on disk:

```python
from mne_bids import BIDSPath, read_raw_bids

bp = BIDSPath(subject="01", task="t", run="5H", datatype="eeg",
              suffix="eeg", extension=".edf", root=root, check=False)
raw = read_raw_bids(bp)
# OK: 139 channels, 3072 samples, channels.tsv sidecar resolved correctly
```

`_find_matching_sidecar` is unaffected — it already sets `check=False` internally on the bids_path copy it uses.

## Tests

Folded into existing `test_path.py` tests rather than a new file:

- `test_make_filenames`: positive (`check=False`) + negative (default raises) for `run="5H"`.
- `test_bids_path`: positive + negative for `datatype="fnirs"` (covering the same `check=False` escape hatch already used by some real-world datasets that ship `fnirs/` instead of the spec's `nirs/`).

Strict default behavior is unchanged.

## Related

Part of the broader effort to read non-spec OpenNeuro datasets (#1591, #1593, #1599). The other items in the table at [#1519](https://github.com/mne-tools/mne-bids/issues/1519) (case-mismatched entities, separator typos, fuzzy participant_id) are matching/parsing concerns, not BIDSPath construction — those need separate PRs.