### PR TITLE
ENH: add keywords parameter to make_dataset_description

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -43,7 +43,7 @@ Detailed list of changes
 - Speed up :func:`mne_bids.get_datatypes` by restricting filesystem traversal to ``bids_root/sub-*/(ses-*/)<datatype>`` directories, by `Eric Larson`_ (:gh:`1563`)
 - Speed up :meth:`mne_bids.BIDSPath.find_matching_sidecar` by searching most likely file locations first, by `Eric Larson`_ (:gh:`1565`)
 - Add support for CHPI channels and gracefully handle incorrect channel definition ``MEGGRAD``, by `Eric Larson`_ (:gh:`1578`)
-- Add ``keywords`` parameter to :func:`mne_bids.make_dataset_description` for the BIDS ``Keywords`` field, by `Bruno Aristimunha`_
+- Add ``keywords`` parameter to :func:`mne_bids.make_dataset_description` for the BIDS ``Keywords`` field, by `Bruno Aristimunha`_ (:gh:`1602`)
 
 🧐 API and behavior changes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -43,6 +43,7 @@ Detailed list of changes
 - Speed up :func:`mne_bids.get_datatypes` by restricting filesystem traversal to ``bids_root/sub-*/(ses-*/)<datatype>`` directories, by `Eric Larson`_ (:gh:`1563`)
 - Speed up :meth:`mne_bids.BIDSPath.find_matching_sidecar` by searching most likely file locations first, by `Eric Larson`_ (:gh:`1565`)
 - Add support for CHPI channels and gracefully handle incorrect channel definition ``MEGGRAD``, by `Eric Larson`_ (:gh:`1578`)
+- Add ``keywords`` parameter to :func:`mne_bids.make_dataset_description` for the BIDS ``Keywords`` field, by `Bruno Aristimunha`_
 
 🧐 API and behavior changes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -431,6 +431,7 @@ def test_make_dataset_description(tmp_path, monkeypatch):
         authors="MNE B., MNE P., MNE Ł.",
         funding="GSOC2019, GSOC2021",
         references_and_links="https://doi.org/10.21105/joss.01896",
+        keywords="eeg, motor-imagery",
         dataset_type="derivative",
         overwrite=True,
         verbose=True,
@@ -439,6 +440,7 @@ def test_make_dataset_description(tmp_path, monkeypatch):
     with open(op.join(tmp_path, "dataset_description.json"), encoding="utf-8") as fid:
         dataset_description_json = json.load(fid)
         assert dataset_description_json["Authors"] == ["MNE B.", "MNE P.", "MNE Ł."]
+        assert dataset_description_json["Keywords"] == ["eeg", "motor-imagery"]
         # If the text on disk is unicode, json.load will convert it. So let's test that
         # the text was encoded correctly on disk.
         fid.seek(0)

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1598,9 +1598,10 @@ def make_dataset_description(
         List of references to publication that contain information on the
         dataset, or links.  Must be a list of str (e.g., ['a', 'b', 'c'])
         or a single comma-separated str (e.g., 'a, b, c').
-    keywords : list
+    keywords : list | str | None
         List of keywords describing the dataset (BIDS ``Keywords`` field).
-        Must be a list of str (e.g., ``['eeg', 'motor-imagery']``).
+        Must be a list of str (e.g., ``['eeg', 'motor-imagery']``) or a single
+        comma-separated str (e.g., ``'eeg, motor-imagery'``).
     doi : str | None
         The Digital Object Identifier of the dataset (not the corresponding
         paper). Must be of the form ``doi:<insert_doi>`` (e.g.,

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1602,6 +1602,8 @@ def make_dataset_description(
         List of keywords describing the dataset (BIDS ``Keywords`` field).
         Must be a list of str (e.g., ``['eeg', 'motor-imagery']``) or a single
         comma-separated str (e.g., ``'eeg, motor-imagery'``).
+
+        .. versionadded:: 0.19
     doi : str | None
         The Digital Object Identifier of the dataset (not the corresponding
         paper). Must be of the form ``doi:<insert_doi>`` (e.g.,

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1550,7 +1550,7 @@ def make_dataset_description(
     funding=None,
     ethics_approvals=None,
     references_and_links=None,
-    keywords=(),
+    keywords=None,
     doi=None,
     generated_by=None,
     source_datasets=None,

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1550,7 +1550,7 @@ def make_dataset_description(
     funding=None,
     ethics_approvals=None,
     references_and_links=None,
-    keywords=None,
+    keywords=(),
     doi=None,
     generated_by=None,
     source_datasets=None,

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1598,10 +1598,9 @@ def make_dataset_description(
         List of references to publication that contain information on the
         dataset, or links.  Must be a list of str (e.g., ['a', 'b', 'c'])
         or a single comma-separated str (e.g., 'a, b, c').
-    keywords : list | str | None
+    keywords : list
         List of keywords describing the dataset (BIDS ``Keywords`` field).
-        Must be a list of str (e.g., ``['eeg', 'motor-imagery']``) or a single
-        comma-separated str (e.g., ``'eeg, motor-imagery'``).
+        Must be a list of str (e.g., ``['eeg', 'motor-imagery']``).
     doi : str | None
         The Digital Object Identifier of the dataset (not the corresponding
         paper). Must be of the form ``doi:<insert_doi>`` (e.g.,

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1550,6 +1550,7 @@ def make_dataset_description(
     funding=None,
     ethics_approvals=None,
     references_and_links=None,
+    keywords=None,
     doi=None,
     generated_by=None,
     source_datasets=None,
@@ -1597,6 +1598,10 @@ def make_dataset_description(
         List of references to publication that contain information on the
         dataset, or links.  Must be a list of str (e.g., ['a', 'b', 'c'])
         or a single comma-separated str (e.g., 'a, b, c').
+    keywords : list | str | None
+        List of keywords describing the dataset (BIDS ``Keywords`` field).
+        Must be a list of str (e.g., ``['eeg', 'motor-imagery']``) or a single
+        comma-separated str (e.g., ``'eeg, motor-imagery'``).
     doi : str | None
         The Digital Object Identifier of the dataset (not the corresponding
         paper). Must be of the form ``doi:<insert_doi>`` (e.g.,
@@ -1624,12 +1629,12 @@ def make_dataset_description(
     by mne_bids.
     """
     # Convert potential string input into list of strings
-    convert_vars = [authors, funding, references_and_links, ethics_approvals]
+    convert_vars = [authors, funding, references_and_links, ethics_approvals, keywords]
     convert_vars = [
         [i.strip() for i in var.split(",")] if isinstance(var, str) else var
         for var in convert_vars
     ]
-    authors, funding, references_and_links, ethics_approvals = convert_vars
+    authors, funding, references_and_links, ethics_approvals, keywords = convert_vars
 
     # Perform input checks
     if dataset_type not in ["raw", "derivative"]:
@@ -1693,6 +1698,7 @@ def make_dataset_description(
             ("Funding", funding),
             ("EthicsApprovals", ethics_approvals),
             ("ReferencesAndLinks", references_and_links),
+            ("Keywords", keywords),
             ("DatasetDOI", doi),
             ("GeneratedBy", generated_by),
             ("SourceDatasets", source_datasets),


### PR DESCRIPTION
Closes #1549.

Add a ``keywords`` parameter to ``make_dataset_description`` so users can populate the BIDS ``Keywords`` field directly instead of post-patching ``dataset_description.json``.

```python
make_dataset_description(
    path=root, name="my-dataset",
    keywords=["eeg", "motor-imagery"],  # or "eeg, motor-imagery"
)
```

Accepts list / comma-separated str / ``None``, matching the neighbouring list-valued params.