### PR TITLE
FIX: warn instead of raise on missing coordsystem.json for iEEG

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -63,7 +63,7 @@ Detailed list of changes
 - Fix :func:`mne_bids.BIDSPath.find_matching_sidecar` to search for sidecar files at the dataset root level per the BIDS inheritance principle, by `Bruno Aristimunha`_ (:gh:`1508`)
 - Reinstate the requirement for ``coordsystem.json`` whenever ``electrodes.tsv`` is present (including EMG), by `Bruno Aristimunha`_ (:gh:`1508`)
 - Fix :func:`read_raw_bids` ignoring ``electrodes.tsv`` when ``EEGCoordinateUnits`` is ``"n/a"`` by inferring the unit from coordinate magnitudes, and synthesize approximate fiducials for ``ctf_head`` montages to enable the coordinate transform to ``head`` frame, by `Bruno Aristimunha`_ (:gh:`1506`)
-- Improve :func:`mne_bids.read_raw_bids` handling when ``electrodes.tsv`` exists without ``coordsystem.json``: keep strict failure for iEEG, and for EEG/MEG emit a warning and continue without applying a montage, by `Bruno Aristimunha`_
+- Improve :func:`mne_bids.read_raw_bids` handling when ``electrodes.tsv`` exists without ``coordsystem.json``: emit a warning and continue without applying a montage (previously raised for iEEG), by `Bruno Aristimunha`_
 - Allow ``task=None`` in :func:`mne_bids.read_raw_bids` for BIDS paths without a task entity (e.g. datasets that omit task in the path), by `Aman Jaiswal`_
 - Fix :func:`mne_bids.read_raw_bids` and related read paths failing with ``PermissionError`` on datalad/git-annex datasets by keeping the file lock next to the symlink instead of its (read-only) target, and gracefully continuing without a lock when one cannot be created, by `Bruno Aristimunha`_ (:gh:`1569`)
 - Avoid modifying calibration files by making :func:`mne_bids.write_meg_calibration` copy instead of parsing and rewriting, by `Marijn van Vliet`_ (:gh:`1576`)

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -1403,8 +1403,6 @@ def read_raw_bids(
                     f"Please add coordsystem.json for {bids_path.basename} and "
                     "re-run the BIDS validator."
                 )
-                if datatype == "ieeg":
-                    raise RuntimeError(msg)
                 warn(msg + " Skipping reading electrode locations.")
             elif datatype in ("meg", "eeg", "ieeg"):
                 _read_dig_bids(

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -1561,13 +1561,13 @@ def test_handle_ieeg_coords_reading(bids_path, tmp_path):
     for digpoint in raw_test.info["dig"]:
         assert digpoint["coord_frame"] == coord_frame_int
 
-    # if we delete the coordsystem.json file, an error will be raised
+    # if we delete the coordsystem.json file, a warning is emitted
     os.remove(coordsystem_fname)
-    with pytest.raises(
-        RuntimeError,
+    with pytest.warns(
+        RuntimeWarning,
         match="coordsystem.json is REQUIRED whenever electrodes.tsv is present",
     ):
-        raw = read_raw_bids(bids_path=bids_fname, verbose=False)
+        read_raw_bids(bids_path=bids_fname, verbose=False)
 
     # test error message if electrodes is not a subset of Raw
     bids_path.update(root=tmp_path)


### PR DESCRIPTION
## Summary

I added the stricter requirement in #1508, but after spending more time with real iEEG datasets I think it was the wrong call. Electrode locations can also reach the `Raw` through the recording's own montage / `channels.tsv` / `space-*` sidecars, so refusing to read at all when only `coordsystem.json` is missing was too aggressive.

This aligns iEEG with the existing EEG/MEG behavior: warn and return the raw without applying a montage.

## Test plan

- [x] `test_handle_ieeg_coords_reading` (both parameterizations) — assertion flipped from `pytest.raises` to `pytest.warns`
- [x] `test_read_eeg_missing_coordsystem_warns`, `test_read_eeg_root_electrodes_no_coordsystem`, `test_read_meg_missing_coordsystem_warns` — unchanged, still pass