### PR TITLE
FIX: warn instead of raise when subject row missing from participants.tsv

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -75,6 +75,7 @@ Detailed list of changes
 - Allow non-numeric ``run`` entities (e.g. ``run-5H``) in :class:`mne_bids.BIDSPath` when ``check=False``, by `Bruno Aristimunha`_ (:gh:`1601`)
 - :func:`mne_bids.write_raw_bids` now writes an ``*_electrodes.json`` sidecar so derivative datasets pass the BIDS validator, by `Bruno Aristimunha`_ (:gh:`1545`)
 - :func:`mne_bids.read_raw_bids` now strips whitespace-padded ``n/a`` cells and normalizes European-locale decimal commas in TSV sidecars, by `Bruno Aristimunha`_ (:gh:`1599`)
+- :func:`mne_bids.read_raw_bids` now warns (instead of raising ``ValueError``) when ``participants.tsv`` exists but does not list the requested subject, leaving ``raw.info["subject_info"]`` empty. This unifies behavior with the existing missing-``participants.tsv`` path, by `Bruno Aristimunha`_ (:gh:`1606`)
 
 ⚕️ Code health
 ^^^^^^^^^^^^^^

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -297,6 +297,10 @@ def _verbose_list_index(lst, val, *, allow_all=False):
 def _handle_participants_reading(participants_fname, raw, subject):
     participants_tsv = _from_tsv(participants_fname)
     subjects = participants_tsv["participant_id"]
+    if subject not in subjects:
+        warn(f"Subject {subject!r} is not listed in {participants_fname.name}")
+        raw.info["subject_info"] = dict()
+        return raw
     row_ind = _verbose_list_index(subjects, subject, allow_all=True)
     raw.info["subject_info"] = dict()  # start from scratch
 

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -414,6 +414,16 @@ def test_read_participants_data(tmp_path):
 
     assert raw.info["subject_info"] == dict()
 
+    # test reading if subject row is missing from participants.tsv
+    raw = _read_raw_fif(raw_fname, verbose=False)
+    write_raw_bids(raw, bids_path, overwrite=True, verbose=False)
+    participants_tsv = _from_tsv(participants_tsv_fpath)
+    participants_tsv["participant_id"][0] = "sub-doesnotexist"
+    _to_tsv(participants_tsv, participants_tsv_fpath)
+    with pytest.warns(RuntimeWarning, match="not listed in participants.tsv"):
+        raw = read_raw_bids(bids_path=bids_path)
+    assert raw.info["subject_info"] == dict()
+
 
 @pytest.mark.parametrize(
     ("hand_bids", "hand_mne", "sex_bids", "sex_mne"),


### PR DESCRIPTION
Closes #1606.

## Summary

When `participants.tsv` exists but does not contain a row for the requested subject, `read_raw_bids` raised a `ValueError` and aborted the read. Now it emits a warning and leaves `raw.info[\"subject_info\"]` empty — the same behavior as when `participants.tsv` is entirely absent.

`_handle_participants_reading` only writes `raw.info[\"subject_info\"]` (sex, hand, height, weight, age, …); it never touches the signal, channels, or timing. So a missing row is functionally equivalent to a missing file, and treating them the same way unblocks reading datasets where the curators forgot to update `participants.tsv` after adding subjects.

## Impact

Datasets observed in a recent EEG/MEG read sweep that this unblocks:

| Dataset | Records affected |
|---|---|
| `ds003645` | 8 (`sub-emptyroom` sessions) |
| `ds004816` | 5 |
| `ds005540` | 3 |
| `ds005697` | 1 |

## Diff

Three files, +15 lines, 0 deletions:

- `mne_bids/read.py` (+4): four-line guard in `_handle_participants_reading` that early-returns with a warning when the subject is absent from the TSV. No signature change, no new parameter.
- `mne_bids/tests/test_read.py` (+10): regression case appended to `test_read_participants_data` — rewrites `participants.tsv` to drop the subject and asserts the warning + empty `subject_info`.
- `doc/whats_new.rst` (+1): bug-fix entry under 0.19.

## Backward compatibility

Anyone catching `ValueError` from `read_raw_bids` for this specific case will lose the exception, but a `RuntimeWarning` is emitted in its place.

## Test plan

- [x] `pytest mne_bids/tests/test_read.py -k participants` — 7 passed locally
- [x] New regression case `test_read_participants_data` covers the missing-row branch