### PR TITLE
rotate changelog

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -9,9 +9,9 @@
 What's new?
 ===========
 
-.. _changes_0_19:
+.. _changes_0_20:
 
-Version 0.19 (2026-05-26)
+Version 0.20 (unreleased)
 -------------------------
 
 👩🏽‍💻 Authors
@@ -19,23 +19,11 @@ Version 0.19 (2026-05-26)
 
 The following authors contributed for the first time. Thank you so much! 🤩
 
-* `Thomas Binns`_
+* None yet
 
 The following authors had contributed before. Thank you for sticking around! 🤘
 
-* `Alexandre Gramfort`_
-* `Aman Jaiswal`_
-* `Bruno Aristimunha`_
-* `Clemens Brunner`_
-* `Daniel McCloy`_
-* `Eric Larson`_
-* `Flore Boscher`_
-* `Marijn van Vliet`_
-* `Maximilien Chaumon`_
-* `Pierre Guetschel`_
-* `Scott Huberty`_
-* `Stefan Appelhoff`_
-* `Teon Brooks`_
+* None yet
 
 Detailed list of changes
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -43,49 +31,22 @@ Detailed list of changes
 🚀 Enhancements
 ^^^^^^^^^^^^^^^
 
-- Add support for reading and writing MEF3 (Multiscale Electrophysiology Format) iEEG data with the ``.mefd`` extension. Requires MNE-Python 1.12 or later, by `Bruno Aristimunha`_ (:gh:`1511`)
-- Save ``Annotations.extras`` fields in events.tsv files when writing events, by `Pierre Guetschel`_ (:gh:`1502`)
-- Added support for ``EEGLAB`` and ``EEGLAB-HJ`` coordinate systems as defined in the BIDS specification. Both use ALS orientation (identical to CTF) and map to MNE's ``ctf_head`` coordinate frame, by `Bruno Aristimunha`_ (:gh:`1514`)
-- :func:`mne_bids.read_raw_bids` now reads channel units from ``channels.tsv`` and sets them on the raw object. This includes support for units like ``rad`` (radians), ``V``, ``µV``, ``mV``, ``T``, ``T/m``, ``S``, ``oC``, ``M``, and ``px``. The write path was also updated to correctly write ``rad`` units to ``channels.tsv``, by `Alexandre Gramfort`_ (:gh:`1509`)
-- Added support for hashing ``BIDSPath`` objects so they can be used in caching and other contexts that require hashable objects, by `Eric Larson`_ (:gh:`1563`)
-- Speed up :func:`mne_bids.get_datatypes` by restricting filesystem traversal to ``bids_root/sub-*/(ses-*/)<datatype>`` directories, by `Eric Larson`_ (:gh:`1563`)
-- Speed up :meth:`mne_bids.BIDSPath.find_matching_sidecar` by searching most likely file locations first, by `Eric Larson`_ (:gh:`1565`)
-- Add support for CHPI channels and gracefully handle incorrect channel definition ``MEGGRAD``, by `Eric Larson`_ (:gh:`1578`)
-- Add ``keywords`` parameter to :func:`mne_bids.make_dataset_description` for the BIDS ``Keywords`` field, by `Bruno Aristimunha`_ (:gh:`1602`)
+- None yet
 
 🧐 API and behavior changes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-- MNE-BIDS now writes text files (``README.txt``, ``*.tsv`` etc.) using ``utf-8`` encoding instead of ``utf-8-sig``.
-- Expected format conversions notices are now logged at ``info`` instead of ``warn`` level, by `Bruno Aristimunha`_ (:gh:`1589`)
-- Add ``readme`` parameter to :func:`mne_bids.write_raw_bids`; pass ``readme=False`` to leave any existing ``README`` untouched and skip creating one, by `Bruno Aristimunha`_ (:gh:`1550`)
-- :func:`mne_bids.make_dataset_description` preserves BIDS-spec keys it does not model when merging with an existing ``dataset_description.json``, by `Bruno Aristimunha`_ (:gh:`1548`)
+- None yet
 
 🛠 Requirements
 ^^^^^^^^^^^^^^^
 
-- MEF3 (``.mefd``) file format support requires MNE-Python 1.12 or later, by `Bruno Aristimunha`_ (:gh:`1511`)
+- None yet
 
 🪲 Bug fixes
 ^^^^^^^^^^^^
 
-- Fix :func:`mne_bids.BIDSPath.find_matching_sidecar` to search for sidecar files at the dataset root level per the BIDS inheritance principle, by `Bruno Aristimunha`_ (:gh:`1508`)
-- Reinstate the requirement for ``coordsystem.json`` whenever ``electrodes.tsv`` is present (including EMG), by `Bruno Aristimunha`_ (:gh:`1508`)
-- Fix :func:`read_raw_bids` ignoring ``electrodes.tsv`` when ``EEGCoordinateUnits`` is ``"n/a"`` by inferring the unit from coordinate magnitudes, and synthesize approximate fiducials for ``ctf_head`` montages to enable the coordinate transform to ``head`` frame, by `Bruno Aristimunha`_ (:gh:`1506`)
-- Improve :func:`mne_bids.read_raw_bids` handling when ``electrodes.tsv`` exists without ``coordsystem.json``: emit a warning and continue without applying a montage (previously raised for iEEG), by `Bruno Aristimunha`_
-- Allow ``task=None`` in :func:`mne_bids.read_raw_bids` for BIDS paths without a task entity (e.g. datasets that omit task in the path), by `Aman Jaiswal`_
-- Fix :func:`mne_bids.read_raw_bids` and related read paths failing with ``PermissionError`` on datalad/git-annex datasets by keeping the file lock next to the symlink instead of its (read-only) target, and gracefully continuing without a lock when one cannot be created, by `Bruno Aristimunha`_ (:gh:`1569`)
-- Avoid modifying calibration files by making :func:`mne_bids.write_meg_calibration` copy instead of parsing and rewriting, by `Marijn van Vliet`_ (:gh:`1576`)
-- Fix bug with :meth:`mne_bids.BIDSPath.find_matching_sidecar` not searching parent directories properly, by `Eric Larson`_ (:gh:`1565`)
-- Detect TSV file encoding before reading, fixing ``UnicodeDecodeError`` on non-UTF-8 sidecars (e.g. ``channels.tsv`` with ``µV`` in latin-1), by `Bruno Aristimunha`_ (:gh:`1593`)
-- Fix :func:`mne_bids.events_file_to_annotation_kwargs` to drop rows with invalid ``onset`` values (``n/a``, ``nan``, ``NaN``, empty string) before float conversion. This makes reading real-world OpenNeuro datasets (e.g. ``ds004841``, ``ds004842``, ``ds004843``) succeed instead of either raising or returning ``NaN`` onsets, by `Bruno Aristimunha`_ (:gh:`1547`)
-- Fix :func:`mne_bids.events_file_to_annotation_kwargs` to fall back to the ``value`` column when ``trial_type`` is entirely ``n/a`` but ``value`` contains trigger codes, instead of dropping all events, by `Bruno Aristimunha`_ (:gh:`947`)
-- :func:`mne_bids.read_raw_bids` now tolerates malformed ``scans.tsv`` entries and ISO 8601 ``acq_time`` variants, by `Bruno Aristimunha`_ (:gh:`1591`)
-- :func:`mne_bids.read_raw_bids` is more tolerant of imperfect ``channels.tsv`` files and supports a new ``on_ch_mismatch="warn"`` option, by `Bruno Aristimunha`_ (:gh:`1603`)
-- Allow non-numeric ``run`` entities (e.g. ``run-5H``) in :class:`mne_bids.BIDSPath` when ``check=False``, by `Bruno Aristimunha`_ (:gh:`1601`)
-- :func:`mne_bids.write_raw_bids` now writes an ``*_electrodes.json`` sidecar so derivative datasets pass the BIDS validator, by `Bruno Aristimunha`_ (:gh:`1545`)
-- :func:`mne_bids.read_raw_bids` now strips whitespace-padded ``n/a`` cells and normalizes European-locale decimal commas in TSV sidecars, by `Bruno Aristimunha`_ (:gh:`1599`)
-- :func:`mne_bids.read_raw_bids` now warns (instead of raising ``ValueError``) when ``participants.tsv`` exists but does not list the requested subject, leaving ``raw.info["subject_info"]`` empty. This unifies behavior with the existing missing-``participants.tsv`` path, by `Bruno Aristimunha`_ (:gh:`1606`)
+- None yet
 
 ⚕️ Code health
 ^^^^^^^^^^^^^^

--- a/doc/whats_new_previous_releases.rst
+++ b/doc/whats_new_previous_releases.rst
@@ -9,6 +9,84 @@
 What was new in previous releases?
 ==================================
 
+.. _changes_0_19:
+
+Version 0.19 (2026-05-26)
+-------------------------
+
+👩🏽‍💻 Authors
+~~~~~~~~~~~~~~~
+
+The following authors contributed for the first time. Thank you so much! 🤩
+
+* `Thomas Binns`_
+
+The following authors had contributed before. Thank you for sticking around! 🤘
+
+* `Alexandre Gramfort`_
+* `Aman Jaiswal`_
+* `Bruno Aristimunha`_
+* `Clemens Brunner`_
+* `Daniel McCloy`_
+* `Eric Larson`_
+* `Flore Boscher`_
+* `Marijn van Vliet`_
+* `Maximilien Chaumon`_
+* `Pierre Guetschel`_
+* `Scott Huberty`_
+* `Stefan Appelhoff`_
+* `Teon Brooks`_
+
+Detailed list of changes
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+🚀 Enhancements
+^^^^^^^^^^^^^^^
+
+- Add support for reading and writing MEF3 (Multiscale Electrophysiology Format) iEEG data with the ``.mefd`` extension. Requires MNE-Python 1.12 or later, by `Bruno Aristimunha`_ (:gh:`1511`)
+- Save ``Annotations.extras`` fields in events.tsv files when writing events, by `Pierre Guetschel`_ (:gh:`1502`)
+- Added support for ``EEGLAB`` and ``EEGLAB-HJ`` coordinate systems as defined in the BIDS specification. Both use ALS orientation (identical to CTF) and map to MNE's ``ctf_head`` coordinate frame, by `Bruno Aristimunha`_ (:gh:`1514`)
+- :func:`mne_bids.read_raw_bids` now reads channel units from ``channels.tsv`` and sets them on the raw object. This includes support for units like ``rad`` (radians), ``V``, ``µV``, ``mV``, ``T``, ``T/m``, ``S``, ``oC``, ``M``, and ``px``. The write path was also updated to correctly write ``rad`` units to ``channels.tsv``, by `Alexandre Gramfort`_ (:gh:`1509`)
+- Added support for hashing ``BIDSPath`` objects so they can be used in caching and other contexts that require hashable objects, by `Eric Larson`_ (:gh:`1563`)
+- Speed up :func:`mne_bids.get_datatypes` by restricting filesystem traversal to ``bids_root/sub-*/(ses-*/)<datatype>`` directories, by `Eric Larson`_ (:gh:`1563`)
+- Speed up :meth:`mne_bids.BIDSPath.find_matching_sidecar` by searching most likely file locations first, by `Eric Larson`_ (:gh:`1565`)
+- Add support for CHPI channels and gracefully handle incorrect channel definition ``MEGGRAD``, by `Eric Larson`_ (:gh:`1578`)
+- Add ``keywords`` parameter to :func:`mne_bids.make_dataset_description` for the BIDS ``Keywords`` field, by `Bruno Aristimunha`_ (:gh:`1602`)
+
+🧐 API and behavior changes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- MNE-BIDS now writes text files (``README.txt``, ``*.tsv`` etc.) using ``utf-8`` encoding instead of ``utf-8-sig``.
+- Expected format conversions notices are now logged at ``info`` instead of ``warn`` level, by `Bruno Aristimunha`_ (:gh:`1589`)
+- Add ``readme`` parameter to :func:`mne_bids.write_raw_bids`; pass ``readme=False`` to leave any existing ``README`` untouched and skip creating one, by `Bruno Aristimunha`_ (:gh:`1550`)
+- :func:`mne_bids.make_dataset_description` preserves BIDS-spec keys it does not model when merging with an existing ``dataset_description.json``, by `Bruno Aristimunha`_ (:gh:`1548`)
+
+🛠 Requirements
+^^^^^^^^^^^^^^^
+
+- MEF3 (``.mefd``) file format support requires MNE-Python 1.12 or later, by `Bruno Aristimunha`_ (:gh:`1511`)
+
+🪲 Bug fixes
+^^^^^^^^^^^^
+
+- Fix :func:`mne_bids.BIDSPath.find_matching_sidecar` to search for sidecar files at the dataset root level per the BIDS inheritance principle, by `Bruno Aristimunha`_ (:gh:`1508`)
+- Reinstate the requirement for ``coordsystem.json`` whenever ``electrodes.tsv`` is present (including EMG), by `Bruno Aristimunha`_ (:gh:`1508`)
+- Fix :func:`read_raw_bids` ignoring ``electrodes.tsv`` when ``EEGCoordinateUnits`` is ``"n/a"`` by inferring the unit from coordinate magnitudes, and synthesize approximate fiducials for ``ctf_head`` montages to enable the coordinate transform to ``head`` frame, by `Bruno Aristimunha`_ (:gh:`1506`)
+- Improve :func:`mne_bids.read_raw_bids` handling when ``electrodes.tsv`` exists without ``coordsystem.json``: emit a warning and continue without applying a montage (previously raised for iEEG), by `Bruno Aristimunha`_
+- Allow ``task=None`` in :func:`mne_bids.read_raw_bids` for BIDS paths without a task entity (e.g. datasets that omit task in the path), by `Aman Jaiswal`_
+- Fix :func:`mne_bids.read_raw_bids` and related read paths failing with ``PermissionError`` on datalad/git-annex datasets by keeping the file lock next to the symlink instead of its (read-only) target, and gracefully continuing without a lock when one cannot be created, by `Bruno Aristimunha`_ (:gh:`1569`)
+- Avoid modifying calibration files by making :func:`mne_bids.write_meg_calibration` copy instead of parsing and rewriting, by `Marijn van Vliet`_ (:gh:`1576`)
+- Fix bug with :meth:`mne_bids.BIDSPath.find_matching_sidecar` not searching parent directories properly, by `Eric Larson`_ (:gh:`1565`)
+- Detect TSV file encoding before reading, fixing ``UnicodeDecodeError`` on non-UTF-8 sidecars (e.g. ``channels.tsv`` with ``µV`` in latin-1), by `Bruno Aristimunha`_ (:gh:`1593`)
+- Fix :func:`mne_bids.events_file_to_annotation_kwargs` to drop rows with invalid ``onset`` values (``n/a``, ``nan``, ``NaN``, empty string) before float conversion. This makes reading real-world OpenNeuro datasets (e.g. ``ds004841``, ``ds004842``, ``ds004843``) succeed instead of either raising or returning ``NaN`` onsets, by `Bruno Aristimunha`_ (:gh:`1547`)
+- Fix :func:`mne_bids.events_file_to_annotation_kwargs` to fall back to the ``value`` column when ``trial_type`` is entirely ``n/a`` but ``value`` contains trigger codes, instead of dropping all events, by `Bruno Aristimunha`_ (:gh:`947`)
+- :func:`mne_bids.read_raw_bids` now tolerates malformed ``scans.tsv`` entries and ISO 8601 ``acq_time`` variants, by `Bruno Aristimunha`_ (:gh:`1591`)
+- :func:`mne_bids.read_raw_bids` is more tolerant of imperfect ``channels.tsv`` files and supports a new ``on_ch_mismatch="warn"`` option, by `Bruno Aristimunha`_ (:gh:`1603`)
+- Allow non-numeric ``run`` entities (e.g. ``run-5H``) in :class:`mne_bids.BIDSPath` when ``check=False``, by `Bruno Aristimunha`_ (:gh:`1601`)
+- :func:`mne_bids.write_raw_bids` now writes an ``*_electrodes.json`` sidecar so derivative datasets pass the BIDS validator, by `Bruno Aristimunha`_ (:gh:`1545`)
+- :func:`mne_bids.read_raw_bids` now strips whitespace-padded ``n/a`` cells and normalizes European-locale decimal commas in TSV sidecars, by `Bruno Aristimunha`_ (:gh:`1599`)
+- :func:`mne_bids.read_raw_bids` now warns (instead of raising ``ValueError``) when ``participants.tsv`` exists but does not list the requested subject, leaving ``raw.info["subject_info"]`` empty. This unifies behavior with the existing missing-``participants.tsv`` path, by `Bruno Aristimunha`_ (:gh:`1606`)
+
 .. _changes_0_18:
 
 Version 0.18 (2025-12-23)


### PR DESCRIPTION
@scott-huberty I didn't want the final steps of the release process to wait over the weekend so I:

- squashed all the auto-commits on the gh-pages branch, rebuilt the docs locally, and added the built docs to `stable` and `v0.19` folder (force-pushed to `gh-pages`, see also #1614)
- rotated the changelogs (this PR)

I'll mark for merge-when-green because this only touches docs; if Circle is happy then we should be good.