### PR TITLE
Fix TypeError writing ANT Neuro .cnt files by disambiguating the reader (fixes #1500)

### DIFF
--- a/doc/authors.rst
+++ b/doc/authors.rst
@@ -28,6 +28,7 @@
 .. _Ford McDonald: https://github.com/fordmcdonald
 .. _Franziska von Albedyll: https://www.researchgate.net/profile/Franziska-Von-Albedyll
 .. _Fu-Te Wong: https://github.com/zuxfoucault
+.. _gaoflow: https://github.com/gaoflow
 .. _Harrison Ritz: https://github.com/harrisonritz
 .. _Jean-Rémi King: https://kingjr.github.io
 .. _Jonathan Vanhoecke: https://sfb-retune.de/people/jonathan-vanhoecke/

--- a/doc/authors.rst
+++ b/doc/authors.rst
@@ -28,7 +28,6 @@
 .. _Ford McDonald: https://github.com/fordmcdonald
 .. _Franziska von Albedyll: https://www.researchgate.net/profile/Franziska-Von-Albedyll
 .. _Fu-Te Wong: https://github.com/zuxfoucault
-.. _gaoflow: https://github.com/gaoflow
 .. _Harrison Ritz: https://github.com/harrisonritz
 .. _Jean-Rémi King: https://kingjr.github.io
 .. _Jonathan Vanhoecke: https://sfb-retune.de/people/jonathan-vanhoecke/
@@ -62,6 +61,7 @@
 .. _Thomas Binns: https://github.com/tsbinns
 .. _Thomas Hartmann: https://github.com/thht
 .. _Tom Donoghue: https://github.com/TomDonoghue
+.. _Vincent Gao: https://github.com/gaoflow
 .. _waldie11: https://github.com/waldie11
 .. _William Turner: https://bootstrapbill.github.io/
 .. _Yorguin Mantilla: https://github.com/yjmantilla

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -19,7 +19,7 @@ Version 0.20 (unreleased)
 
 The following authors contributed for the first time. Thank you so much! 🤩
 
-* `gaoflow`_
+* `Vincent Gao`_
 
 The following authors had contributed before. Thank you for sticking around! 🤘
 
@@ -46,7 +46,7 @@ Detailed list of changes
 🪲 Bug fixes
 ^^^^^^^^^^^^
 
-- :func:`mne_bids.write_raw_bids` no longer raises a ``TypeError`` when writing ANT Neuro eego recordings (``.cnt``): the reader used to re-read the original file is now chosen from the class of the ``raw`` object, disambiguating extensions shared by multiple MNE readers (e.g. ``.cnt`` for Neuroscan and ANT Neuro), by `gaoflow`_ (:gh:`1617`)
+- :func:`mne_bids.write_raw_bids` no longer raises a ``TypeError`` when writing ANT Neuro eego recordings (``.cnt``), by `Vincent Gao`_ (:gh:`1617`)
 
 ⚕️ Code health
 ^^^^^^^^^^^^^^

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -19,7 +19,7 @@ Version 0.20 (unreleased)
 
 The following authors contributed for the first time. Thank you so much! 🤩
 
-* None yet
+* `gaoflow`_
 
 The following authors had contributed before. Thank you for sticking around! 🤘
 
@@ -46,7 +46,7 @@ Detailed list of changes
 🪲 Bug fixes
 ^^^^^^^^^^^^
 
-- None yet
+- :func:`mne_bids.write_raw_bids` no longer raises a ``TypeError`` when writing ANT Neuro eego recordings (``.cnt``): the reader used to re-read the original file is now chosen from the class of the ``raw`` object, disambiguating extensions shared by multiple MNE readers (e.g. ``.cnt`` for Neuroscan and ANT Neuro), by `gaoflow`_ (:gh:`1617`)
 
 ⚕️ Code health
 ^^^^^^^^^^^^^^

--- a/mne_bids/config.py
+++ b/mne_bids/config.py
@@ -154,6 +154,45 @@ if hasattr(io, "read_raw_mef"):
     reader[".mefd"] = io.read_raw_mef
 
 
+# Some file extensions are ambiguous: more than one MNE reader can produce a
+# file with that extension. For example, ``.cnt`` is used both by Neuroscan,
+# read via :func:`mne.io.read_raw_cnt`, and by ANT Neuro eego recordings, read
+# via :func:`mne.io.read_raw_ant`. When re-reading the original file (e.g. to
+# obtain an unmodified copy), the extension alone is therefore not always enough
+# to pick the reader that produced a given ``raw`` object; using the wrong one
+# passes mismatched ``raw._init_kwargs`` (e.g. ``read_raw_cnt`` does not accept
+# the ``fname`` argument used by ``read_raw_ant``) and raises ``TypeError``.
+# This maps the class name of the ``raw`` object to the reader that created it,
+# taking precedence over the extension-based ``reader`` lookup.
+# See https://github.com/mne-tools/mne-bids/issues/1500
+reader_by_raw_class = {}
+if hasattr(io, "read_raw_ant"):
+    reader_by_raw_class["RawANT"] = io.read_raw_ant
+
+
+def _reader_for_raw(raw, ext):
+    """Return the MNE reader function that produced ``raw``.
+
+    Most file extensions map to a single reader, but some are shared by multiple
+    readers (see :data:`reader_by_raw_class`). In that case the class of ``raw``
+    is used to disambiguate, so the original file is re-read with the same reader
+    that created it rather than one inferred from the (ambiguous) extension.
+
+    Parameters
+    ----------
+    raw : instance of mne.io.BaseRaw
+        The raw object whose original file should be re-read.
+    ext : str
+        The file extension (including the leading dot) of the original file.
+
+    Returns
+    -------
+    reader : callable
+        The ``mne.io.read_raw_*`` function to use.
+    """
+    return reader_by_raw_class.get(type(raw).__name__, reader[ext])
+
+
 # Merge the manufacturer dictionaries in a python2 / python3 compatible way
 # MANUFACTURERS dictionary only includes the extension of the input filename
 # that mne-python accepts (e.g. BrainVision has three files, but the reader

--- a/mne_bids/config.py
+++ b/mne_bids/config.py
@@ -165,7 +165,7 @@ if hasattr(io, "read_raw_mef"):
 # This maps the class name of the ``raw`` object to the reader that created it,
 # taking precedence over the extension-based ``reader`` lookup.
 # See https://github.com/mne-tools/mne-bids/issues/1500
-reader_by_raw_class = {}
+reader_by_raw_class = dict()
 if hasattr(io, "read_raw_ant"):
     reader_by_raw_class["RawANT"] = io.read_raw_ant
 

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -4552,3 +4552,53 @@ def test_write_hed_annotations(tmp_path, _bids_validate):
     # Semantic HED validation against the declared HEDVersion schema.
     issues = BidsDataset(str(bids_root)).validate(check_for_warnings=True)
     assert issues == [], issues
+
+
+def test_reader_for_raw_ambiguous_extension():
+    """Re-reading picks the reader by raw class for ambiguous extensions.
+
+    Regression test for gh-1500: the ``.cnt`` extension is used by both
+    Neuroscan (read via ``read_raw_cnt``) and ANT Neuro eego (read via
+    ``read_raw_ant``) recordings. When ``write_raw_bids`` re-reads the original
+    file, the reader must be chosen from the class of the ``raw`` object, not
+    from the (ambiguous) extension: choosing by extension passed
+    ``read_raw_ant``'s ``_init_kwargs`` (which use ``fname``) to
+    ``read_raw_cnt`` (which expects ``input_fname``) and raised ``TypeError``.
+    """
+    import inspect
+
+    import mne.io as io
+
+    from mne_bids.config import _reader_for_raw, reader
+
+    # Unambiguous extensions resolve to the extension-based reader, regardless
+    # of the raw object's class.
+    class RawArray:
+        pass
+
+    assert _reader_for_raw(RawArray(), ".fif") is reader[".fif"]
+    assert _reader_for_raw(RawArray(), ".vhdr") is reader[".vhdr"]
+
+    # A Neuroscan ``.cnt`` recording uses ``read_raw_cnt`` ...
+    class RawCNT:
+        pass
+
+    assert _reader_for_raw(RawCNT(), ".cnt") is reader[".cnt"]
+    assert reader[".cnt"] is io.read_raw_cnt
+
+    # ... while an ANT Neuro ``.cnt`` recording must use ``read_raw_ant``.
+    if hasattr(io, "read_raw_ant"):
+
+        class RawANT:
+            pass
+
+        assert _reader_for_raw(RawANT(), ".cnt") is io.read_raw_ant
+        assert _reader_for_raw(RawANT(), ".cnt") is not reader[".cnt"]
+
+        # The extension-based reader would be passed ``read_raw_ant``'s init
+        # kwargs (which use ``fname``) and reject them: this is the original
+        # ``TypeError`` reported in gh-1500.
+        ant_params = inspect.signature(io.read_raw_ant).parameters
+        cnt_params = inspect.signature(reader[".cnt"]).parameters
+        assert "fname" in ant_params
+        assert "fname" not in cnt_params

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -61,7 +61,7 @@ from mne_bids.config import (
     UNITS_FIFF_TO_BIDS_MAP,
     UNITS_MNE_TO_BIDS_MAP,
     _map_options,
-    reader,
+    _reader_for_raw,
 )
 from mne_bids.copyfiles import (
     copyfile_brainvision,
@@ -2147,7 +2147,7 @@ def write_raw_bids(
                 "Symlinks are currently only supported for FIFF files."
             )
 
-        raw_orig = reader[ext](**raw._init_kwargs)
+        raw_orig = _reader_for_raw(raw, ext)(**raw._init_kwargs)
     else:
         if format in FORMAT_EXTENSIONS:
             ext = FORMAT_EXTENSIONS[format]


### PR DESCRIPTION
Fixes #1500.

### Problem

`write_raw_bids()` raises a `TypeError` when writing ANT Neuro eego recordings:

```
TypeError: read_raw_cnt() got an unexpected keyword argument 'fname'
```

The `.cnt` extension is **ambiguous** — it is used both by Neuroscan (read via `mne.io.read_raw_cnt`, kwarg `input_fname`) and by ANT Neuro eego recordings (read via `mne.io.read_raw_ant`, kwarg `fname`). When `write_raw_bids` re-reads the original file to obtain an unmodified copy (`write.py`), it picked the reader purely from the file extension:

```python
raw_orig = reader[ext](**raw._init_kwargs)
```

So a `raw` loaded with `read_raw_ant` (whose `_init_kwargs` use `fname`) was re-read with `read_raw_cnt`, which does not accept `fname` → `TypeError`.

### Fix

As suggested by @larsoner in the issue, the reader is now chosen from the **class of the `raw` object** rather than from the (ambiguous) extension. A small `reader_by_raw_class` map (currently `{"RawANT": read_raw_ant}`, guarded by `hasattr(io, "read_raw_ant")` for older MNE) takes precedence over the extension-based `reader` lookup, via a new helper `_reader_for_raw(raw, ext)`. Unambiguous extensions are unaffected (they fall through to `reader[ext]` exactly as before).

This re-reads the original file with the same reader that created it, so `raw._init_kwargs` always match.

### Verification

- New offline regression test `test_reader_for_raw_ambiguous_extension` (no data required): asserts that a `RawANT`-classed object resolves to `read_raw_ant` while a `RawCNT`-classed object and unambiguous extensions still resolve to the extension-based reader, and documents the root-cause kwarg mismatch (`fname` vs `input_fname`). Fails on `main` (helper absent / wrong reader), passes with the fix.
- `ruff check` / `ruff format` clean; `test_write.py` collects without errors.