### PR TITLE
Speed up write_raw_bids for recordings with many channels

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -51,6 +51,6 @@ Detailed list of changes
 ⚕️ Code health
 ^^^^^^^^^^^^^^
 
-- None yet
+- Sped up writing of recordings with many channels by avoiding redundant per-channel work in :func:`mne_bids.write_raw_bids` (single-pass channel-type counting, cached coil-type lookup, and a fixed quadratic loop when writing BrainVision units), by `Stefan Appelhoff`_ (:gh:`1620`)
 
 :doc:`Find out what was new in previous releases <whats_new_previous_releases>`

--- a/mne_bids/pick.py
+++ b/mne_bids/pick.py
@@ -3,9 +3,12 @@
 # Authors: The MNE-BIDS developers
 # SPDX-License-Identifier: BSD-3-Clause
 
+from functools import cache
+
 from mne.io.constants import FIFF
 
 
+@cache
 def get_coil_types():
     """Return all known coil types.
 

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -11,7 +11,7 @@ import shutil
 import subprocess
 import sys
 import warnings
-from collections import OrderedDict, defaultdict
+from collections import Counter, OrderedDict, defaultdict
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
@@ -1157,22 +1157,19 @@ def _sidecar_json(
     )
     # all ignored channels are trigger channels at the moment...
 
-    n_megchan = len([ch for ch in raw.info["chs"] if ch["kind"] == FIFF.FIFFV_MEG_CH])
-    n_megrefchan = len(
-        [ch for ch in raw.info["chs"] if ch["kind"] == FIFF.FIFFV_REF_MEG_CH]
-    )
-    n_eegchan = len([ch for ch in raw.info["chs"] if ch["kind"] == FIFF.FIFFV_EEG_CH])
-    n_ecogchan = len([ch for ch in raw.info["chs"] if ch["kind"] == FIFF.FIFFV_ECOG_CH])
-    n_seegchan = len([ch for ch in raw.info["chs"] if ch["kind"] == FIFF.FIFFV_SEEG_CH])
-    n_eogchan = len([ch for ch in raw.info["chs"] if ch["kind"] == FIFF.FIFFV_EOG_CH])
-    n_ecgchan = len([ch for ch in raw.info["chs"] if ch["kind"] == FIFF.FIFFV_ECG_CH])
-    n_emgchan = len([ch for ch in raw.info["chs"] if ch["kind"] == FIFF.FIFFV_EMG_CH])
-    n_miscchan = len([ch for ch in raw.info["chs"] if ch["kind"] == FIFF.FIFFV_MISC_CH])
-    n_stimchan = (
-        len([ch for ch in raw.info["chs"] if ch["kind"] == FIFF.FIFFV_STIM_CH])
-        - n_ignored
-    )
-    n_dbschan = len([ch for ch in raw.info["chs"] if ch["kind"] == FIFF.FIFFV_DBS_CH])
+    # Count channels per kind in a single pass over raw.info["chs"].
+    n_chan_per_kind = Counter(ch["kind"] for ch in raw.info["chs"])
+    n_megchan = n_chan_per_kind[FIFF.FIFFV_MEG_CH]
+    n_megrefchan = n_chan_per_kind[FIFF.FIFFV_REF_MEG_CH]
+    n_eegchan = n_chan_per_kind[FIFF.FIFFV_EEG_CH]
+    n_ecogchan = n_chan_per_kind[FIFF.FIFFV_ECOG_CH]
+    n_seegchan = n_chan_per_kind[FIFF.FIFFV_SEEG_CH]
+    n_eogchan = n_chan_per_kind[FIFF.FIFFV_EOG_CH]
+    n_ecgchan = n_chan_per_kind[FIFF.FIFFV_ECG_CH]
+    n_emgchan = n_chan_per_kind[FIFF.FIFFV_EMG_CH]
+    n_miscchan = n_chan_per_kind[FIFF.FIFFV_MISC_CH]
+    n_stimchan = n_chan_per_kind[FIFF.FIFFV_STIM_CH] - n_ignored
+    n_dbschan = n_chan_per_kind[FIFF.FIFFV_DBS_CH]
     nirs_channels = [ch for ch in raw.info["chs"] if ch["kind"] == FIFF.FIFFV_FNIRS_CH]
     n_nirscwchan = len(nirs_channels)
     n_nirscwsrc = len(
@@ -1457,7 +1454,7 @@ def _write_raw_brainvision(raw, bids_fname, events, overwrite):
             unit.append("µV")
         else:
             unit.append(_unit2human.get(chs["unit"], "n/a"))
-            unit = [u if u not in ["NA"] else "n/a" for u in unit]
+    unit = [u if u not in ["NA"] else "n/a" for u in unit]
 
     # We enforce conversion to float32 format
     # XXX: pybv can also write to int16, to do that, we need to get


### PR DESCRIPTION
(PR and content generated with the help of Claude)

Three small, behavior-preserving optimizations on the channel-writing hot path in `write_raw_bids`. Each was verified to produce identical output to the previous code.

### Changes

1. **`pick.get_coil_types()` — cache the constant dict.**
   `coil_type()` is called once per channel and rebuilt this large dict of FIFF constants every time. It is now built once via `functools.cache`. (read-only, internal use only)

2. **`_sidecar_json()` — single-pass channel counting.**
   Replaced 11 separate `len([ch for ch in raw.info["chs"] if ch["kind"] == ...])` comprehensions (11 full passes building throwaway lists) with one `Counter` pass.

3. **`_write_raw_brainvision()` — fix quadratic unit loop.**
   The `"NA" -> "n/a"` fixup comprehension lived *inside* the per-channel loop, rebuilding the entire `unit` list on every iteration (O(n²)). Moved it to a single pass after the loop. The fixup is idempotent, so the result is identical.

### Measured impact (microbenchmarks, representative channel counts)

| Change | Before | After | Speedup |
|---|---|---|---|
| coil_type ×300 channels | 0.320 ms | 0.161 ms | ~2× |
| channel counting (279 ch) | 111.6 µs | 19.3 µs | ~5.8× |
| BrainVision unit loop (270 ch) | 655 µs | 35 µs | ~18.8× |

### Testing

- Equivalence checks confirm the new channel-counting and unit-loop code produce identical results to the originals across all channel kinds (including the `FIFF_UNIT_NONE -> "NA"` case).
- `test_write.py`, `test_pick.py`, `test_read.py`: 215 passed, 0 new failures. (The 7 pre-existing `curry` failures and skips are environmental and also fail on `main`.)

No behavior or output changes.