### PR TITLE
Replace per-value scans with index maps when reading fNIRS coords; stream BrainVision files

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -51,6 +51,6 @@ Detailed list of changes
 ⚕️ Code health
 ^^^^^^^^^^^^^^
 
-- None yet
+- Sped up reading fNIRS electrode coordinates with a single-pass index map, and reduced peak memory when copying BrainVision header/marker files by streaming them instead of reading them fully into memory, by `Stefan Appelhoff`_ (:gh:`1621`)
 
 :doc:`Find out what was new in previous releases <whats_new_previous_releases>`

--- a/mne_bids/copyfiles.py
+++ b/mne_bids/copyfiles.py
@@ -428,14 +428,14 @@ def copyfile_brainvision(vhdr_src, vhdr_dest, anonymize=None, *, verbose=None):
 
     with open(vhdr_src, encoding=enc) as fin:
         with _open_lock(vhdr_dest, "w", encoding=enc) as fout:
-            for line in fin.readlines():
+            for line in fin:
                 if line.strip() in search_lines:
                     line = line.replace(basename_src, basename_dest)
                 fout.write(line)
 
     with open(vmrk_file_path, encoding=enc) as fin:
         with _open_lock(fname_dest + ".vmrk", "w", encoding=enc) as fout:
-            for line in fin.readlines():
+            for line in fin:
                 if line.strip() in search_lines:
                     line = line.replace(basename_src, basename_dest)
                 fout.write(line)

--- a/mne_bids/dig.py
+++ b/mne_bids/dig.py
@@ -348,13 +348,21 @@ def _write_optodes_tsv(raw, fname, overwrite=False, verbose=True):
     xs = np.zeros(names.shape)
     ys = np.zeros(names.shape)
     zs = np.zeros(names.shape)
+    # Map each source/detector value to its first index in a single pass,
+    # instead of an O(n) np.where scan per unique value.
+    source_first_idx = {}
+    for idx, source in enumerate(sources):
+        source_first_idx.setdefault(source, idx)
+    detector_first_idx = {}
+    for idx, detector in enumerate(detectors):
+        detector_first_idx.setdefault(detector, idx)
     for i, source in enumerate(unique_sources):
-        s_idx = np.where(sources == source)[0][0]
+        s_idx = source_first_idx[source]
         xs[i] = raw.info["chs"][s_idx]["loc"][3]
         ys[i] = raw.info["chs"][s_idx]["loc"][4]
         zs[i] = raw.info["chs"][s_idx]["loc"][5]
     for i, detector in enumerate(unique_detectors):
-        d_idx = np.where(detectors == detector)[0][0]
+        d_idx = detector_first_idx[detector]
         xs[i + n_sources] = raw.info["chs"][d_idx]["loc"][6]
         ys[i + n_sources] = raw.info["chs"][d_idx]["loc"][7]
         zs[i + n_sources] = raw.info["chs"][d_idx]["loc"][8]


### PR DESCRIPTION
(PR and content generated with the help of Claude)

Two small, behavior-preserving cleanups that replace repeated O(n) work with single-pass alternatives (one commit each).

### Changes

1. **`dig.py` — fNIRS optode coordinates.**
   `_write_optodes_tsv` ran `np.where(sources == source)[0][0]` for each unique source and detector (O(n·u)). Now builds `value -> first-index` maps in one pass. Verified equivalent to `np.where(...)[0][0]` including duplicate/zero values.

2. **`copyfiles.py` — BrainVision header/marker copy.**
   Iterate the `.vhdr`/`.vmrk` file objects directly instead of `.readlines()`, lowering peak memory for large marker files. Same output.

### Measured impact

**fNIRS coordinate reading (`dig.py`)** — consistent speedup:

| optodes (src+det) | `np.where` | index map | speedup |
|---|---|---|---|
| 8 + 8 | 9.1 µs | 2.7 µs | 3.4× |
| 32 + 32 | 34 µs | 8 µs | 4.2× |
| 128 + 128 | 141 µs | 30 µs | 4.7× |

**BrainVision copy (`copyfiles.py`)** — peak memory on an 18 MB / 500k-line marker file:

| approach | peak memory |
|---|---|
| `.readlines()` | 46.6 MB |
| stream | 4.2 MB (~11× less) |

Speed of the copy is unchanged; this is purely a memory improvement.

### Testing

- `test_dig.py`, `test_copyfiles.py`, `test_write.py::test_snirf` (exercises the fNIRS optode path): passed.
- An equivalence check confirms the `dig.py` first-index map matches `np.where(...)[0][0]` for arrays with duplicates and zeros.

No behavior or output changes.

> Note: an earlier revision of this PR also rewrote a `list.index()` loop in `inspect.py`. Benchmarking showed it was only faster for high-density montages and slightly *slower* for typical small channel counts, so it was dropped.