### PR TITLE
MAINT: enable ssh debugging

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,14 @@ on:
     branches: ['**']
   schedule:
     - cron: "0 4 * * 1"  # every Monday at 4:00 UTC
+  # adapted from mne-python which adapted theirs from spyder-ide/spyder
+  workflow_dispatch:
+    inputs:
+      ssh:
+        description: 'Enable ssh debugging'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   style:  # takes ~10s
@@ -157,6 +165,22 @@ jobs:
     - uses: actions/checkout@v7
       with:
         fetch-depth: 0
+    - name: Get commit message
+      run: echo "COMMIT_MESSAGE=$(git show -s --format=%s ${{ github.event.pull_request.head.sha || github.sha }})" | tee -a ${GITHUB_ENV}
+    - name: Triage SSH
+      run: |
+        if [[ "${{ inputs.ssh }}" == "true" ]] || [[ "$COMMIT_MESSAGE" == *"[actions ssh]"* ]]; then
+          echo "ENABLE_SSH=true" | tee -a $GITHUB_ENV
+        else
+          echo "ENABLE_SSH=false" | tee -a $GITHUB_ENV
+        fi
+    - name: Setup Remote SSH Connection
+      if: env.ENABLE_SSH == 'true'
+      uses: Warpbuilds/action-debugger@v1.3
+      timeout-minutes: 80
+      with:
+        detached: true
+        limit-access-to-actor: true
 
     - uses: denoland/setup-deno@v2
       with:


### PR DESCRIPTION
Allows for ssh tunneling into the CI environments, for interactive debugging. I would like this feature so e.g. I can gain better visibility into the failures over at #1630, which I can't replicate locally.

I basically just copied the `warpbuild/action-debugger` configuration over at [MNE-Python](https://github.com/mne-tools/mne-python/blob/31a73266fb6ee0aed10de777ddaa4d8474da315f/.github/workflows/tests.yml#L109).

The only difference between here and mne-python is that I set `limit-access-to-actor: true` in the `action-debugger` config. My understanding from their [documentation](https://github.com/WarpBuilds/action-debugger#use-registered-public-ssh-keys) is that by default, if the ssh session is triggered by a user who _does not have any public ssh keys on their GitHub profile_, then `action-debugger` will create an ssh link that _anyone can access_. `limit-access-to-actor: true` requires one to have a public ssh key associated with their GitHub profile before they can trigger an interactive ssh job, which ensures that only they can access the shh tunnel.