### PR TITLE
FIX: Don't let lock files persist in BIDS datasets

### DIFF
--- a/mne_bids/_fileio.py
+++ b/mne_bids/_fileio.py
@@ -95,7 +95,7 @@ def _get_lock_context(path, *, timeout=None, lock=True):
         try:
             # Ensure parent directory exists
             Path(lock_path).parent.mkdir(parents=True, exist_ok=True)
-            lock_context = filelock.FileLock(
+            lock_context = filelock.SoftFileLock(
                 str(lock_path),
                 timeout=timeout,
             )

--- a/mne_bids/tests/test_fileio.py
+++ b/mne_bids/tests/test_fileio.py
@@ -144,7 +144,7 @@ def test_get_lock_context_oserror(tmp_path):
     test_file = tmp_path / "test.txt"
     test_file.write_text("test")
 
-    with patch.object(filelock, "FileLock", side_effect=_mock_filelock_oserror):
+    with patch.object(filelock, "SoftFileLock", side_effect=_mock_filelock_oserror):
         with pytest.warns(RuntimeWarning, match="Could not create lock"):
             with _get_lock_context(test_file) as lock_ctx:
                 assert lock_ctx is not None
@@ -157,7 +157,7 @@ def test_get_lock_context_typeerror(tmp_path):
     test_file = tmp_path / "test.txt"
     test_file.write_text("test")
 
-    with patch.object(filelock, "FileLock", side_effect=_mock_filelock_typeerror):
+    with patch.object(filelock, "SoftFileLock", side_effect=_mock_filelock_typeerror):
         with pytest.warns(RuntimeWarning, match="Could not create lock"):
             with _get_lock_context(test_file) as lock_ctx:
                 assert lock_ctx is not None

--- a/mne_bids/tests/test_write.py
+++ b/mne_bids/tests/test_write.py
@@ -4488,14 +4488,6 @@ def test_parallel_write_many_subjects(tmp_path):
     dataset_description = bids_root / "dataset_description.json"
     assert dataset_description.exists()
 
-    # Clean up remaining lock files created during parallel writes
-    for lock_file in bids_root.rglob("*.lock"):
-        try:
-            lock_file.unlink()
-        except OSError:
-            # In case lock is still held or file is in use, that's OK
-            pass
-
     # putting some sleep to make sure all file locks are released
     time.sleep(1)
     # No stale lock files should remain after the parallel writes complete.


### PR DESCRIPTION
Fixes #1632 

Found `SoftFileLock` on the filelock doc:

- https://py-filelock.readthedocs.io/en/latest/api.html#filelock.SoftFileLock
- https://py-filelock.readthedocs.io/en/latest/how-to.html#detect-stale-locks-soft-locks-only

IIUC this will remove the lock file for us when the process that created it finishes. 

The important thing for the team to know is that `SoftFileLock` uses a different locking mechanism than `FileLock`. `FileLock` will use OS-level locking mechanisms, `SoftFileLock` uses the existence of the lock file itself as the locking mechanism.

Using `SoftFileLock` makes the tests pass again locally. If the CI's pass too, I think this is one way to fix the issue, but maybe in the medium-to-long-term there are better ways, (EDIT) as I imagine that the [concerns about unlinking ](https://py-filelock.readthedocs.io/en/latest/api.html#filelock.UnixFileLock)a lock file on unix systems still applies when using `SoftFileLock`

