### PR TITLE
Document tracking system parameters

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -233,6 +233,8 @@ authors:
       family-names: Boscher
       affiliation: 'Laboratoire de Psychologie et Neurocognition, Grenoble, France'
       orcid: 'https://orcid.org/0009-0005-1615-1369'
+    - given-names: Daria
+      family-names: Agafonova
     - given-names: Alexandre
       family-names: Gramfort
       affiliation: 'Université Paris-Saclay, Inria, CEA, Palaiseau, France'

--- a/doc/authors.rst
+++ b/doc/authors.rst
@@ -16,6 +16,7 @@
 .. _Christian O'Reilly: https://github.com/christian-oreilly
 .. _Clemens Brunner: https://github.com/cbrnr
 .. _Daniel McCloy: http://dan.mccloy.info
+.. _Daria Agafonova: https://github.com/viranovskaya
 .. _Denis Engemann: https://github.com/dengemann
 .. _Diego Lozano-Soldevilla: https://orcid.org/0000-0003-1794-8204
 .. _Dominik Welke: https://github.com/dominikwelke

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -19,6 +19,7 @@ Version 0.20 (unreleased)
 
 The following authors contributed for the first time. Thank you so much! 🤩
 
+* `Daria Agafonova`_
 * `Vincent Gao`_
 
 The following authors had contributed before. Thank you for sticking around! 🤘
@@ -31,6 +32,7 @@ Detailed list of changes
 🚀 Enhancements
 ^^^^^^^^^^^^^^^
 
+- Clarify that the ``tracking_system`` parameter of :class:`mne_bids.BIDSPath` and the ``tracking_systems`` parameter of :func:`mne_bids.find_matching_paths` correspond to the Motion-BIDS ``tracksys`` entity, by `Daria Agafonova`_ (:gh:`1562`)
 - Add :func:`mne_bids.read_epochs_bids` to read epoched BIDS recordings (``"RecordingType": "epoched"``) as :class:`mne.Epochs`; :func:`mne_bids.read_raw_bids` now raises a helpful error for such recordings, by `Bruno Aristimunha`_ (:gh:`1605`)
 
 🧐 API and behavior changes

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -280,7 +280,10 @@ class BIDSPath:
 
         .. versionadded:: 0.11
     tracking_system : str | None
-        The motion tracking system.
+        The motion tracking system for Motion-BIDS data. This corresponds to
+        the BIDS entity ``tracksys``. For example,
+        ``tracking_system="omcA"`` produces filenames containing
+        ``tracksys-omcA``.
 
         .. versionadded:: 0.18
     root : path-like | None
@@ -2806,7 +2809,10 @@ def find_matching_paths(
 
         .. versionadded:: 0.11
     tracking_systems : str | array-like of str | None
-        The motion tracking systems used.
+        The motion tracking systems to match for Motion-BIDS data. This
+        corresponds to the BIDS entity ``tracksys``. For example,
+        ``tracking_systems="omcA"`` matches filenames containing
+        ``tracksys-omcA``.
 
         .. versionadded:: 0.19
     suffixes : str | array-like of str | None

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -281,8 +281,7 @@ class BIDSPath:
         .. versionadded:: 0.11
     tracking_system : str | None
         The motion tracking system label for Motion-BIDS data. This corresponds
-        to the BIDS entity ``tracksys``, rather than the human-readable
-        ``TrackingSystemName`` metadata. For example,
+        to the BIDS entity ``tracksys``. For example,
         ``tracking_system="omcA"`` produces filenames containing
         ``tracksys-omcA``.
 
@@ -2811,8 +2810,7 @@ def find_matching_paths(
         .. versionadded:: 0.11
     tracking_systems : str | array-like of str | None
         The motion tracking system labels to match for Motion-BIDS data. These
-        correspond to the BIDS entity ``tracksys``, rather than the
-        human-readable ``TrackingSystemName`` metadata. For example,
+        correspond to the BIDS entity ``tracksys``. For example,
         ``tracking_systems="omcA"`` matches filenames containing
         ``tracksys-omcA``.
 

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -280,8 +280,9 @@ class BIDSPath:
 
         .. versionadded:: 0.11
     tracking_system : str | None
-        The motion tracking system for Motion-BIDS data. This corresponds to
-        the BIDS entity ``tracksys``. For example,
+        The motion tracking system label for Motion-BIDS data. This corresponds
+        to the BIDS entity ``tracksys``, rather than the human-readable
+        ``TrackingSystemName`` metadata. For example,
         ``tracking_system="omcA"`` produces filenames containing
         ``tracksys-omcA``.
 
@@ -2809,8 +2810,9 @@ def find_matching_paths(
 
         .. versionadded:: 0.11
     tracking_systems : str | array-like of str | None
-        The motion tracking systems to match for Motion-BIDS data. This
-        corresponds to the BIDS entity ``tracksys``. For example,
+        The motion tracking system labels to match for Motion-BIDS data. These
+        correspond to the BIDS entity ``tracksys``, rather than the
+        human-readable ``TrackingSystemName`` metadata. For example,
         ``tracking_systems="omcA"`` matches filenames containing
         ``tracksys-omcA``.
 


### PR DESCRIPTION
Closes #1562.

The `tracking_system` and `tracking_systems` parameters did not explain how
their values map to BIDS filenames.

This update identifies them as Motion-BIDS parameters, connects them to the
`tracksys` entity, distinguishes the concise filename label from the
human-readable `TrackingSystemName` metadata, and uses the specification's
`omcA` example.

Checks: all pre-commit hooks pass on the changed files.
