### PR TITLE
Fix BIDSPath.match roots for nested datasets

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -48,7 +48,7 @@ Detailed list of changes
 🪲 Bug fixes
 ^^^^^^^^^^^^
 
-- Preserve the actual root of files returned by :meth:`mne_bids.BIDSPath.match`, avoiding duplicate paths and paths that do not exist when matching inside nested BIDS roots, by `Daria Agafonova`_ (:gh:`1561`)
+- Preserve the actual root of files returned by :meth:`mne_bids.BIDSPath.match`, avoiding duplicate paths and paths that do not exist when matching inside nested BIDS roots, by `Daria Agafonova`_ (:gh:`1637`)
 - :func:`mne_bids.write_raw_bids` no longer raises a ``TypeError`` when writing ANT Neuro eego recordings (``.cnt``), by `Vincent Gao`_ (:gh:`1617`)
 
 ⚕️ Code health

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -48,6 +48,7 @@ Detailed list of changes
 🪲 Bug fixes
 ^^^^^^^^^^^^
 
+- Preserve the actual root of files returned by :meth:`mne_bids.BIDSPath.match`, avoiding duplicate paths and paths that do not exist when matching inside nested BIDS roots, by `Daria Agafonova`_ (:gh:`1561`)
 - :func:`mne_bids.write_raw_bids` no longer raises a ``TypeError`` when writing ANT Neuro eego recordings (``.cnt``), by `Vincent Gao`_ (:gh:`1617`)
 
 ⚕️ Code health

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -3046,8 +3046,12 @@ def _fnames_to_bidspaths(fnames, root, check=False):
     for fname in fnames:
         datatype = _infer_datatype_from_path(fname)
         bids_path = get_bids_path_from_fname(fname, check=False)
+        inferred_root = bids_path.root
         bids_path.root = root
         bids_path.datatype = datatype
+        expected_fpath = bids_path.directory / bids_path.basename
+        if expected_fpath != Path(fname):
+            bids_path.root = inferred_root
         bids_path.check = True
 
         try:

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -444,7 +444,6 @@ def bids_root_dense(tmp_path):
 def test_path_benchmark(bids_root_dense, monkeypatch, path_counter):
     """Benchmark exploring bids tree."""
     tmp_bids_root = bids_root_dense.root
-    n_subjects = bids_root_dense.n_subjects
     n_sessions = bids_root_dense.n_sessions
     # This benchmark is to verify the speed-up in function call get_entity_vals with
     # `include_match=sub-*/` in face of a bids tree hosting derivatives and sourcedata.
@@ -492,13 +491,9 @@ def test_path_benchmark(bids_root_dense, monkeypatch, path_counter):
         root=tmp_bids_root,
     )
     paths = path.match()
-    # TODO: We *should* have n_subjects * n_sessions of these, but we get way more:
     assert len(paths) == 684
-    # This is because we have duplicate files here with BIDS entities, like:
-    # bids_root/derivatives/derivatives0/sub-1/ses-1/meg/sub-1_ses-1_task-audvis_meg.ds
-    # bids_root/derivatives/derivatives1/sub-1/ses-1/meg/sub-1_ses-1_task-audvis_meg.ds
-    # And _fnames_to_bidspaths converts these to the same names!
-    assert paths[0] == paths[n_subjects * n_sessions]
+    assert len(set(paths)) == len(paths)
+    assert all(path.fpath.exists() for path in paths)
     assert path_counter.count == 3420
     path.subject = "1"  # add subject
     paths = path.match()
@@ -1771,6 +1766,39 @@ def test_match_advanced(tmp_path):
     )
     matches = path.match()
     assert len(matches) == len(fnames), path
+
+
+def test_match_preserves_nested_roots(tmp_path):
+    """Keep identical filenames from nested BIDS roots distinct."""
+    nested_roots = (
+        tmp_path / "sourcedata",
+        tmp_path / "derivatives" / "pipeline-a",
+    )
+    expected = set()
+    for root in nested_roots:
+        bids_path = BIDSPath(
+            root=root,
+            subject="01",
+            task="rest",
+            datatype="eeg",
+            suffix="eeg",
+            extension=".edf",
+        )
+        bids_path.mkdir()
+        bids_path.fpath.touch()
+        expected.add(bids_path.fpath)
+
+    query = BIDSPath(
+        root=tmp_path,
+        datatype="eeg",
+        suffix="eeg",
+        extension=".edf",
+    )
+    matches = query.match()
+
+    assert {match.fpath for match in matches} == expected
+    assert len(set(matches)) == len(expected)
+    assert all(match.fpath.exists() for match in matches)
 
 
 def test_find_matching_paths(bids_root):

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -1770,12 +1770,13 @@ def test_match_advanced(tmp_path):
 
 def test_match_preserves_nested_roots(tmp_path):
     """Keep identical filenames from nested BIDS roots distinct."""
-    nested_roots = (
+    roots = (
+        tmp_path,
         tmp_path / "sourcedata",
         tmp_path / "derivatives" / "pipeline-a",
     )
     expected = set()
-    for root in nested_roots:
+    for root in roots:
         bids_path = BIDSPath(
             root=root,
             subject="01",
@@ -1797,6 +1798,7 @@ def test_match_preserves_nested_roots(tmp_path):
     matches = query.match()
 
     assert {match.fpath for match in matches} == expected
+    assert {match.root for match in matches} == set(roots)
     assert len(set(matches)) == len(expected)
     assert all(match.fpath.exists() for match in matches)
 

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -444,7 +444,9 @@ def bids_root_dense(tmp_path):
 def test_path_benchmark(bids_root_dense, monkeypatch, path_counter):
     """Benchmark exploring bids tree."""
     tmp_bids_root = bids_root_dense.root
+    n_subjects = bids_root_dense.n_subjects
     n_sessions = bids_root_dense.n_sessions
+    n_bids_roots = len(bids_root_dense.bids_subdirectories)
     # This benchmark is to verify the speed-up in function call get_entity_vals with
     # `include_match=sub-*/` in face of a bids tree hosting derivatives and sourcedata.
     fnames = mne_bids.path._return_root_paths(tmp_bids_root)
@@ -491,7 +493,9 @@ def test_path_benchmark(bids_root_dense, monkeypatch, path_counter):
         root=tmp_bids_root,
     )
     paths = path.match()
-    assert len(paths) == 684
+    # Each BIDS root contains one .ds recording per subject-session pair.
+    expected_n_paths = n_subjects * n_sessions * n_bids_roots
+    assert len(paths) == expected_n_paths
     assert len(set(paths)) == len(paths)
     assert all(path.fpath.exists() for path in paths)
     assert path_counter.count == 3420


### PR DESCRIPTION
Fixes #1561.

`BIDSPath.match()` now keeps the root inferred from each matched filename when replacing it with the requested root would point somewhere else. This keeps same-named files in `sourcedata` and `derivatives` distinct and ensures that the returned paths refer to files that exist.

The regression test covers identical filenames in two nested BIDS roots. The existing dense-tree benchmark now also checks that every match is unique and exists.

Checks:

- `ruff check mne_bids/path.py mne_bids/tests/test_path.py`
- `ruff format --check mne_bids/path.py mne_bids/tests/test_path.py`
- 19 related path matching, filtering, and parsing tests passed
- dense-tree path benchmark passed
