### PR TITLE
ENH: write eyetracking data

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,12 +13,19 @@ repos:
         # D205: 1 blank line required between summary line and description
         args: ["--ignore=D103,D400,D205"]
         files: ^examples/
+      - id: ruff
+        name: ruff doc/
+        files: ^doc/
+        args: ["--fix"]
       - id: ruff-format
         name: ruff format mne_bids/
         files: ^mne_bids/
       - id: ruff-format
         name: ruff format examples/
         files: ^examples/
+      - id: ruff-format
+        name: ruff format doc/
+        files: ^doc/
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -86,3 +86,20 @@ mne_bids.copyfiles
    copyfile_bti
    copyfile_kit
    copyfile_mef
+
+
+mne_bids.physio
+---------------
+
+:py:mod:`mne_bids.physio`:
+
+.. automodule:: mne_bids.physio
+   :no-members:
+   :no-inherited-members:
+
+.. currentmodule:: mne_bids.physio
+
+.. autosummary::
+   :toctree: generated/
+
+   write_eyetrack_calibration

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -63,6 +63,7 @@ numpydoc_xref_aliases = {
     "list": ":class:`list <python:list>`",
     "tuple": ":class:`tuple <python:tuple>`",
     "NibabelImageObject": "nibabel.spatialimages.SpatialImage",
+    "CalibrationObject": "mne.preprocessing.eyetracking.Calibration"
 }
 numpydoc_xref_ignore = {
     # words
@@ -216,3 +217,9 @@ sphinx_gallery_conf = {
 }
 
 assert is_serializable(sphinx_gallery_conf)
+
+# Reusable hyperlink targets that can be referenced in our Documentation/Docstrings
+rst_epilog = """
+.. _The Eyetracking BIDS specification:
+   https://bids-specification.readthedocs.io/en/stable/modality-specific-files/physiological-recordings.html#eye-tracking
+"""

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -5,8 +5,8 @@
 
 import os
 import sys
-from pathlib import Path
 from datetime import date
+from pathlib import Path
 
 from intersphinx_registry import get_intersphinx_mapping
 from sphinx.config import is_serializable
@@ -63,7 +63,7 @@ numpydoc_xref_aliases = {
     "list": ":class:`list <python:list>`",
     "tuple": ":class:`tuple <python:tuple>`",
     "NibabelImageObject": "nibabel.spatialimages.SpatialImage",
-    "CalibrationObject": "mne.preprocessing.eyetracking.Calibration"
+    "CalibrationObject": "mne.preprocessing.eyetracking.Calibration",
 }
 numpydoc_xref_ignore = {
     # words

--- a/doc/sphinxext/gh_substitutions.py
+++ b/doc/sphinxext/gh_substitutions.py
@@ -14,8 +14,9 @@ from docutils.nodes import reference
 from docutils.parsers.rst.roles import set_classes
 
 
-def gh_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
+def gh_role(name, rawtext, text, lineno, inliner, options=None, content=None):
     """Link to a GitHub issue."""
+    options = {} if options is None else options
     try:
         # issue/PR mode (issues/PR-num will redirect to pull/PR-num)
         int(text)

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -33,6 +33,7 @@ Detailed list of changes
 ^^^^^^^^^^^^^^^
 
 - Clarify that the ``tracking_system`` parameter of :class:`mne_bids.BIDSPath` and the ``tracking_systems`` parameter of :func:`mne_bids.find_matching_paths` correspond to the Motion-BIDS ``tracksys`` entity, by `Daria Agafonova`_ (:gh:`1562`)
+- Add support for writing eyetracking data with :func:`mne_bids.write_raw_bids` (new ``eyetrack_calibration`` parameter) and for updating calibration metadata with :func:`mne_bids.physio.write_eyetrack_calibration`, by `Scott Huberty`_ (:gh:`1642`)
 - Add :func:`mne_bids.read_epochs_bids` to read epoched BIDS recordings (``"RecordingType": "epoched"``) as :class:`mne.Epochs`; :func:`mne_bids.read_raw_bids` now raises a helpful error for such recordings, by `Bruno Aristimunha`_ (:gh:`1605`)
 
 🧐 API and behavior changes

--- a/examples/convert_eyetracking_to_bids.py
+++ b/examples/convert_eyetracking_to_bids.py
@@ -122,6 +122,7 @@ eye1_json = bids_path.fpath.with_suffix("").with_suffix(".json")
 print(f"Filepath: {eye1_json}")
 pprint(json.loads(eye1_json.read_text()), indent=2)
 
+# %%
 # Convert simultaneous EEG + eyetracking data to BIDS
 # ---------------------------------------------------
 #
@@ -207,7 +208,8 @@ print_dir_tree(bids_root_simultaneous)
 
 # %%
 # Again, let's inspect the saved metadata for one eye. Note that the units for our
-# eyegaze channels are 'pixel', meaining these data are 'pixel-on-screen' coordinates.
+# eyegaze channels are 'pixel', meaning these data are 'pixel-on-screen' coordinates.
+
 # %%
 eye1_json = bids_path_eeg.find_matching_sidecar(suffix="physio", extension=".json")
 print(f"Filepath: {eye1_json}")

--- a/examples/convert_eyetracking_to_bids.py
+++ b/examples/convert_eyetracking_to_bids.py
@@ -83,7 +83,7 @@ bids_path = BIDSPath(
 # ----------------------------
 #
 # To write eyetracking BIDS, you need to pass both the Raw object with the eytracking
-# data, and a `:class:~mne.preprocessing.eyetracking.Calibration` object that
+# data, and a :class:`~mne.preprocessing.eyetracking.Calibration` object that
 # contains necessary metadata about the presentation display used in the experiment.
 # MNE-BIDS will write one ``*_physio.tsv.gz`` + ``*_physio.json`` pair per eye,
 # with matching ``*_physioevents.tsv.gz`` files. Additionally, we are going to convert

--- a/examples/convert_eyetracking_to_bids.py
+++ b/examples/convert_eyetracking_to_bids.py
@@ -22,6 +22,8 @@ MNE-BIDS.
 # %%
 import json
 import shutil
+import tempfile
+from pathlib import Path
 from pprint import pprint
 
 import mne
@@ -62,9 +64,7 @@ raw.plot(scalings="auto")
 # writing of ``eye2`` data for us.)
 
 # %%
-bids_root = data_path.parent / "MNE-eyetrack-data-bids-example"
-if bids_root.exists():
-    shutil.rmtree(bids_root)
+bids_root = Path(tempfile.mkdtemp(prefix="mne_bids_eyetrack_"))
 
 bids_path = BIDSPath(
     root=bids_root,
@@ -177,9 +177,7 @@ del raw_eeg  # free up some memory
 # Write the merged EEG + eyetracking recording.
 
 # %%
-bids_root_simultaneous = eyelink_root.parent / "MNE-eyetrack-eeg-bids-example"
-if bids_root_simultaneous.exists():
-    shutil.rmtree(bids_root_simultaneous)
+bids_root_simultaneous = Path(tempfile.mkdtemp(prefix="mne_bids_eyetrack_eeg_"))
 
 bids_path_eeg = BIDSPath(
     root=bids_root_simultaneous,
@@ -214,3 +212,6 @@ print_dir_tree(bids_root_simultaneous)
 eye1_json = bids_path_eeg.find_matching_sidecar(suffix="physio", extension=".json")
 print(f"Filepath: {eye1_json}")
 pprint(json.loads(eye1_json.read_text()), indent=2)
+
+shutil.rmtree(bids_root)
+shutil.rmtree(bids_root_simultaneous)

--- a/examples/convert_eyetracking_to_bids.py
+++ b/examples/convert_eyetracking_to_bids.py
@@ -1,0 +1,214 @@
+"""
+.. currentmodule:: mne_bids
+
+.. _ex-convert-eyetracking-to-bids:
+
+=======================================
+Convert eyetracking data to BIDS Format
+=======================================
+
+This example shows how to convert Eyelink eyetracking data to BIDS using
+MNE-BIDS.
+
+.. seealso::
+
+   | `Working with eyetracking data in MNE-Python <https://mne.tools/stable/auto_tutorials/preprocessing/90_eyetracking_data.html>`_
+   | `The Eyetracking BIDS specification`_
+"""  # noqa: D400
+
+# Authors: The MNE-BIDS developers
+# SPDX-License-Identifier: BSD-3-Clause
+
+# %%
+import json
+import shutil
+from pprint import pprint
+
+import mne
+from mne.datasets import testing
+from mne.datasets.eyelink import data_path as eyelink_data_path
+from mne.preprocessing.eyetracking import read_eyelink_calibration
+
+from mne_bids import BIDSPath, print_dir_tree, write_raw_bids
+
+# %%
+# Load example eyetracking data
+# -----------------------------
+#
+# Here we use an Eyelink file from the MNE-Python testing data.
+
+data_path = testing.data_path(download=False)
+eyetrack_fpath = data_path / "eyetrack" / "test_eyelink.asc"
+raw = mne.io.read_raw_eyelink(eyetrack_fpath)
+cals = read_eyelink_calibration(eyetrack_fpath)
+for cal in cals:
+    cal["screen_origin"] = ["top", "left"]
+raw
+
+# %%
+raw.plot(scalings="auto")
+
+# %%
+# Where are BIDS compliant eyetracking files stored?
+# --------------------------------------------------
+#
+# Eyetracking-only data is stored in the ``'beh'`` modality directory. Eyetracking data
+# that was collected alongside another modality (``eeg``, ``meg``, etc) will be stored
+# in the same directory as that modality. When defining a BIDSPath instance to read or
+# write eyetracking data, pass ``datatype="beh"`` for eyetracking-only data, and for
+# example ``datatype='eeg'`` if data were collected simultaneously with EEG data.
+# Either way, you should also pass ``suffix="physio"``, and ``recording='eye1'`` to the
+# BIDSPath constructor (even for binocular data, MNE-BIDS will handle reading and
+# writing of ``eye2`` data for us.)
+
+# %%
+bids_root = data_path.parent / "MNE-eyetrack-data-bids-example"
+if bids_root.exists():
+    shutil.rmtree(bids_root)
+
+bids_path = BIDSPath(
+    root=bids_root,
+    datatype="beh",
+    subject="01",
+    session="01",
+    task="eyetrack",
+    run="01",
+    recording="eye1",
+    suffix="physio",
+    extension=".tsv.gz",
+)
+
+# %%
+# Write BIDS eyetracking files
+# ----------------------------
+#
+# To write eyetracking BIDS, you need to pass both the Raw object with the eytracking
+# data, and a `:class:~mne.preprocessing.eyetracking.Calibration` object that
+# contains necessary metadata about the presentation display used in the experiment.
+# MNE-BIDS will write one ``*_physio.tsv.gz`` + ``*_physio.json`` pair per eye,
+# with matching ``*_physioevents.tsv.gz`` files. Additionally, we are going to convert
+# our eyetracking eyegaze channels from pixels-on-screen to radians-of-visual-angle, to
+# demonstrate how BIDS stores the units.
+
+cal = cals[0]
+cal["screen_resolution"] = (1920, 1080)
+cal["screen_size"] = (0.53, 0.3)
+cal["screen_distance"] = 0.9
+mne.preprocessing.eyetracking.convert_units(raw, calibration=cal, to="radians")
+
+write_raw_bids(
+    raw=raw,
+    bids_path=bids_path,
+    allow_preload=True,
+    eyetrack_calibration=cals,
+    overwrite=True,
+)
+
+# %%
+# Inspect the generated BIDS directory tree.
+
+# %%
+print_dir_tree(bids_root)
+
+# %%
+# Inspect one sidecar JSON file.
+# ------------------------------
+# Notice 1) that the calibration information was written to this physio.json file, and
+# 2) that the units for the eyegaze channels are ``'rad'``, meaning "radians of visual
+# angle."
+
+# %%
+eye1_json = bids_path.fpath.with_suffix("").with_suffix(".json")
+print(f"Filepath: {eye1_json}")
+pprint(json.loads(eye1_json.read_text()), indent=2)
+
+# Convert simultaneous EEG + eyetracking data to BIDS
+# ---------------------------------------------------
+#
+# When eyetracking data is collected simultaneously with another BIDS modality, then the
+# eyetracking files will be written to that modality folder. In other words, instead of
+# being written to a ``beh`` directory, as the stand-alone eyetracking data that we just
+# used was, the dataset below will be written alongside the EEG data in the ``'eeg'``
+# directory. Additionally, unlike the previous example, where we converted our eyegaze
+# channel units from pixels-on-screen to radians-of-visual-angle, in this example we'll
+# keep the data as pixels-on-screen, and this will be reflected in the BIDS metadata.
+
+eyelink_root = eyelink_data_path()
+et_fpath = eyelink_root / "eeg-et" / "sub-01_task-plr_eyetrack.asc"
+eeg_fpath = eyelink_root / "eeg-et" / "sub-01_task-plr_eeg.mff"
+cals = mne.preprocessing.eyetracking.read_eyelink_calibration(et_fpath)
+cals[0]["screen_origin"] = ["top", "left"]
+cals[0]["screen_resolution"] = (1920, 1080)
+cals[0]["screen_size"] = (0.53, 0.3)
+cals[0]["screen_distance"] = 0.9
+
+raw_et = mne.io.read_raw_eyelink(et_fpath)
+raw_eeg = mne.io.read_raw_egi(eeg_fpath, events_as_annotations=True).load_data()
+
+# %%
+# Interpolate NaN blink periods prior to merging with EEG data
+
+# %%
+mne.preprocessing.eyetracking.interpolate_blinks(
+    raw_et, buffer=(0.05, 0.2), interpolate_gaze=True
+)
+
+# %%
+# Merge with EEG data
+et_events = mne.find_events(raw_et, min_duration=0.01, shortest_event=1, uint_cast=True)
+eeg_events = mne.find_events(raw_eeg, stim_channel="DIN3")
+# Convert event onsets from samples to seconds
+et_flash_times = et_events[:, 0] / raw_et.info["sfreq"]
+eeg_flash_times = eeg_events[:, 0] / raw_eeg.info["sfreq"]
+# Align the data
+mne.preprocessing.realign_raw(
+    raw_et, raw_eeg, et_flash_times, eeg_flash_times, verbose="error"
+)
+
+# %%
+# Add EEG channels to the eye-tracking raw object
+
+# %%
+raw_et.add_channels([raw_eeg], force_update_info=True)
+del raw_eeg  # free up some memory
+
+# %%
+# Write the merged EEG + eyetracking recording.
+
+# %%
+bids_root_simultaneous = eyelink_root.parent / "MNE-eyetrack-eeg-bids-example"
+if bids_root_simultaneous.exists():
+    shutil.rmtree(bids_root_simultaneous)
+
+bids_path_eeg = BIDSPath(
+    root=bids_root_simultaneous,
+    subject="01",
+    session="01",
+    run="01",
+    task="plr",
+    datatype="eeg",
+    suffix="eeg",
+)
+write_raw_bids(
+    raw_et,
+    bids_path_eeg,
+    allow_preload=True,
+    format="BrainVision",
+    eyetrack_calibration=cals,
+    verbose="error",
+)
+
+# %%
+# Inspect the generated dataset. Besides EEG files, MNE-BIDS will create
+# eyetracking ``*_physio`` files in the same modality folder.
+
+# %%
+print_dir_tree(bids_root_simultaneous)
+
+# %%
+# Again, let's inspect the saved metadata for one eye. Note that the units for our
+# eyegaze channels are 'pixel', meaining these data are 'pixel-on-screen' coordinates.
+# %%
+eye1_json = bids_path_eeg.find_matching_sidecar(suffix="physio", extension=".json")
+print(f"Filepath: {eye1_json}")
+pprint(json.loads(eye1_json.read_text()), indent=2)

--- a/mne_bids/__init__.py
+++ b/mne_bids/__init__.py
@@ -11,6 +11,7 @@ except Exception:
     __version__ = "0.0.0"
 
 from mne_bids import commands
+from mne_bids import physio
 from mne_bids.report import make_report
 from mne_bids.path import (
     BIDSPath,

--- a/mne_bids/config.py
+++ b/mne_bids/config.py
@@ -672,7 +672,6 @@ REFERENCES = {
     "Pollonini, L. (2023). fNIRS-BIDS, the Brain Imaging Data Structure "
     "Extended to Functional Near-Infrared Spectroscopy. PsyArXiv. "
     "https://doi.org/10.31219/osf.io/7nmcp",
-    # TODO: really this entry should be eyetrack, but lets circle back on that.
     "beh": "Szinte, M., Bach, DR., Draschkow, D., Esteban, O., Gagle, B., "
     "Gau, R., Gregorova, K., Halchenko, Y.O., Huberty, S., Kling, S., Kulkarni, S., "
     "Markiewicz, C., Mikkelsen, M., Oostenveld, R., Pfarr, JK. (2026). "

--- a/mne_bids/config.py
+++ b/mne_bids/config.py
@@ -61,6 +61,9 @@ UNITS_MNE_TO_BIDS_MAP = {
 # Mapping from FIFF unit constants to BIDS unit strings for writing
 # This supplements MNE's _unit2human which doesn't include all FIFF units
 UNITS_FIFF_TO_BIDS_MAP = {
+    FIFF.FIFF_UNIT_M: "m",
+    FIFF.FIFF_UNIT_NONE: "arbitrary",
+    FIFF.FIFF_UNIT_PX: "pixel",
     FIFF.FIFF_UNIT_RAD: "rad",
 }
 
@@ -76,6 +79,8 @@ UNITS_BIDS_TO_FIFF_MAP = {
     "oC": FIFF.FIFF_UNIT_CEL,
     "M": FIFF.FIFF_UNIT_MOL,
     "px": FIFF.FIFF_UNIT_PX,
+    "pixel": FIFF.FIFF_UNIT_PX,
+    "arbitrary": FIFF.FIFF_UNIT_NONE,
 }
 
 meg_manufacturers = {
@@ -667,6 +672,12 @@ REFERENCES = {
     "Pollonini, L. (2023). fNIRS-BIDS, the Brain Imaging Data Structure "
     "Extended to Functional Near-Infrared Spectroscopy. PsyArXiv. "
     "https://doi.org/10.31219/osf.io/7nmcp",
+    # TODO: really this entry should be eyetrack, but lets circle back on that.
+    "beh": "Szinte, M., Bach, DR., Draschkow, D., Esteban, O., Gagle, B., "
+    "Gau, R., Gregorova, K., Halchenko, Y.O., Huberty, S., Kling, S., Kulkarni, S., "
+    "Markiewicz, C., Mikkelsen, M., Oostenveld, R., Pfarr, JK. (2026). "
+    "Eye-Tracking-BIDS: the Brain Imaging Data Structure extended to gaze position "
+    "and pupil data. (In review).",
     "emg": "In preparation",
 }
 

--- a/mne_bids/physio/__init__.py
+++ b/mne_bids/physio/__init__.py
@@ -1,5 +1,6 @@
 from .eyetracking import (
     EYETRACK_CALIBRATION_TO_STIMULUS_PRESENTATION,
+    _eyetrack_calibration_to_events_metadata,
     _get_eyetrack_annotation_inds,
     _get_eyetrack_ch_names,
     _write_eyetrack_tsvs,

--- a/mne_bids/physio/__init__.py
+++ b/mne_bids/physio/__init__.py
@@ -1,0 +1,7 @@
+from .eyetracking import (
+    EYETRACK_CALIBRATION_TO_STIMULUS_PRESENTATION,
+    _get_eyetrack_annotation_inds,
+    _get_eyetrack_ch_names,
+    _write_eyetrack_tsvs,
+    write_eyetrack_calibration,
+)

--- a/mne_bids/physio/__init__.py
+++ b/mne_bids/physio/__init__.py
@@ -1,8 +1,3 @@
-from .eyetracking import (
-    EYETRACK_CALIBRATION_TO_STIMULUS_PRESENTATION,
-    _eyetrack_calibration_to_events_metadata,
-    _get_eyetrack_annotation_inds,
-    _get_eyetrack_ch_names,
-    _write_eyetrack_tsvs,
-    write_eyetrack_calibration,
-)
+__all__ = ["write_eyetrack_calibration"]
+
+from .eyetracking import write_eyetrack_calibration

--- a/mne_bids/physio/eyetracking.py
+++ b/mne_bids/physio/eyetracking.py
@@ -68,7 +68,9 @@ def _get_eyetrack_annotation_inds(raw):
         [
             annot_idx
             for annot_idx, this_annot in enumerate(raw.annotations)
-            if any(ch_name in eye_ch_names for ch_name in this_annot["ch_names"])
+            if any(
+                ch_name in eye_ch_names for ch_name in this_annot.get("ch_names", [])
+            )
         ],
         dtype=int,
     )
@@ -378,10 +380,13 @@ def write_eyetrack_calibration(
     cals_by_eye = {"left": [], "right": []}
     for cal in calibrations:
         eye = cal["eye"]
+        if eye not in cals_by_eye.keys():
+            raise ValueError(
+                "Each mne.preprocessing.Calibration instance must contain either "
+                f"'left' or 'right' in its 'eye' key. Got {eye} "
+            )
         cals_by_eye[eye].append(cal)
     eyes_present = {eye for eye, cals in cals_by_eye.items() if len(cals)}
-    if not eyes_present:
-        raise ValueError("No calibration entries were provided.")
 
     # Determine monocular vs binocular mapping to the *_physio.tsv files
     if eyes_present == {"left", "right"}:

--- a/mne_bids/physio/eyetracking.py
+++ b/mne_bids/physio/eyetracking.py
@@ -415,3 +415,53 @@ def write_eyetrack_calibration(
             _write_json(sidecar_fpath, sidecar, overwrite=True)
             updated_sidecar_fpaths.append(sidecar_fpath)
     return updated_sidecar_fpaths
+
+
+def _eyetrack_calibration_to_events_metadata(eyetrack_calibration):
+    """Extract BIDS StimulusPresentation metadata from eyetracking calibration."""
+    if eyetrack_calibration is None:
+        raise ValueError(
+            "Writing eyetracking data requires `eyetrack_calibration`. The "
+            "calibration object must include screen_distance, screen_origin, "
+            "screen_resolution, and screen_size."
+        )
+    if isinstance(eyetrack_calibration, mne.preprocessing.eyetracking.Calibration):
+        calibrations = [eyetrack_calibration]
+    else:
+        _validate_type(
+            eyetrack_calibration, (list, tuple), item_name="eyetrack_calibration"
+        )
+        calibrations = list(eyetrack_calibration)
+    if len(calibrations) == 0:
+        raise ValueError(
+            "`eyetrack_calibration` must contain at least one calibration."
+        )
+
+    stimulus_presentation = {}
+    missing = []
+    for mne_key, bids_key in EYETRACK_CALIBRATION_TO_STIMULUS_PRESENTATION:
+        values = []
+        for calibration in calibrations:
+            value = calibration.get(mne_key)
+            if value is not None:
+                if isinstance(value, np.ndarray):
+                    value = value.tolist()
+                elif isinstance(value, tuple):
+                    value = list(value)
+                values.append(value)
+        if not values:
+            missing.append(mne_key)
+            continue
+        first_value = values[0]
+        if any(value != first_value for value in values[1:]):
+            raise ValueError(
+                f"`eyetrack_calibration` contains inconsistent values for {mne_key!r}."
+            )
+        stimulus_presentation[bids_key] = first_value
+
+    if missing:
+        raise ValueError(
+            "`eyetrack_calibration` is missing screen metadata required for "
+            "eyetracking BIDS: " + ", ".join(missing)
+        )
+    return {"StimulusPresentation": stimulus_presentation}

--- a/mne_bids/physio/eyetracking.py
+++ b/mne_bids/physio/eyetracking.py
@@ -1,0 +1,412 @@
+"""Code to facilitate I/O of BIDS compliant eyetracking data (BEP 020)."""
+
+import json
+from pathlib import Path
+
+import mne
+import numpy as np
+from mne.preprocessing.eyetracking import Calibration
+from mne.utils import _validate_type, logger, warn
+
+from mne_bids.config import UNITS_FIFF_TO_BIDS_MAP
+from mne_bids.path import BIDSPath
+from mne_bids.utils import _write_json, _write_tsv
+
+# Parameters accepted by MNE's Calibration class
+BIDS_CALIBRATION_TO_MNE = {
+    "AverageCalibrationError": "avg_error",
+    "MaximalCalibrationError": "max_error",
+    "CalibrationType": "model",
+    "CalibrationPosition": "positions",
+    "CalibrationDistance": "screen_distance",
+    # FIXME: Add CalibrationUnit to MNE's Calibration constructor
+    "CalibrationUnit": "unit",
+}
+MNE_CALIBRATION_TO_BIDS = {
+    bids_key: mne_key for mne_key, bids_key in BIDS_CALIBRATION_TO_MNE.items()
+}
+
+EYETRACK_CALIBRATION_TO_STIMULUS_PRESENTATION = (
+    ("screen_distance", "ScreenDistance"),
+    ("screen_origin", "ScreenOrigin"),
+    ("screen_resolution", "ScreenResolution"),
+    ("screen_size", "ScreenSize"),
+)
+
+
+def _get_eyetrack_ch_names(raw):
+    """Check if the raw object contains eyetracking data.
+
+    Parameters
+    ----------
+    raw : mne.io.Raw
+        The raw object.
+
+    Returns
+    -------
+    list
+        A list with the names of the eyetracking channels, if any.
+    """
+    _validate_type(raw, mne.io.BaseRaw, item_name="raw")
+    ch_types = raw.get_channel_types()
+    eye_chs = [
+        ch
+        for ch, ch_type in zip(raw.ch_names, ch_types)
+        if ch_type in ["eyegaze", "pupil"]
+    ]
+    return eye_chs
+
+
+def _get_eyetrack_annotation_inds(raw):
+    """Get indices of annotations associated with eyetracking channels."""
+    _validate_type(raw, mne.io.BaseRaw, item_name="raw")
+    eye_ch_names = _get_eyetrack_ch_names(raw)
+    if len(eye_ch_names) == 0:
+        return np.array([], dtype=int)
+
+    return np.array(
+        [
+            annot_idx
+            for annot_idx, this_annot in enumerate(raw.annotations)
+            if any(ch_name in eye_ch_names for ch_name in this_annot["ch_names"])
+        ],
+        dtype=int,
+    )
+
+
+def _nan_to_na(values):
+    """Replace NaN samples with the BIDS missing-value marker."""
+    values = np.asarray(values)
+    out = values.astype(object)
+    out[np.isnan(values)] = "n/a"
+    return out
+
+
+def _write_single_eye_physio(
+    *, raw, bids_path, eye_chs, eye_recording_tag, recorded_eye, overwrite
+):
+    """Write TSV, JSON, and physioevents for a single eye.
+
+    Parameters
+    ----------
+    raw : mne.io.Raw
+        The raw data.
+    bids_path : mne_bids.BIDSPath
+        The BIDSPath object.
+    eye_chs : list of str
+        Channel names corresponding to this eye.
+    eye_recording_tag : str
+        Recording entity value (e.g., "eye1" or "eye2").
+    recorded_eye : str
+        "left" or "right".
+    overwrite : bool
+        Whether to overwrite existing files.
+    """
+    phys_bpath = bids_path.copy().update(
+        recording=eye_recording_tag,
+        suffix="physio",
+        extension="tsv.gz",
+    )
+    fname_tsv = phys_bpath.fpath
+
+    data, times = raw.get_data(picks=eye_chs, return_times=True)
+    ch_types = raw.get_channel_types(picks=eye_chs)
+    data_dict = {"timestamp": times}
+
+    # Build sidecar JSON template
+    json_dict = {
+        "SamplingFrequency": raw.info["sfreq"],
+        "StartTime": times[0],
+        "Columns": ["timestamp"],
+        "PhysioType": "eyetrack",
+        "RecordedEye": recorded_eye,
+        "SampleCoordinateSystem": "gaze-on-screen",
+        "timestamp": {
+            "Description": "The timestamp of the data, in seconds.",
+            "Units": "s",
+        },
+    }
+    # Update sidecar JSON with channels specific info
+    raw_ch_names_to_bids = {}
+    for ch_i, (ch_name, ch_type) in enumerate(zip(eye_chs, ch_types)):
+        ch_idx = raw.ch_names.index(ch_name)
+        bids_ch_name = ch_name
+        unit = UNITS_FIFF_TO_BIDS_MAP[raw.info["chs"][ch_idx]["unit"]]
+        # FIXME: Assumes only 1 x-coordinate and 1 y-coordinate eyegaze ch per eye
+        if ch_type == "eyegaze":
+            axis_code = raw.info["chs"][ch_idx]["loc"][4]
+            if axis_code == -1:
+                bids_ch_name = "x_coordinate"
+                description = "The x-coordinate of the gaze on the screen."
+            elif axis_code == 1:
+                bids_ch_name = "y_coordinate"
+                description = "The y-coordinate of the gaze on the screen."
+            else:
+                raise ValueError(
+                    "Eyegaze channels must set "
+                    "raw.info['chs'][channel_index]['loc'][4] to -1 for x-coordinate "
+                    f"or 1 for y-coordinate. Got {axis_code} for channel {ch_name}. "
+                    "Please use  "
+                    "`mne.preprocessing.eyetracking.set_channel_types_eyetrack` to "
+                    "Set eyetrack channel info according to MNE expectations."
+                )
+        elif ch_type == "pupil":
+            bids_ch_name = "pupil_size"
+            description = "Pupil size of the recorded eye"
+        else:
+            description = "Additional Channel written by MNE-Python"
+
+        raw_ch_names_to_bids[ch_name] = bids_ch_name
+        if bids_ch_name in data_dict:
+            raise ValueError(
+                f"Trying to rename {ch_name} to a BIDS compliant eyetracking name of "
+                f"{bids_ch_name}, but this will result in duplicate BIDS names. Is it "
+                "possible that  you have more than 1 x-coordinate, y-coordinate, "
+                "and/or pupil size channel(s) for a single eye? Here is the current "
+                f"mapping of your channel names to BIDS names:\n {raw_ch_names_to_bids}"
+            )
+
+        data_dict[bids_ch_name] = _nan_to_na(data[ch_i])
+        json_dict["Columns"].append(bids_ch_name)
+        json_dict[bids_ch_name] = {
+            "Description": description,
+            "Units": unit,
+        }
+    _write_tsv(fname_tsv, data_dict, compress=True, overwrite=overwrite)
+
+    fname_json = (
+        bids_path.copy()
+        .update(
+            recording=eye_recording_tag,
+            suffix="physio",
+            extension=".json",
+        )
+        .fpath
+    )
+    _write_json(fname_json, json_dict, overwrite=overwrite)
+
+    # Write physioevents TSV
+    fname_events = (
+        bids_path.copy()
+        .update(
+            recording=eye_recording_tag,
+            suffix="physioevents",
+            extension=".tsv.gz",
+            check=False,  # physioevents is not an allowed suffix
+        )
+        .fpath
+    )
+    _write_eyetrack_events_tsv(raw=raw, fname_tsv=fname_events, overwrite=overwrite)
+
+
+def _write_eyetrack_tsvs(raw, bids_path, overwrite, calibration=None):
+    """Write eyetracking physio files (per-eye TSV, JSON, and physioevents)."""
+    logger.info("Writing eyetracking data to physio.tsv files.")
+    # Write the physio files to the modality that eyetracking was collected with.
+    datatype = bids_path.datatype
+    if datatype is None:
+        raise ValueError("datatype must be specified in the BIDSPath object.")
+    # Find the eyetracking channels
+    info_array = np.array([raw.ch_names, raw.get_channel_types()]).T
+    eyegaze_ch_idx = np.where(info_array[:, 1] == "eyegaze")[0]
+    pupil_ch_idx = np.where(info_array[:, 1] == "pupil")[0]
+    assert len(eyegaze_ch_idx)
+    assert len(pupil_ch_idx)
+    # What eyes were recorded.
+    left_eye_chs = []
+    right_eye_chs = []
+    for idx in np.concatenate([eyegaze_ch_idx, pupil_ch_idx]):
+        # index 3 the loc array specifies left/right eye
+        which_eye = raw.info["chs"][idx]["loc"][3]
+        if which_eye == -1:
+            left_eye_chs.append(raw.ch_names[idx])
+        elif which_eye == 1:
+            right_eye_chs.append(raw.ch_names[idx])
+        else:
+            raise ValueError(
+                "A raw object with eyetrack channels must specify the eye that each "
+                "channel corresponds to in raw.info['chs'][channel_index]['loc'][3]. "
+                "This value must be -1 for the left eye, or 1 for the right eye. "
+                f"Got {which_eye}."
+            )
+    # If we have data for both eyes, left eye is eye1 and right eye is eye2
+    if all([len(left_eye_chs) and len(right_eye_chs)]):
+        eye1_chs = left_eye_chs
+        eye2_chs = right_eye_chs
+        recorded_eye_1 = "left"
+        recorded_eye_2 = "right"
+    # Otherwise, if we only have data for one eye, that eye is eye1
+    elif len(left_eye_chs):
+        eye1_chs = left_eye_chs
+        eye2_chs = []
+        recorded_eye_1 = "left"
+    elif len(right_eye_chs):
+        eye1_chs = right_eye_chs
+        eye2_chs = []
+        recorded_eye_1 = "right"
+    # Write the *_physio.tsv/.json and *_physioevents.tsv files for each eye
+    if eye1_chs:
+        _write_single_eye_physio(
+            raw=raw,
+            bids_path=bids_path,
+            eye_chs=eye1_chs,
+            eye_recording_tag="eye1",
+            recorded_eye=recorded_eye_1,
+            overwrite=overwrite,
+        )
+    if eye2_chs:
+        _write_single_eye_physio(
+            raw=raw,
+            bids_path=bids_path,
+            eye_chs=eye2_chs,
+            eye_recording_tag="eye2",
+            recorded_eye=recorded_eye_2,
+            overwrite=overwrite,
+        )
+
+
+def _write_eyetrack_events_tsv(*, raw, fname_tsv, overwrite):
+    """Write a <match>_physioevents.tsv file."""
+    from mne_bids.write import _events_json, _events_tsv
+
+    raw = raw.copy()
+    annotations = raw.annotations.copy()
+    if "BAD_blink" in annotations.description:
+        annotations.rename({"BAD_blink": "blink"})
+    raw.set_annotations(annotations)
+    eye_annot_indices = _get_eyetrack_annotation_inds(raw)
+    if len(eye_annot_indices) == 0:
+        warn(f"No eyetracking annotations found. {fname_tsv} will NOT be written.")
+        return
+    # Get the descriptions of the eyetracking annotations
+    eye_annotations = annotations[eye_annot_indices]
+    descriptions = eye_annotations.description
+    durations = eye_annotations.duration
+    # Use mne.events_from_annotations to convert the annotations to events
+    unique_descriptions = np.unique(descriptions)
+    event_ids = {desc: ii for ii, desc in enumerate(unique_descriptions, start=1)}
+    events, event_id = mne.events_from_annotations(raw, event_id=event_ids)
+    # Let's use the _events_tsv function to write the file.
+    assert len(durations) == len(events)
+    ev_dict = _events_tsv(
+        events=events,
+        durations=durations,
+        raw=raw,
+        fname=fname_tsv,
+        trial_type=event_id,
+        event_metadata=None,
+        compress=True,
+        overwrite=overwrite,
+    )
+    # Write the JSON file
+    metadata = {"Columns": list(ev_dict.keys()), "OnsetSource": "timestamp"}
+    fname_json = fname_tsv.with_suffix("").with_suffix(".json")
+    _events_json(
+        fname_json, metadata=metadata, has_trial_type=True, overwrite=overwrite
+    )
+
+
+def _json_safe(value):
+    """Convert values to JSON-serializable equivalents when needed."""
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    if isinstance(value, np.generic):
+        # np.int32 etc
+        return value.item()
+    return value
+
+
+def _calibration_to_sidecar_updates(calibrations):
+    """Convert calibration object(s) for one eye to sidecar updates."""
+    updates = {}
+    updates["CalibrationCount"] = len(calibrations)
+    # FIXME: BEP020 allows CalibrationCount (per session/run) yet only provides one set
+    # of Calibration* fields per physio sidecar. For now, if more than 1 calibrations
+    # were run, I guess it makes most sense to take the last calibration.
+    cal = calibrations[-1].copy()
+
+    for from_key, to_key in MNE_CALIBRATION_TO_BIDS.items():
+        value = cal.get(from_key)
+        if value is not None:
+            updates[to_key] = _json_safe(value)
+    return updates
+
+
+def write_eyetrack_calibration(
+    bids_path: BIDSPath,
+    calibrations: Calibration | list[Calibration],
+) -> list[Path]:
+    """Write eyetracking calibration metadata into an existing ``*_physio.json`` sidecar.
+
+    Parameters
+    ----------
+    bids_path : mne_bids.BIDSPath
+        BIDSPath for the eyetracking recording. The BIDSPath should point to a modality
+        directory (e.g. ``beh`` or ``eeg``) that contains ``<match>_physio.json``
+        file(s). If the BIDSPath contains a ``recording`` entity (e.g. ``eye1``), it
+        will be ignored (see the notes section).
+    calibration : CalibrationObject | list of CalibrationObject
+        Calibration instance(s) (e.g., an item returned by
+        :func:`~mne.preprocessing.eyetracking.read_eyelink_calibration`). Each instance
+        must expose an ``eye`` attribute with value ``"left"`` or ``"right"``
+
+    Returns
+    -------
+    Updated sidecar filepaths : list of pathlib.Path
+        a list of filepaths pointing to the ``<match>_physio.tsv`` files that were
+        updated with calibration information.
+
+    Notes
+    -----
+    This function routes calibration metadata to the correct per-eye physio sidecar(s):
+
+    - Binocular recordings: left eye -> ``<match>_recording-eye1_physio.tsv``,
+      right eye -> ``<match>_recording-eye2_physio.tsv``
+    - Monocular recordings: whichever eye was recorded ->
+      ``<match>_recording-eye1_physio.tsv``
+
+    If more than one calibration was run on the participant, this function will write
+    the last calibration in the sequence passed to the ``calibration`` parameter.
+
+    See `The Eyetracking BIDS specification`_.
+    """  # noqa: E501 FIXME: Can we use an alias to make the long line fit?
+    _validate_type(bids_path, BIDSPath, item_name="bids_path")
+
+    if isinstance(calibrations, mne.preprocessing.eyetracking.Calibration):
+        calibrations = [calibrations]
+
+    cals_by_eye = {"left": [], "right": []}
+    for cal in calibrations:
+        eye = cal["eye"]
+        cals_by_eye[eye].append(cal)
+    eyes_present = {eye for eye, cals in cals_by_eye.items() if len(cals)}
+    if not eyes_present:
+        raise ValueError("No calibration entries were provided.")
+
+    # Determine monocular vs binocular mapping to the *_physio.tsv files
+    if eyes_present == {"left", "right"}:
+        eye_to_recording = {"left": "eye1", "right": "eye2"}
+    else:
+        only_eye = next(iter(eyes_present))
+        eye_to_recording = {only_eye: "eye1"}
+
+    # Construct base path eye1 and/or eye2 <match>_physio.tsv files
+    base_path = bids_path.copy().update(suffix="physio", extension=".json")
+
+    updated_sidecar_fpaths = []
+    for eye, recording_tag in eye_to_recording.items():
+        sidecar_fpath = base_path.copy().update(recording=recording_tag).fpath
+        if not sidecar_fpath.exists():
+            msg = (
+                "Eyetracking sidecar not found at "
+                f"{sidecar_fpath}. Write the BIDS dataset first using write_raw_bids."
+            )
+            raise FileNotFoundError(msg)
+
+        updates = _calibration_to_sidecar_updates(cals_by_eye[eye])
+        if updates:
+            sidecar = json.loads(sidecar_fpath.read_text(encoding="utf-8-sig"))
+            sidecar.update(updates)
+            _write_json(sidecar_fpath, sidecar, overwrite=True)
+            updated_sidecar_fpaths.append(sidecar_fpath)
+    return updated_sidecar_fpaths

--- a/mne_bids/physio/eyetracking.py
+++ b/mne_bids/physio/eyetracking.py
@@ -76,14 +76,6 @@ def _get_eyetrack_annotation_inds(raw):
     )
 
 
-def _nan_to_na(values):
-    """Replace NaN samples with the BIDS missing-value marker."""
-    values = np.asarray(values)
-    out = values.astype(object)
-    out[np.isnan(values)] = "n/a"
-    return out
-
-
 def _write_single_eye_physio(
     *, raw, bids_path, eye_chs, eye_recording_tag, recorded_eye, overwrite
 ):
@@ -168,7 +160,7 @@ def _write_single_eye_physio(
                 f"mapping of your channel names to BIDS names:\n {raw_ch_names_to_bids}"
             )
 
-        data_dict[bids_ch_name] = _nan_to_na(data[ch_i])
+        data_dict[bids_ch_name] = data[ch_i]
         json_dict["Columns"].append(bids_ch_name)
         json_dict[bids_ch_name] = {
             "Description": description,
@@ -212,8 +204,7 @@ def _write_eyetrack_tsvs(raw, bids_path, overwrite, calibration=None):
     info_array = np.array([raw.ch_names, raw.get_channel_types()]).T
     eyegaze_ch_idx = np.where(info_array[:, 1] == "eyegaze")[0]
     pupil_ch_idx = np.where(info_array[:, 1] == "pupil")[0]
-    assert len(eyegaze_ch_idx)
-    assert len(pupil_ch_idx)
+
     # What eyes were recorded.
     left_eye_chs = []
     right_eye_chs = []
@@ -322,10 +313,19 @@ def _calibration_to_sidecar_updates(calibrations):
     """Convert calibration object(s) for one eye to sidecar updates."""
     updates = {}
     updates["CalibrationCount"] = len(calibrations)
-    # FIXME: BEP020 allows CalibrationCount (per session/run) yet only provides one set
+    # BEP020 allows CalibrationCount (per session/run) yet only provides one set
     # of Calibration* fields per physio sidecar. For now, if more than 1 calibrations
-    # were run, I guess it makes most sense to take the last calibration.
-    cal = calibrations[-1].copy()
+    # and the user passes a squence of calibrations in, I guess it makes most sense to
+    # take the last calibration collected.
+    if (n_cals := len(calibrations)) > 1:
+        most_recent = max(calibrations, key=lambda c: c["onset"])
+        logger.info(
+            f"{n_cals} calibrations were provided {most_recent['eye']} eye, writing "
+            f" the calibration collected at {most_recent['onset']} seconds."
+        )
+        cal = most_recent.copy()
+    else:
+        cal = calibrations[-1]
 
     for from_key, to_key in MNE_CALIBRATION_TO_BIDS.items():
         value = cal.get(from_key)
@@ -338,7 +338,7 @@ def write_eyetrack_calibration(
     bids_path: BIDSPath,
     calibrations: Calibration | list[Calibration],
 ) -> list[Path]:
-    """Write eyetracking calibration metadata into an existing ``*_physio.json`` sidecar.
+    """Write eyetrack calibration metadata into an existing ``*_physio.json`` sidecar.
 
     Parameters
     ----------
@@ -371,7 +371,7 @@ def write_eyetrack_calibration(
     the last calibration in the sequence passed to the ``calibrations`` parameter.
 
     See `The Eyetracking BIDS specification`_.
-    """  # noqa: E501 FIXME: Can we use an alias to make the long line fit?
+    """
     _validate_type(bids_path, BIDSPath, item_name="bids_path")
 
     if isinstance(calibrations, mne.preprocessing.eyetracking.Calibration):

--- a/mne_bids/physio/eyetracking.py
+++ b/mne_bids/physio/eyetracking.py
@@ -345,15 +345,15 @@ def write_eyetrack_calibration(
         directory (e.g. ``beh`` or ``eeg``) that contains ``<match>_physio.json``
         file(s). If the BIDSPath contains a ``recording`` entity (e.g. ``eye1``), it
         will be ignored (see the notes section).
-    calibration : CalibrationObject | list of CalibrationObject
+    calibrations : CalibrationObject | list of CalibrationObject
         Calibration instance(s) (e.g., an item returned by
         :func:`~mne.preprocessing.eyetracking.read_eyelink_calibration`). Each instance
-        must expose an ``eye`` attribute with value ``"left"`` or ``"right"``
+        must expose an ``eye`` attribute with value ``"left"`` or ``"right"``.
 
     Returns
     -------
     Updated sidecar filepaths : list of pathlib.Path
-        a list of filepaths pointing to the ``<match>_physio.tsv`` files that were
+        A list of filepaths pointing to the ``<match>_physio.tsv`` files that were
         updated with calibration information.
 
     Notes
@@ -366,7 +366,7 @@ def write_eyetrack_calibration(
       ``<match>_recording-eye1_physio.tsv``
 
     If more than one calibration was run on the participant, this function will write
-    the last calibration in the sequence passed to the ``calibration`` parameter.
+    the last calibration in the sequence passed to the ``calibrations`` parameter.
 
     See `The Eyetracking BIDS specification`_.
     """  # noqa: E501 FIXME: Can we use an alias to make the long line fit?

--- a/mne_bids/physio/eyetracking.py
+++ b/mne_bids/physio/eyetracking.py
@@ -57,10 +57,10 @@ def _get_eyetrack_ch_names(raw):
     return eye_chs
 
 
-def _get_eyetrack_annotation_inds(raw):
+def _get_eyetrack_annotation_inds(raw, eye_chs=None):
     """Get indices of annotations associated with eyetracking channels."""
     _validate_type(raw, mne.io.BaseRaw, item_name="raw")
-    eye_ch_names = _get_eyetrack_ch_names(raw)
+    eye_ch_names = _get_eyetrack_ch_names(raw) if eye_chs is None else eye_chs
     if len(eye_ch_names) == 0:
         return np.array([], dtype=int)
 
@@ -99,7 +99,7 @@ def _write_single_eye_physio(
     phys_bpath = bids_path.copy().update(
         recording=eye_recording_tag,
         suffix="physio",
-        extension="tsv.gz",
+        extension=".tsv.gz",
     )
     fname_tsv = phys_bpath.fpath
 
@@ -190,10 +190,12 @@ def _write_single_eye_physio(
         )
         .fpath
     )
-    _write_eyetrack_events_tsv(raw=raw, fname_tsv=fname_events, overwrite=overwrite)
+    _write_eyetrack_events_tsv(
+        raw=raw, fname_tsv=fname_events, eye_chs=eye_chs, overwrite=overwrite
+    )
 
 
-def _write_eyetrack_tsvs(raw, bids_path, overwrite, calibration=None):
+def _write_eyetrack_tsvs(raw, bids_path, overwrite):
     """Write eyetracking physio files (per-eye TSV, JSON, and physioevents)."""
     logger.info("Writing eyetracking data to physio.tsv files.")
     # Write the physio files to the modality that eyetracking was collected with.
@@ -223,17 +225,17 @@ def _write_eyetrack_tsvs(raw, bids_path, overwrite, calibration=None):
                 f"Got {which_eye}."
             )
     # If we have data for both eyes, left eye is eye1 and right eye is eye2
-    if all([len(left_eye_chs) and len(right_eye_chs)]):
+    if left_eye_chs and right_eye_chs:
         eye1_chs = left_eye_chs
         eye2_chs = right_eye_chs
         recorded_eye_1 = "left"
         recorded_eye_2 = "right"
     # Otherwise, if we only have data for one eye, that eye is eye1
-    elif len(left_eye_chs):
+    elif left_eye_chs:
         eye1_chs = left_eye_chs
         eye2_chs = []
         recorded_eye_1 = "left"
-    elif len(right_eye_chs):
+    elif right_eye_chs:
         eye1_chs = right_eye_chs
         eye2_chs = []
         recorded_eye_1 = "right"
@@ -258,7 +260,7 @@ def _write_eyetrack_tsvs(raw, bids_path, overwrite, calibration=None):
         )
 
 
-def _write_eyetrack_events_tsv(*, raw, fname_tsv, overwrite):
+def _write_eyetrack_events_tsv(*, raw, fname_tsv, eye_chs=None, overwrite):
     """Write a <match>_physioevents.tsv file."""
     from mne_bids.write import _events_json, _events_tsv
 
@@ -267,12 +269,13 @@ def _write_eyetrack_events_tsv(*, raw, fname_tsv, overwrite):
     if "BAD_blink" in annotations.description:
         annotations.rename({"BAD_blink": "blink"})
     raw.set_annotations(annotations)
-    eye_annot_indices = _get_eyetrack_annotation_inds(raw)
+    eye_annot_indices = _get_eyetrack_annotation_inds(raw, eye_chs=eye_chs)
     if len(eye_annot_indices) == 0:
         warn(f"No eyetracking annotations found. {fname_tsv} will NOT be written.")
         return
-    # Get the descriptions of the eyetracking annotations
+    # Keep only this eye's annotations, so the eye1/eye2 files don't each get both eyes
     eye_annotations = annotations[eye_annot_indices]
+    raw.set_annotations(eye_annotations)
     descriptions = eye_annotations.description
     durations = eye_annotations.duration
     # Use mne.events_from_annotations to convert the annotations to events
@@ -320,8 +323,8 @@ def _calibration_to_sidecar_updates(calibrations):
     if (n_cals := len(calibrations)) > 1:
         most_recent = max(calibrations, key=lambda c: c["onset"])
         logger.info(
-            f"{n_cals} calibrations were provided {most_recent['eye']} eye, writing "
-            f" the calibration collected at {most_recent['onset']} seconds."
+            f"{n_cals} calibrations were provided for the {most_recent['eye']} eye, "
+            f"writing the calibration collected at {most_recent['onset']} seconds."
         )
         cal = most_recent.copy()
     else:
@@ -355,17 +358,17 @@ def write_eyetrack_calibration(
     Returns
     -------
     Updated sidecar filepaths : list of pathlib.Path
-        A list of filepaths pointing to the ``<match>_physio.tsv`` files that were
-        updated with calibration information.
+        A list of filepaths pointing to the ``<match>_physio.json`` sidecar files that
+        were updated with calibration information.
 
     Notes
     -----
     This function routes calibration metadata to the correct per-eye physio sidecar(s):
 
-    - Binocular recordings: left eye -> ``<match>_recording-eye1_physio.tsv``,
-      right eye -> ``<match>_recording-eye2_physio.tsv``
+    - Binocular recordings: left eye -> ``<match>_recording-eye1_physio.json``,
+      right eye -> ``<match>_recording-eye2_physio.json``
     - Monocular recordings: whichever eye was recorded ->
-      ``<match>_recording-eye1_physio.tsv``
+      ``<match>_recording-eye1_physio.json``
 
     If more than one calibration was run on the participant, this function will write
     the last calibration in the sequence passed to the ``calibrations`` parameter.

--- a/mne_bids/tests/test_eyetracking.py
+++ b/mne_bids/tests/test_eyetracking.py
@@ -1,0 +1,186 @@
+"""Tests for I/O of BIDS-compliant eyetracking data (BEP 020)."""
+
+import json
+
+import mne
+import numpy as np
+import pytest
+from mne.datasets import testing
+from mne.io import RawArray, read_raw_egi, read_raw_eyelink
+
+from mne_bids import BIDSPath, write_raw_bids
+from mne_bids.physio import _get_eyetrack_annotation_inds, write_eyetrack_calibration
+
+
+@pytest.fixture(scope="module")
+def eyelink_fpath():
+    """Get path to MNE testing Eyelink file."""
+    return testing.data_path(download=False) / "eyetrack" / "test_eyelink.asc"
+
+
+@pytest.fixture(scope="module")
+def raw_eye_and_cals(eyelink_fpath):
+    """Get re-usable raw eyetracking object and calibrations."""
+    raw = read_raw_eyelink(eyelink_fpath)
+    cals = mne.preprocessing.eyetracking.read_eyelink_calibration(eyelink_fpath)
+    cals = _add_screen_metadata(cals)
+    return raw, cals
+
+
+@pytest.fixture
+def eyetrack_bpath(tmp_path):
+    """Get fresh base BIDSPath for eyetracking-only datasets."""
+    return BIDSPath(
+        root=tmp_path / "bids",
+        datatype="beh",
+        subject="01",
+        session="01",
+        task="foo",
+        run="01",
+        recording="eye1",
+        suffix="physio",
+        extension=".tsv.gz",
+    )
+
+
+def _add_screen_metadata(calibrations):
+    """Add BIDS-required screen metadata to eyetracking calibrations."""
+    calibrations = [cal.copy() for cal in calibrations]
+    for cal in calibrations:
+        cal["screen_distance"] = 0.9
+        cal["screen_origin"] = ["top", "left"]
+        cal["screen_resolution"] = [1920, 1080]
+        cal["screen_size"] = [0.53, 0.3]
+    return calibrations
+
+
+def test_get_eyetrack_annotation_inds():
+    """Test selecting annotations tied to eyetracking channels."""
+    info = mne.create_info(
+        ch_names=["xpos_left", "pupil_left", "eeg1"],
+        sfreq=100,
+        ch_types=["eyegaze", "pupil", "eeg"],
+    )
+    raw = RawArray(np.zeros((3, 400)), info)
+    raw.set_annotations(
+        mne.Annotations(
+            onset=[0.0, 1.0, 2.0, 3.0],
+            duration=[0.1, 0.1, 0.1, 0.1],
+            description=["fixation", "stim", "blink", "misc"],
+            ch_names=[("xpos_left",), ("eeg1",), ("pupil_left",), ()],
+        )
+    )
+
+    got = _get_eyetrack_annotation_inds(raw)
+    want = np.array([0, 2])
+    np.testing.assert_array_equal(got, want)
+
+
+def test_write_eyetracking_calibration(tmp_path, eyetrack_bpath):
+    """Calibration writer should add calibration keys to the right eye files."""
+    bpath = eyetrack_bpath.copy().update(extension=".json")
+    eye1_json = bpath.fpath
+    eye2_json = bpath.copy().update(recording="eye2").fpath
+
+    eye1_json.parent.mkdir(parents=True, exist_ok=True)
+    eye1_json.write_text(json.dumps({"PhysioType": "eyetrack", "RecordedEye": "left"}))
+    eye2_json.write_text(json.dumps({"PhysioType": "eyetrack", "RecordedEye": "right"}))
+
+    calibrations = [
+        {
+            "eye": "left",
+            "avg_error": 0.1,
+            "max_error": 0.2,
+            "model": "HV3",
+            "positions": np.array([[0.0, 1.0], [2.0, 3.0], [4.0, 5.0]]),
+            "screen_distance": 0.6,
+            "screen_origin": ["top", "left"],
+            "screen_resolution": [1920, 1080],
+            "screen_size": [0.53, 0.3],
+        },
+        {
+            "eye": "right",
+            "avg_error": 0.3,
+            "max_error": 0.5,
+            "model": "HV3",
+            "positions": np.array([[1.0, 1.0], [3.0, 3.0], [5.0, 5.0]]),
+            "screen_distance": 0.6,
+            "screen_origin": ["top", "left"],
+            "screen_resolution": [1920, 1080],
+            "screen_size": [0.53, 0.3],
+        },
+    ]
+    updated = write_eyetrack_calibration(eyetrack_bpath, calibrations)
+
+    assert set(updated) == {eye1_json, eye2_json}
+    eye1 = json.loads(eye1_json.read_text())
+    eye2 = json.loads(eye2_json.read_text())
+
+    assert eye1["CalibrationCount"] == 1
+    assert eye1["AverageCalibrationError"] == 0.1
+    assert eye1["MaximalCalibrationError"] == 0.2
+    assert eye1["CalibrationType"] == "HV3"
+    assert eye1["CalibrationDistance"] == 0.6
+
+    assert eye2["CalibrationCount"] == 1
+    assert eye2["AverageCalibrationError"] == 0.3
+    assert eye2["MaximalCalibrationError"] == 0.5
+
+    # If no BIDS dataset on disk, should raise
+    dupe_bpath = eyetrack_bpath.update(root=tmp_path)
+    with pytest.raises(FileNotFoundError, match="Eyetracking sidecar not found"):
+        write_eyetrack_calibration(dupe_bpath, calibrations)
+
+
+@testing.requires_testing_data
+def test_write_eyetracking(_bids_validate, raw_eye_and_cals, eyetrack_bpath):
+    """Test writing eyetracking-only data to BIDS."""
+    raw, cals = raw_eye_and_cals
+
+    write_raw_bids(
+        raw,
+        eyetrack_bpath,
+        allow_preload=True,
+        format="auto",
+        eyetrack_calibration=cals,
+        overwrite=False,
+    )
+    _bids_validate(eyetrack_bpath.root)
+
+
+@testing.requires_testing_data
+@pytest.mark.filterwarnings("ignore:Converting data:RuntimeWarning")
+@pytest.mark.filterwarnings(
+    "ignore:Encountered unsupported non-voltage units:UserWarning"
+)
+def test_write_eeg_eyetracking(_bids_validate, tmp_path, eyetrack_bpath):
+    """Test writing simultaneous EEG+eyetracking data to BIDS."""
+    eyetrack_fpath = testing.data_path(download=False) / "eyetrack" / "test_eyelink.asc"
+    egi_fpath = testing.data_path(download=False) / "EGI" / "test_egi.mff"
+    raw_eye = read_raw_eyelink(eyetrack_fpath)
+    raw_egi = read_raw_egi(egi_fpath, events_as_annotations=False).load_data()
+    cals = mne.preprocessing.eyetracking.read_eyelink_calibration(eyetrack_fpath)
+    cals = _add_screen_metadata(cals)
+
+    # Hack together the raws
+    raw_eye.crop(tmax=raw_egi.times[-1]).resample(100, method="polyphase")
+    raw_egi.resample(100)
+    raw_eye.set_meas_date(None)
+    raw_egi.set_meas_date(None)
+
+    raw = raw_egi.copy().add_channels([raw_eye], force_update_info=True)
+    raw.set_annotations(raw.annotations + raw_eye.annotations)
+
+    eyetrack_bpath.update(datatype="eeg")
+    eeg_bpath = eyetrack_bpath.copy().update(
+        recording=None, datatype="eeg", suffix="eeg", extension=".vhdr"
+    )
+
+    write_raw_bids(
+        raw,
+        eeg_bpath,
+        allow_preload=True,
+        format="BrainVision",
+        eyetrack_calibration=cals,
+    )
+    _bids_validate(eeg_bpath.root)

--- a/mne_bids/tests/test_eyetracking.py
+++ b/mne_bids/tests/test_eyetracking.py
@@ -149,6 +149,7 @@ def test_write_eyetracking_bino(_bids_validate, raw_eye_and_cals, eyetrack_bpath
     _bids_validate(eyetrack_bpath.root)
 
 
+@testing.requires_testing_data
 @pytest.mark.parametrize("eye", ["left", "right"], ids=["left", "right"])
 def test_write_eyetracking_mono(_bids_validate, raw_eye_and_cals, eyetrack_bpath, eye):
     """Test writing monocular eyetracking data."""
@@ -166,6 +167,7 @@ def test_write_eyetracking_mono(_bids_validate, raw_eye_and_cals, eyetrack_bpath
     _bids_validate(eyetrack_bpath.root)
 
 
+@testing.requires_testing_data
 def test_write_eyetrack_without_annotations(
     _bids_validate, raw_eye_and_cals, eyetrack_bpath
 ):

--- a/mne_bids/tests/test_eyetracking.py
+++ b/mne_bids/tests/test_eyetracking.py
@@ -1,5 +1,6 @@
 """Tests for I/O of BIDS-compliant eyetracking data (BEP 020)."""
 
+import gzip
 import json
 
 import mne
@@ -148,6 +149,19 @@ def test_write_eyetracking_bino(_bids_validate, raw_eye_and_cals, eyetrack_bpath
         overwrite=False,
     )
     _bids_validate(eyetrack_bpath.root)
+
+    # each eye gets only its own annotations in *_physioevents.tsv.gz
+    events_bpath = eyetrack_bpath.copy().update(
+        suffix="physioevents", extension=".tsv.gz", check=False
+    )
+    n_events = []
+    for recording in ("eye1", "eye2"):
+        fpath = events_bpath.copy().update(recording=recording).fpath
+        with gzip.open(fpath, "rt") as fid:
+            n_events.append(len(fid.read().splitlines()))
+    n_annots = len(_get_eyetrack_annotation_inds(raw))
+    assert sum(n_events) == n_annots
+    assert min(n_events) > 0
 
 
 @testing.requires_testing_data

--- a/mne_bids/tests/test_eyetracking.py
+++ b/mne_bids/tests/test_eyetracking.py
@@ -8,6 +8,7 @@ import pytest
 from mne.datasets import testing
 from mne.io import RawArray, read_raw_egi, read_raw_eyelink
 
+import mne_bids
 from mne_bids import BIDSPath, write_raw_bids
 from mne_bids.physio import _get_eyetrack_annotation_inds, write_eyetrack_calibration
 
@@ -18,7 +19,7 @@ def eyelink_fpath():
     return testing.data_path(download=False) / "eyetrack" / "test_eyelink.asc"
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def raw_eye_and_cals(eyelink_fpath):
     """Get re-usable raw eyetracking object and calibrations."""
     raw = read_raw_eyelink(eyelink_fpath)
@@ -133,7 +134,7 @@ def test_write_eyetracking_calibration(tmp_path, eyetrack_bpath):
 
 
 @testing.requires_testing_data
-def test_write_eyetracking(_bids_validate, raw_eye_and_cals, eyetrack_bpath):
+def test_write_eyetracking_bino(_bids_validate, raw_eye_and_cals, eyetrack_bpath):
     """Test writing eyetracking-only data to BIDS."""
     raw, cals = raw_eye_and_cals
 
@@ -145,6 +146,50 @@ def test_write_eyetracking(_bids_validate, raw_eye_and_cals, eyetrack_bpath):
         eyetrack_calibration=cals,
         overwrite=False,
     )
+    _bids_validate(eyetrack_bpath.root)
+
+
+@pytest.mark.parametrize("eye", ["left", "right"], ids=["left", "right"])
+def test_write_eyetracking_mono(_bids_validate, raw_eye_and_cals, eyetrack_bpath, eye):
+    """Test writing monocular eyetracking data."""
+    raw, cals = raw_eye_and_cals
+    raw.drop_channels([f"xpos_{eye}", f"ypos_{eye}", f"pupil_{eye}"])
+    cal = cals[0] if eye == "left" else cals[1]
+    write_raw_bids(
+        raw,
+        eyetrack_bpath,
+        allow_preload=True,
+        format="auto",
+        eyetrack_calibration=cal,
+        overwrite=False,
+    )
+    _bids_validate(eyetrack_bpath.root)
+
+
+def test_write_eyetrack_without_annotations(
+    _bids_validate, raw_eye_and_cals, eyetrack_bpath
+):
+    """Ensure ET data without annotations can be written and is complaint."""
+    raw, cals = raw_eye_and_cals
+    eye_annot_inds = [
+        ii
+        for ii, names in enumerate(raw.annotations.ch_names)
+        if (
+            names == ("xpos_left", "ypos_left", "pupil_left")
+            or names == ("xpos_right", "ypos_right", "pupil_right")
+        )
+    ]
+    raw.annotations.delete(eye_annot_inds)
+
+    with pytest.warns(match="No eyetracking annotations found."):
+        write_raw_bids(
+            raw,
+            eyetrack_bpath,
+            allow_preload=True,
+            format="auto",
+            eyetrack_calibration=cals,
+            overwrite=False,
+        )
     _bids_validate(eyetrack_bpath.root)
 
 
@@ -184,3 +229,78 @@ def test_write_eeg_eyetracking(_bids_validate, tmp_path, eyetrack_bpath):
         eyetrack_calibration=cals,
     )
     _bids_validate(eeg_bpath.root)
+
+
+@testing.requires_testing_data
+def test_write_raises(raw_eye_and_cals, eyetrack_bpath):
+    """Ensure that malformed raw objects hit our error messages when writing."""
+    # 1. We need the loc array to be properly set for eyetracking channels.
+    raw, cals = raw_eye_and_cals
+    orig_coord = raw.info["chs"][0]["loc"][4].copy()
+    raw.info["chs"][0]["loc"][4] = 4
+    with pytest.raises(match="Eyegaze channels must set"):
+        write_raw_bids(
+            raw,
+            eyetrack_bpath,
+            allow_preload=True,
+            format="auto",
+            eyetrack_calibration=cals,
+            overwrite=False,
+        )
+    raw.info["chs"][0]["loc"][4] = orig_coord
+
+    # 2: BIDS can't handle e.g. two x-coordinate channels for the left eye..
+    new_data = raw.get_data(picks="xpos_left").copy()
+    new_info = mne.create_info(
+        ch_names=["xpos_left_2"], sfreq=raw.info["sfreq"], ch_types=["eyegaze"]
+    )
+    new_channel = mne.io.RawArray(new_data, new_info)
+    new_channel = mne.preprocessing.eyetracking.set_channel_types_eyetrack(
+        new_channel, mapping={"xpos_left_2": ("eyegaze", "px", "left", "x")}
+    )
+    raw.add_channels([new_channel])
+    with pytest.raises(match="this will result in duplicate BIDS names"):
+        write_raw_bids(
+            raw,
+            eyetrack_bpath,
+            allow_preload=True,
+            format="auto",
+            eyetrack_calibration=cals,
+            overwrite=False,
+        )
+    raw.drop_channels("xpos_left_2")
+
+    # 3 The user needs to specify the datatype
+    eyetrack_bpath_bad = eyetrack_bpath.copy().update(datatype=None)
+    with pytest.raises(match="datatype must be specified"):
+        mne_bids.physio.eyetracking._write_eyetrack_tsvs(
+            raw=raw,
+            bids_path=eyetrack_bpath_bad,
+            overwrite=False,
+        )
+    del eyetrack_bpath_bad
+
+    # 4. Again, the loc array must be properly set for eyetrack channels
+    orig_eye = raw.info["chs"][0]["loc"][3].copy()
+    raw.info["chs"][0]["loc"][3] = 999.0
+    with pytest.raises(match="must specify the eye"):
+        mne_bids.physio.eyetracking._write_eyetrack_tsvs(
+            raw=raw,
+            bids_path=eyetrack_bpath,
+            overwrite=False,
+        )
+    raw.info["chs"][0]["loc"][3] = orig_eye
+
+    # 4. Calibraiton objects must contain 'left' or 'right' in their 'eye' key
+    cal_bad = cals[0].copy()
+    cal_bad["eye"] = "foo"
+    with pytest.raises(match="'left' or 'right' in its 'eye' key."):
+        write_raw_bids(
+            raw,
+            eyetrack_bpath,
+            allow_preload=True,
+            format="auto",
+            eyetrack_calibration=cal_bad,
+            overwrite=False,
+        )
+    del cal_bad

--- a/mne_bids/tests/test_eyetracking.py
+++ b/mne_bids/tests/test_eyetracking.py
@@ -10,7 +10,8 @@ from mne.io import RawArray, read_raw_egi, read_raw_eyelink
 
 import mne_bids
 from mne_bids import BIDSPath, write_raw_bids
-from mne_bids.physio import _get_eyetrack_annotation_inds, write_eyetrack_calibration
+from mne_bids.physio import write_eyetrack_calibration
+from mne_bids.physio.eyetracking import _get_eyetrack_annotation_inds
 
 
 @pytest.fixture(scope="module")
@@ -293,7 +294,7 @@ def test_write_raises(raw_eye_and_cals, eyetrack_bpath):
         )
     raw.info["chs"][0]["loc"][3] = orig_eye
 
-    # 4. Calibraiton objects must contain 'left' or 'right' in their 'eye' key
+    # 4. Calibration objects must contain 'left' or 'right' in their 'eye' key
     cal_bad = cals[0].copy()
     cal_bad["eye"] = "foo"
     with pytest.raises(match="'left' or 'right' in its 'eye' key."):

--- a/mne_bids/tsv_handler.py
+++ b/mne_bids/tsv_handler.py
@@ -317,7 +317,14 @@ def _tsv_to_str(data, rows=5, *, include_header=True):
     # write column data.
     max_rows = min(n_rows, rows)
     for idx in range(max_rows):
-        row_data = list(str(data[key][idx]) for key in data)
+        row_data = list(_nansafe_to_str(data[key][idx]) for key in data)
         output.append("\t".join(row_data))
 
     return "\n".join(output)
+
+
+def _nansafe_to_str(value):
+    """Convert np.nan to 'n/a, which BIDS tsv files require."""
+    if isinstance(value, float | np.floating) and np.isnan(value):
+        return "n/a"
+    return str(value)

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -245,14 +245,16 @@ def _write_json(fname, dictionary, *, overwrite=False, lock=True):
 
 
 @verbose
-def _write_tsv(fname, dictionary, *, overwrite=False, lock=True, verbose=None):
+def _write_tsv(
+    fname, dictionary, *, overwrite=False, lock=True, compress=False, verbose=None
+):
     """Write an ordered dictionary to a .tsv file."""
     fname = Path(fname)
     if fname.exists() and not overwrite:
         raise FileExistsError(
             f'"{fname}" already exists. Please set overwrite to True.'
         )
-    _to_tsv(dictionary, fname, lock=lock)
+    _to_tsv(dictionary, fname, lock=lock, compress=compress)
 
     logger.info(f"Writing '{fname}'...")
 
@@ -491,7 +493,7 @@ def _check_datatype(raw, datatype):
     datatype : str
         Can be one of either ``'meg'``, ``'eeg'``, or ``'ieeg'``.
     """
-    supported_types = ("eeg", "emg", "ieeg", "meg", "nirs")
+    supported_types = ("beh", "eeg", "emg", "ieeg", "meg", "nirs")
     if datatype not in supported_types:
         raise ValueError(
             f"The specified datatype {datatype} is currently not supported. "
@@ -511,6 +513,10 @@ def _check_datatype(raw, datatype):
     elif datatype == "ieeg":
         ieeg_types = ("seeg", "ecog", "dbs")
         if any(ieeg_type in raw for ieeg_type in ieeg_types):
+            datatype_matches = True
+    elif datatype == "beh":
+        beh_types = ("eyegaze", "pupil")
+        if any(beh_type in raw for beh_type in beh_types):
             datatype_matches = True
     if not datatype_matches:
         raise ValueError(

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -516,7 +516,7 @@ def _check_datatype(raw, datatype):
             datatype_matches = True
     elif datatype == "beh":
         beh_types = ("eyegaze", "pupil")
-        if any(beh_type in raw for beh_type in beh_types):
+        if any(beh_type in raw.get_channel_types() for beh_type in beh_types):
             datatype_matches = True
     if not datatype_matches:
         raise ValueError(

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -51,6 +51,7 @@ from mne_bids.config import (
     BIDS_STANDARD_TEMPLATE_COORDINATE_SYSTEMS,
     BIDS_VERSION,
     CONVERT_FORMATS,
+    EPHY_ALLOWED_DATATYPES,
     EXT_TO_UNIT_MAP,
     FORMAT_EXTENSIONS,
     IGNORED_CHANNELS,
@@ -78,6 +79,13 @@ from mne_bids.dig import (
     _write_empty_ieeg_positions,
 )
 from mne_bids.path import _mkdir_p, _parse_ext, _path_to_str
+from mne_bids.physio import (
+    EYETRACK_CALIBRATION_TO_STIMULUS_PRESENTATION,
+    _get_eyetrack_annotation_inds,
+    _get_eyetrack_ch_names,
+    _write_eyetrack_tsvs,
+    write_eyetrack_calibration,
+)
 from mne_bids.pick import coil_type
 from mne_bids.read import _find_matching_sidecar, _read_events
 from mne_bids.sidecar_updates import update_sidecar_json
@@ -395,8 +403,10 @@ def _events_tsv(
     raw,
     fname,
     trial_type,
+    *,
     event_metadata=None,
     extras_columns=None,
+    compress=False,
     overwrite=False,
 ):
     """Create an events.tsv file and save it.
@@ -425,6 +435,8 @@ def _events_tsv(
     event_metadata : pandas.DataFrame | None
         Additional metadata to be stored in the events.tsv file. Must have one
         row per event.
+    compress : bool
+        Whether to gzip the tsv file, e.g. for <match>_physioevents.tsv.gz files.
     extras_columns : dict | None
         Optional column data derived from annotation extras, mapping column name to
         per-event values.
@@ -484,7 +496,8 @@ def _events_tsv(
             continue
         data[key] = values
 
-    _write_tsv(fname, data, overwrite=overwrite)
+    _write_tsv(fname, data, compress=compress, overwrite=overwrite)
+    return data
 
 
 def _extract_hed_for_write(raw, *, n_events):
@@ -525,6 +538,7 @@ def _events_json(
     extra_columns=None,
     has_trial_type=True,
     hed_by_trial_type=None,
+    metadata=None,
     overwrite=False,
 ):
     """Create events.json for non-default columns in accompanying TSV.
@@ -545,6 +559,8 @@ def _events_json(
     """
     if extra_columns is None:
         extra_columns = dict()
+    if metadata is None:
+        metadata = dict()
 
     new_data = {
         "onset": {
@@ -585,6 +601,8 @@ def _events_json(
     for key, value in extra_columns.items():
         new_data[key] = {"Description": value}
 
+    for key, val in metadata.items():
+        new_data[key] = val
     # make sure to append any JSON fields added by the user
     fname = Path(fname)
     if fname.exists():
@@ -594,6 +612,56 @@ def _events_json(
         new_data = {**orig_data, **new_data}
 
     _write_json(fname, new_data, overwrite=overwrite)
+
+
+def _eyetrack_calibration_to_events_metadata(eyetrack_calibration):
+    """Extract BIDS StimulusPresentation metadata from eyetracking calibration."""
+    if eyetrack_calibration is None:
+        raise ValueError(
+            "Writing eyetracking data requires `eyetrack_calibration`. The "
+            "calibration object must include screen_distance, screen_origin, "
+            "screen_resolution, and screen_size."
+        )
+    if isinstance(eyetrack_calibration, mne.preprocessing.eyetracking.Calibration):
+        calibrations = [eyetrack_calibration]
+    else:
+        _validate_type(
+            eyetrack_calibration, (list, tuple), item_name="eyetrack_calibration"
+        )
+        calibrations = list(eyetrack_calibration)
+    if len(calibrations) == 0:
+        raise ValueError(
+            "`eyetrack_calibration` must contain at least one calibration."
+        )
+
+    stimulus_presentation = {}
+    missing = []
+    for mne_key, bids_key in EYETRACK_CALIBRATION_TO_STIMULUS_PRESENTATION:
+        values = []
+        for calibration in calibrations:
+            value = calibration.get(mne_key)
+            if value is not None:
+                if isinstance(value, np.ndarray):
+                    value = value.tolist()
+                elif isinstance(value, tuple):
+                    value = list(value)
+                values.append(value)
+        if not values:
+            missing.append(mne_key)
+            continue
+        first_value = values[0]
+        if any(value != first_value for value in values[1:]):
+            raise ValueError(
+                f"`eyetrack_calibration` contains inconsistent values for {mne_key!r}."
+            )
+        stimulus_presentation[bids_key] = first_value
+
+    if missing:
+        raise ValueError(
+            "`eyetrack_calibration` is missing screen metadata required for "
+            "eyetracking BIDS: " + ", ".join(missing)
+        )
+    return {"StimulusPresentation": stimulus_presentation}
 
 
 def _readme(datatype, fname):
@@ -1112,7 +1180,7 @@ def _sidecar_json(
     fname : str | mne_bids.BIDSPath
         Filename to save the sidecar json to.
     datatype : str
-        Type of the data as in ALLOWED_ELECTROPHYSIO_DATATYPE.
+        Type of the data as in EPHY_ALLOWED_DATATYPES.
     emg_placement : "Measured" | "ChannelSpecific" | "Other" | None
         How the EMG sensor locations were determined. Must be one of the literal strings
         if ``datatype="emg"`` and should be ``None`` for all other datatypes.
@@ -1772,6 +1840,7 @@ def write_raw_bids(
     acpc_aligned=False,
     electrodes_tsv_task=False,
     emg_placement=None,
+    eyetrack_calibration=None,
     overwrite=False,
     readme=True,
     verbose=None,
@@ -1961,6 +2030,13 @@ def write_raw_bids(
     emg_placement : "Measured" | "ChannelSpecific" | "Other" | None
         How the EMG sensor locations were determined. Must be one of the literal strings
         if datatype is "emg" and should be ``None`` for all other datatypes.
+    eyetrack_calibration : mne.preprocessing.eyetracking.Calibration | list | None
+        Eyetracking calibration metadata. Required when writing eyetracking data.
+        The calibration object(s) must include ``"screen_distance"``,
+        ``"screen_origin"``, ``"screen_resolution"``, and ``"screen_size"`` so
+        MNE-BIDS can write the BIDS-required ``"StimulusPresentation"`` metadata
+        to ``*_events.json``. Calibration metadata is also written to the per-eye
+        ``*_physio.json`` sidecars.
     overwrite : bool
         Whether to overwrite existing files or data in files.
         Defaults to ``False``.
@@ -2039,6 +2115,9 @@ def write_raw_bids(
     """
     if not isinstance(raw, BaseRaw):
         raise ValueError(f"raw_file must be an instance of BaseRaw, got {type(raw)}")
+    is_eyetracking_only = all(
+        [ch in ["eyegaze", "pupil"] for ch in raw.get_channel_types()]
+    )
 
     if raw.preload is not False and not allow_preload:
         raise ValueError(
@@ -2114,8 +2193,8 @@ def write_raw_bids(
     convert = False  # flag if converting not copying
 
     # Load file, filename, extension
+    raw_fname = raw.filenames[0]
     if not allow_preload:
-        raw_fname = raw.filenames[0]
         if ".ds" in op.dirname(raw.filenames[0]):
             raw_fname = op.dirname(raw.filenames[0])
         # point to file containing header info for multifile systems
@@ -2146,7 +2225,9 @@ def write_raw_bids(
 
         raw_orig = _reader_for_raw(raw, ext)(**raw._init_kwargs)
     else:
-        if format in FORMAT_EXTENSIONS:
+        if is_eyetracking_only and format == "auto":
+            ext = bids_path.extension or ".tsv.gz"
+        elif format in FORMAT_EXTENSIONS:
             ext = FORMAT_EXTENSIONS[format]
         else:
             msg = (
@@ -2192,7 +2273,9 @@ def write_raw_bids(
     # Initialize BIDSPath
     datatype = _handle_datatype(raw, bids_path.datatype)
     bids_path = bids_path.copy().update(
-        datatype=datatype, suffix=datatype, extension=ext
+        datatype=datatype,
+        suffix=bids_path.suffix if datatype == "beh" else datatype,
+        extension=ext,
     )
 
     if datatype == "emg" and emg_placement not in (
@@ -2298,6 +2381,26 @@ def write_raw_bids(
 
     data_path = bids_path.mkdir().directory
 
+    # If eyetrack channels are alongside eeg, meg etc. Then
+    eyetrack_ch_names = _get_eyetrack_ch_names(raw)
+    events_json_metadata = None
+    if eyetrack_ch_names:
+        events_json_metadata = _eyetrack_calibration_to_events_metadata(
+            eyetrack_calibration
+        )
+    if eyetrack_ch_names:
+        _write_eyetrack_tsvs(raw, bids_path, overwrite=overwrite)
+        write_eyetrack_calibration(bids_path, eyetrack_calibration)
+        if not is_eyetracking_only:
+            # ET data were written to TSVs, so don't save them to binary file.
+            logger.debug(f"Dropping eyetracking channels from raw: {eyetrack_ch_names}")
+            raw = raw.copy()
+            raw.drop_channels(eyetrack_ch_names)
+        # Now delete annotations tied to eyetracking channels so they aren't written
+        # to the <match>_events files.
+        ocular_event_inds = _get_eyetrack_annotation_inds(raw)
+        raw.annotations.delete(ocular_event_inds)
+
     # create *_scans.tsv
     session_path = BIDSPath(
         subject=bids_path.subject, session=bids_path.session, root=bids_path.root
@@ -2331,6 +2434,8 @@ def write_raw_bids(
 
     sidecar_path = bids_path.copy().update(suffix=bids_path.datatype, extension=".json")
     events_tsv_path = bids_path.copy().update(suffix="events", extension=".tsv")
+    if is_eyetracking_only:
+        events_tsv_path.update(recording=None)
     events_json_path = events_tsv_path.copy().update(extension=".json")
     channels_path = bids_path.copy().update(suffix="channels", extension=".tsv")
 
@@ -2482,6 +2587,7 @@ def write_raw_bids(
                 extra_columns=events_extra_columns,
                 has_trial_type=has_trial_type,
                 hed_by_trial_type=hed["sidecar_map"] if hed else None,
+                metadata=events_json_metadata,
                 overwrite=overwrite,
             )
         # Kepp events_array around for BrainVision writing below.
@@ -2498,23 +2604,25 @@ def write_raw_bids(
         overwrite=False,
     )
 
-    _sidecar_json(
-        raw,
-        task=bids_path.task,
-        manufacturer=manufacturer,
-        fname=sidecar_path.fpath,
-        datatype=bids_path.datatype,
-        emptyroom_fname=associated_er_path,
-        emg_placement=emg_placement,
-        overwrite=overwrite,
-    )
+    # This func is specifically for writing sidecar for datatypes with channel info
+    if bids_path.datatype in EPHY_ALLOWED_DATATYPES:
+        _sidecar_json(
+            raw,
+            task=bids_path.task,
+            manufacturer=manufacturer,
+            fname=sidecar_path.fpath,
+            datatype=bids_path.datatype,
+            emptyroom_fname=associated_er_path,
+            emg_placement=emg_placement,
+            overwrite=overwrite,
+        )
 
     # create parent directories if needed
     _mkdir_p(os.path.dirname(data_path))
 
     # If not already converting for anonymization, we may still need to do it
     # if current format not BIDS compliant
-    if not convert:
+    if not convert and not is_eyetracking_only:
         convert = ext not in ALLOWED_DATATYPE_EXTENSIONS[bids_path.datatype]
 
         if convert and symlink:
@@ -2571,12 +2679,13 @@ def write_raw_bids(
         bids_path.update(extension=FORMAT_EXTENSIONS[write_format])
 
     # this can't happen until after value of `convert` has been determined
-    _channels_tsv(
-        raw,
-        channels_path.fpath,
-        convert_fmt=write_format if convert else None,
-        overwrite=overwrite,
-    )
+    if not is_eyetracking_only:
+        _channels_tsv(
+            raw,
+            channels_path.fpath,
+            convert_fmt=write_format if convert else None,
+            overwrite=overwrite,
+        )
 
     # raise error when trying to copy files (copyfile_*) into same location
     # (src == dest, see https://github.com/mne-tools/mne-bids/issues/867)
@@ -2593,7 +2702,7 @@ def write_raw_bids(
 
     # otherwise if the BIDSPath currently exists, check if we
     # would like to overwrite the existing dataset
-    if bids_path.fpath.exists():
+    if bids_path.fpath.exists() and not is_eyetracking_only:
         if overwrite:
             # Need to load data before removing its source
             raw.load_data()
@@ -2632,6 +2741,8 @@ def write_raw_bids(
             _write_raw_brainvision(
                 raw, bids_path.fpath, events=events_array, overwrite=overwrite
             )
+    elif is_eyetracking_only:
+        pass
     elif ext == ".fif":
         if symlink:
             link_target = Path(raw.filenames[0])

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -1986,7 +1986,13 @@ def write_raw_bids(
         ``"screen_origin"``, ``"screen_resolution"``, and ``"screen_size"`` so
         MNE-BIDS can write the BIDS-required ``"StimulusPresentation"`` metadata
         to ``*_events.json``. Calibration metadata is also written to the per-eye
-        ``*_physio.json`` sidecars.
+        ``*_physio.json`` sidecars. Examples of valid values for these keys are:
+
+        - ``screen_origin``: ``["top", "left"]``
+        - ``screen_resolution``: ``[1920, 1080]``
+        - ``screen_size``: ``[0.53, 0.3] # meters``
+        - ``screen_distance``: ``0.9 # meters``
+
     overwrite : bool
         Whether to overwrite existing files or data in files.
         Defaults to ``False``.

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -80,7 +80,7 @@ from mne_bids.dig import (
 )
 from mne_bids.path import _mkdir_p, _parse_ext, _path_to_str
 from mne_bids.physio import (
-    EYETRACK_CALIBRATION_TO_STIMULUS_PRESENTATION,
+    _eyetrack_calibration_to_events_metadata,
     _get_eyetrack_annotation_inds,
     _get_eyetrack_ch_names,
     _write_eyetrack_tsvs,
@@ -612,56 +612,6 @@ def _events_json(
         new_data = {**orig_data, **new_data}
 
     _write_json(fname, new_data, overwrite=overwrite)
-
-
-def _eyetrack_calibration_to_events_metadata(eyetrack_calibration):
-    """Extract BIDS StimulusPresentation metadata from eyetracking calibration."""
-    if eyetrack_calibration is None:
-        raise ValueError(
-            "Writing eyetracking data requires `eyetrack_calibration`. The "
-            "calibration object must include screen_distance, screen_origin, "
-            "screen_resolution, and screen_size."
-        )
-    if isinstance(eyetrack_calibration, mne.preprocessing.eyetracking.Calibration):
-        calibrations = [eyetrack_calibration]
-    else:
-        _validate_type(
-            eyetrack_calibration, (list, tuple), item_name="eyetrack_calibration"
-        )
-        calibrations = list(eyetrack_calibration)
-    if len(calibrations) == 0:
-        raise ValueError(
-            "`eyetrack_calibration` must contain at least one calibration."
-        )
-
-    stimulus_presentation = {}
-    missing = []
-    for mne_key, bids_key in EYETRACK_CALIBRATION_TO_STIMULUS_PRESENTATION:
-        values = []
-        for calibration in calibrations:
-            value = calibration.get(mne_key)
-            if value is not None:
-                if isinstance(value, np.ndarray):
-                    value = value.tolist()
-                elif isinstance(value, tuple):
-                    value = list(value)
-                values.append(value)
-        if not values:
-            missing.append(mne_key)
-            continue
-        first_value = values[0]
-        if any(value != first_value for value in values[1:]):
-            raise ValueError(
-                f"`eyetrack_calibration` contains inconsistent values for {mne_key!r}."
-            )
-        stimulus_presentation[bids_key] = first_value
-
-    if missing:
-        raise ValueError(
-            "`eyetrack_calibration` is missing screen metadata required for "
-            "eyetracking BIDS: " + ", ".join(missing)
-        )
-    return {"StimulusPresentation": stimulus_presentation}
 
 
 def _readme(datatype, fname):
@@ -2388,7 +2338,6 @@ def write_raw_bids(
         events_json_metadata = _eyetrack_calibration_to_events_metadata(
             eyetrack_calibration
         )
-    if eyetrack_ch_names:
         _write_eyetrack_tsvs(raw, bids_path, overwrite=overwrite)
         write_eyetrack_calibration(bids_path, eyetrack_calibration)
         if not is_eyetracking_only:

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -79,12 +79,12 @@ from mne_bids.dig import (
     _write_empty_ieeg_positions,
 )
 from mne_bids.path import _mkdir_p, _parse_ext, _path_to_str
-from mne_bids.physio import (
+from mne_bids.physio import write_eyetrack_calibration
+from mne_bids.physio.eyetracking import (
     _eyetrack_calibration_to_events_metadata,
     _get_eyetrack_annotation_inds,
     _get_eyetrack_ch_names,
     _write_eyetrack_tsvs,
-    write_eyetrack_calibration,
 )
 from mne_bids.pick import coil_type
 from mne_bids.read import _find_matching_sidecar, _read_events
@@ -2149,8 +2149,8 @@ def write_raw_bids(
     convert = False  # flag if converting not copying
 
     # Load file, filename, extension
-    raw_fname = raw.filenames[0]
     if not allow_preload:
+        raw_fname = raw.filenames[0]
         if ".ds" in op.dirname(raw.filenames[0]):
             raw_fname = op.dirname(raw.filenames[0])
         # point to file containing header info for multifile systems
@@ -2645,7 +2645,9 @@ def write_raw_bids(
     # raise error when trying to copy files (copyfile_*) into same location
     # (src == dest, see https://github.com/mne-tools/mne-bids/issues/867)
     if (
-        bids_path.fpath.exists()
+        not allow_preload
+        and not is_eyetracking_only
+        and bids_path.fpath.exists()
         and not convert
         and bids_path.fpath.as_posix() == Path(raw_fname).as_posix()
     ):


### PR DESCRIPTION
Towards #1342 

This strips out the previously written eyetrack writing code from #1512 in order to keep the diff manageable.

FYI this Adds a parameter `eyetrack_calibration` to `write_raw_bids`, which must be passed when the Raw data include eyetrack channels, as BIDS wants metadata about the experimental display that can't be automatically inferred.