### PR TITLE
Nest expensive imports to speed up import time

### DIFF
--- a/mne_bids/copyfiles.py
+++ b/mne_bids/copyfiles.py
@@ -18,7 +18,6 @@ from pathlib import Path
 import numpy as np
 from mne.io import anonymize_info, read_raw_bdf, read_raw_brainvision, read_raw_edf
 from mne.utils import logger, verbose
-from scipy.io import loadmat, savemat
 
 from mne_bids._fileio import _chmod_rw_R, _open_lock
 from mne_bids.path import BIDSPath, _mkdir_p, _parse_ext
@@ -608,6 +607,8 @@ def copyfile_eeglab(src, dest):
         raise ValueError(
             f"Need to move data with same extension but got {ext_src}, {ext_dest}"
         )
+
+    from scipy.io import loadmat, savemat
 
     # Load the EEG struct
     # NOTE: do *not* simplify cells, because this changes the underlying

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -14,7 +14,11 @@ from pathlib import Path
 import mne
 import numpy as np
 from mne import events_from_annotations, io, pick_channels_regexp, read_events
-from mne.coreg import fit_matched_points
+
+try:  # MNE 1.13+
+    from mne.transforms import fit_matched_points
+except ImportError:
+    from mne.coreg import fit_matched_points
 from mne.transforms import apply_trans
 from mne.utils import _validate_type, check_version, get_subjects_dir, logger
 

--- a/mne_bids/report/_report.py
+++ b/mne_bids/report/_report.py
@@ -5,9 +5,9 @@
 
 import json
 import textwrap
+from functools import cache
 from pathlib import Path
 
-import jinja2
 import numpy as np
 from mne.utils import logger, verbose
 
@@ -24,11 +24,17 @@ from mne_bids.path import (
 from mne_bids.tsv_handler import _from_tsv
 from mne_bids.utils import warn
 
-jinja_env = jinja2.Environment(
-    loader=jinja2.PackageLoader(
-        package_name="mne_bids.report", package_path="templates"
+
+@cache
+def _jinja_env():
+    """Build the template environment lazily, to keep jinja2 off the import path."""
+    import jinja2
+
+    return jinja2.Environment(
+        loader=jinja2.PackageLoader(
+            package_name="mne_bids.report", package_path="templates"
+        )
     )
-)
 
 
 def _pretty_str(listed):
@@ -502,14 +508,16 @@ def make_report(root, session=None, verbose=None):
     if not participant_summary:
         participants_info = ""
     else:
-        particpants_info_template = jinja_env.get_template("participants.jinja")
+        particpants_info_template = _jinja_env().get_template("participants.jinja")
         participants_info = particpants_info_template.render(**participant_summary)
         logger.info(f"The participant template found: {participants_info}")
 
     if not scans_summary:
         datatype_agnostic_info = ""
     else:
-        datatype_agnostic_template = jinja_env.get_template("datatype_agnostic.jinja")
+        datatype_agnostic_template = _jinja_env().get_template(
+            "datatype_agnostic.jinja"
+        )
         datatype_agnostic_info = datatype_agnostic_template.render(
             **dataset_agnostic_summary
         )
@@ -528,7 +536,7 @@ def make_report(root, session=None, verbose=None):
     # lower-case templates are "Recommended",
     # while upper-case templates are "Required".
 
-    dataset_summary_template = jinja_env.get_template("dataset_summary.jinja")
+    dataset_summary_template = _jinja_env().get_template("dataset_summary.jinja")
     dataset_summary_info = dataset_summary_template.render(**dataset_summary)
 
     # Concatenate info and clean the paragraph

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -20,7 +20,6 @@ import mne.preprocessing
 import numpy as np
 from mne import Epochs, channel_type
 from mne.channels.channels import _get_meg_system, _unit2human
-from mne.chpi import get_chpi_info
 from mne.io import BaseRaw, read_fiducials
 from mne.io.constants import FIFF
 from mne.io.pick import _picks_to_idx
@@ -1224,6 +1223,8 @@ def _sidecar_json(
             n_active_hpi = mne.chpi.get_active_chpi(raw, on_missing="ignore")
             chpi = bool(n_active_hpi.sum() > 0)
             if chpi:
+                from mne.chpi import get_chpi_info
+
                 hpi_freqs, _, _ = get_chpi_info(info=raw.info, on_missing="ignore")
                 hpi_freqs = list(hpi_freqs)
 


### PR DESCRIPTION
Sibling PR of https://github.com/mne-tools/mne-bids-pipeline/pull/1294, related to https://github.com/mne-tools/mne-bids-pipeline/issues/675. This has a modest effect (~10 ms) but it's easy to include.

Will need a companion MNE-Python PR (forthcoming) for the `fit_matched_points` move, so leaving this in draft mode for now.