### PR TITLE
Parallelize CI testing and doc build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,15 @@ jobs:
               python -m pip install -e .[test,doc]
 
         - run:
+            name: Download datasets shared by multiple examples
+            # The gallery executes examples in parallel, so anything fetched by more
+            # than one of them has to be on disk before the build starts.
+            command: |
+              python -c "import mne; mne.datasets.sample.data_path()"
+              python -c "import mne; mne.datasets.testing.data_path()"
+              python -c "import mne; mne.datasets.eegbci.load_data(subjects=[1, 2], runs=[2, 4, 8, 12], update_path=True)"
+
+        - run:
             name: Build the documentation
             no_output_timeout: 30m
             command: |

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -8,6 +8,7 @@ permissions:
 jobs:
   autobot:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: (github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'pre-commit-ci[bot]') && github.repository == 'mne-tools/mne-bids'
     steps:
       - name: Enable auto-merge for bot PRs

--- a/.github/workflows/autopush.yml
+++ b/.github/workflows/autopush.yml
@@ -10,6 +10,7 @@ jobs:
     permissions:
       contents: write
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/cffconvert.yml
+++ b/.github/workflows/cffconvert.yml
@@ -12,6 +12,7 @@ jobs:
   validate:
     name: "validate"
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Check out a copy of the repository
         uses: actions/checkout@v7

--- a/.github/workflows/circle_artifacts.yml
+++ b/.github/workflows/circle_artifacts.yml
@@ -5,6 +5,7 @@ permissions: read-all
 jobs:
   circleci_artifacts_redirector_job:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: "${{ startsWith(github.event.context, 'ci/circleci: docs-build') }}"
     permissions:
       statuses: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ permissions:
 jobs:
   package:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
     - uses: actions/checkout@v7
       with:
@@ -41,6 +42,7 @@ jobs:
   pypi-upload:
     needs: package
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: github.event_name == 'release'
     permissions:
       id-token: write  # for trusted publishing

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -90,6 +90,9 @@ jobs:
       TZ: Europe/Berlin
       FORCE_COLOR: true
       MNE_BIDS_FILELOCK_TIMEOUT: 5  # be more stringent than it would be for end-users
+      # Explicit worker counts (in the spirit of SciPy's CI) rather than "auto":
+      # the Linux and Windows runners have 4 cores, the macOS ones fewer and less RAM
+      PYTEST_XDIST_N: ${{ startsWith(matrix.os, 'macos') && 2 || 4 }}
     strategy:
       fail-fast: false
       matrix:
@@ -231,7 +234,7 @@ jobs:
 
     # Only run on a limited set of jobs
     - name: Run pytest without testing data
-      run: make test
+      run: make test JOBS="$PYTEST_XDIST_N"
       if: ${{ matrix.test-with-no-testing-data }}
 
     # Get testing data
@@ -258,7 +261,7 @@ jobs:
       working-directory: mne-python
       name: 'Get testing data and set it read-only'
 
-    - run: make test ARGS="${{ matrix.test-mode }}"
+    - run: make test JOBS="$PYTEST_XDIST_N" ARGS="${{ matrix.test-mode }}"
 
     - uses: codecov/codecov-action@v7
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,7 +82,7 @@ jobs:
 
   test:
     name: test (${{ matrix.os }}, ${{ matrix.python-version }}, ${{ matrix.mne-version }}, ${{ matrix.mne-bids-install }}, validator-${{ matrix.bids-validator-version }})
-    timeout-minutes: 60
+    timeout-minutes: 20
     needs: style  # just to avoid CI overuse
     runs-on: ${{ matrix.os }}
     env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,6 +156,14 @@ you can then simply use the following command from the root of the `mne-bids` re
 make test
 ```
 
+Tests are distributed over CPU cores with [pytest-xdist](https://pytest-xdist.readthedocs.io).
+Pass `JOBS=<n>` to pick the number of workers, or `JOBS=0` to run everything in a
+single process, which is what you want for `--pdb`:
+
+```Shell
+make test JOBS=0 ARGS="--pdb"
+```
+
 ## Building the documentation
 
 The documentation can be built using [Sphinx](https://www.sphinx-doc.org).

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ inplace:
 	@python -m pip install -e ".[dev]"
 
 test:
-	pytest mne_bids -v -n ${JOBS} ${ARGS}
+	pytest mne_bids -v -n ${JOBS} --timeout=180 --timeout-method=thread ${ARGS}
 
 build-doc:
 	@echo "Building documentation"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
 ARGS=
+# pytest-xdist workers; JOBS=0 runs in-process, e.g. for --pdb. Beyond ~4 the
+# bids-validator subprocesses contend and per-worker startup dominates, so this is a
+# fixed number rather than "auto" (CI overrides it per runner image).
+JOBS=4
 
 .PHONY: all clean-pyc clean-so clean-build clean-ctags clean-cache clean-e clean inplace test ruff-check ruff-format pep build-doc dist-build
 
@@ -29,7 +33,7 @@ inplace:
 	@python -m pip install -e ".[dev]"
 
 test:
-	pytest mne_bids -v ${ARGS}
+	pytest mne_bids -v -n ${JOBS} ${ARGS}
 
 build-doc:
 	@echo "Building documentation"

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    = -nWT --keep-going
+SPHINXOPTS    = -nWT --keep-going -j auto
 SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = mne_bids
 PAPER         =

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -213,6 +213,7 @@ sphinx_gallery_conf = {
     "within_subsection_order": "mne_bids.utils._example_sorter",
     "gallery_dirs": "auto_examples",
     "filename_pattern": "^((?!sgskip).)*$",
+    "parallel": True,  # use sphinx-build's -j value
 }
 
 assert is_serializable(sphinx_gallery_conf)

--- a/doc/sphinxext/gen_cli.py
+++ b/doc/sphinxext/gen_cli.py
@@ -18,6 +18,7 @@ from mne.utils import hashfunc, run_subprocess
 def setup(app):
     """Set up the app."""
     app.connect("builder-inited", generate_cli_rst)
+    return {"parallel_read_safe": True, "parallel_write_safe": True}
 
 
 # Header markings go:

--- a/doc/sphinxext/gh_substitutions.py
+++ b/doc/sphinxext/gh_substitutions.py
@@ -34,4 +34,4 @@ def gh_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
 def setup(app):
     """Do setup."""
     app.add_role("gh", gh_role)
-    return
+    return {"parallel_read_safe": True, "parallel_write_safe": True}

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -55,5 +55,6 @@ Detailed list of changes
 ^^^^^^^^^^^^^^
 
 - Sped up writing of recordings with many channels by avoiding redundant per-channel work in :func:`mne_bids.write_raw_bids` (single-pass channel-type counting, cached coil-type lookup, and a fixed quadratic loop when writing BrainVision units), by `Stefan Appelhoff`_ (:gh:`1620`)
+- Run the test suite with ``pytest-xdist`` and build the documentation with parallel Sphinx and Sphinx-Gallery workers, by `Eric Larson`_ (:gh:`1648`)
 
 :doc:`Find out what was new in previous releases <whats_new_previous_releases>`

--- a/examples/anonymize_dataset.py
+++ b/examples/anonymize_dataset.py
@@ -53,8 +53,8 @@ cal_path = data_path / "SSS" / "sss_cal_mgh.dat"
 ct_path = data_path / "SSS" / "ct_sparse_mgh.fif"
 t1w_path = data_path / "subjects" / "sample" / "mri" / "T1.mgz"
 
-bids_root = data_path.parent / "MNE-sample-data-bids"
-bids_root_anon = data_path.parent / "MNE-sample-data-bids-anon"
+bids_root = data_path.parent / "MNE-sample-data-bids-anonymize"
+bids_root_anon = data_path.parent / "MNE-sample-data-bids-anonymize-anon"
 
 # %%
 # To ensure the output paths don't contain any leftover files from previous

--- a/examples/convert_empty_room.py
+++ b/examples/convert_empty_room.py
@@ -42,7 +42,7 @@ from mne_bids import BIDSPath, print_dir_tree, read_raw_bids, write_raw_bids
 data_path = sample.data_path()
 raw_fname = data_path / "MEG" / "sample" / "sample_audvis_raw.fif"
 
-bids_root = data_path.parent / "MNE-sample-data-bids"
+bids_root = data_path.parent / "MNE-sample-data-bids-empty-room"
 
 # %%
 # To ensure the output path doesn't contain any leftover files from previous

--- a/examples/convert_mne_sample.py
+++ b/examples/convert_mne_sample.py
@@ -60,7 +60,7 @@ event_id = {
 raw_fname = data_path / "MEG" / "sample" / "sample_audvis_raw.fif"
 er_fname = data_path / "MEG" / "sample" / "ernoise_raw.fif"  # empty room
 events_fname = data_path / "MEG" / "sample" / "sample_audvis_raw-eve.fif"
-output_path = data_path.parent / "MNE-sample-data-bids"
+output_path = data_path.parent / "MNE-sample-data-bids-convert"
 
 # %%
 # To ensure the output path doesn't contain any leftover files from previous

--- a/examples/convert_mri_and_trans.py
+++ b/examples/convert_mri_and_trans.py
@@ -68,7 +68,7 @@ event_id = {
 }
 raw_fname = data_path / "MEG" / "sample" / "sample_audvis_raw.fif"
 events_fname = data_path / "MEG" / "sample" / "sample_audvis_raw-eve.fif"
-output_path = data_path.parent / "MNE-sample-data-bids"
+output_path = data_path.parent / "MNE-sample-data-bids-mri-and-trans"
 fs_subjects_dir = data_path / "subjects"  # FreeSurfer subjects dir
 
 # %%

--- a/examples/mark_bad_channels.py
+++ b/examples/mark_bad_channels.py
@@ -48,7 +48,7 @@ event_id = {
     "Smiley": 5,
     "Button": 32,
 }
-bids_root = data_path.parent / "MNE-sample-data-bids"
+bids_root = data_path.parent / "MNE-sample-data-bids-mark-bad-channels"
 bids_path = BIDSPath(
     subject="01", session="01", task="audiovisual", run="01", root=bids_root
 )

--- a/mne_bids/conftest.py
+++ b/mne_bids/conftest.py
@@ -2,6 +2,7 @@
 
 # Authors: The MNE-BIDS developers
 # SPDX-License-Identifier: BSD-3-Clause
+import os
 from datetime import datetime
 
 import mne
@@ -13,6 +14,15 @@ def pytest_configure(config):
     """Configure pytest options."""
     # Fixtures
     config.addinivalue_line("usefixtures", "monkeypatch_mne")
+    # inspect_dataset() calls plt.show(block=True) on any backend but agg, so a test
+    # that reaches it before something else has switched backends hangs forever
+    os.environ.setdefault("MPLBACKEND", "Agg")
+    try:
+        import matplotlib
+    except ImportError:
+        pass
+    else:
+        matplotlib.use(os.environ["MPLBACKEND"], force=True)
 
 
 @pytest.fixture(autouse=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dev = ["mne_bids[test,doc,full]", "pre-commit"]
 # Dependencies for building the documentation
 doc = [
   "intersphinx_registry",
+  "joblib",  # for sphinx_gallery_conf["parallel"]
   "matplotlib",
   "mne-nirs",
   "nilearn",
@@ -76,7 +77,7 @@ full = [
   "pymatreader",
 ]
 # Dependencies for running the test infrastructure
-test = ["curryreader", "mne_bids[full]", "packaging", "pytest", "pytest-cov", "pytest-rerunfailures", "pytest-sugar", "ruff"]
+test = ["curryreader", "mne_bids[full]", "packaging", "pytest", "pytest-cov", "pytest-rerunfailures", "pytest-sugar", "pytest-xdist", "ruff"]
 
 [project.urls]
 "Bug Tracker" = "https://github.com/mne-tools/mne-bids/issues/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ full = [
   "pymatreader",
 ]
 # Dependencies for running the test infrastructure
-test = ["curryreader", "mne_bids[full]", "packaging", "pytest", "pytest-cov", "pytest-rerunfailures", "pytest-sugar", "pytest-xdist", "ruff"]
+test = ["curryreader", "mne_bids[full]", "packaging", "pytest", "pytest-cov", "pytest-rerunfailures", "pytest-sugar", "pytest-timeout", "pytest-xdist", "ruff"]
 
 [project.urls]
 "Bug Tracker" = "https://github.com/mne-tools/mne-bids/issues/"


### PR DESCRIPTION
I had Claude Opus 5 port over the recent MNE-Python changes to make tests parallel using `pytest-xdist` and docs via `-j auto`. Should speed up both here.