### PR TITLE
Fix CI cache keys so datasets stop being re-downloaded

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,15 +21,16 @@ jobs:
         - run:
             <<: *check_skip
 
-        # restore cache from last build. Unless __init__.py has changed since then
+        # Fixed key (bump by hand): the datasets are several GB, so a miss is costly
         - restore_cache:
             keys:
-              - data-cache-0-{{ checksum "./mne_bids/__init__.py" }}
+              - data-cache-1
 
         # Also restore pip cache to speed up installations
         - restore_cache:
             keys:
               - pip-cache-0-{{ checksum "./pyproject.toml" }}
+              - pip-cache-0-
 
         - run:
             name: Setup Python3 environment
@@ -77,15 +78,17 @@ jobs:
             path: doc/_build/html/
             destination: dev
 
-        # Store the data cache
+        # Store the data cache (after the build: some examples fetch as they run)
         - save_cache:
-            key: data-cache-0-{{ checksum "./mne_bids/__init__.py" }}
+            key: data-cache-1
+            when: always
             paths:
               - ~/mne_data
 
         # Store pip cache
         - save_cache:
             key: pip-cache-0-{{ checksum "./pyproject.toml" }}
+            when: always
             paths:
               - ~/.cache/pip
 
@@ -130,6 +133,7 @@ jobs:
       - restore_cache:
           keys:
             - pip-cache-0-{{ checksum "./pyproject.toml" }}
+            - pip-cache-0-
 
       - run:
           name: Setup Python3 environment

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -241,13 +241,19 @@ jobs:
     - run: ./tools/get_testing_version.sh
       working-directory: mne-python
 
+    # The trimming below is part of what ends up in the cache, so the key carries a
+    # suffix to bump when that list changes.
     - uses: actions/cache@v6
       with:
-        key: testing_data-${{ env.TESTING_VERSION }}
+        key: testing_data-trimmed-1-${{ env.TESTING_VERSION }}
         path: ~/mne_data
       name: 'Cache testing data'
 
-    - run: |
+    # MNE-Python's download script fetches the misc dataset too by default; we have
+    # no use for it here, and it is not covered by the cache key above.
+    - env:
+        MNE_CI_DATASETS: testing
+      run: |
         ./tools/github_actions_download.sh
         # Trim some large files we don't need (speeds up caching)
         TEST_PATH=$(python -c "import mne; print(mne.datasets.testing.data_path(verbose=False))")


### PR DESCRIPTION
Some cache improvements I saw while inspecting with Claude Opus 5