### PR TITLE
Speed up BIDSPath.copy and BIDSPath.fpath

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -59,5 +59,6 @@ Detailed list of changes
 
 - Sped up writing of recordings with many channels by avoiding redundant per-channel work in :func:`mne_bids.write_raw_bids` (single-pass channel-type counting, cached coil-type lookup, and a fixed quadratic loop when writing BrainVision units), by `Stefan Appelhoff`_ (:gh:`1620`)
 - Run the test suite with ``pytest-xdist`` and build the documentation with parallel Sphinx and Sphinx-Gallery workers, by `Eric Larson`_ (:gh:`1648`)
+- Sped up :meth:`mne_bids.BIDSPath.copy` and :attr:`mne_bids.BIDSPath.fpath` when the suffix or extension has to be inferred from the filesystem, by `Eric Larson`_ (:gh:`1657`)
 
 :doc:`Find out what was new in previous releases <whats_new_previous_releases>`

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -59,6 +59,6 @@ Detailed list of changes
 
 - Sped up writing of recordings with many channels by avoiding redundant per-channel work in :func:`mne_bids.write_raw_bids` (single-pass channel-type counting, cached coil-type lookup, and a fixed quadratic loop when writing BrainVision units), by `Stefan Appelhoff`_ (:gh:`1620`)
 - Run the test suite with ``pytest-xdist`` and build the documentation with parallel Sphinx and Sphinx-Gallery workers, by `Eric Larson`_ (:gh:`1648`)
-- Sped up :meth:`mne_bids.BIDSPath.copy` and :attr:`mne_bids.BIDSPath.fpath` when the suffix or extension has to be inferred from the filesystem, by `Eric Larson`_ (:gh:`1657`)
+- Sped up :meth:`mne_bids.BIDSPath.copy`, :attr:`mne_bids.BIDSPath.fpath` when the suffix or extension has to be inferred from the filesystem, and ``import mne_bids`` (roughly 2.5x faster), which no longer eagerly imports MNE's preprocessing, visualization, or file-format reader modules, nor SciPy, by `Eric Larson`_ (:gh:`1657`)
 
 :doc:`Find out what was new in previous releases <whats_new_previous_releases>`

--- a/mne_bids/commands/mne_bids_mark_channels.py
+++ b/mne_bids/commands/mne_bids_mark_channels.py
@@ -15,7 +15,7 @@ from mne.utils import logger
 
 import mne_bids
 from mne_bids import BIDSPath, mark_channels
-from mne_bids.config import reader
+from mne_bids.config import _get_readers
 
 
 def run():
@@ -115,7 +115,7 @@ def run():
 
     bids_paths = bids_path.match()
     # Only keep data we can actually read & write.
-    allowed_extensions = list(reader.keys())
+    allowed_extensions = list(_get_readers("reader"))
     bids_paths = [p for p in bids_paths if p.extension in allowed_extensions]
 
     if not bids_paths:

--- a/mne_bids/config.py
+++ b/mne_bids/config.py
@@ -3,7 +3,8 @@
 # Authors: The MNE-BIDS developers
 # SPDX-License-Identifier: BSD-3-Clause
 
-from mne import io
+import functools
+
 from mne.io.constants import FIFF
 
 BIDS_VERSION = "1.9.0"
@@ -134,42 +135,42 @@ emg_manufacturers = {
 
 nirs_manufacturers = {".snirf": "SNIRF"}
 
-# file-extension map to mne-python readers
-reader = {
-    ".con": io.read_raw_kit,
-    ".sqd": io.read_raw_kit,
-    ".fif": io.read_raw_fif,
-    ".pdf": io.read_raw_bti,
-    ".ds": io.read_raw_ctf,
-    ".vhdr": io.read_raw_brainvision,
-    ".edf": io.read_raw_edf,
-    ".EDF": io.read_raw_edf,
-    ".bdf": io.read_raw_bdf,
-    ".set": io.read_raw_eeglab,
-    ".lay": io.read_raw_persyst,
-    ".EEG": io.read_raw_nihon,
-    ".cnt": io.read_raw_cnt,
-    ".CNT": io.read_raw_cnt,
-    ".bin": io.read_raw_egi,
-    ".snirf": io.read_raw_snirf,
-    ".cdt": io.read_raw_curry,
+# file-extension map to the *names* of mne-python readers. Resolving a name to the
+# function imports that reader (and, transitively, much of MNE), so it is deferred
+# to _get_readers() rather than done when mne_bids is imported.
+_READER_NAMES = {
+    ".con": "read_raw_kit",
+    ".sqd": "read_raw_kit",
+    ".fif": "read_raw_fif",
+    ".pdf": "read_raw_bti",
+    ".ds": "read_raw_ctf",
+    ".vhdr": "read_raw_brainvision",
+    ".edf": "read_raw_edf",
+    ".EDF": "read_raw_edf",
+    ".bdf": "read_raw_bdf",
+    ".set": "read_raw_eeglab",
+    ".lay": "read_raw_persyst",
+    ".EEG": "read_raw_nihon",
+    ".cnt": "read_raw_cnt",
+    ".CNT": "read_raw_cnt",
+    ".bin": "read_raw_egi",
+    ".snirf": "read_raw_snirf",
+    ".cdt": "read_raw_curry",
+    ".mefd": "read_raw_mef",
 }
 
-# MEF3 support requires MNE >= 1.12
-if hasattr(io, "read_raw_mef"):
-    reader[".mefd"] = io.read_raw_mef
-
-
-epoch_reader = {".set": io.read_epochs_eeglab}
+_EPOCH_READER_NAMES = {".set": "read_epochs_eeglab"}
 
 # Continuous-format files where each "trial" is a fixed-length segment of the
 # file. Trial duration is read from the sidecar's ``EpochLength`` field.
-_continuous_epoched_reader = {
-    ".edf": io.read_raw_edf,
-    ".bdf": io.read_raw_bdf,
-    ".vhdr": io.read_raw_brainvision,
+_CONTINUOUS_EPOCHED_READER_NAMES = {
+    ".edf": "read_raw_edf",
+    ".bdf": "read_raw_bdf",
+    ".vhdr": "read_raw_brainvision",
 }
-_EPOCHED_EXTS = frozenset(epoch_reader) | frozenset(_continuous_epoched_reader)
+_EPOCHED_EXTS = frozenset(_EPOCH_READER_NAMES) | frozenset(
+    _CONTINUOUS_EPOCHED_READER_NAMES
+)
 # Some file extensions are ambiguous: more than one MNE reader can produce a
 # file with that extension. For example, ``.cnt`` is used both by Neuroscan,
 # read via :func:`mne.io.read_raw_cnt`, and by ANT Neuro eego recordings, read
@@ -181,9 +182,47 @@ _EPOCHED_EXTS = frozenset(epoch_reader) | frozenset(_continuous_epoched_reader)
 # This maps the class name of the ``raw`` object to the reader that created it,
 # taking precedence over the extension-based ``reader`` lookup.
 # See https://github.com/mne-tools/mne-bids/issues/1500
-reader_by_raw_class = dict()
-if hasattr(io, "read_raw_ant"):
-    reader_by_raw_class["RawANT"] = io.read_raw_ant
+_READER_BY_RAW_CLASS_NAMES = {"RawANT": "read_raw_ant"}
+
+_LAZY_READERS = {
+    "reader": _READER_NAMES,
+    "epoch_reader": _EPOCH_READER_NAMES,
+    "_continuous_epoched_reader": _CONTINUOUS_EPOCHED_READER_NAMES,
+    "reader_by_raw_class": _READER_BY_RAW_CLASS_NAMES,
+}
+
+
+@functools.cache
+def _get_readers(name):
+    """Get one of the ``_LAZY_READERS`` maps, with the names resolved (and cached).
+
+    Parameters
+    ----------
+    name : str
+        Which map to get.
+
+    Returns
+    -------
+    readers : dict
+        Maps file extensions (or ``raw`` class names) to ``mne.io`` functions.
+    """
+    from mne import io
+
+    # hasattr because a few readers need a newer MNE than we require: read_raw_mef
+    # (MNE >= 1.12) and read_raw_ant (MNE >= 1.9)
+    return {
+        key: getattr(io, func)
+        for key, func in _LAZY_READERS[name].items()
+        if hasattr(io, func)
+    }
+
+
+def __getattr__(name):
+    # PEP 562: keep ``from mne_bids.config import reader`` (etc.) working, without
+    # building the maps -- and thus importing mne.io -- at import time
+    if name in _LAZY_READERS:
+        return _get_readers(name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def _reader_for_raw(raw, ext):
@@ -206,7 +245,9 @@ def _reader_for_raw(raw, ext):
     reader : callable
         The ``mne.io.read_raw_*`` function to use.
     """
-    return reader_by_raw_class.get(type(raw).__name__, reader[ext])
+    return _get_readers("reader_by_raw_class").get(
+        type(raw).__name__, _get_readers("reader")[ext]
+    )
 
 
 # Merge the manufacturer dictionaries in a python2 / python3 compatible way

--- a/mne_bids/copyfiles.py
+++ b/mne_bids/copyfiles.py
@@ -16,7 +16,6 @@ import shutil as sh
 from pathlib import Path
 
 import numpy as np
-from mne.io import anonymize_info, read_raw_bdf, read_raw_brainvision, read_raw_edf
 from mne.utils import logger, verbose
 
 from mne_bids._fileio import _chmod_rw_R, _open_lock
@@ -440,6 +439,8 @@ def copyfile_brainvision(vhdr_src, vhdr_dest, anonymize=None, *, verbose=None):
                 fout.write(line)
 
     if anonymize is not None:
+        from mne.io import anonymize_info, read_raw_brainvision
+
         raw = read_raw_brainvision(vhdr_src, preload=False, verbose=verbose)
         daysback, keep_his, _ = _check_anonymize(anonymize, raw, ".vhdr")
         raw.info = anonymize_info(raw.info, daysback=daysback, keep_his=keep_his)
@@ -536,6 +537,8 @@ def copyfile_edf(src, dest, anonymize=None, *, verbose=None):
 
     # Anonymize EDF/BDF data, if requested
     if anonymize is not None:
+        from mne.io import anonymize_info, read_raw_bdf, read_raw_edf
+
         if ext_src in [".bdf", ".BDF"]:
             raw = read_raw_bdf(dest, preload=False, verbose=verbose)
         elif ext_src in [".edf", ".EDF"]:

--- a/mne_bids/inspect.py
+++ b/mne_bids/inspect.py
@@ -7,9 +7,7 @@ from pathlib import Path
 
 import mne
 import numpy as np
-from mne.preprocessing import annotate_amplitude
 from mne.utils import logger, verbose
-from mne.viz import use_browser_backend
 
 from mne_bids import mark_channels, read_raw_bids
 from mne_bids.config import ALLOWED_DATATYPE_EXTENSIONS
@@ -133,6 +131,8 @@ def _inspect_raw(
     # Delay the import
     import matplotlib
     import matplotlib.pyplot as plt
+    from mne.preprocessing import annotate_amplitude
+    from mne.viz import use_browser_backend
 
     extra_params = dict()
     if bids_path.extension == ".fif":

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -29,7 +29,7 @@ from mne_bids.config import (
     ALLOWED_PATH_ENTITIES_SHORT,
     ALLOWED_SPACES,
     ENTITY_VALUE_TYPE,
-    reader,
+    _get_readers,
 )
 from mne_bids.tsv_handler import _detect_file_encoding, _drop, _from_tsv, _to_tsv
 from mne_bids.utils import (
@@ -78,7 +78,7 @@ def _find_empty_room_candidates(bids_path):
         split=None, run=None, task="noise", datatype=datatype, suffix=datatype
     )
 
-    allowed_extensions = list(reader.keys())
+    allowed_extensions = list(_get_readers("reader"))
 
     # Get possible noise task files in the same directory as the recording.
     noisetask_tmp = [

--- a/mne_bids/path.py
+++ b/mne_bids/path.py
@@ -3,13 +3,13 @@
 # Authors: The MNE-BIDS developers
 # SPDX-License-Identifier: BSD-3-Clause
 
+import copy
 import glob
 import inspect
 import json
 import os
 import re
 import shutil as sh
-from copy import deepcopy
 from datetime import datetime
 from io import StringIO
 from os import path as op
@@ -700,6 +700,15 @@ class BIDSPath:
         """Compare str representations."""
         return str(self) == str(other)
 
+    def __copy__(self):
+        """Return a shallow copy of the instance."""
+        # All state is immutable (enforced by a test), so this is equivalent to a
+        # deepcopy while skipping the re-validation that __setstate__ (update) does
+        cls = self.__class__
+        new = cls.__new__(cls)
+        new.__dict__.update(self.__dict__)
+        return new
+
     def copy(self):
         """Copy the instance.
 
@@ -708,7 +717,7 @@ class BIDSPath:
         bidspath : BIDSPath
             The copied bidspath.
         """
-        return deepcopy(self)
+        return copy.copy(self)
 
     def mkdir(self, exist_ok=True):
         """Create the directory structure of the BIDS path.
@@ -1421,14 +1430,19 @@ def _get_matching_bidspaths_from_filesystem(bids_path):
     sub, ses = bids_path.subject, bids_path.session
     datatype = bids_path.datatype
     basename, bids_root = bids_path.basename, bids_path.root
-    check = bids_path.check
 
     if datatype is None:
         datatype = _infer_datatype(root=bids_root, sub=sub, ses=ses)
 
-    data_dir = BIDSPath(
-        subject=sub, session=ses, datatype=datatype, root=bids_root, check=check
-    ).directory
+    # Same as BIDSPath(...).directory, but without paying for entity validation
+    parts = []
+    if sub is not None:
+        parts.append(f"sub-{sub}")
+    if ses is not None:
+        parts.append(f"ses-{ses}")
+    if datatype is not None:
+        parts.append(datatype)
+    data_dir = bids_root.joinpath(*parts)  # bids_root is a Path (set by update)
 
     # For BTi data, return the run directory (with or without '.pdf' suffix)
     bti_dir_with_ext = op.join(data_dir, f"{basename}")
@@ -1441,23 +1455,32 @@ def _get_matching_bidspaths_from_filesystem(bids_path):
         matching_paths = [bti_dir]
     # otherwise, search for valid file paths
     else:
-        search_str = bids_root
-        # parse down the BIDS directory structure
-        if sub is not None:
-            search_str = op.join(search_str, f"sub-{sub}")
-        if ses is not None:
-            search_str = op.join(search_str, f"ses-{ses}")
-        if datatype is not None:
-            search_str = op.join(search_str, datatype)
-        else:
-            search_str = op.join(search_str, "**")
         # The basename should end with a separator "_" or a period "."
         # to avoid matching only the beggining of a value.
-        search_str = op.join(search_str, f"{basename}[_.]*")
+        if datatype is None:
+            # datatype unknown: one level of subdirectories below data_dir
+            matching_paths = glob.glob(str(data_dir / "**" / f"{basename}[_.]*"))
+        else:
+            # equivalent to glob.glob(str(data_dir / f"{basename}[_.]*")) but much
+            # cheaper; compared as str (normcase because glob/fnmatch ignore case
+            # on Windows) rather than building a Path per directory entry
+            normcase = op.normcase
+            base = normcase(basename)
+            n_char = len(base)
+            try:
+                with os.scandir(data_dir) as entries:
+                    matching_paths = [
+                        entry.path
+                        for entry in entries
+                        if (name := normcase(entry.name)).startswith(base)
+                        and len(name) > n_char
+                        and name[n_char] in "_."
+                    ]
+            except OSError:  # nonexistent (or unreadable) directory
+                matching_paths = []
 
         # Find all matching files in all supported formats.
         valid_exts = ALLOWED_FILENAME_EXTENSIONS
-        matching_paths = glob.glob(search_str)
         matching_paths = [p for p in matching_paths if _parse_ext(p)[1] in valid_exts]
     return matching_paths
 
@@ -1672,6 +1695,12 @@ def _parse_ext(raw_fname):
     if not raw_fname:
         return None, None
     raw_fname = Path(raw_fname)
+
+    # fast path for the common single-extension case (e.g. "..._meg.fif"), which
+    # avoids the repeated Path manipulations below
+    stem, _, ext = raw_fname.name.partition(".")
+    if stem and ext and "." not in ext and "c,rf" not in stem:
+        return raw_fname.with_name(stem), f".{ext}"
 
     fname, exts = raw_fname.with_suffix(""), raw_fname.suffixes
     while fname.suffix:

--- a/mne_bids/physio/eyetracking.py
+++ b/mne_bids/physio/eyetracking.py
@@ -2,7 +2,6 @@
 
 import json
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 import mne
 import numpy as np
@@ -11,11 +10,6 @@ from mne.utils import _validate_type, logger, warn
 from mne_bids.config import UNITS_FIFF_TO_BIDS_MAP
 from mne_bids.path import BIDSPath
 from mne_bids.utils import _write_json, _write_tsv
-
-if TYPE_CHECKING:
-    # importing this at runtime would eagerly import much of MNE (and SciPy),
-    # which makes `import mne_bids` an order of magnitude slower
-    from mne.preprocessing.eyetracking import Calibration
 
 # Parameters accepted by MNE's Calibration class
 BIDS_CALIBRATION_TO_MNE = {
@@ -344,7 +338,11 @@ def _calibration_to_sidecar_updates(calibrations):
 
 def write_eyetrack_calibration(
     bids_path: BIDSPath,
-    calibrations: "Calibration | list[Calibration]",
+    # spelled out rather than imported so that `import mne_bids` does not eagerly
+    # import mne.preprocessing.eyetracking (and hence SciPy), and so that Sphinx
+    # can still resolve the annotation
+    calibrations: "mne.preprocessing.eyetracking.Calibration"
+    " | list[mne.preprocessing.eyetracking.Calibration]",
 ) -> list[Path]:
     """Write eyetrack calibration metadata into an existing ``*_physio.json`` sidecar.
 

--- a/mne_bids/physio/eyetracking.py
+++ b/mne_bids/physio/eyetracking.py
@@ -2,15 +2,20 @@
 
 import json
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import mne
 import numpy as np
-from mne.preprocessing.eyetracking import Calibration
 from mne.utils import _validate_type, logger, warn
 
 from mne_bids.config import UNITS_FIFF_TO_BIDS_MAP
 from mne_bids.path import BIDSPath
 from mne_bids.utils import _write_json, _write_tsv
+
+if TYPE_CHECKING:
+    # importing this at runtime would eagerly import much of MNE (and SciPy),
+    # which makes `import mne_bids` an order of magnitude slower
+    from mne.preprocessing.eyetracking import Calibration
 
 # Parameters accepted by MNE's Calibration class
 BIDS_CALIBRATION_TO_MNE = {
@@ -339,7 +344,7 @@ def _calibration_to_sidecar_updates(calibrations):
 
 def write_eyetrack_calibration(
     bids_path: BIDSPath,
-    calibrations: Calibration | list[Calibration],
+    calibrations: "Calibration | list[Calibration]",
 ) -> list[Path]:
     """Write eyetrack calibration metadata into an existing ``*_physio.json`` sidecar.
 

--- a/mne_bids/read.py
+++ b/mne_bids/read.py
@@ -14,12 +14,6 @@ from pathlib import Path
 import mne
 import numpy as np
 from mne import events_from_annotations, io, pick_channels_regexp, read_events
-
-try:  # MNE 1.13+
-    from mne.transforms import fit_matched_points
-except ImportError:
-    from mne.coreg import fit_matched_points
-from mne.transforms import apply_trans
 from mne.utils import _validate_type, check_version, get_subjects_dir, logger
 
 from mne_bids._fileio import _open_lock
@@ -29,10 +23,8 @@ from mne_bids.config import (
     ANNOTATIONS_TO_KEEP,
     EPHY_ALLOWED_DATATYPES,
     UNITS_BIDS_TO_FIFF_MAP,
-    _continuous_epoched_reader,
+    _get_readers,
     _map_options,
-    epoch_reader,
-    reader,
 )
 from mne_bids.dig import _read_dig_bids
 from mne_bids.path import (
@@ -65,6 +57,7 @@ def _read_raw(
 ):
     """Read a raw file into MNE, making inferences based on extension."""
     _, ext = _parse_ext(raw_path)
+    reader = _get_readers("reader")
 
     # KIT systems
     if ext in [".con", ".sqd"]:
@@ -1613,11 +1606,12 @@ def read_epochs_bids(
         bids_path.update(suffix=bids_path.datatype)
 
     ext = bids_path.fpath.suffix
+    epoch_reader = _get_readers("epoch_reader")
     if ext in epoch_reader:
         epochs = epoch_reader[ext](
             bids_path.fpath, verbose=verbose, **(extra_params or {})
         )
-    elif ext in _continuous_epoched_reader:
+    elif ext in _get_readers("_continuous_epoched_reader"):
         epochs = _read_epochs_from_continuous(
             bids_path, extra_params=extra_params, verbose=verbose
         )
@@ -1643,7 +1637,7 @@ def _read_epochs_from_continuous(bids_path, *, extra_params=None, verbose=None):
                 f"{bids_path.fpath.name} sidecar is missing 'EpochLength'; "
                 "required to slice an 'epoched' continuous file."
             ) from None
-    raw = _continuous_epoched_reader[bids_path.fpath.suffix](
+    raw = _get_readers("_continuous_epoched_reader")[bids_path.fpath.suffix](
         bids_path.fpath, preload=False, verbose=verbose, **(extra_params or {})
     )
     events_fname = _find_matching_sidecar(
@@ -1760,6 +1754,13 @@ def get_head_mri_trans(
     trans : mne.transforms.Transform
         The data transformation matrix from head to MRI coordinates.
     """
+    from mne.transforms import apply_trans
+
+    try:  # MNE 1.13+
+        from mne.transforms import fit_matched_points
+    except ImportError:
+        from mne.coreg import fit_matched_points
+
     nib = _import_nibabel("get a head to MRI transform")
 
     if not isinstance(bids_path, BIDSPath):

--- a/mne_bids/sidecar_updates.py
+++ b/mne_bids/sidecar_updates.py
@@ -7,8 +7,6 @@ import json
 from collections import OrderedDict
 
 import numpy as np
-from mne.channels import DigMontage, make_dig_montage
-from mne.io import read_fiducials
 from mne.io.constants import FIFF
 from mne.utils import (
     _check_on_missing,
@@ -208,6 +206,8 @@ def update_anat_landmarks(
     -----
     .. versionadded:: 0.8
     """
+    from mne.channels import DigMontage
+
     _validate_type(item=bids_path, types=BIDSPath, item_name="bids_path")
     _validate_type(
         item=landmarks, types=(DigMontage, "path-like"), item_name="landmarks"
@@ -346,6 +346,9 @@ def _get_landmarks_from_fiducials_file(
     *, bids_path, fname, fs_subject, fs_subjects_dir
 ):
     """Get anatomical landmarks from fiducials file, in MRI voxel space."""
+    from mne.channels import make_dig_montage
+    from mne.io import read_fiducials
+
     # avoid dicrular imports
     from mne_bids.write import (
         _get_fid_coords,

--- a/mne_bids/tests/test_eyetracking.py
+++ b/mne_bids/tests/test_eyetracking.py
@@ -10,6 +10,7 @@ import numpy as np
 import pytest
 from mne.datasets import testing
 from mne.io import RawArray, read_raw_egi, read_raw_eyelink
+from mne.utils import check_version
 
 import mne_bids
 from mne_bids import BIDSPath, write_raw_bids
@@ -371,11 +372,17 @@ print(_get_readers.cache_info().currsize)
 
 def test_no_eager_imports():
     """Test that importing mne_bids does not import heavy or optional modules."""
+    forbidden = FORBIDDEN_IMPORTS
+    if not check_version("mne", "1.13"):
+        # before mne-tools/mne-python#14168, mne.annotations and mne._fiff.{tag,write}
+        # import scipy.{io,sparse} at module scope, which mne_bids cannot avoid; every
+        # other module below is still guarded on old MNE
+        forbidden = tuple(f for f in forbidden if f != "scipy")
     # in a subprocess so that whatever pytest itself imported cannot mask a regression
     script = _IMPORT_CHECK.format(
         allowed=MNE_ALLOWED_EXACT,
         prefixes=MNE_ALLOWED_PREFIXES,
-        forbidden=FORBIDDEN_IMPORTS,
+        forbidden=forbidden,
     )
     modules, n_reader_maps = subprocess.run(
         [sys.executable, "-c", script], capture_output=True, text=True, check=True

--- a/mne_bids/tests/test_eyetracking.py
+++ b/mne_bids/tests/test_eyetracking.py
@@ -2,6 +2,8 @@
 
 import gzip
 import json
+import subprocess
+import sys
 
 import mne
 import numpy as np
@@ -321,3 +323,71 @@ def test_write_raises(raw_eye_and_cals, eyetrack_bpath):
             overwrite=False,
         )
     del cal_bad
+
+
+# The only parts of MNE that `import mne_bids` may pull in. Everything else -- a
+# file-format reader, mne.epochs, mne.preprocessing, mne.viz, ... -- costs every
+# user interpreter startup time and belongs inside the function that needs it.
+MNE_ALLOWED_PREFIXES = (
+    "mne._fiff",  # FIFF constants and Info, used by config/dig/pick/write
+    "mne.html_templates",  # pulled in by mne._fiff (the HTML repr of Info)
+    "mne.utils",  # logger/verbose/_validate_type, used throughout mne_bids
+)
+MNE_ALLOWED_EXACT = (
+    "mne",  # lazily loaded: attribute access is what does the real importing
+    "mne.annotations",  # pulled in by mne._fiff.meas_info
+    "mne.defaults",  # ditto
+    "mne.event",  # ditto
+    "mne.fixes",  # ditto
+    "mne.io",  # lazy-loader package init only: no reader below it may load
+    "mne.io.constants",  # FIFF constants, a shim for mne._fiff.constants
+    "mne.io.pick",  # _picks_to_idx, a shim for mne._fiff.pick
+)
+# Non-MNE packages that must stay lazy: optional dependencies (nibabel, pandas),
+# plotting (matplotlib), and scipy, which is only needed by a few MRI helpers.
+FORBIDDEN_IMPORTS = ("matplotlib", "nibabel", "pandas", "scipy")
+
+_IMPORT_CHECK = """\
+import sys
+import mne_bids
+from mne_bids.config import _get_readers
+
+allowed, prefixes, forbidden = {allowed!r}, {prefixes!r}, {forbidden!r}
+bad = [
+    m
+    for m in sys.modules
+    if (m == "mne" or m.startswith("mne."))
+    and m not in allowed
+    and not any(m == p or m.startswith(p + ".") for p in prefixes)
+]
+bad += [
+    m for m in sys.modules if any(m == f or m.startswith(f + ".") for f in forbidden)
+]
+# shallowest first: the roots of a cascade are the informative ones
+print(" ".join(sorted(bad, key=lambda m: (m.count("."), m))))
+print(_get_readers.cache_info().currsize)
+"""
+
+
+def test_no_eager_imports():
+    """Test that importing mne_bids does not import heavy or optional modules."""
+    # in a subprocess so that whatever pytest itself imported cannot mask a regression
+    script = _IMPORT_CHECK.format(
+        allowed=MNE_ALLOWED_EXACT,
+        prefixes=MNE_ALLOWED_PREFIXES,
+        forbidden=FORBIDDEN_IMPORTS,
+    )
+    modules, n_reader_maps = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True, check=True
+    ).stdout.splitlines()
+    bad = modules.split()
+    assert not bad, (
+        f"`import mne_bids` eagerly imported {len(bad)} module(s): "
+        f"{' '.join(bad[:12])}{' ...' if len(bad) > 12 else ''}. Move the import "
+        "inside the function that needs it, or, for an annotation, spell the type "
+        "out as a string (see mne_bids/physio/eyetracking.py)."
+    )
+    assert n_reader_maps == "0", (
+        "`import mne_bids` built a mne_bids.config reader map, which imports every "
+        "mne.io reader it names; call _get_readers where the readers are needed."
+    )

--- a/mne_bids/tests/test_path.py
+++ b/mne_bids/tests/test_path.py
@@ -3,6 +3,7 @@
 # Authors: The MNE-BIDS developers
 # SPDX-License-Identifier: BSD-3-Clause
 
+import copy
 import functools
 import glob
 import os
@@ -12,7 +13,7 @@ import shutil as sh
 import timeit
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from pathlib import Path
+from pathlib import Path, PurePath
 
 import mne
 import pytest
@@ -765,11 +766,12 @@ def test_parse_ext():
     assert fname == f.with_suffix("")
     assert ext == ".vhdr"
 
-    # Test for case where no extension: assume BTi format
-    f = "sub-01_task-rest"
-    fname, ext = _parse_ext(f)
-    assert fname == Path(f)
-    assert ext == ".pdf"
+    # Test for case where no extension: assume BTi format (a leading period is
+    # not an extension)
+    for f in ("sub-01_task-rest", ".sub-01_task-rest"):
+        fname, ext = _parse_ext(f)
+        assert fname == Path(f)
+        assert ext == ".pdf"
 
     # Get a .nii.gz file, and pass str as input
     f = "sub-01_task-rest.nii.gz"
@@ -2376,8 +2378,24 @@ def test_fpath_common_prefix(tmp_path):
     )
 
 
+# Guard the shallow-copy contract of __copy__: every piece of instance state
+# must be immutable, otherwise a copy would share it with the original. If this
+# fails for an attribute you added, either use an immutable type (extending the
+# allowlist below), or give __copy__ special handling for it.
+def _assert_immutable(obj, name):
+    __tracebackhide__ = True  # report the failure at the caller, not in here
+    if isinstance(obj, tuple | frozenset):
+        for ii, item in enumerate(obj):
+            _assert_immutable(item, f"{name}[{ii}]")
+    else:
+        assert isinstance(obj, str | int | bytes | PurePath | None), (
+            f"Mutable (or unvetted) type {type(obj).__name__} in "
+            f"BIDSPath.__dict__[{name!r}] breaks BIDSPath.__copy__"
+        )
+
+
 def test_hash():
-    """Test that BIDSPath is hashable."""
+    """Test that BIDSPath is hashable, copyable, and picklable."""
     bp1 = BIDSPath(subject="01", datatype="eeg", root=Path("foo"))
     bp2 = BIDSPath(subject="01", datatype="eeg", root=Path("foo"))
     # test standard hash properties:
@@ -2391,6 +2409,18 @@ def test_hash():
     bp3 = pickle.loads(pickle.dumps(bp1))  # test pickling
     assert bp1 == bp3
     assert hash(bp1) == hash(bp3)
+    for bp_copy in (bp1.copy(), copy.copy(bp1), copy.deepcopy(bp1)):  # test copying
+        assert bp_copy is not bp1
+        assert bp_copy.__dict__ == bp1.__dict__
+
+    for key, val in vars(bp1).items():
+        _assert_immutable(val, key)
+
+    class _SubPath(BIDSPath):  # copies of subclasses stay subclasses
+        pass
+
+    assert type(_SubPath(subject="01", root=Path("foo")).copy()) is _SubPath
+
     # equality and pickling
     assert bp1.__dict__ != bp_other.__dict__  # different content
     assert bp1.fpath == bp_other.fpath  # okay, I guess

--- a/mne_bids/tests/test_read.py
+++ b/mne_bids/tests/test_read.py
@@ -33,6 +33,7 @@ from mne_bids.config import (
     BIDS_SHARED_COORDINATE_FRAMES,
     BIDS_TO_MNE_FRAMES,
     MNE_STR_TO_FRAME,
+    _get_readers,
 )
 from mne_bids.path import _find_matching_sidecar
 from mne_bids.read import (
@@ -186,11 +187,9 @@ def test_not_implemented(tmp_path):
 
 def test_mefd_requires_supported_mne(tmp_path, monkeypatch):
     """Test that reading .mefd requires a registered reader implementation."""
-    import mne_bids.read as read_module
-
     mefd_path = tmp_path / "test.mefd"
     mefd_path.mkdir()
-    monkeypatch.delitem(read_module.reader, ".mefd", raising=False)
+    monkeypatch.delitem(_get_readers("reader"), ".mefd", raising=False)
 
     with pytest.raises(ValueError, match="MEF3 support requires MNE-Python >= 1.12"):
         _read_raw(mefd_path)
@@ -198,8 +197,6 @@ def test_mefd_requires_supported_mne(tmp_path, monkeypatch):
 
 def test_mefd_read_uses_reader_registry(tmp_path, monkeypatch):
     """Test that reading .mefd uses the registered reader from config."""
-    import mne_bids.read as read_module
-
     mefd_path = tmp_path / "test.mefd"
     mefd_path.mkdir()
     sentinel = object()
@@ -211,7 +208,7 @@ def test_mefd_read_uses_reader_registry(tmp_path, monkeypatch):
         assert kwargs == {"preload": False}
         return sentinel
 
-    monkeypatch.setitem(read_module.reader, ".mefd", _fake_mefd_reader)
+    monkeypatch.setitem(_get_readers("reader"), ".mefd", _fake_mefd_reader)
 
     assert _read_raw(mefd_path, preload=False) is sentinel
 

--- a/mne_bids/utils.py
+++ b/mne_bids/utils.py
@@ -10,9 +10,6 @@ from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
 
 import numpy as np
-from mne import pick_types
-from mne.channels import get_builtin_montages, make_standard_montage
-from mne.io.kit.kit import get_kit_info
 from mne.utils import logger, verbose
 from mne.utils import warn as _warn
 
@@ -283,6 +280,8 @@ def _check_key_val(key, val):
 
 def _get_mrk_meas_date(mrk):
     """Find the measurement date from a KIT marker file."""
+    from mne.io.kit.kit import get_kit_info
+
     info = get_kit_info(mrk, False)[0]
     meas_date = info.get("meas_date", None)
     if isinstance(meas_date, tuple | list | np.ndarray):
@@ -311,6 +310,9 @@ def _infer_eeg_placement_scheme(raw):
         extraction.
 
     """
+    from mne import pick_types
+    from mne.channels import get_builtin_montages, make_standard_montage
+
     placement_scheme = "n/a"
     # Check if the raw data contains eeg data at all
     if "eeg" not in raw:

--- a/mne_bids/write.py
+++ b/mne_bids/write.py
@@ -16,14 +16,9 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import mne
-import mne.preprocessing
 import numpy as np
-from mne import Epochs, channel_type
-from mne.channels.channels import _get_meg_system, _unit2human
-from mne.io import BaseRaw, read_fiducials
 from mne.io.constants import FIFF
 from mne.io.pick import _picks_to_idx
-from mne.transforms import _get_trans, apply_trans, rotation, translation
 from mne.utils import (
     Bunch,
     ProgressBar,
@@ -33,7 +28,6 @@ from mne.utils import (
     logger,
     verbose,
 )
-from scipy import linalg
 
 from mne_bids import (
     BIDSPath,
@@ -170,6 +164,10 @@ def _channels_tsv(raw, fname, *, convert_fmt, overwrite=False):
         Defaults to False.
 
     """
+    # hoisted out of the per-channel loop below
+    from mne import channel_type
+    from mne.channels.channels import _unit2human
+
     # Get channel type mappings between BIDS and MNE nomenclatures
     map_chs = _get_ch_type_mapping(fro="mne", to="bids")
 
@@ -1031,6 +1029,8 @@ def _meg_landmarks_to_mri_landmarks(meg_landmarks, trans):
     mri_landmarks : np.ndarray, shape (3, 3)
         The mri RAS landmark data converted to from m to mm.
     """
+    from mne.transforms import apply_trans
+
     # Transform MEG landmarks into MRI space, adjust units by * 1e3
     return apply_trans(trans, meg_landmarks, move=True) * 1e3
 
@@ -1050,6 +1050,9 @@ def _mri_landmarks_to_mri_voxels(mri_landmarks, t1_mgh):
     vox_landmarks : np.ndarray, shape (3, 3)
         The MRI voxel-space landmark data.
     """
+    from mne.transforms import apply_trans
+    from scipy import linalg
+
     # Get landmarks in voxel space, using the T1 data
     vox2ras_tkr_t = t1_mgh.header.get_vox2ras_tkr()
     ras_tkr2vox_t = linalg.inv(vox2ras_tkr_t)
@@ -1073,6 +1076,8 @@ def _mri_voxels_to_mri_scanner_ras(mri_landmarks, img_mgh):
     ras_landmarks : np.ndarray, shape (3, 3)
         The MRI scanner RAS landmark data.
     """
+    from mne.transforms import apply_trans
+
     # Get landmarks in voxel space, using the T1 data
     vox2ras = img_mgh.header.get_vox2ras()
     ras_landmarks = apply_trans(vox2ras, mri_landmarks)  # in scanner RAS
@@ -1094,6 +1099,9 @@ def _mri_scanner_ras_to_mri_voxels(ras_landmarks, img_mgh):
     vox_landmarks : np.ndarray, shape (3, 3)
         The MRI voxel-space landmark data.
     """
+    from mne.transforms import apply_trans
+    from scipy import linalg
+
     # Get landmarks in voxel space, using the T1 data
     vox2ras = img_mgh.header.get_vox2ras()
     ras2vox = linalg.inv(vox2ras)
@@ -1157,9 +1165,9 @@ def _sidecar_json(
             "is unknown, set it to None"
         )
 
-    if isinstance(raw, BaseRaw):
+    if isinstance(raw, mne.io.BaseRaw):
         rec_type = "continuous"
-    elif isinstance(raw, Epochs):
+    elif isinstance(raw, mne.Epochs):
         rec_type = "epoched"
     else:
         rec_type = "n/a"
@@ -1218,6 +1226,8 @@ def _sidecar_json(
     }
 
     # Compile cHPI information, if any.
+    from mne.channels.channels import _get_meg_system
+
     system, _ = _get_meg_system(raw.info)
     chpi = None
     hpi_freqs = []
@@ -1381,6 +1391,8 @@ def _deface(image, landmarks, deface):
     # now comes the actual defacing
     # 1. move center of voxels to (nasion - inset)
     # 2. rotate the head by theta from vertical
+    from mne.transforms import apply_trans, rotation, translation
+
     x, y, z = nib.affines.apply_affine(image.affine, landmarks)[1]
     idxs = apply_trans(translation(x=-x, y=-y + inset, z=-z), idxs)
     idxs = apply_trans(rotation(x=-np.pi / 2 + np.deg2rad(theta)), idxs)
@@ -1467,6 +1479,8 @@ def _write_raw_brainvision(raw, bids_fname, events, overwrite):
 
     # pybv needs to know the units of the data for appropriate scaling
     # get voltage units as micro-volts and all other units "as is"
+    from mne.channels.channels import _unit2human  # hoisted out of the loop
+
     unit = []
     for chs in raw.info["chs"]:
         if chs["unit"] == FIFF.FIFF_UNIT_V:
@@ -2070,7 +2084,7 @@ def write_raw_bids(
     When writing EDF or BDF files, all file extensions are forced to be
     lower-case, in compliance with the BIDS specification.
     """
-    if not isinstance(raw, BaseRaw):
+    if not isinstance(raw, mne.io.BaseRaw):
         raise ValueError(f"raw_file must be an instance of BaseRaw, got {type(raw)}")
     is_eyetracking_only = all(
         [ch in ["eyegaze", "pupil"] for ch in raw.get_channel_types()]
@@ -2819,6 +2833,8 @@ def get_anat_landmarks(image, info, trans, fs_subject, fs_subjects_dir=None):
     )
 
     # get trans and ensure it is from head to MRI
+    from mne.transforms import _get_trans
+
     trans, _ = _get_trans(trans, fro="head", to="mri")
     landmarks = _meg_landmarks_to_mri_landmarks(landmarks, trans)
 
@@ -2864,6 +2880,7 @@ def _get_t1w_mgh(fs_subject, fs_subjects_dir):
 
 def _get_landmarks(landmarks, image_nii, kind=""):
     import nibabel as nib
+    from mne.io import read_fiducials
 
     if isinstance(landmarks, str | Path):
         landmarks, coord_frame = read_fiducials(landmarks)


### PR DESCRIPTION
I'm looking into MNE-BIDS-Pipeline bottlenecks, and one is `BIDSPath.copy()`. Changes drafted by Claude Opus 5 and reviewed by me. Related to my previous PRs like https://github.com/mne-tools/mne-bids/pull/1563, but this speeds things up even further using immutability (which I should have thought of sooner!).

@bruAristimunha can you look and see if you agree this speeds things up? :rocket: If so then I think we should be good to merge!